### PR TITLE
LCORE-175: Define central storage path config option for user data collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ llama_stack:
   url: http://localhost:8321
 user_data_collection:
   feedback_enabled: true
-  feedback_storage: "/tmp/data/feedback"
   transcripts_enabled: true
-  transcripts_storage: "/tmp/data/transcripts"
+  user_data_dir: "/tmp/data"
 ```
 
 ### Llama Stack project and configuration
@@ -186,9 +185,8 @@ llama_stack:
   library_client_config_path: <path-to-llama-stack-run.yaml-file>
 user_data_collection:
   feedback_enabled: true
-  feedback_storage: "/tmp/data/feedback"
   transcripts_enabled: true
-  transcripts_storage: "/tmp/data/transcripts"
+  user_data_dir: "/tmp/data"
 ```
 
 ## System prompt
@@ -438,9 +436,8 @@ The data collector service is configured through the `user_data_collection.data_
 ```yaml
 user_data_collection:
   feedback_enabled: true
-  feedback_storage: "/tmp/data/feedback"
   transcripts_enabled: true
-  transcripts_storage: "/tmp/data/transcripts"
+  user_data_dir: "/tmp/data"
   data_collector:
     enabled: true
     ingress_server_url: "https://your-ingress-server.com"

--- a/lightspeed-stack.yaml
+++ b/lightspeed-stack.yaml
@@ -17,9 +17,8 @@ llama_stack:
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true
-  feedback_storage: "/tmp/data/feedback"
   transcripts_enabled: true
-  transcripts_storage: "/tmp/data/transcripts"
+  user_data_dir: "/tmp/data"
   data_collector:
     enabled: false
     ingress_server_url: null

