### PR TITLE
LCORE-220: Add metrics to lightspeed-stack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "llama-stack>=0.2.13",
     "rich>=14.0.0",
     "cachetools>=6.1.0",
+    "prometheus-client>=0.22.1",
+    "starlette>=0.47.1",
 ]
 
 [tool.pyright]

--- a/src/app/endpoints/metrics.py
+++ b/src/app/endpoints/metrics.py
@@ -1,0 +1,16 @@
+"""Handler for REST API call to provide metrics."""
+
+from fastapi.responses import PlainTextResponse
+from fastapi import APIRouter, Request
+from prometheus_client import (
+    generate_latest,
+    CONTENT_TYPE_LATEST,
+)
+
+router = APIRouter(tags=["metrics"])
+
+
+@router.get("/metrics", response_class=PlainTextResponse)
+def metrics_endpoint_handler(_request: Request) -> PlainTextResponse:
+    """Handle request to the /metrics endpoint."""
+    return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,13 +1,18 @@
 """Definition of FastAPI based web service."""
 
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from app import routers
+from typing import Callable, Awaitable
 
-import version
-from log import get_logger
+from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.routing import Mount, Route, WebSocketRoute
+
+from app import routers
 from configuration import configuration
+from log import get_logger
+import metrics
+from metrics.utils import setup_model_metrics
 from utils.common import register_mcp_servers_async
+import version
 
 logger = get_logger(__name__)
 
