### PR TITLE
Make config_file configurable

### DIFF
--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -36,6 +36,13 @@ def create_argument_parser() -> ArgumentParser:
         action="store_true",
         default=None,
     )
+    parser.add_argument(
+        "-c",
+        "--config",
+        dest="config_file",
+        help="path to configuration file (default: lightspeed-stack.yaml)",
+        default="lightspeed-stack.yaml",
+    )
     return parser
 
 
@@ -45,7 +52,7 @@ def main() -> None:
     parser = create_argument_parser()
     args = parser.parse_args()
 
-    configuration.load_configuration("lightspeed-stack.yaml")
+    configuration.load_configuration(args.config_file)
     logger.info("Configuration: %s", configuration.configuration)
     logger.info(
         "Llama stack configuration: %s", configuration.llama_stack_configuration


### PR DESCRIPTION
## Description

Make config_file configurable. One can provide configuration through the args, instead of having hardcoded `lightspeed-stack.yaml` from the repo root.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
