### PR TITLE
Add work-around for tool_calls with granite models and /query endpoint.

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -31,6 +31,7 @@ from utils.common import retrieve_user_id
 from utils.endpoints import check_configuration_loaded, get_system_prompt
 from utils.mcp_headers import mcp_headers_dependency
 from utils.suid import get_suid
+from utils.types import GraniteToolParser
 
 logger = logging.getLogger("app.endpoints.handlers")
 router = APIRouter(tags=["query"])
@@ -83,6 +84,7 @@ def get_agent(
         model=model_id,
         instructions=system_prompt,
         input_shields=available_shields if available_shields else [],
+        tool_parser=GraniteToolParser.get_parser(model_id),
         enable_session_persistence=True,
     )
     conversation_id = agent.create_session(get_suid())

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -913,6 +913,7 @@ def test_get_agent_cache_miss_with_conversation_id(
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1"],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -963,6 +964,7 @@ def test_get_agent_no_conversation_id(setup_configuration, prepare_agent_mocks, 
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1"],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -1013,6 +1015,7 @@ def test_get_agent_empty_shields(setup_configuration, prepare_agent_mocks, mocke
         model="test_model",
         instructions="test_prompt",
         input_shields=[],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -1064,6 +1067,7 @@ def test_get_agent_multiple_mcp_servers(
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1", "shield2"],
+        tool_parser=None,
         enable_session_persistence=True,
     )
 
@@ -1109,5 +1113,6 @@ def test_get_agent_session_persistence_enabled(
         model="test_model",
         instructions="test_prompt",
         input_shields=["shield1"],
+        tool_parser=None,
         enable_session_persistence=True,
     )


### PR DESCRIPTION
## Description

Further to #211 my colleague @ldjebran pointed out I'd missed the `/query` endpoint.

This PR fills that gap.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # N/A
- Closes # https://issues.redhat.com/browse/AAP-48374

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
