### PR TITLE
fix: resolve asyncio event loop conflicts in MCP server registration

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -6,7 +6,7 @@ from app import routers
 import version
 from log import get_logger
 from configuration import configuration
-from utils.common import register_mcp_servers
+from utils.common import register_mcp_servers_async
 
 logger = get_logger(__name__)
 
@@ -32,8 +32,7 @@ routers.include_routers(app)
 @app.on_event("startup")
 async def startup_event() -> None:
     """Perform logger setup on service startup."""
+    logger.info("Registering MCP servers")
+    await register_mcp_servers_async(logger, configuration.configuration)
     get_logger("app.endpoints.handlers")
-    logger.info("Starting up: registering MCP servers")
-    register_mcp_servers(logger, configuration.configuration)
-    logger.info("Including routers")
-    routers.include_routers(app)
+    logger.info("App startup complete")

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -1,11 +1,17 @@
 """Common utilities for the project."""
 
-from typing import Any
+from typing import Any, List, cast
 from logging import Logger
 
+from llama_stack_client import LlamaStackClient
+
+from llama_stack.distribution.library_client import (
+    LlamaStackAsLibraryClient,
+    AsyncLlamaStackAsLibraryClient,
+)
 
 from client import get_llama_stack_client
-from models.config import Configuration
+from models.config import Configuration, ModelContextProtocolServer
 
 
 # TODO(lucasagomes): implement this function to retrieve user ID from auth
@@ -22,20 +28,81 @@ def retrieve_user_id(auth: Any) -> str:  # pylint: disable=unused-argument
     return "user_id_placeholder"
 
 
+async def register_mcp_servers_async(
+    logger: Logger, configuration: Configuration
+) -> None:
+    """Register Model Context Protocol (MCP) servers with the LlamaStack client (async)."""
+    if configuration.llama_stack.use_as_library_client:
+        # Library client - use async interface
+        # config.py validation ensures library_client_config_path is not None
+        # when use_as_library_client is True
+        config_path = cast(str, configuration.llama_stack.library_client_config_path)
+        client = LlamaStackAsLibraryClient(config_path)
+        await client.async_client.initialize()
+
+        await _register_mcp_toolgroups_async(
+            client.async_client, configuration.mcp_servers, logger
+        )
+    else:
+        # Service client - use sync interface
+        register_mcp_servers(logger, configuration)
+
+
 def register_mcp_servers(logger: Logger, configuration: Configuration) -> None:
-    """Register Model Context Protocol (MCP) servers with the LlamaStack client."""
-    # Get list of registered tools and extract their toolgroup IDs
+    """Register Model Context Protocol (MCP) servers with the LlamaStack client (sync)."""
+    # Service client - use sync interface
     client = get_llama_stack_client(configuration.llama_stack)
+
+    _register_mcp_toolgroups_sync(client, configuration.mcp_servers, logger)
+
+
+async def _register_mcp_toolgroups_async(
+    client: AsyncLlamaStackAsLibraryClient,
+    mcp_servers: List[ModelContextProtocolServer],
+    logger: Logger,
+) -> None:
+    """Async logic for registering MCP toolgroups."""
+    # Get registered tools
+    registered_tools = await client.tools.list()
+    registered_toolgroups = [tool.toolgroup_id for tool in registered_tools]
+    logger.debug("Registered toolgroups: %s", set(registered_toolgroups))
+
+    # Register toolgroups for MCP servers if not already registered
+    for mcp in mcp_servers:
+        if mcp.name not in registered_toolgroups:
+            logger.debug("Registering MCP server: %s, %s", mcp.name, mcp.url)
+
+            registration_params = {
+                "toolgroup_id": mcp.name,
+                "provider_id": mcp.provider_id,
+                "mcp_endpoint": {"uri": mcp.url},
+            }
+
+            await client.toolgroups.register(**registration_params)
+            logger.debug("MCP server %s registered successfully", mcp.name)
+
+
+def _register_mcp_toolgroups_sync(
+    client: LlamaStackClient,
+    mcp_servers: List[ModelContextProtocolServer],
+    logger: Logger,
+) -> None:
+    """Sync logic for registering MCP toolgroups."""
+    # Get registered tools
     registered_tools = client.tools.list()
     registered_toolgroups = [tool.toolgroup_id for tool in registered_tools]
     logger.debug("Registered toolgroups: %s", set(registered_toolgroups))
+
     # Register toolgroups for MCP servers if not already registered
-    for mcp in configuration.mcp_servers:
-        if mcp.name not in registered_toolgroups:  # required
+    for mcp in mcp_servers:
+        if mcp.name not in registered_toolgroups:
             logger.debug("Registering MCP server: %s, %s", mcp.name, mcp.url)
-            client.toolgroups.register(
-                toolgroup_id=mcp.name,
-                provider_id=mcp.provider_id,
-                mcp_endpoint={"uri": mcp.url},
-            )
+
+            registration_params = {
+                "toolgroup_id": mcp.name,
+                "provider_id": mcp.provider_id,
+                "mcp_endpoint": {"uri": mcp.url},
+            }
+
+            client.toolgroups.register(**registration_params)
             logger.debug("MCP server %s registered successfully", mcp.name)


### PR DESCRIPTION
## Description
Add async/await support for LlamaStackAsLibraryClient to prevent
"Cannot run event loop while another loop is running" RuntimeError.
    
Changes:
    - Introduce register_mcp_servers_async() for async MCP server registration
    - Refactor MCP registration logic into separate sync/async helper functions
    - Use async client methods (client.async_client) for library clients
      to avoid "Cannot run event loop while another loop is running" errors
    - Add async tests for library client configuration
    
The LlamaStackAsLibraryClient requires async initialization, but the previous
sync implementation caused event loop conflicts. This change provides dual
support for both service clients (sync) and library clients (async).
    

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
Fixes RuntimeError when configuration.llama_stack.use_as_library_client = true

- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
