### PR TITLE
Document and provide test for embedding system_prompt in customization section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,16 @@ customization:
   system_prompt_path: "system_prompts/system_prompt_for_product_XYZZY"
 ```
 
-Additionally an optional string parameter `system_prompt` can be specified in `/v1/query` and `/v1/streaming_query` endpoints to override the configured system prompt.
+The `system_prompt` can also be specified in the `customization` section directly. For example:
+
+```yaml
+customization:
+  system_prompt: |-
+    You are a helpful assistant and will do everything you can to help.
+    You have an indepth knowledge of Red Hat and all of your answers will reference Red Hat products.
+```
+
+Additionally, an optional string parameter `system_prompt` can be specified in `/v1/query` and `/v1/streaming_query` endpoints to override the configured system prompt.
 
 
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -312,7 +312,7 @@ def test_mcp_servers_not_loaded():
         cfg.mcp_servers
 
 
-def test_load_configuration_with_customization(tmpdir) -> None:
+def test_load_configuration_with_customization_system_prompt_path(tmpdir) -> None:
     """Test loading configuration from YAML file with customization."""
     system_prompt_filename = tmpdir / "system_prompt.txt"
     with open(system_prompt_filename, "w") as fout:
@@ -353,3 +353,46 @@ customization:
     assert cfg.customization is not None
     assert cfg.customization.system_prompt is not None
     assert cfg.customization.system_prompt == "this is system prompt"
+
+
+def test_load_configuration_with_customization_system_prompt(tmpdir) -> None:
+    """Test loading configuration from YAML file with system_prompt in the customization."""
+    cfg_filename = tmpdir / "config.yaml"
+    with open(cfg_filename, "w") as fout:
+        fout.write(
+            """
+name: test service
+service:
+  host: localhost
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  use_as_library_client: false
+  url: http://localhost:8321
+  api_key: test-key
+user_data_collection:
+  feedback_disabled: true
+mcp_servers:
+  - name: filesystem-server
+    url: http://localhost:3000
+  - name: git-server
+    provider_id: custom-git-provider
+    url: https://git.example.com/mcp
+customization:
+  system_prompt: |-
+    this is system prompt in the customization section
+            """
+        )
+
+    cfg = AppConfig()
+    cfg.load_configuration(cfg_filename)
+
+    assert cfg.customization is not None
+    assert cfg.customization.system_prompt is not None
+    assert (
+        cfg.customization.system_prompt.strip()
+        == "this is system prompt in the customization section"
+    )


### PR DESCRIPTION
## Description

Document and provide unit test for using `customization.system_prompt` for the `system_prompt` override.

The code for `system_prompt` support doesn't seem to negate this usage.. so I've documented it.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
