### PR TITLE
LCORE-175: Use patches to not modify global config value in test_feedback

### DIFF
--- a/tests/unit/app/endpoints/test_feedback.py
+++ b/tests/unit/app/endpoints/test_feedback.py
@@ -1,5 +1,7 @@
 """Unit tests for the /feedback REST API endpoint."""
 
+from unittest.mock import patch
+
 from fastapi import HTTPException, status
 import pytest
 
@@ -15,14 +17,20 @@ from app.endpoints.feedback import (
 
 def test_is_feedback_enabled():
     """Test that is_feedback_enabled returns True when feedback is not disabled."""
-    configuration.user_data_collection_configuration.feedback_enabled = True
-    assert is_feedback_enabled() is True, "Feedback should be enabled"
+    with patch(
+        "app.endpoints.feedback.configuration.user_data_collection_configuration.feedback_enabled",
+        True,
+    ):
+        assert is_feedback_enabled() is True, "Feedback should be enabled"
 
 
 def test_is_feedback_disabled():
     """Test that is_feedback_enabled returns False when feedback is disabled."""
-    configuration.user_data_collection_configuration.feedback_enabled = False
-    assert is_feedback_enabled() is False, "Feedback should be disabled"
+    with patch(
+        "app.endpoints.feedback.configuration.user_data_collection_configuration.feedback_enabled",
+        False,
+    ):
+        assert is_feedback_enabled() is False, "Feedback should be disabled"
 
 
 async def test_assert_feedback_enabled_disabled(mocker):


### PR DESCRIPTION
## Description

Use patches in test_is_feedback_enabled and test_is_feedback_disabled to not modify global config value.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

https://issues.redhat.com/browse/LCORE-175

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by updating feedback configuration tests to use temporary overrides during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->