### PR TITLE
fix: Replace lifespan context manager with startup event handler

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,7 +1,5 @@
 """Definition of FastAPI based web service."""
 
-from contextlib import asynccontextmanager
-from collections.abc import AsyncGenerator
 from fastapi import FastAPI
 from app import routers
 
@@ -17,24 +15,6 @@ logger.info("Initializing app")
 service_name = configuration.configuration.name
 
 
-@asynccontextmanager
-async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None, None]:
-    """Handle app lifespan events."""
-    # Startup
-    logger.info("Starting up: registering MCP servers")
-    register_mcp_servers(logger, configuration.configuration)
-    logger.info("Including routers")
-    routers.include_routers(fastapi_app)
-
-    # Setup logger for handlers
-    get_logger("app.endpoints.handlers")
-
-    yield
-
-    # Shutdown (if needed)
-    logger.info("Shutting down")
-
-
 app = FastAPI(
     title=f"{service_name} service - OpenAPI",
     description=f"{service_name} service API specification.",
@@ -43,5 +23,17 @@ app = FastAPI(
         "name": "Apache 2.0",
         "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
     },
-    lifespan=lifespan,
 )
+
+logger.info("Including routers")
+routers.include_routers(app)
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    """Perform logger setup on service startup."""
+    get_logger("app.endpoints.handlers")
+    logger.info("Starting up: registering MCP servers")
+    register_mcp_servers(logger, configuration.configuration)
+    logger.info("Including routers")
+    routers.include_routers(app)


### PR DESCRIPTION
## Description

- Remove asynccontextmanager lifespan implementation
- Use @app.on_event('startup') decorator instead
- Resolves RuntimeError: asyncio.run() cannot be called from a running event loop
- Maintains same startup functionality with compatible async context


<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
