### PR TITLE
LCORE-312: Support MCP Headers

### DIFF
--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -62,13 +62,15 @@ async def _register_mcp_toolgroups_async(
 ) -> None:
     """Async logic for registering MCP toolgroups."""
     # Get registered tools
-    registered_tools = await client.tools.list()
-    registered_toolgroups = [tool.toolgroup_id for tool in registered_tools]
-    logger.debug("Registered toolgroups: %s", set(registered_toolgroups))
+    registered_toolgroups = await client.toolgroups.list()
+    registered_toolgroups_ids = [
+        tool_group.provider_resource_id for tool_group in registered_toolgroups
+    ]
+    logger.debug("Registered toolgroups: %s", registered_toolgroups_ids)
 
     # Register toolgroups for MCP servers if not already registered
     for mcp in mcp_servers:
-        if mcp.name not in registered_toolgroups:
+        if mcp.name not in registered_toolgroups_ids:
             logger.debug("Registering MCP server: %s, %s", mcp.name, mcp.url)
 
             registration_params = {
@@ -87,14 +89,16 @@ def _register_mcp_toolgroups_sync(
     logger: Logger,
 ) -> None:
     """Sync logic for registering MCP toolgroups."""
-    # Get registered tools
-    registered_tools = client.tools.list()
-    registered_toolgroups = [tool.toolgroup_id for tool in registered_tools]
-    logger.debug("Registered toolgroups: %s", set(registered_toolgroups))
+    # Get registered tool groups
+    registered_toolgroups = client.toolgroups.list()
+    registered_toolgroups_ids = [
+        tool_group.provider_resource_id for tool_group in registered_toolgroups
+    ]
+    logger.debug("Registered toolgroups: %s", registered_toolgroups_ids)
 
     # Register toolgroups for MCP servers if not already registered
     for mcp in mcp_servers:
-        if mcp.name not in registered_toolgroups:
+        if mcp.name not in registered_toolgroups_ids:
             logger.debug("Registering MCP server: %s, %s", mcp.name, mcp.url)
 
             registration_params = {

--- a/src/utils/mcp_headers.py
+++ b/src/utils/mcp_headers.py
@@ -1,0 +1,48 @@
+"""MCP headers handling."""
+
+import json
+import logging
+from fastapi import Request
+
+logger = logging.getLogger("app.endpoints.dependencies")
+
+
+async def mcp_headers_dependency(_request: Request) -> dict[str, dict[str, str]]:
+    """Get the mcp headers dependency to passed to mcp servers.
+
+    mcp headers is a json dictionary or mcp url paths and their respective headers
+
+    Args:
+        request (Request): The FastAPI request object.
+
+    Returns:
+        The mcp headers dictionary, or empty dictionary if not found or on json decoding error
+    """
+    return extract_mcp_headers(_request)
+
+
+def extract_mcp_headers(request: Request) -> dict[str, dict[str, str]]:
+    """Extract mcp headers from MCP-HEADERS header.
+
+    Args:
+        request: The FastAPI request object
+
+    Returns:
+        The mcp headers dictionary, or empty dictionary if not found or on json decoding error
+    """
+    mcp_headers_string = request.headers.get("MCP-HEADERS", "")
+    mcp_headers = {}
+    if mcp_headers_string:
+        try:
+            mcp_headers = json.loads(mcp_headers_string)
+        except json.decoder.JSONDecodeError as e:
+            logger.error("MCP headers decode error: %s", e)
+
+        if not isinstance(mcp_headers, dict):
+            logger.error(
+                "MCP headers wrong type supplied (mcp headers must be a dictionary), "
+                "but type %s was supplied",
+                type(mcp_headers),
+            )
+            mcp_headers = {}
+    return mcp_headers

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -64,8 +64,8 @@ async def test_register_mcp_servers_single_server_not_registered(mocker):
     # Mock the LlamaStack client
     mock_client = Mock()
     mock_tool = Mock()
-    mock_tool.toolgroup_id = "existing-server"
-    mock_client.tools.list.return_value = [mock_tool]
+    mock_tool.provider_resource_id = "existing-server"
+    mock_client.toolgroups.list.return_value = [mock_tool]
     mock_client.toolgroups.register.return_value = None
     mocker.patch("utils.common.get_llama_stack_client", return_value=mock_client)
 
@@ -87,8 +87,8 @@ async def test_register_mcp_servers_single_server_not_registered(mocker):
     # Call the function
     await register_mcp_servers_async(mock_logger, config)
 
-    # Verify client.tools.list was called
-    mock_client.tools.list.assert_called_once()
+    # Verify client.toolgroups.list was called
+    mock_client.toolgroups.list.assert_called_once()
     # Verify client.toolgroups.register was called with correct parameters
     mock_client.toolgroups.register.assert_called_once_with(
         toolgroup_id="new-server",
@@ -108,8 +108,8 @@ async def test_register_mcp_servers_single_server_already_registered(mocker):
     # Mock the LlamaStack client
     mock_client = Mock()
     mock_tool = Mock()
-    mock_tool.toolgroup_id = "existing-server"
-    mock_client.tools.list.return_value = [mock_tool]
+    mock_tool.provider_resource_id = "existing-server"
+    mock_client.toolgroups.list.return_value = [mock_tool]
     mocker.patch("utils.common.get_llama_stack_client", return_value=mock_client)
 
     # Create configuration with MCP server that matches existing toolgroup
@@ -131,7 +131,7 @@ async def test_register_mcp_servers_single_server_already_registered(mocker):
     await register_mcp_servers_async(mock_logger, config)
 
     # Verify client.tools.list was called
-    mock_client.tools.list.assert_called_once()
+    mock_client.toolgroups.list.assert_called_once()
     # Verify client.toolgroups.register was NOT called since server already registered
     assert not mock_client.toolgroups.register.called
 
@@ -145,10 +145,10 @@ async def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
     # Mock the LlamaStack client
     mock_client = Mock()
     mock_tool1 = Mock()
-    mock_tool1.toolgroup_id = "existing-server"
+    mock_tool1.provider_resource_id = "existing-server"
     mock_tool2 = Mock()
-    mock_tool2.toolgroup_id = "another-existing"
-    mock_client.tools.list.return_value = [mock_tool1, mock_tool2]
+    mock_tool2.provider_resource_id = "another-existing"
+    mock_client.toolgroups.list.return_value = [mock_tool1, mock_tool2]
     mock_client.toolgroups.register.return_value = None
     mocker.patch("utils.common.get_llama_stack_client", return_value=mock_client)
 
@@ -177,7 +177,7 @@ async def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
     await register_mcp_servers_async(mock_logger, config)
 
     # Verify client.tools.list was called
-    mock_client.tools.list.assert_called_once()
+    mock_client.toolgroups.list.assert_called_once()
     # Verify client.toolgroups.register was called twice (for the two new servers)
     assert mock_client.toolgroups.register.call_count == 2
 
@@ -205,7 +205,7 @@ async def test_register_mcp_servers_with_custom_provider(mocker):
 
     # Mock the LlamaStack client
     mock_client = Mock()
-    mock_client.tools.list.return_value = []
+    mock_client.toolgroups.list.return_value = []
     mock_client.toolgroups.register.return_value = None
     mocker.patch("utils.common.get_llama_stack_client", return_value=mock_client)
 
@@ -251,8 +251,8 @@ async def test_register_mcp_servers_async_with_library_client(mocker):
 
     # Mock tools.list to return empty list
     mock_tool = Mock()
-    mock_tool.toolgroup_id = "existing-tool"
-    mock_async_client.tools.list = AsyncMock(return_value=[mock_tool])
+    mock_tool.provider_resource_id = "existing-tool"
+    mock_async_client.toolgroups.list = AsyncMock(return_value=[mock_tool])
     mock_async_client.toolgroups.register = AsyncMock()
 
     mocker.patch(
@@ -281,7 +281,7 @@ async def test_register_mcp_servers_async_with_library_client(mocker):
     # Verify initialization was called
     mock_async_client.initialize.assert_called_once()
     # Verify tools.list was called
-    mock_async_client.tools.list.assert_called_once()
+    mock_async_client.toolgroups.list.assert_called_once()
     # Verify toolgroups.register was called for the new server
     mock_async_client.toolgroups.register.assert_called_once_with(
         toolgroup_id="test-server",


### PR DESCRIPTION
## Description

issue: https://issues.redhat.com/browse/LCORE-312
this supports the client providing the headers to supply to mcp servers via llama-stack in the form of a dictionary like:
{
    "mcp-server-url-1": {"HEADER-1": "HEADER-1-VALUE-1", "HEADER-1": "HEADER-1-VALUE-2"},
    "mcp-server-url-2": {"HEADER-2": "HEADER-2-VALUE"}
}

Suppose each different mcp server support it's own authentication type, or needs some headers to be supplied, this PR will allow to fine tune which headers may be passed to which mcp server.

For the moment did not moved the extra_headers to create_turn function as the AsyncAgent is not supporting that. 

moved the toolgroups to create_turn function as when declared at the agent, the headers are not sent to mcp servers the first time llama-stack is listing the tools from mcp servers, that may lead to authentication failure.

The optimal is to move also the headers to be declared in create_turn function and not at the agent level, but this should be done in it's own task ticket. as we weed to implement the same for AsyncAgent. This will allow us to have one agent instance for all sessions and remove the agent caching. 


## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Closes # https://issues.redhat.com/browse/LCORE-312

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
Tested with 2 mcp servers that support authentication, the mcp servers does not allow tools listing without authentication too, put in configuration file lightspeed-stack.yaml
```
...
mcp_servers:
- name: mcp::aap-controller
  provider_id: model-context-protocol
  url: http://localhost:8004/sse
- name: mcp::aap-gateway
  provider_id: model-context-protocol
  url: http://localhost:8003/sse
...
```

The llama-stack was running as an external service by default using model "granite-3.3-8b-instruct" via vllm container runing in openshift 

Created 2 scripts one for streaming and one for non streaming endpoints:

https://github.com/user-attachments/assets/623bf79c-9d90-44ca-9938-2ec857baa9f6



  