@@ -34,8 +39,42 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.middleware("")
+async def rest_api_metrics(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Middleware with REST API counter update logic."""
+    path = request.url.path
+    logger.debug("Received request for path: %s", path)
+
+    # ignore paths that are not part of the app routes
+    if path not in app_routes_paths:
+        return await call_next(request)
+
+    logger.debug("Processing API request for path: %s", path)
+
+    # measure time to handle duration + update histogram
+    with metrics.response_duration_seconds.labels(path).time():
+        response = await call_next(request)
+
+    # ignore /metrics endpoint that will be called periodically
+    if not path.endswith("/metrics"):
+        # just update metrics
+        metrics.rest_api_calls_total.labels(path, response.status_code).inc()
+    return response
+
+
 logger.info("Including routers")
 routers.include_routers(app)
+
+app_routes_paths = [
+    route.path
+    for route in app.routes
+    if isinstance(route, (Mount, Route, WebSocketRoute))
+]
+
+setup_model_metrics()
 
 
 @app.on_event("startup")

--- a/src/app/routers.py
+++ b/src/app/routers.py
@@ -13,6 +13,7 @@ from app.endpoints import (
     streaming_query,
     authorized,
     conversations,
+    metrics,
 )
 
 
@@ -34,3 +35,4 @@ def include_routers(app: FastAPI) -> None:
     # road-core does not version these endpoints
     app.include_router(health.router)
     app.include_router(authorized.router)
+    app.include_router(metrics.router)

--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -1,0 +1,51 @@
+"""Metrics module for Lightspeed Stack."""
+
+from prometheus_client import (
+    Counter,
+    Gauge,
+    Histogram,
+)
+
+# Counter to track REST API calls
+# This will be used to count how many times each API endpoint is called
+# and the status code of the response
+rest_api_calls_total = Counter(
+    "ls_rest_api_calls_total", "REST API calls counter", ["path", "status_code"]
+)
+
+# Histogram to measure response durations
+# This will be used to track how long it takes to handle requests
+response_duration_seconds = Histogram(
+    "ls_response_duration_seconds", "Response durations", ["path"]
+)
+
+# Metric that indicates what provider + model customers are using so we can
+# understand what is popular/important
+provider_model_configuration = Gauge(
+    "ls_provider_model_configuration",
+    "LLM provider/models combinations defined in configuration",
+    ["provider", "model"],
+)
+
+# Metric that counts how many LLM calls were made for each provider + model
+llm_calls_total = Counter(
+    "ls_llm_calls_total", "LLM calls counter", ["provider", "model"]
+)
+
+# Metric that counts how many LLM calls failed
+llm_calls_failures_total = Counter("ls_llm_calls_failures_total", "LLM calls failures")
+
+# Metric that counts how many LLM calls had validation errors
+llm_calls_validation_errors_total = Counter(
+    "ls_llm_validation_errors_total", "LLM validation errors"
+)
+
+# TODO(lucasagomes): Add metric for token usage
+llm_token_sent_total = Counter(
+    "ls_llm_token_sent_total", "LLM tokens sent", ["provider", "model"]
+)
+
+# TODO(lucasagomes): Add metric for token usage
+llm_token_received_total = Counter(
+    "ls_llm_token_received_total", "LLM tokens received", ["provider", "model"]
+)

--- a/src/metrics/utils.py
+++ b/src/metrics/utils.py
@@ -1,0 +1,32 @@
+"""Utility functions for metrics handling."""
+
+from client import LlamaStackClientHolder
+from log import get_logger
+import metrics
+
+logger = get_logger(__name__)
+
+
+# TODO(lucasagomes): Change this metric once we are allowed to set the the
+# default model/provider via the configuration.The default provider/model
+# will be set to 1, and the rest will be set to 0.
+def setup_model_metrics() -> None:
+    """Perform setup of all metrics related to LLM model and provider."""
+    client = LlamaStackClientHolder().get_client()
+    models = [
+        model
+        for model in client.models.list()
+        if model.model_type == "llm"  # pyright: ignore[reportAttributeAccessIssue]
+    ]
+
+    for model in models:
+        provider = model.provider_id
+        model_name = model.identifier
+        if provider and model_name:
+            label_key = (provider, model_name)
+            metrics.provider_model_configuration.labels(*label_key).set(1)
+            logger.debug(
+                "Set provider/model configuration for %s/%s to 1",
+                provider,
+                model_name,
+            )

--- a/tests/unit/app/endpoints/test_metrics.py
+++ b/tests/unit/app/endpoints/test_metrics.py
@@ -1,0 +1,25 @@
+"""Unit tests for the /metrics REST API endpoint."""
+
+from app.endpoints.metrics import metrics_endpoint_handler
+
+
+def test_metrics_endpoint():
+    """Test the metrics endpoint handler."""
+    response = metrics_endpoint_handler(None)
+    assert response is not None
+    assert response.status_code == 200
+    assert "text/plain" in response.headers["Content-Type"]
+
+    response_body = response.body.decode()
+
+    # Check if the response contains Prometheus metrics format
+    assert "# TYPE ls_rest_api_calls_total counter" in response_body
+    assert "# TYPE ls_response_duration_seconds histogram" in response_body
+    assert "# TYPE ls_provider_model_configuration gauge" in response_body
+    assert "# TYPE ls_llm_calls_total counter" in response_body
+    assert "# TYPE ls_llm_calls_failures_total counter" in response_body
+    assert "# TYPE ls_llm_calls_failures_created gauge" in response_body
+    assert "# TYPE ls_llm_validation_errors_total counter" in response_body
+    assert "# TYPE ls_llm_validation_errors_created gauge" in response_body
+    assert "# TYPE ls_llm_token_sent_total counter" in response_body
+    assert "# TYPE ls_llm_token_received_total counter" in response_body

--- a/tests/unit/app/test_routers.py
+++ b/tests/unit/app/test_routers.py
@@ -15,6 +15,7 @@ from app.endpoints import (
     feedback,
     streaming_query,
     authorized,
+    metrics,
 )  # noqa:E402
 
 
@@ -44,7 +45,7 @@ def test_include_routers() -> None:
     include_routers(app)
 
     # are all routers added?
-    assert len(app.routers) == 10
+    assert len(app.routers) == 11
     assert root.router in app.get_routers()
     assert info.router in app.get_routers()
     assert models.router in app.get_routers()
@@ -55,6 +56,7 @@ def test_include_routers() -> None:
     assert health.router in app.get_routers()
     assert authorized.router in app.get_routers()
     assert conversations.router in app.get_routers()
+    assert metrics.router in app.get_routers()
 
 
 def test_check_prefixes() -> None:
@@ -63,7 +65,7 @@ def test_check_prefixes() -> None:
     include_routers(app)
 
     # are all routers added?
-    assert len(app.routers) == 10
+    assert len(app.routers) == 11
     assert app.get_router_prefix(root.router) is None
     assert app.get_router_prefix(info.router) == "/v1"
     assert app.get_router_prefix(models.router) == "/v1"
@@ -74,3 +76,4 @@ def test_check_prefixes() -> None:
     assert app.get_router_prefix(health.router) is None
     assert app.get_router_prefix(authorized.router) is None
     assert app.get_router_prefix(conversations.router) == "/v1"
+    assert app.get_router_prefix(metrics.router) is None

--- a/tests/unit/metrics/__init__.py
+++ b/tests/unit/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for metrics."""

--- a/tests/unit/metrics/test_utis.py
+++ b/tests/unit/metrics/test_utis.py
@@ -1,0 +1,23 @@
+"""Unit tests for functions defined in metrics/utils.py"""
+
+from metrics.utils import setup_model_metrics
+
+
+def test_setup_model_metrics(mocker):
+    """Test the setup_model_metrics function."""
+
+    # Mock the LlamaStackAsLibraryClient
+    mock_client = mocker.patch("client.LlamaStackClientHolder.get_client").return_value
+
+    mock_metric = mocker.patch("metrics.provider_model_configuration")
+    fake_model = mocker.Mock(
+        provider_id="test_provider",
+        identifier="test_model",
+        model_type="llm",
+    )
+    mock_client.models.list.return_value = [fake_model]
+
+    setup_model_metrics()
+
+    # Assert that the metric was set correctly
+    mock_metric.labels("test_provider", "test_model").set.assert_called_once_with(1)

--- a/uv.lock
+++ b/uv.lock
@@ -835,7 +835,9 @@ dependencies = [
     { name = "fastapi" },
     { name = "kubernetes" },
     { name = "llama-stack" },
+    { name = "prometheus-client" },
     { name = "rich" },
+    { name = "starlette" },
     { name = "uvicorn" },
 ]
 
@@ -867,7 +869,9 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.6" },
     { name = "kubernetes", specifier = ">=30.1.0" },
     { name = "llama-stack", specifier = ">=0.2.13" },
+    { name = "prometheus-client", specifier = ">=0.22.1" },
     { name = "rich", specifier = ">=14.0.0" },
+    { name = "starlette", specifier = ">=0.47.1" },
     { name = "uvicorn", specifier = ">=0.34.3" },
 ]
 
