### PR TITLE
LCORE-199: pass TLS settings to start Uvicorn

### DIFF
--- a/src/runners/uvicorn.py
+++ b/src/runners/uvicorn.py
@@ -25,7 +25,7 @@ def start_uvicorn(configuration: ServiceConfiguration) -> None:
         log_level=log_level,
         ssl_keyfile=configuration.tls_config.tls_key_path,
         ssl_certfile=configuration.tls_config.tls_certificate_path,
-        ssl_keyfile_password=str(configuration.tls_config.tls_key_password),
+        ssl_keyfile_password=str(configuration.tls_config.tls_key_password or ""),
         use_colors=True,
         access_log=True,
     )

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -8,7 +8,7 @@ from runners.uvicorn import start_uvicorn
 
 
 def test_start_uvicorn() -> None:
-    """Test the function to start Uvicorn server."""
+    """Test the function to start Uvicorn server using de-facto default configuration."""
     configuration = ServiceConfiguration(host="localhost", port=8080, workers=1)
 
     # don't start real Uvicorn server
@@ -20,6 +20,9 @@ def test_start_uvicorn() -> None:
             port=8080,
             workers=1,
             log_level=20,
+            ssl_certfile=None,
+            ssl_keyfile=None,
+            ssl_keyfile_password="",
             use_colors=True,
             access_log=True,
         )


### PR DESCRIPTION
## Description

LCORE-199: pass TLS settings to start Uvicorn

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-199
