### PR TITLE
LCORE-219: Convert application/yaml as plain/text for attachments/documents

### DIFF
--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -465,7 +465,7 @@ def test_retrieve_response_with_two_attachments(mocker):
             },
             {
                 "content": "kind: Pod\n" " metadata:\n" " name:    private-reg",
-                "mime_type": "application/yaml",
+                "mime_type": "text/plain",  # YAML converted to text/plain for LlamaStack compatibility
             },
         ],
     )


### PR DESCRIPTION
## Description

Convert application/yaml as plain/text for attachments/documents

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
