### PR TITLE
LCORE-173: Fixed Unit Tests

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:ddc6729ca7e479d4260806c2d960487f750aa598b025763a771c9563ac84e7ff"
+content_hash = "sha256:910b28fc47a38a82cf708002e2acd98de248bbe659eb0ca2e78b6d210eeba7c6"
 
 [[metadata.targets]]
 requires_python = ">=3.11.1,<=3.12.10"
@@ -87,6 +87,20 @@ dependencies = [
 files = [
     {file = "aiosignal-1.3.2-py2.py3-none-any.whl", hash = "sha256:45cde58e409a301715980c2b01d0c28bdde3770d8290b5eb2173759d9acb31a5"},
     {file = "aiosignal-1.3.2.tar.gz", hash = "sha256:a8c255c66fafb1e499c9351d0bf32ff2d8a0321595ebac3b93713656d2436f54"},
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.21.0"
+requires_python = ">=3.9"
+summary = "asyncio bridge to the standard sqlite3 module"
+groups = ["dev"]
+dependencies = [
+    "typing-extensions>=4.0",
+]
+files = [
+    {file = "aiosqlite-0.21.0-py3-none-any.whl", hash = "sha256:2549cf4057f95f53dcba16f2b64e8e2791d7e1adedb13197dd8ed77bb226d7d0"},
+    {file = "aiosqlite-0.21.0.tar.gz", hash = "sha256:131bb8056daa3bc875608c631c678cda73922a2d4ba8aec373b19f18c17e7aa3"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "mypy>=1.16.0",
     "types-PyYAML>=6.0.2",
     "ruff>=0.11.13",
+    "aiosqlite",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/configuration/minimal-stack.yaml
+++ b/tests/configuration/minimal-stack.yaml
@@ -1,0 +1,6 @@
+version: '2'
+image_name: llamastack-minimal-stack
+container_image: null
+
+apis: []
+providers: {}

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,8 +1,6 @@
 """Unit tests for functions defined in src/client.py."""
 
-import os
 import pytest
-from unittest.mock import patch
 
 from client import get_llama_stack_client
 from models.config import LLamaStackConfiguration

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -9,7 +9,6 @@ from models.config import LLamaStackConfiguration
 
 
 # [tisnik] Need to resolve dependencies on CI to be able to run this tests
-@patch.dict(os.environ, {"INFERENCE_MODEL": "llama3.2:3b-instruct-fp16"})
 def test_get_llama_stack_library_client() -> None:
     cfg = LLamaStackConfiguration(
         url=None,
@@ -22,7 +21,6 @@ def test_get_llama_stack_library_client() -> None:
     assert client is not None
 
 
-@patch.dict(os.environ, {"INFERENCE_MODEL": "llama3.2:3b-instruct-fp16"})
 def test_get_llama_stack_remote_client() -> None:
     cfg = LLamaStackConfiguration(
         url="http://localhost:8321",
@@ -34,7 +32,6 @@ def test_get_llama_stack_remote_client() -> None:
     assert client is not None
 
 
-@patch.dict(os.environ, {"INFERENCE_MODEL": "llama3.2:3b-instruct-fp16"})
 def test_get_llama_stack_wrong_configuration() -> None:
     cfg = LLamaStackConfiguration(
         url=None,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -10,13 +10,14 @@ from models.config import LLamaStackConfiguration
 
 # [tisnik] Need to resolve dependencies on CI to be able to run this tests
 @patch.dict(os.environ, {"INFERENCE_MODEL": "llama3.2:3b-instruct-fp16"})
-def _test_get_llama_stack_library_client() -> None:
+def test_get_llama_stack_library_client() -> None:
     cfg = LLamaStackConfiguration(
         url=None,
         api_key=None,
         use_as_library_client=True,
-        library_client_config_path="ollama",
+        library_client_config_path="./tests/configuration/minimal-stack.yaml",
     )
+
     client = get_llama_stack_client(cfg)
     assert client is not None
 
@@ -27,7 +28,7 @@ def test_get_llama_stack_remote_client() -> None:
         url="http://localhost:8321",
         api_key=None,
         use_as_library_client=False,
-        library_client_config_path="ollama",
+        library_client_config_path="./tests/configuration/minimal-stack.yaml",
     )
     client = get_llama_stack_client(cfg)
     assert client is not None
@@ -39,7 +40,7 @@ def test_get_llama_stack_wrong_configuration() -> None:
         url=None,
         api_key=None,
         use_as_library_client=True,
-        library_client_config_path="ollama",
+        library_client_config_path="./tests/configuration/minimal-stack.yaml",
     )
     cfg.library_client_config_path = None
     with pytest.raises(


### PR DESCRIPTION
## Description
Added fix for LCORE-173. The fix includes adding a minimal llama-stack configuration file so that inference models don't need to be served during unit testing.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [X] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Closes LCORE-173

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
