### PR TITLE
Support providing a 'stack' configuration for 'as a library' usage

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -85,7 +85,9 @@ def get_llama_stack_client(
 ) -> LlamaStackClient:
     if llama_stack_config.use_as_library_client is True:
         logger.info("Using Llama stack as library client")
-        client = LlamaStackAsLibraryClient("ollama")
+        client = LlamaStackAsLibraryClient(
+            llama_stack_config.library_client_config_path
+        )
         client.initialize()
         return client
     else:

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -10,6 +10,7 @@ class LLamaStackConfiguration(BaseModel):
     url: Optional[str] = None
     api_key: Optional[str] = None
     use_as_library_client: Optional[bool] = None
+    library_client_config_path: Optional[str] = None
     chat_completion_mode: bool = False
 
     @model_validator(mode="after")
@@ -25,6 +26,11 @@ class LLamaStackConfiguration(BaseModel):
                 )
         if self.use_as_library_client is None:
             self.use_as_library_client = False
+        if self.use_as_library_client:
+            if self.library_client_config_path is None:
+                raise ValueError(
+                    "LLama stack library client mode is enabled but a configuration file path is not specified"
+                )
         return self
 
 


### PR DESCRIPTION
## Description

Support providing the path to a `llama-stack` configuration file when using it "as a library".

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Try a configuration file:
```
name: foo bar baz
llama_stack:
  use_as_library_client: true
  library_client_config_path: /home/manstis/.llama/distributions/ollama/ollama-run.yaml
  url: http://localhost:8321
  api_key: xyzzy
  chat_completion_mode: true
```