### PR TITLE
LCORE-303: silent improper Pyright warning in e2e's common.py

### DIFF
--- a/tests/e2e/features/steps/common.py
+++ b/tests/e2e/features/steps/common.py
@@ -1,16 +1,16 @@
 """Implementation of common test steps."""
 
-from behave import given
+from behave import given  # pyright: ignore[reportAttributeAccessIssue]
 from behave.runner import Context
 
 
 @given("the service is started locally")
 def service_is_started_locally(context: Context) -> None:
     """Check the service status."""
-    pass
+    assert context is not None
 
 
 @given("the system is in default state")
 def system_in_default_state(context: Context) -> None:
     """Check the default system state."""
-    pass
+    assert context is not None


### PR DESCRIPTION
## Description

LCORE-303: silent improper Pyright warning in e2e's common.py

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-303
