### PR TITLE
Nit: Add system_prompt parameter to QueryRequest docstring

### DIFF
--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -60,6 +60,7 @@ class QueryRequest(BaseModel):
         conversation_id: The optional conversation ID (UUID).
         provider: The optional provider.
         model: The optional model.
+        system_prompt: The optional system prompt.
         attachments: The optional attachments.
 
     Example:


### PR DESCRIPTION
## Description

Nit and straigh-forward patch. The system_prompt parameter was missing from the docstring. This patch just add it.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
