### PR TITLE
Containerfile COPY adjustment

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,7 @@
 FROM registry.access.redhat.com/ubi9/python-312-minimal AS builder
 
 ARG APP_ROOT=/app-root
+ARG LSC_SOURCE_DIR=.
 
 # UV_PYTHON_DOWNLOADS=0 : Disable Python interpreter downloads and use the system interpreter.
 ENV UV_COMPILE_BYTECODE=0 \
@@ -15,8 +16,8 @@ RUN pip3.12 install uv
 
 # Add explicit files and directories
 # (avoid accidental inclusion of local directories or env files or credentials)
-COPY src ./src
-COPY pyproject.toml LICENSE README.md uv.lock ./
+COPY ${LSC_SOURCE_DIR}/src ./src
+COPY ${LSC_SOURCE_DIR}/pyproject.toml ${LSC_SOURCE_DIR}/LICENSE ${LSC_SOURCE_DIR}/README.md ${LSC_SOURCE_DIR}/uv.lock ./
 
 RUN uv sync --locked --no-install-project --no-dev
 


### PR DESCRIPTION
## Description

We need to do some ugly hack in our assisted-chat repo to make our pipelines work correctly, and it would make it easier for us if we could configure where this Containerfile copies its files from.

It's a bit hard to explain the motivation, but if you don't mind it we would appreciate it if we can have this until we can get rid of the hack in the assisted-chat repo, when LSC has proper releases that we can use out of the box.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Tried to build, successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container build process to allow configuring the source directory at build time via a new build argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->