--- a/src/app/endpoints/feedback.py
+++ b/src/app/endpoints/feedback.py
@@ -109,19 +109,18 @@ def store_feedback(user_id: str, feedback: dict) -> None:
         feedback: The feedback to store.
     """
     logger.debug("Storing feedback for user %s", user_id)
-    # Creates storage path only if it doesn't exist. The `exist_ok=True` prevents
-    # race conditions in case of multiple server instances trying to set up storage
-    # at the same location.
-    storage_path = Path(
-        configuration.user_data_collection_configuration.feedback_storage or ""
-    )
-    storage_path.mkdir(parents=True, exist_ok=True)
+
+    # Create feedback directory if it doesn't exist
+    feedback_dir = Path(
+        configuration.user_data_collection_configuration.feedback_storage
+    ) or Path("")
+    feedback_dir.mkdir(parents=True, exist_ok=True)
 
     current_time = str(datetime.now(UTC))
     data_to_store = {"user_id": user_id, "timestamp": current_time, **feedback}
 
     # stores feedback in a file under unique uuid
-    feedback_file_path = storage_path / f"{get_suid()}.json"
+    feedback_file_path = feedback_dir / f"{get_suid()}.json"
     with open(feedback_file_path, "w", encoding="utf-8") as feedback_file:
         json.dump(data_to_store, feedback_file)
 

--- a/src/app/endpoints/feedback.py
+++ b/src/app/endpoints/feedback.py
@@ -113,7 +113,7 @@ def store_feedback(user_id: str, feedback: dict) -> None:
     # Create feedback directory if it doesn't exist
     feedback_dir = Path(
         configuration.user_data_collection_configuration.feedback_storage
-    ) or Path("")
+    )
     feedback_dir.mkdir(parents=True, exist_ok=True)
 
     current_time = str(datetime.now(UTC))

--- a/src/app/endpoints/feedback.py
+++ b/src/app/endpoints/feedback.py
@@ -2,7 +2,6 @@
 
 import logging
 from typing import Any
-from pathlib import Path
 import json
 from datetime import datetime, UTC
 
@@ -111,9 +110,7 @@ def store_feedback(user_id: str, feedback: dict) -> None:
     logger.debug("Storing feedback for user %s", user_id)
 
     # Create feedback directory if it doesn't exist
-    feedback_dir = Path(
-        configuration.user_data_collection_configuration.feedback_storage
-    )
+    feedback_dir = configuration.user_data_collection_configuration.feedback_storage
     feedback_dir.mkdir(parents=True, exist_ok=True)
 
     current_time = str(datetime.now(UTC))

--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -350,9 +350,7 @@ def construct_transcripts_path(user_id: str, conversation_id: str) -> Path:
     # this Path sanitization pattern
     uid = os.path.normpath("/" + user_id).lstrip("/")
     cid = os.path.normpath("/" + conversation_id).lstrip("/")
-    file_path = (
-        configuration.user_data_collection_configuration.transcripts_storage or ""
-    )
+    file_path = configuration.user_data_collection_configuration.transcripts_storage
     return Path(file_path, uid, cid)
 
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -130,21 +130,19 @@ class UserDataCollection(BaseModel):
     """User data collection configuration."""
 
     feedback_enabled: bool = False
-    feedback_storage: Optional[str] = None
     transcripts_enabled: bool = False
-    transcripts_storage: Optional[str] = None
+    user_data_dir: str = "user_data"
     data_collector: DataCollectorConfiguration = DataCollectorConfiguration()
 
-    @model_validator(mode="after")
-    def check_storage_location_is_set_when_needed(self) -> Self:
-        """Check that storage_location is set when enabled."""
-        if self.feedback_enabled and self.feedback_storage is None:
-            raise ValueError("feedback_storage is required when feedback is enabled")
-        if self.transcripts_enabled and self.transcripts_storage is None:
-            raise ValueError(
-                "transcripts_storage is required when transcripts is enabled"
-            )
-        return self
+    @property
+    def feedback_storage(self) -> str:
+        """Feedback storage directory path."""
+        return str(Path(self.user_data_dir) / "feedback")
+
+    @property
+    def transcripts_storage(self) -> str:
+        """Transcripts storage directory path."""
+        return str(Path(self.user_data_dir) / "transcripts")
 
 
 class AuthenticationConfiguration(BaseModel):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -131,18 +131,18 @@ class UserDataCollection(BaseModel):
 
     feedback_enabled: bool = False
     transcripts_enabled: bool = False
-    user_data_dir: str = "user_data"
+    user_data_dir: Path = Path("user_data")
     data_collector: DataCollectorConfiguration = DataCollectorConfiguration()
 
     @property
-    def feedback_storage(self) -> str:
+    def feedback_storage(self) -> Path:
         """Feedback storage directory path."""
-        return str(Path(self.user_data_dir) / "feedback")
+        return self.user_data_dir / "feedback"
 
     @property
-    def transcripts_storage(self) -> str:
+    def transcripts_storage(self) -> Path:
         """Transcripts storage directory path."""
-        return str(Path(self.user_data_dir) / "transcripts")
+        return self.user_data_dir / "transcripts"
 
 
 class AuthenticationConfiguration(BaseModel):

--- a/src/services/data_collector.py
+++ b/src/services/data_collector.py
@@ -71,13 +71,13 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         try:
             if feedback_files:
                 udc_config = configuration.user_data_collection_configuration
-                feedback_base = Path(udc_config.feedback_storage)
+                feedback_base = udc_config.feedback_storage
                 collections_sent += self._create_and_send_tarball(
                     feedback_files, "feedback", feedback_base
                 )
             if transcript_files:
                 udc_config = configuration.user_data_collection_configuration
-                transcript_base = Path(udc_config.transcripts_storage)
+                transcript_base = udc_config.transcripts_storage
                 collections_sent += self._create_and_send_tarball(
                     transcript_files, "transcripts", transcript_base
                 )
@@ -96,7 +96,7 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         if not udc_config.feedback_enabled:
             return []
 
-        feedback_dir = Path(udc_config.feedback_storage)
+        feedback_dir = udc_config.feedback_storage
         if not feedback_dir.exists():
             return []
 
@@ -109,7 +109,7 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         if not udc_config.transcripts_enabled:
             return []
 
-        transcripts_dir = Path(udc_config.transcripts_storage)
+        transcripts_dir = udc_config.transcripts_storage
         if not transcripts_dir.exists():
             return []
 
@@ -224,7 +224,7 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         if not udc_config.transcripts_enabled:
             return
 
-        transcripts_dir = Path(udc_config.transcripts_storage)
+        transcripts_dir = udc_config.transcripts_storage
         if not transcripts_dir.exists():
             return
 

--- a/src/services/data_collector.py
+++ b/src/services/data_collector.py
@@ -71,18 +71,16 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         try:
             if feedback_files:
                 udc_config = configuration.user_data_collection_configuration
-                if udc_config.feedback_storage:
-                    feedback_base = Path(udc_config.feedback_storage)
-                    collections_sent += self._create_and_send_tarball(
-                        feedback_files, "feedback", feedback_base
-                    )
+                feedback_base = Path(udc_config.feedback_storage)
+                collections_sent += self._create_and_send_tarball(
+                    feedback_files, "feedback", feedback_base
+                )
             if transcript_files:
                 udc_config = configuration.user_data_collection_configuration
-                if udc_config.transcripts_storage:
-                    transcript_base = Path(udc_config.transcripts_storage)
-                    collections_sent += self._create_and_send_tarball(
-                        transcript_files, "transcripts", transcript_base
-                    )
+                transcript_base = Path(udc_config.transcripts_storage)
+                collections_sent += self._create_and_send_tarball(
+                    transcript_files, "transcripts", transcript_base
+                )
 
             logger.info(
                 "Successfully sent %s collections to ingress server", collections_sent
@@ -95,7 +93,7 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         """Collect all feedback files that need to be collected."""
         udc_config = configuration.user_data_collection_configuration
 
-        if not udc_config.feedback_enabled or not udc_config.feedback_storage:
+        if not udc_config.feedback_enabled:
             return []
 
         feedback_dir = Path(udc_config.feedback_storage)
@@ -108,7 +106,7 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         """Collect all transcript files that need to be collected."""
         udc_config = configuration.user_data_collection_configuration
 
-        if not udc_config.transcripts_enabled or not udc_config.transcripts_storage:
+        if not udc_config.transcripts_enabled:
             return []
 
         transcripts_dir = Path(udc_config.transcripts_storage)
@@ -223,7 +221,7 @@ class DataCollectorService:  # pylint: disable=too-few-public-methods
         """Remove empty directories from transcript storage."""
         udc_config = configuration.user_data_collection_configuration
 
-        if not udc_config.transcripts_enabled or not udc_config.transcripts_storage:
+        if not udc_config.transcripts_enabled:
             return
 
         transcripts_dir = Path(udc_config.transcripts_storage)

--- a/tests/configuration/lightspeed-stack.yaml
+++ b/tests/configuration/lightspeed-stack.yaml
@@ -17,7 +17,7 @@ llama_stack:
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true
-  feedback_storage: "/tmp/data/feedback"
+  user_data_dir: "/tmp/ls_user_data"
 mcp_servers:
   - name: "server1"
     provider_id: "provider1"

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -1,5 +1,7 @@
 """Integration tests for configuration loading and handling."""
 
+from pathlib import Path
+
 import pytest
 from configuration import configuration
 
@@ -56,7 +58,7 @@ def test_loading_proper_configuration(configuration_filename: str) -> None:
     # check 'user_data_collection' section
     udc_config = cfg.user_data_collection_configuration
     assert udc_config.feedback_enabled is True
-    assert udc_config.feedback_storage == "/tmp/ls_user_data/feedback"
+    assert udc_config.feedback_storage == Path("/tmp/ls_user_data/feedback")
 
     # check MCP servers section
     mcp_servers = cfg.mcp_servers

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -56,7 +56,7 @@ def test_loading_proper_configuration(configuration_filename: str) -> None:
     # check 'user_data_collection' section
     udc_config = cfg.user_data_collection_configuration
     assert udc_config.feedback_enabled is True
-    assert udc_config.feedback_storage == "/tmp/data/feedback"
+    assert udc_config.feedback_storage == "/tmp/ls_user_data/feedback"
 
     # check MCP servers section
     mcp_servers = cfg.mcp_servers

--- a/tests/unit/app/endpoints/test_feedback.py
+++ b/tests/unit/app/endpoints/test_feedback.py
@@ -1,5 +1,7 @@
 """Unit tests for the /feedback REST API endpoint."""
 
+from pathlib import Path
+
 from fastapi import HTTPException, status
 import pytest
 
@@ -96,10 +98,11 @@ def test_feedback_endpoint_handler_error(mocker):
 
 def test_store_feedback(mocker):
     """Test that store_feedback calls the correct storage function."""
-    configuration.user_data_collection_configuration.user_data_dir = "fake"
+    configuration.user_data_collection_configuration.user_data_dir = Path("fake")
 
     mocker.patch("builtins.open", mocker.mock_open())
-    mocker.patch("app.endpoints.feedback.Path", return_value=mocker.MagicMock())
+    # Mock mkdir to prevent actual directory creation
+    mocker.patch.object(Path, "mkdir")
     mocker.patch("app.endpoints.feedback.get_suid", return_value="fake-uuid")
 
     # Mock the JSON to assert the data is stored correctly

--- a/tests/unit/app/endpoints/test_feedback.py
+++ b/tests/unit/app/endpoints/test_feedback.py
@@ -96,7 +96,7 @@ def test_feedback_endpoint_handler_error(mocker):
 
 def test_store_feedback(mocker):
     """Test that store_feedback calls the correct storage function."""
-    configuration.user_data_collection_configuration.feedback_storage = "fake-path"
+    configuration.user_data_collection_configuration.user_data_dir = "fake"
 
     mocker.patch("builtins.open", mocker.mock_open())
     mocker.patch("app.endpoints.feedback.Path", return_value=mocker.MagicMock())

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -2,6 +2,8 @@
 
 # pylint: disable=too-many-lines
 
+from pathlib import Path
+
 import json
 from fastapi import HTTPException, status
 import pytest
@@ -911,7 +913,7 @@ def test_retrieve_response_shield_violation(prepare_agent_mocks, mocker):
 def test_construct_transcripts_path(setup_configuration, mocker):
     """Test the construct_transcripts_path function."""
     # Update configuration for this test
-    setup_configuration.user_data_collection_configuration.user_data_dir = "/tmp"
+    setup_configuration.user_data_collection_configuration.user_data_dir = Path("/tmp")
     mocker.patch("app.endpoints.query.configuration", setup_configuration)
 
     user_id = "user123"

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -911,9 +911,7 @@ def test_retrieve_response_shield_violation(prepare_agent_mocks, mocker):
 def test_construct_transcripts_path(setup_configuration, mocker):
     """Test the construct_transcripts_path function."""
     # Update configuration for this test
-    setup_configuration.user_data_collection_configuration.transcripts_storage = (
-        "/tmp/transcripts"
-    )
+    setup_configuration.user_data_collection_configuration.user_data_dir = "/tmp"
     mocker.patch("app.endpoints.query.configuration", setup_configuration)
 
     user_id = "user123"

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -137,8 +137,8 @@ def test_user_data_collection_feedback_enabled() -> None:
     cfg = UserDataCollection(feedback_enabled=False)
     assert cfg is not None
     assert cfg.feedback_enabled is False
-    assert cfg.user_data_dir == "user_data"
-    assert cfg.feedback_storage == "user_data/feedback"
+    assert cfg.user_data_dir == Path("user_data")
+    assert cfg.feedback_storage == Path("user_data/feedback")
 
 
 def test_user_data_collection_transcripts_enabled() -> None:
@@ -147,15 +147,15 @@ def test_user_data_collection_transcripts_enabled() -> None:
     cfg = UserDataCollection(transcripts_enabled=False)
     assert cfg is not None
     assert cfg.transcripts_enabled is False
-    assert cfg.user_data_dir == "user_data"
-    assert cfg.transcripts_storage == "user_data/transcripts"
+    assert cfg.user_data_dir == Path("user_data")
+    assert cfg.transcripts_storage == Path("user_data/transcripts")
 
 
 def test_user_data_collection_custom_dir() -> None:
     """Test the UserDataCollection constructor with custom directory."""
     cfg = UserDataCollection(user_data_dir="/custom/path")
-    assert cfg.feedback_storage == "/custom/path/feedback"
-    assert cfg.transcripts_storage == "/custom/path/transcripts"
+    assert cfg.feedback_storage == Path("/custom/path/feedback")
+    assert cfg.transcripts_storage == Path("/custom/path/transcripts")
 
 
 def test_user_data_collection_data_collector_enabled() -> None:

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -134,37 +134,28 @@ def test_llama_stack_wrong_configuration_no_config_file() -> None:
 def test_user_data_collection_feedback_enabled() -> None:
     """Test the UserDataCollection constructor for feedback."""
     # correct configuration
-    cfg = UserDataCollection(feedback_enabled=False, feedback_storage=None)
+    cfg = UserDataCollection(feedback_enabled=False)
     assert cfg is not None
     assert cfg.feedback_enabled is False
-    assert cfg.feedback_storage is None
-
-
-def test_user_data_collection_feedback_disabled() -> None:
-    """Test the UserDataCollection constructor for feedback."""
-    # incorrect configuration
-    with pytest.raises(
-        ValueError,
-        match="feedback_storage is required when feedback is enabled",
-    ):
-        UserDataCollection(feedback_enabled=True, feedback_storage=None)
+    assert cfg.user_data_dir == "user_data"
+    assert cfg.feedback_storage == "user_data/feedback"
 
 
 def test_user_data_collection_transcripts_enabled() -> None:
     """Test the UserDataCollection constructor for transcripts."""
     # correct configuration
-    cfg = UserDataCollection(transcripts_enabled=False, transcripts_storage=None)
+    cfg = UserDataCollection(transcripts_enabled=False)
     assert cfg is not None
+    assert cfg.transcripts_enabled is False
+    assert cfg.user_data_dir == "user_data"
+    assert cfg.transcripts_storage == "user_data/transcripts"
 
 
-def test_user_data_collection_transcripts_disabled() -> None:
-    """Test the UserDataCollection constructor for transcripts."""
-    # incorrect configuration
-    with pytest.raises(
-        ValueError,
-        match="transcripts_storage is required when transcripts is enabled",
-    ):
-        UserDataCollection(transcripts_enabled=True, transcripts_storage=None)
+def test_user_data_collection_custom_dir() -> None:
+    """Test the UserDataCollection constructor with custom directory."""
+    cfg = UserDataCollection(user_data_dir="/custom/path")
+    assert cfg.feedback_storage == "/custom/path/feedback"
+    assert cfg.transcripts_storage == "/custom/path/transcripts"
 
 
 def test_user_data_collection_data_collector_enabled() -> None:
@@ -337,9 +328,7 @@ def test_configuration_empty_mcp_servers() -> None:
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
-        user_data_collection=UserDataCollection(
-            feedback_enabled=False, feedback_storage=None
-        ),
+        user_data_collection=UserDataCollection(feedback_enabled=False),
         mcp_servers=[],
         customization=None,
     )
@@ -362,9 +351,7 @@ def test_configuration_single_mcp_server() -> None:
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
-        user_data_collection=UserDataCollection(
-            feedback_enabled=False, feedback_storage=None
-        ),
+        user_data_collection=UserDataCollection(feedback_enabled=False),
         mcp_servers=[mcp_server],
         customization=None,
     )
@@ -394,9 +381,7 @@ def test_configuration_multiple_mcp_servers() -> None:
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
-        user_data_collection=UserDataCollection(
-            feedback_enabled=False, feedback_storage=None
-        ),
+        user_data_collection=UserDataCollection(feedback_enabled=False),
         mcp_servers=mcp_servers,
         customization=None,
     )
@@ -421,9 +406,7 @@ def test_dump_configuration(tmp_path) -> None:
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
-        user_data_collection=UserDataCollection(
-            feedback_enabled=False, feedback_storage=None
-        ),
+        user_data_collection=UserDataCollection(feedback_enabled=False),
         mcp_servers=[],
         customization=None,
     )
@@ -468,9 +451,8 @@ def test_dump_configuration(tmp_path) -> None:
             },
             "user_data_collection": {
                 "feedback_enabled": False,
-                "feedback_storage": None,
                 "transcripts_enabled": False,
-                "transcripts_storage": None,
+                "user_data_dir": "user_data",
                 "data_collector": {
                     "enabled": False,
                     "ingress_server_url": None,
@@ -511,9 +493,7 @@ def test_dump_configuration_with_one_mcp_server(tmp_path) -> None:
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
-        user_data_collection=UserDataCollection(
-            feedback_enabled=False, feedback_storage=None
-        ),
+        user_data_collection=UserDataCollection(feedback_enabled=False),
         mcp_servers=mcp_servers,
         customization=None,
     )
@@ -553,9 +533,8 @@ def test_dump_configuration_with_one_mcp_server(tmp_path) -> None:
             },
             "user_data_collection": {
                 "feedback_enabled": False,
-                "feedback_storage": None,
                 "transcripts_enabled": False,
-                "transcripts_storage": None,
+                "user_data_dir": "user_data",
                 "data_collector": {
                     "enabled": False,
                     "ingress_server_url": None,
@@ -605,9 +584,7 @@ def test_dump_configuration_with_more_mcp_servers(tmp_path) -> None:
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
-        user_data_collection=UserDataCollection(
-            feedback_enabled=False, feedback_storage=None
-        ),
+        user_data_collection=UserDataCollection(feedback_enabled=False),
         mcp_servers=mcp_servers,
         customization=None,
     )
@@ -653,9 +630,8 @@ def test_dump_configuration_with_more_mcp_servers(tmp_path) -> None:
             },
             "user_data_collection": {
                 "feedback_enabled": False,
-                "feedback_storage": None,
                 "transcripts_enabled": False,
-                "transcripts_storage": None,
+                "user_data_dir": "user_data",
                 "data_collector": {
                     "enabled": False,
                     "ingress_server_url": None,

--- a/tests/unit/services/test_data_collector.py
+++ b/tests/unit/services/test_data_collector.py
@@ -58,17 +58,6 @@ def test_collect_feedback_files_disabled(mock_config) -> None:
 
 
 @patch("services.data_collector.configuration")
-def test_collect_feedback_files_no_storage(mock_config) -> None:
-    """Test collecting feedback files when no storage configured."""
-    service = DataCollectorService()
-    mock_config.user_data_collection_configuration.feedback_enabled = True
-    mock_config.user_data_collection_configuration.feedback_storage = None
-
-    result = service._collect_feedback_files()
-    assert result == []
-
-
-@patch("services.data_collector.configuration")
 def test_collect_feedback_files_directory_not_exists(mock_config) -> None:
     """Test collecting feedback files when directory doesn't exist."""
     service = DataCollectorService()


### PR DESCRIPTION
## Description

Create a single storage path. The feedback/transcripts/XYZ shouldn't be configurable, but hardcoded in lightspeed-core to ensure the archive's inner structure.

While it won't break the planned data ingestion, the current OLS reporting depends on this archive structure. So, unless there is a request to change it or have it configurable (not the scenario for a new datapoint inside the archive), let's remove it from configuration.


## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

https://issues.redhat.com/browse/LCORE-175

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation and configuration examples to use a unified user data directory for feedback and transcripts storage.

* **Refactor**
  * Simplified configuration by replacing separate feedback and transcripts storage paths with a single user data directory.
  * Updated internal logic and tests to use the new unified storage configuration.

* **Tests**
  * Revised and removed outdated tests to align with the new storage configuration approach.
  * Added tests to verify correct behavior with the unified user data directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->