### PR TITLE
refactor: consolidate MCP server registration into single async function

### DIFF
--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -45,15 +45,9 @@ async def register_mcp_servers_async(
         )
     else:
         # Service client - use sync interface
-        register_mcp_servers(logger, configuration)
+        client = get_llama_stack_client(configuration.llama_stack)
 
-
-def register_mcp_servers(logger: Logger, configuration: Configuration) -> None:
-    """Register Model Context Protocol (MCP) servers with the LlamaStack client (sync)."""
-    # Service client - use sync interface
-    client = get_llama_stack_client(configuration.llama_stack)
-
-    _register_mcp_toolgroups_sync(client, configuration.mcp_servers, logger)
+        _register_mcp_toolgroups_sync(client, configuration.mcp_servers, logger)
 
 
 async def _register_mcp_toolgroups_async(

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -6,7 +6,6 @@ from logging import Logger
 
 from utils.common import (
     retrieve_user_id,
-    register_mcp_servers,
     register_mcp_servers_async,
 )
 from models.config import (
@@ -25,7 +24,8 @@ def test_retrieve_user_id():
     assert user_id == "user_id_placeholder"
 
 
-def test_register_mcp_servers_empty_list(mocker):
+@pytest.mark.asyncio
+async def test_register_mcp_servers_empty_list(mocker):
     """Test register_mcp_servers with empty MCP servers list."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -40,14 +40,13 @@ def test_register_mcp_servers_empty_list(mocker):
         name="test",
         service=ServiceConfiguration(),
         llama_stack=LLamaStackConfiguration(
-            use_as_library_client=True, library_client_config_path="foo"
+            use_as_library_client=False, url="http://localhost:8321"
         ),
         user_data_collection=UserDataCollection(feedback_disabled=True),
         mcp_servers=[],
     )
-
     # Call the function
-    register_mcp_servers(mock_logger, config)
+    await register_mcp_servers_async(mock_logger, config)
 
     # Verify client.tools.list was called
     mock_client.tools.list.assert_called_once()
@@ -55,7 +54,8 @@ def test_register_mcp_servers_empty_list(mocker):
     assert not mock_client.toolgroups.register.called
 
 
-def test_register_mcp_servers_single_server_not_registered(mocker):
+@pytest.mark.asyncio
+async def test_register_mcp_servers_single_server_not_registered(mocker):
     """Test register_mcp_servers with single MCP server that is not yet registered."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -76,14 +76,14 @@ def test_register_mcp_servers_single_server_not_registered(mocker):
         name="test",
         service=ServiceConfiguration(),
         llama_stack=LLamaStackConfiguration(
-            use_as_library_client=True, library_client_config_path="foo"
+            use_as_library_client=False, url="http://localhost:8321"
         ),
         user_data_collection=UserDataCollection(feedback_disabled=True),
         mcp_servers=[mcp_server],
     )
 
     # Call the function
-    register_mcp_servers(mock_logger, config)
+    await register_mcp_servers_async(mock_logger, config)
 
     # Verify client.tools.list was called
     mock_client.tools.list.assert_called_once()
@@ -97,7 +97,8 @@ def test_register_mcp_servers_single_server_not_registered(mocker):
     mock_logger.debug.assert_called()
 
 
-def test_register_mcp_servers_single_server_already_registered(mocker):
+@pytest.mark.asyncio
+async def test_register_mcp_servers_single_server_already_registered(mocker):
     """Test register_mcp_servers with single MCP server that is already registered."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -117,14 +118,14 @@ def test_register_mcp_servers_single_server_already_registered(mocker):
         name="test",
         service=ServiceConfiguration(),
         llama_stack=LLamaStackConfiguration(
-            use_as_library_client=True, library_client_config_path="foo"
+            use_as_library_client=False, url="http://localhost:8321"
         ),
         user_data_collection=UserDataCollection(feedback_disabled=True),
         mcp_servers=[mcp_server],
     )
 
     # Call the function
-    register_mcp_servers(mock_logger, config)
+    await register_mcp_servers_async(mock_logger, config)
 
     # Verify client.tools.list was called
     mock_client.tools.list.assert_called_once()
@@ -132,7 +133,8 @@ def test_register_mcp_servers_single_server_already_registered(mocker):
     assert not mock_client.toolgroups.register.called
 
 
-def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
+@pytest.mark.asyncio
+async def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
     """Test register_mcp_servers with multiple MCP servers - some registered, some not."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -161,14 +163,14 @@ def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
         name="test",
         service=ServiceConfiguration(),
         llama_stack=LLamaStackConfiguration(
-            use_as_library_client=True, library_client_config_path="foo"
+            use_as_library_client=False, url="http://localhost:8321"
         ),
         user_data_collection=UserDataCollection(feedback_disabled=True),
         mcp_servers=mcp_servers,
     )
 
     # Call the function
-    register_mcp_servers(mock_logger, config)
+    await register_mcp_servers_async(mock_logger, config)
 
     # Verify client.tools.list was called
     mock_client.tools.list.assert_called_once()
@@ -191,7 +193,8 @@ def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
     mock_client.toolgroups.register.assert_has_calls(expected_calls, any_order=True)
 
 
-def test_register_mcp_servers_with_custom_provider(mocker):
+@pytest.mark.asyncio
+async def test_register_mcp_servers_with_custom_provider(mocker):
     """Test register_mcp_servers with MCP server using custom provider."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -212,14 +215,14 @@ def test_register_mcp_servers_with_custom_provider(mocker):
         name="test",
         service=ServiceConfiguration(),
         llama_stack=LLamaStackConfiguration(
-            use_as_library_client=True, library_client_config_path="foo"
+            use_as_library_client=False, url="http://localhost:8321"
         ),
         user_data_collection=UserDataCollection(feedback_disabled=True),
         mcp_servers=[mcp_server],
     )
 
     # Call the function
-    register_mcp_servers(mock_logger, config)
+    await register_mcp_servers_async(mock_logger, config)
 
     # Verify client.toolgroups.register was called with custom provider
     mock_client.toolgroups.register.assert_called_once_with(


### PR DESCRIPTION
## Description

- Remove register_mcp_servers function and merge its logic into register_mcp_servers_async
- Fix unit tests to properly await register_mcp_servers_async calls
- Update test configurations to use sync flow (use_as_library_client=False)

This simplifies the API by having a single entry point for MCP server registration.


## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
