### PR TITLE
fix: Replace deprecated typing.AsyncGenerator with collections.abc.AsyncGenerator

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,7 +1,7 @@
 """Definition of FastAPI based web service."""
 
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator
+from collections.abc import AsyncGenerator
 from fastapi import FastAPI
 from app import routers
 
@@ -18,7 +18,7 @@ service_name = configuration.configuration.name
 
 
 @asynccontextmanager
-async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None]:
+async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None, None]:
     """Handle app lifespan events."""
     # Startup
     logger.info("Starting up: registering MCP servers")


### PR DESCRIPTION
## Description

- Resolves TypeError: Too few arguments for typing.AsyncGenerator; actual 1, expected 2
- Ensures compatibility with Python 3.9+ typing standards where typing.AsyncGenerator is deprecated


## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
