### PR TITLE
LCORE-168: GH actions: Check image building only on PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,6 @@
-name: Build image
+name: Check image building
 
 on:
-  - push
   - pull_request
 
 jobs:


### PR DESCRIPTION
## Description

LCORE-168: GH actions: Check image building only on PRs. Image for distribution is built by quay.io on push to main branch.

## Type of change

- [x] CI configuration change

## Related Tickets & Documents

- Related Issue #LCORE-168

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.