### PR TITLE
LCORE-326: Add arm64 image building for releases

### DIFF
--- a/.github/workflows/build_and_push_release.yaml
+++ b/.github/workflows/build_and_push_release.yaml
@@ -24,7 +24,8 @@ jobs:
       - name: Install buildah
         run: |
           sudo apt update
-          sudo apt install -y buildah
+          # qemu is required for arm64 builds
+          sudo apt install -y buildah qemu-user-static
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Build image with Buildah
@@ -37,7 +38,17 @@ jobs:
             ${{ env.LATEST_TAG }}
           containerfiles: |
             ${{ env.CONTAINER_FILE }}
+          archs: amd64, arm64
           oci: true
+      - name: Check images
+        run: |
+          buildah images | grep '${{ env.IMAGE_NAME }}'
+          echo '${{ steps.build_image.outputs.image }}'
+          echo '${{ steps.build_image.outputs.tags }}'
+      - name: Check manifest
+        run: |
+          set -x
+          buildah manifest inspect ${{ steps.build_image.outputs.image }}:${{ env.LATEST_TAG }}
       - name: Push image to Quay.io
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ To pull and run the image with own configuration:
 
 If a connection in your browser does not work please check that in the config file `host` option looks like: `host: 0.0.0.0`.
 
+Container images are built for the following platforms:
+1. `linux/amd64` - main platform for deployment
+1. `linux/arm64`- Mac users with M1/M2/M3 CPUs
+
 # Endpoints
 
 The service provides health check endpoints that can be used for monitoring, load balancing, and orchestration systems like Kubernetes.


### PR DESCRIPTION
## Description

LCORE-326: Add arm64 image building for releases

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container images are now built for both amd64 and arm64 platforms, supporting a wider range of devices including Macs with M1, M2, or M3 CPUs.

* **Documentation**
  * Updated the README to specify supported platforms for container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->