### PR TITLE
Add work-around for tool_calls with granite models.

### DIFF
--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -24,7 +24,7 @@ from utils.endpoints import check_configuration_loaded, get_system_prompt
 from utils.common import retrieve_user_id
 from utils.mcp_headers import mcp_headers_dependency
 from utils.suid import get_suid
-
+from utils.types import GraniteToolParser
 
 from app.endpoints.query import (
     get_rag_toolgroups,
@@ -62,6 +62,7 @@ async def get_agent(
         model=model_id,
         instructions=system_prompt,
         input_shields=available_shields if available_shields else [],
+        tool_parser=GraniteToolParser.get_parser(model_id),
         enable_session_persistence=True,
     )
     conversation_id = await agent.create_session(get_suid())

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -1,5 +1,11 @@
 """Common types for the project."""
 
+from typing import Optional
+
+from llama_stack_client.lib.agents.tool_parser import ToolParser
+from llama_stack_client.types.shared.completion_message import CompletionMessage
+from llama_stack_client.types.shared.tool_call import ToolCall
+
 
 class Singleton(type):
     """Metaclass for Singleton support."""
@@ -11,3 +17,21 @@ class Singleton(type):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
+
+
+# See https://github.com/meta-llama/llama-stack-client-python/issues/206
+class GraniteToolParser(ToolParser):
+    """Workaround for 'tool_calls' with granite models."""
+
+    def get_tool_calls(self, output_message: CompletionMessage) -> list[ToolCall]:
+        """Use 'tool_calls' associated with the CompletionMessage, if available."""
+        if output_message and output_message.tool_calls:
+            return output_message.tool_calls
+        return []
+
+    @staticmethod
+    def get_parser(model_id: str) -> Optional[ToolParser]:
+        """Get the applicable ToolParser for the model."""
+        if model_id and model_id.lower().startswith("granite"):
+            return GraniteToolParser()
+        return None

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -874,6 +874,7 @@ async def test_get_agent_cache_miss_with_conversation_id(
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1"],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -930,6 +931,7 @@ async def test_get_agent_no_conversation_id(
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1"],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -986,6 +988,7 @@ async def test_get_agent_empty_shields(
         model="test_model",
         instructions="test_prompt",
         input_shields=[],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -1041,6 +1044,7 @@ async def test_get_agent_multiple_mcp_servers(
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1", "shield2"],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -1090,5 +1094,6 @@ async def test_get_agent_session_persistence_enabled(
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1"],
+        tool_parser=None,
         enable_session_persistence=True,
     )

--- a/tests/unit/utils/test_types.py
+++ b/tests/unit/utils/test_types.py
@@ -1,0 +1,48 @@
+"""Test module for utils/types.py."""
+
+from unittest.mock import Mock
+
+from utils.types import GraniteToolParser
+
+
+class TestGraniteToolParser:
+    def test_get_tool_parser_when_model_is_is_not_granite(self):
+        """Test that the tool_parser is None when model_id is not a granite model."""
+        assert (
+            GraniteToolParser.get_parser("ollama3.3") is None
+        ), "tool_parser should be None"
+
+    def test_get_tool_parser_when_model_id_does_not_start_with_granite(self):
+        """Test that the tool_parser is None when model_id does not start with granite."""
+        assert (
+            GraniteToolParser.get_parser("a-fine-trained-granite-model") is None
+        ), "tool_parser should be None"
+
+    def test_get_tool_parser_when_model_id_starts_with_granite(self):
+        """Test that the tool_parser is not None when model_id starts with granite."""
+        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
+        assert tool_parser is not None, "tool_parser should not be None"
+
+    def test_get_tool_calls_from_completion_message_when_none(self):
+        """Test that get_tool_calls returns an empty array when CompletionMessage is None."""
+        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
+        assert tool_parser.get_tool_calls(None) == [], "get_tool_calls should return []"
+
+    def test_get_tool_calls_from_completion_message_when_not_none(self):
+        """Test that get_tool_calls returns an empty array when CompletionMessage has no tool_calls."""
+        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
+        completion_message = Mock()
+        completion_message.tool_calls = []
+        assert (
+            tool_parser.get_tool_calls(completion_message) == []
+        ), "get_tool_calls should return []"
+
+    def test_get_tool_calls_from_completion_message_when_message_has_tool_calls(self):
+        """Test that get_tool_calls returns the tool_calls when CompletionMessage has tool_calls."""
+        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
+        completion_message = Mock()
+        tool_calls = [Mock(tool_name="tool-1"), Mock(tool_name="tool-2")]
+        completion_message.tool_calls = tool_calls
+        assert (
+            tool_parser.get_tool_calls(completion_message) == tool_calls
+        ), f"get_tool_calls should return {tool_calls}"


### PR DESCRIPTION
## Description

During the integration of Ansible Lightspeed with vanilla `llama-stack` invocation of MCP Tool Calls was troublesum.

After much investigation and research by @TamiTakamiya an issue in `llama-stack` with IBM `granite` models was identified.

The fix in this PR was required in our prototype `llama-stack` work to optimise MCP Tool Calls with `granite` models.

We are contributing the same work-around to `lightspeed-stack`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # N/A
- Closes # https://issues.redhat.com/browse/AAP-48374

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved agent capabilities by introducing specialized handling for tool calls in granite models.
* **Tests**
  * Added unit tests to verify the behavior of the new tool parser for granite models.
  * Updated existing tests to align with enhanced agent initialization parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->