### PR TITLE
LCORE-379: fixed run.yaml to be compatible with Llama Stack 0.2.14

### DIFF
--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -89,7 +89,7 @@ providers:
     provider_type: inline::braintrust
   telemetry:
   - config:
-      service_name: ''
+      service_name: 'lightspeed-stack'
       sinks: sqlite
       sqlite_db_path: .llama/distributions/ollama/trace_store.db
     provider_id: meta-reference


### PR DESCRIPTION
## Description

LCORE-379: fixed `run.yaml` to be compatible with Llama Stack 0.2.14

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated telemetry provider configuration to specify a service name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->