### PR TITLE
Add QueryRequest.media_type for backwards compatibility.

### DIFF
--- a/tests/unit/models/test_requests.py
+++ b/tests/unit/models/test_requests.py
@@ -1,5 +1,8 @@
 """Test the QueryRequest, Attachment, and FeedbackRequest models."""
 
+from unittest.mock import Mock
+from logging import Logger
+
 import pytest
 from pydantic import ValidationError
 from models.requests import QueryRequest, Attachment, FeedbackRequest
@@ -142,6 +145,28 @@ class TestQueryRequest:
             ValueError, match="Model must be specified if provider is specified"
         ):
             QueryRequest(query="Tell me about Kubernetes", provider="OpenAI")
+
+    def test_validate_media_type(self, mocker) -> None:
+        """Test the validate_media_type method."""
+
+        # Mock the logger
+        mock_logger = Mock(spec=Logger)
+        mocker.patch("models.requests.logger", mock_logger)
+
+        qr = QueryRequest(
+            query="Tell me about Kubernetes",
+            provider="OpenAI",
+            model="gpt-3.5-turbo",
+            media_type="text/plain",
+        )
+        assert qr is not None
+        assert qr.provider == "OpenAI"
+        assert qr.model == "gpt-3.5-turbo"
+        assert qr.media_type == "text/plain"
+
+        mock_logger.warning.assert_called_once_with(
+            "media_type was set in the request but is not supported. The value will be ignored."
+        )
 
 
 class TestFeedbackRequest:


### PR DESCRIPTION
## Description

Add `QueryRequest.media_type` for backwards compatibility with `road-core` clients.

Ansible Lightspeed currently uses `road-core` and we are switching it to `lightspeed-stack`.

To avoid making changes to our _client_ code I testing/fixing compatibility issues.

This PR adds `media_type` but logs that it's use is not supported.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional media type field in requests to improve compatibility with some clients. A warning will be logged if this field is set, as it is currently not supported.

* **Tests**
  * Introduced new tests to verify logging behavior when the media type field is used in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->