### PR TITLE
Add support for storing transcripts

### DIFF
--- a/lightspeed-stack.yaml
+++ b/lightspeed-stack.yaml
@@ -18,3 +18,5 @@ llama_stack:
 user_data_collection:
   feedback_disabled: false
   feedback_storage: "/tmp/data/feedback"
+  transcripts_disabled: false
+  transcripts_storage: "/tmp/data/transcripts"

--- a/src/app/endpoints/feedback.py
+++ b/src/app/endpoints/feedback.py
@@ -12,6 +12,7 @@ from configuration import configuration
 from models.responses import FeedbackResponse, StatusResponse
 from models.requests import FeedbackRequest
 from utils.suid import get_suid
+from utils.common import retrieve_user_id, auth_dependency
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/feedback", tags=["feedback"])
@@ -29,33 +30,6 @@ def is_feedback_enabled() -> bool:
         bool: True if feedback is enabled, False otherwise.
     """
     return not configuration.user_data_collection_configuration.feedback_disabled
-
-
-# TODO(lucasagomes): implement this function to retrieve user ID from auth
-def retrieve_user_id(auth: Any) -> str:  # pylint: disable=unused-argument
-    """Retrieve the user ID from the authentication handler.
-
-    Args:
-        auth: The Authentication handler (FastAPI Depends) that will
-            handle authentication Logic.
-
-    Returns:
-        str: The user ID.
-    """
-    return "user_id_placeholder"
-
-
-# TODO(lucasagomes): implement this function to handle authentication
-async def auth_dependency(_request: Request) -> bool:
-    """Authenticate dependency to ensure the user is authenticated.
-
-    Args:
-        request (Request): The FastAPI request object.
-
-    Raises:
-        HTTPException: If the user is not authenticated.
-    """
-    return True
 
 
 async def assert_feedback_enabled(_request: Request) -> None:

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -65,12 +65,18 @@ class UserDataCollection(BaseModel):
 
     feedback_disabled: bool = True
     feedback_storage: Optional[str] = None
+    transcripts_disabled: bool = True
+    transcripts_storage: Optional[str] = None
 
     @model_validator(mode="after")
     def check_storage_location_is_set_when_needed(self) -> Self:
         """Check that storage_location is set when enabled."""
         if not self.feedback_disabled and self.feedback_storage is None:
             raise ValueError("feedback_storage is required when feedback is enabled")
+        if not self.transcripts_disabled and self.transcripts_storage is None:
+            raise ValueError(
+                "transcripts_storage is required when transcripts is enabled"
+            )
         return self
 
 

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -1,0 +1,32 @@
+"""Common utilities for the project."""
+
+from typing import Any
+
+from fastapi import Request
+
+
+# TODO(lucasagomes): implement this function to retrieve user ID from auth
+def retrieve_user_id(auth: Any) -> str:  # pylint: disable=unused-argument
+    """Retrieve the user ID from the authentication handler.
+
+    Args:
+        auth: The Authentication handler (FastAPI Depends) that will
+            handle authentication Logic.
+
+    Returns:
+        str: The user ID.
+    """
+    return "user_id_placeholder"
+
+
+# TODO(lucasagomes): implement this function to handle authentication
+async def auth_dependency(_request: Request) -> bool:
+    """Authenticate dependency to ensure the user is authenticated.
+
+    Args:
+        request (Request): The FastAPI request object.
+
+    Raises:
+        HTTPException: If the user is not authenticated.
+    """
+    return True

--- a/tests/unit/app/endpoints/test_feedback.py
+++ b/tests/unit/app/endpoints/test_feedback.py
@@ -4,9 +4,7 @@ import pytest
 from configuration import configuration
 from app.endpoints.feedback import (
     is_feedback_enabled,
-    retrieve_user_id,
     assert_feedback_enabled,
-    auth_dependency,
     feedback_endpoint_handler,
     store_feedback,
     feedback_status,
@@ -23,13 +21,6 @@ def test_is_feedback_disabled():
     """Test that is_feedback_enabled returns False when feedback is disabled."""
     configuration.user_data_collection_configuration.feedback_disabled = True
     assert is_feedback_enabled() is False, "Feedback should be disabled"
-
-
-# TODO(lucasagomes): Implement this test when the retrieve_user_id function is implemented
-def test_retrieve_user_id():
-    """Test that retrieve_user_id returns a user ID."""
-    user_id = retrieve_user_id(None)
-    assert user_id == "user_id_placeholder"
 
 
 async def test_assert_feedback_enabled_disabled(mocker):
@@ -55,18 +46,11 @@ async def test_assert_feedback_enabled(mocker):
     await assert_feedback_enabled(mocker.Mock())
 
 
-# TODO(lucasagomes): Implement this test when the auth_dependency function is implemented
-async def test_auth_dependency(mocker):
-    """Test that auth_dependency does not raise an exception."""
-    result = await auth_dependency(mocker.Mock())
-    assert result is True
-
-
 def test_feedback_endpoint_handler(mocker):
     """Test that feedback_endpoint_handler processes feedback correctly."""
     # Mock the dependencies
     mocker.patch("app.endpoints.feedback.assert_feedback_enabled", return_value=None)
-    mocker.patch("app.endpoints.feedback.retrieve_user_id", return_value="test_user_id")
+    mocker.patch("utils.common.retrieve_user_id", return_value="test_user_id")
     mocker.patch("app.endpoints.feedback.store_feedback", return_value=None)
 
     # Mock the feedback request
@@ -87,7 +71,7 @@ def test_feedback_endpoint_handler_error(mocker):
     """Test that feedback_endpoint_handler raises an HTTPException on error."""
     # Mock the dependencies
     mocker.patch("app.endpoints.feedback.assert_feedback_enabled", return_value=None)
-    mocker.patch("app.endpoints.feedback.retrieve_user_id", return_value="test_user_id")
+    mocker.patch("utils.common.retrieve_user_id", return_value="test_user_id")
     mocker.patch(
         "app.endpoints.feedback.store_feedback",
         side_effect=Exception("Error storing feedback"),

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -1,17 +1,57 @@
 from fastapi import HTTPException, status
 import pytest
 
+from configuration import configuration
 from app.endpoints.query import (
     query_endpoint_handler,
     select_model_id,
     retrieve_response,
+    retrieve_conversation_id,
     validate_attachments_metadata,
+    is_transcripts_enabled,
+    construct_transcripts_path,
+    store_transcript,
 )
 from models.requests import QueryRequest, Attachment
 from llama_stack_client.types import UserMessage  # type: ignore
 
 
-def test_query_endpoint_handler(mocker):
+def test_is_transcripts_enabled():
+    """Test that is_transcripts_enabled returns True when feedback is not disabled."""
+    configuration.user_data_collection_configuration.transcripts_disabled = False
+    assert is_transcripts_enabled() is True, "Transcripts should be enabled"
+
+
+def test_is_transcripts_disabled():
+    """Test that is_transcripts_enabled returns False when feedback is disabled."""
+    configuration.user_data_collection_configuration.transcripts_disabled = True
+    assert is_transcripts_enabled() is False, "Transcripts should be disabled"
+
+
+def test_retrieve_conversation_id():
+    """Test the retrieve_conversation_id function."""
+    query_request = QueryRequest(query="What is OpenStack?", conversation_id=None)
+    conversation_id = retrieve_conversation_id(query_request)
+
+    assert conversation_id is not None, "Conversation ID should be generated"
+    assert len(conversation_id) > 0, "Conversation ID should not be empty"
+
+
+def test_retrieve_conversation_id_existing():
+    # Test with an existing conversation ID
+    existing_conversation_id = "123e4567-e89b-12d3-a456-426614174000"
+    query_request = QueryRequest(
+        query="What is OpenStack?", conversation_id=existing_conversation_id
+    )
+
+    conversation_id = retrieve_conversation_id(query_request)
+
+    assert (
+        conversation_id == existing_conversation_id
+    ), "Should return the existing conversation ID"
+
+
+def _test_query_endpoint_handler(mocker, store_transcript=False):
     """Test the query endpoint handler."""
     mock_client = mocker.Mock()
     mock_client.models.list.return_value = [
@@ -23,15 +63,48 @@ def test_query_endpoint_handler(mocker):
         "app.endpoints.query.configuration",
         return_value=mocker.Mock(),
     )
+    llm_response = "LLM answer"
+    query = "What is OpenStack?"
     mocker.patch("app.endpoints.query.get_llama_stack_client", return_value=mock_client)
-    mocker.patch("app.endpoints.query.retrieve_response", return_value="LLM answer")
+    mocker.patch("app.endpoints.query.retrieve_response", return_value=llm_response)
     mocker.patch("app.endpoints.query.select_model_id", return_value="fake_model_id")
+    mocker.patch(
+        "app.endpoints.query.is_transcripts_enabled", return_value=store_transcript
+    )
+    mock_transcript = mocker.patch("app.endpoints.query.store_transcript")
 
-    query_request = QueryRequest(query="What is OpenStack?")
+    query_request = QueryRequest(query=query)
 
     response = query_endpoint_handler(None, query_request)
 
+    # Assert the response is as expected
     assert response.response == "LLM answer"
+
+    # Assert the store_transcript function is called if transcripts are enabled
+    if store_transcript:
+        mock_transcript.assert_called_once_with(
+            user_id="user_id_placeholder",
+            conversation_id=mocker.ANY,
+            query_is_valid=True,
+            query=query,
+            query_request=query_request,
+            response=llm_response,
+            attachments=[],
+            rag_chunks=[],
+            truncated=False,
+        )
+    else:
+        mock_transcript.assert_not_called()
+
+
+def test_query_endpoint_handler(mocker):
+    """Test the query endpoint handler with transcript storage disabled."""
+    _test_query_endpoint_handler(mocker, store_transcript=False)
+
+
+def test_query_endpoint_handler_store_transcript(mocker):
+    """Test the query endpoint handler with transcript storage enabled."""
+    _test_query_endpoint_handler(mocker, store_transcript=True)
 
 
 def test_select_model_id(mocker):
@@ -329,4 +402,79 @@ def test_retrieve_response_with_two_attachments(mocker):
                 "mime_type": "application/yaml",
             },
         ],
+    )
+
+
+def test_construct_transcripts_path(mocker):
+    """Test the construct_transcripts_path function."""
+
+    configuration.user_data_collection_configuration.transcripts_storage = (
+        "/tmp/transcripts"
+    )
+
+    user_id = "user123"
+    conversation_id = "123e4567-e89b-12d3-a456-426614174000"
+
+    path = construct_transcripts_path(user_id, conversation_id)
+
+    assert (
+        str(path) == "/tmp/transcripts/user123/123e4567-e89b-12d3-a456-426614174000"
+    ), "Path should be constructed correctly"
+
+
+def test_store_transcript(mocker):
+    """Test the store_transcript function."""
+
+    mocker.patch("builtins.open", mocker.mock_open())
+    mocker.patch(
+        "app.endpoints.query.construct_transcripts_path",
+        return_value=mocker.MagicMock(),
+    )
+
+    # Mock the JSON to assert the data is stored correctly
+    mock_json = mocker.patch("app.endpoints.query.json")
+
+    # Mock parameters
+    user_id = "user123"
+    conversation_id = "123e4567-e89b-12d3-a456-426614174000"
+    query = "What is OpenStack?"
+    model = "fake-model"
+    provider = "fake-provider"
+    query_request = QueryRequest(query=query, model=model, provider=provider)
+    response = "LLM answer"
+    query_is_valid = True
+    rag_chunks = []
+    truncated = False
+    attachments = []
+
+    store_transcript(
+        user_id,
+        conversation_id,
+        query_is_valid,
+        query,
+        query_request,
+        response,
+        rag_chunks,
+        truncated,
+        attachments,
+    )
+
+    # Assert that the transcript was stored correctly
+    mock_json.dump.assert_called_once_with(
+        {
+            "metadata": {
+                "provider": query_request.provider,
+                "model": query_request.model,
+                "user_id": user_id,
+                "conversation_id": conversation_id,
+                "timestamp": mocker.ANY,
+            },
+            "redacted_query": query,
+            "query_is_valid": query_is_valid,
+            "llm_response": response,
+            "rag_chunks": rag_chunks,
+            "truncated": truncated,
+            "attachments": attachments,
+        },
+        mocker.ANY,
     )

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -87,8 +87,8 @@ def test_llama_stack_wrong_configuration_no_config_file() -> None:
         LLamaStackConfiguration(use_as_library_client=True)
 
 
-def test_user_data_collection_collection_enabled() -> None:
-    """Test the UserDataCollection constructor."""
+def test_user_data_collection_feedback_enabled() -> None:
+    """Test the UserDataCollection constructor for feedback."""
     # correct configuration
     cfg = UserDataCollection(feedback_disabled=True, feedback_storage=None)
     assert cfg is not None
@@ -96,18 +96,31 @@ def test_user_data_collection_collection_enabled() -> None:
     assert cfg.feedback_storage is None
 
 
-def test_user_data_collection_colection_disabled() -> None:
-    """Test the UserDataCollection constructor."""
-    # correct configuration
-    cfg = UserDataCollection(feedback_disabled=False, feedback_storage="")
-    assert cfg is not None
-
+def test_user_data_collection_feedback_disabled() -> None:
+    """Test the UserDataCollection constructor for feedback."""
     # incorrect configuration
     with pytest.raises(
         ValueError,
         match="feedback_storage is required when feedback is enabled",
     ):
         UserDataCollection(feedback_disabled=False, feedback_storage=None)
+
+
+def test_user_data_collection_transcripts_enabled() -> None:
+    """Test the UserDataCollection constructor for transcripts."""
+    # correct configuration
+    cfg = UserDataCollection(transcripts_disabled=True, transcripts_storage=None)
+    assert cfg is not None
+
+
+def test_user_data_collection_transcripts_disabled() -> None:
+    """Test the UserDataCollection constructor for transcripts."""
+    # incorrect configuration
+    with pytest.raises(
+        ValueError,
+        match="transcripts_storage is required when transcripts is enabled",
+    ):
+        UserDataCollection(transcripts_disabled=False, transcripts_storage=None)
 
 
 def test_dump_configuration(tmp_path) -> None:

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -1,0 +1,15 @@
+from utils.common import retrieve_user_id, auth_dependency
+
+
+# TODO(lucasagomes): Implement this test when the retrieve_user_id function is implemented
+def test_retrieve_user_id():
+    """Test that retrieve_user_id returns a user ID."""
+    user_id = retrieve_user_id(None)
+    assert user_id == "user_id_placeholder"
+
+
+# TODO(lucasagomes): Implement this test when the auth_dependency function is implemented
+async def test_auth_dependency(mocker):
+    """Test that auth_dependency does not raise an exception."""
+    result = await auth_dependency(mocker.Mock())
+    assert result is True


### PR DESCRIPTION
## Description

This patch adds support for storing transcripts in lightspeed-core. By default, transcripts are disabled.

The transcripts maintain the same format as they were implemented in road-core so the user data collector and existing pipeline should work seamlessly as before.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-214
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Run unit-tests