### PR TITLE
Fix llama_stack_client log levels

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -4,10 +4,6 @@ import logging
 
 from typing import Optional
 
-from llama_stack.distribution.library_client import (
-    AsyncLlamaStackAsLibraryClient,  # type: ignore
-    LlamaStackAsLibraryClient,  # type: ignore
-)
 from llama_stack_client import AsyncLlamaStackClient, LlamaStackClient  # type: ignore
 from models.config import LLamaStackConfiguration
 from utils.types import Singleton
@@ -26,6 +22,7 @@ class LlamaStackClientHolder(metaclass=Singleton):
         if llama_stack_config.use_as_library_client is True:
             if llama_stack_config.library_client_config_path is not None:
                 logger.info("Using Llama stack as library client")
+                from llama_stack.distribution.library_client import LlamaStackAsLibraryClient  # type: ignore
                 client = LlamaStackAsLibraryClient(
                     llama_stack_config.library_client_config_path
                 )
@@ -62,6 +59,7 @@ class AsyncLlamaStackClientHolder(metaclass=Singleton):
         if llama_stack_config.use_as_library_client is True:
             if llama_stack_config.library_client_config_path is not None:
                 logger.info("Using Llama stack as library client")
+                from llama_stack.distribution.library_client import AsyncLlamaStackAsLibraryClient  # type: ignore
                 client = AsyncLlamaStackAsLibraryClient(
                     llama_stack_config.library_client_config_path
                 )


### PR DESCRIPTION
## Description

Log levels on the llama_stack_client are currently broken and setting
`LLAMA_STACK_LOG=debug` doesn't work as it should.  Log levels are
automatically changed to WARNING.

This is caused by us blindly loading the `llama_stack` library, which
initializes logging to WARNING except a subset of modules that can be
modified using the `LLAMA_STACK_LOGGING` env var.

With this patch we only import `llama_stack` when we are actually going
to use it, so that when we use the normal llama-stack client we can set
its logging level.

## Type of change

- [x] Bug fix

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Just run lightspeed-stack with a remote llama-stack and set the `LLAMA_STACK_LOGGING` to `debug` and see that you don't get debug logs, but you do once you apply this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how certain components are loaded internally to optimize resource usage. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->