### PR TITLE
Fix Makefile "run" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PATH_TO_PLANTUML := ~/bin
 
 
 run: ## Run the service locally
-	python src/lightspeed-stack.py "$@"
+	python src/lightspeed-stack.py
 
 test-unit: ## Run the unit tests
 	@echo "Running unit tests..."


### PR DESCRIPTION
## Description

The recent change introduced by the commit
023076dd824f28d781614333900f7aa273941768 broke the "run" target. Without this patch, starting the service via "pdm start" would fail with the following error:

$ pdm start
python src/lightspeed-stack.py "run"
[09:26:45] INFO     Lightspeed stack startup
usage: lightspeed-stack.py [-h] [-v] [-d]
lightspeed-stack.py: error: unrecognized arguments: run
make: *** [Makefile:6: run] Error 2

## Type of change

- [ ] Refactor
- [ ] New feature
- [x ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Just run "pdm start"
