### PR TITLE
[LCORE-353] Allow mcp headers to contain mcp servers names

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -29,7 +29,7 @@ import constants
 from auth import get_auth_dependency
 from utils.common import retrieve_user_id
 from utils.endpoints import check_configuration_loaded, get_system_prompt
-from utils.mcp_headers import mcp_headers_dependency
+from utils.mcp_headers import mcp_headers_dependency, handle_mcp_headers_with_toolgroups
 from utils.suid import get_suid
 from utils.types import GraniteToolParser
 
@@ -231,6 +231,7 @@ def retrieve_response(
     # preserve compatibility when mcp_headers is not provided
     if mcp_headers is None:
         mcp_headers = {}
+    mcp_headers = handle_mcp_headers_with_toolgroups(mcp_headers, configuration)
     if not mcp_headers and token:
         for mcp_server in configuration.mcp_servers:
             mcp_headers[mcp_server.url] = {

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -22,7 +22,7 @@ from configuration import configuration
 from models.requests import QueryRequest
 from utils.endpoints import check_configuration_loaded, get_system_prompt
 from utils.common import retrieve_user_id
-from utils.mcp_headers import mcp_headers_dependency
+from utils.mcp_headers import mcp_headers_dependency, handle_mcp_headers_with_toolgroups
 from utils.suid import get_suid
 from utils.types import GraniteToolParser
 
@@ -290,6 +290,9 @@ async def retrieve_response(
     # preserve compatibility when mcp_headers is not provided
     if mcp_headers is None:
         mcp_headers = {}
+
+    mcp_headers = handle_mcp_headers_with_toolgroups(mcp_headers, configuration)
+
     if not mcp_headers and token:
         for mcp_server in configuration.mcp_servers:
             mcp_headers[mcp_server.url] = {

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -694,8 +694,14 @@ def test_retrieve_response_with_mcp_servers_and_mcp_headers(mocker):
     model_id = "fake_model_id"
     access_token = ""
     mcp_headers = {
-        "http://localhost:3000": {"Authorization": "Bearer test_token_123"},
-        "https://git.example.com/mcp": {"Authorization": "Bearer test_token_123"},
+        "filesystem-server": {"Authorization": "Bearer test_token_123"},
+        "git-server": {"Authorization": "Bearer test_token_456"},
+        "http://another-server-mcp-server:3000": {
+            "Authorization": "Bearer test_token_789"
+        },
+        "unknown-mcp-server": {
+            "Authorization": "Bearer test_token_for_unknown-mcp-server"
+        },
     }
 
     response, conversation_id = retrieve_response(
@@ -718,11 +724,20 @@ def test_retrieve_response_with_mcp_servers_and_mcp_headers(mocker):
         None,  # conversation_id
     )
 
+    expected_mcp_headers = {
+        "http://localhost:3000": {"Authorization": "Bearer test_token_123"},
+        "https://git.example.com/mcp": {"Authorization": "Bearer test_token_456"},
+        "http://another-server-mcp-server:3000": {
+            "Authorization": "Bearer test_token_789"
+        },
+        # we do not put "unknown-mcp-server" url as it's unknown to lightspeed-stack
+    }
+
     # Check that the agent's extra_headers property was set correctly
     expected_extra_headers = {
         "X-LlamaStack-Provider-Data": json.dumps(
             {
-                "mcp_headers": mcp_headers,
+                "mcp_headers": expected_mcp_headers,
             }
         )
     }

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -762,8 +762,14 @@ async def test_retrieve_response_with_mcp_servers_and_mcp_headers(mocker):
     model_id = "fake_model_id"
     access_token = ""
     mcp_headers = {
-        "http://localhost:3000": {"Authorization": "Bearer test_token_123"},
-        "https://git.example.com/mcp": {"Authorization": "Bearer test_token_456"},
+        "filesystem-server": {"Authorization": "Bearer test_token_123"},
+        "git-server": {"Authorization": "Bearer test_token_456"},
+        "http://another-server-mcp-server:3000": {
+            "Authorization": "Bearer test_token_789"
+        },
+        "unknown-mcp-server": {
+            "Authorization": "Bearer test_token_for_unknown-mcp-server"
+        },
     }
 
     response, conversation_id = await retrieve_response(
@@ -786,9 +792,17 @@ async def test_retrieve_response_with_mcp_servers_and_mcp_headers(mocker):
         None,  # conversation_id
     )
 
+    expected_mcp_headers = {
+        "http://localhost:3000": {"Authorization": "Bearer test_token_123"},
+        "https://git.example.com/mcp": {"Authorization": "Bearer test_token_456"},
+        "http://another-server-mcp-server:3000": {
+            "Authorization": "Bearer test_token_789"
+        },
+        # we do not put "unknown-mcp-server" url as it's unknown to lightspeed-stack
+    }
     # Check that the agent's extra_headers property was set correctly
     expected_extra_headers = {
-        "X-LlamaStack-Provider-Data": json.dumps({"mcp_headers": mcp_headers})
+        "X-LlamaStack-Provider-Data": json.dumps({"mcp_headers": expected_mcp_headers})
     }
     assert mock_agent.extra_headers == expected_extra_headers
 


### PR DESCRIPTION
## Description

In some configurations it's very hard for the application to be configured using the urls of mcp servers as the urls may be generated dynamically, this implementation simplify a lot the application deployments, as mcp servers are defined in earlier stages.   

This PR allow the client to provide mcp headers with mcp servers names mcp_headers = {
    "mcp-server-url-1": {"HEADER-1": "HEADER-1-VALUE-1", "HEADER-1": "HEADER-1-VALUE-2"},
    "mcp-server-name": {"HEADER-2": "HEADER-2-VALUE"}
}

the header with "mcp-server-name" will be replaced with it corresponding url using the configuration.mcp_servers, if it does exit it's getting ignored.

for url validation we use urllib urlpase the same used by llama-stack

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [X] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/LCORE-312
- Closes # https://issues.redhat.com/browse/LCORE-353

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of MCP headers by supporting both server names and URLs, automatically mapping server names to their configured URLs where possible.

* **Bug Fixes**
  * Ensured that only valid and known MCP server URLs are included when processing headers, excluding unknown entries.

* **Tests**
  * Updated tests to reflect the enhanced handling and validation of MCP headers, including scenarios with both server names and URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->