### PR TITLE
Feat: Update base image to fix Konflux RPM signature scan

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,11 +1,7 @@
 # vim: set filetype=dockerfile
-FROM registry.access.redhat.com/ubi9/ubi-minimal AS builder
+FROM registry.access.redhat.com/ubi9/python-312-minimal AS builder
 
 ARG APP_ROOT=/app-root
-
-# Install Python
-RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs \
-    python3.12 python3.12-devel python3.12-pip
 
 # UV_PYTHON_DOWNLOADS=0 : Disable Python interpreter downloads and use the system interpreter.
 ENV UV_COMPILE_BYTECODE=0 \
@@ -26,9 +22,8 @@ RUN uv sync --locked --no-install-project --no-dev
 
 
 # Final image without uv package manager
-FROM registry.access.redhat.com/ubi9/ubi-minimal
+FROM registry.access.redhat.com/ubi9/python-312-minimal
 ARG APP_ROOT=/app-root
-RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs python3.12 python3.12-pip
 WORKDIR /app-root
 
 # PYTHONDONTWRITEBYTECODE 1 : disable the generation of .pyc


### PR DESCRIPTION
## Description

This commit update the Containerfile, switching the base image to the ubi9/python-312 image. This eliminates manual Python installations, resulting in a cleaner and more efficient build. This change resolves issues with the Konflux RPM signature scan by mitigating the risk of unverified artifact injection.


<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container base image to include Python 3.12 by default, streamlining the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->