@@ -1457,6 +1461,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/cf/40dde0a2be27cc1eb41e333d1a674a74ce8b8b0457269cc640fd42b07cf7/prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28", size = 69746, upload-time = "2025-06-02T14:29:01.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/ae/ec06af4fe3ee72d16973474f122541746196aaa16cea6f66d18b963c6177/prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094", size = 58694, upload-time = "2025-06-02T14:29:00.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

This patch is adding the /metrics endpoint to the project.

Differences with road-core/service:

 * The metrics are prefixed with "ls_" instead of "ols_"
 * The "provider_model_configuration" does not set the non-default model/providers to 0 because we currently do not have a way to set a default model/provider in the configuration. A TODO was left in the code.

Supported metrics:

 * rest_api_calls_total: Counter to track REST API calls
 * response_duration_seconds: Histogram to measure how long it takes to handle requests
 * provider_model_configuration: Indicates what provider + model customers are using
 * llm_calls_total: How many LLM calls were made for each provider + model
 * llm_calls_failures_total: How many LLM calls failed
 * llm_calls_validation_errors_total: How many LLM calls had validation errors

Missing metrics:

 * llm_token_sent_total: How many tokens were sent
 * llm_token_received_total: How many tokens were received

The above metrics are missing because token counting PR (https://github.com/lightspeed-core/lightspeed-stack/pull/215) is not merged yet.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-220
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new `/metrics` API endpoint providing real-time Prometheus-compatible metrics for API usage, performance, and LLM interactions.
  * Added middleware to track REST API request counts and durations by endpoint and response status.
  * Enhanced observability with detailed metrics for LLM provider/model usage, total calls, failures, validation errors, and token counts.
  * Model selection updated to include provider information for improved metric granularity.

* **Bug Fixes**
  * Improved error tracking and validation error reporting for LLM-related endpoints.

* **Chores**
  * Added and updated dependencies to support metrics functionality.
  * Expanded and updated unit tests to cover new metrics features and ensure robust monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->