### PR TITLE
LCORE-383: Fix attachments in /conversations

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -18,6 +18,7 @@ from llama_stack_client.types.agents.turn_create_params import (
     Toolgroup,
 )
 from llama_stack_client.types.model_list_response import ModelListResponse
+from llama_stack_client.types.shared.interleaved_content_item import TextContentItem
 
 from fastapi import APIRouter, HTTPException, status, Depends
 
@@ -296,7 +297,7 @@ def retrieve_response(  # pylint: disable=too-many-locals
         mcp_server.name for mcp_server in configuration.mcp_servers
     ]
     response = agent.create_turn(
-        messages=[UserMessage(role="user", content=query_request.query)],
+        messages=[UserMessage(role="user", content=[TextContentItem(type="text", text=query_request.query)])],
         session_id=conversation_id,
         documents=query_request.get_documents(),
         stream=False,

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -562,7 +562,7 @@ async def retrieve_response(
         mcp_server.name for mcp_server in configuration.mcp_servers
     ]
     response = await agent.create_turn(
-        messages=[UserMessage(role="user", content=query_request.query)],
+        messages=[UserMessage(role="user", content=[TextContentItem(type="text", text=query_request.query)])],
         session_id=conversation_id,
         documents=query_request.get_documents(),
         stream=True,


### PR DESCRIPTION
## Description
This PR is one of 2 that is being proposed to close [LCORE-383](https://issues.redhat.com/browse/LCORE-383).

Basically what is happening is that attachment content is being appended to messages when accessing them through the `/conversations` endpoint. 

This error can be seen below along with what it looks like after the fix.

### Before Fix
This is when the attachment is sent before using the `/conversations` endpoint to reload the saved conversation.
<img width="1440" height="900" alt="original_before" src="https://github.com/user-attachments/assets/34326f56-4cc9-4ad1-ab1a-b7072b64f662" />
This is after the `/conversations` endpoint is used to reload the conversation.
<img width="1440" height="900" alt="original_after" src="https://github.com/user-attachments/assets/70220ed9-f98e-4ee5-bcd5-a370ba6d5803" />

### After Fix
This is when the attachment is sent before using the `/conversations` endpoint to reload the saved conversation.
<img width="1440" height="900" alt="new_before" src="https://github.com/user-attachments/assets/3db64897-30e0-4334-9679-158f5991a8fa" />
This is after the `/conversations` endpoint is used to reload the conversation.
<img width="1440" height="900" alt="new_after" src="https://github.com/user-attachments/assets/af4846b0-f273-4a97-86e2-2040707d3de3" />

This is what the response of the `/conversations` endpoint looks like:
```json
{
  "conversation_id": "09f05d2b-5cf5-4d83-8616-b106de972d67",
  "chat_history": [
    {
      "messages": [
        {
          "content": [
            {
              "text": "What does this file say?",
              "type": "text"
            },
            {
              "text": "data:text/plain;base64,SW5ncmVkaWVudHM6Ci0gNiBjdXBzIHRoaW5seSBzbGljZWQgYXBwbGVzCi0gMy80IGN1cCBzdWdhcgotIDIgdGFibGVzcG9vbnMgYWxsLXB1cnBvc2UgZmxvdXIKLSAxLzIgdGVhc3Bvb24gZ3JvdW5kIGNpbm5hbW9uCi0gMS80IHRlYXNwb29uIHNhbHQKLSAxLzggdGVhc3Bvb24gZ3JvdW5kIG51dG1lZwotIDEgdGFibGVzcG9vbiBsZW1vbiBqdWljZQotIDEgcGFja2FnZSAoMiBjcnVzdHMpIHJlZnJpZ2VyYXRlZCBwaWUgY3J1c3RzCgpJbnN0cnVjdGlvbnM6CjEuIFByZWhlYXQgb3ZlbiB0byA0MjUgZGVncmVlcyBGICgyMjAgZGVncmVlcyBDKS4KMi4gSW4gYSBsYXJnZSBib3dsLCBtaXggc2xpY2VkIGFwcGxlcywgc3VnYXIsIGZsb3VyLCBjaW5uYW1vbiwgc2FsdCwgbnV0bWVnLCBhbmQgbGVtb24ganVpY2UuCjMuIFBsYWNlIG9uZSBwaWUgY3J1c3QgaW4gYSBwaWUgZGlzaC4gRmlsbCB3aXRoIGFwcGxlIG1peHR1cmUuIENvdmVyIHdpdGggdGhlIHNlY29uZCBjcnVzdC4KNC4gU2VhbCBhbmQgZmx1dGUgZWRnZXMuIEN1dCBzbGl0cyBpbiB0aGUgdG9wIGNydXN0Lgo1LiBCYWtlIGluIHRoZSBwcmVoZWF0ZWQgb3ZlbiBmb3IgNDUgbWludXRlcyBvciB1bnRpbCBjcnVzdCBpcyBnb2xkZW4gYnJvd24uIEFsbG93IHRvIGNvb2wgYmVmb3JlIHNlcnZpbmcu",
              "type": "text"
            }
          ],
          "type": "user"
        },
        {
          "content": "The decoded text from the base64 string is a recipe with ingredients and instructions for making a pie. Here is the content:\n\n**Ingredients:**\n- 6 cups thinly sliced apples\n- 3/4 cup sugar\n- 2 tablespoons all-purpose flour\n- 1/2 teaspoon ground cinnamon\n- 1/4 teaspoon salt\n- 1/8 teaspoon ground nutmeg\n- 1 tablespoon lemon juice\n- 1 package (2 crusts) refrigerated pie crusts\n\n**Instructions:**\n1. Preheat oven to 425 degrees F (220 degrees C).\n2. In a large bowl, mix sliced apples, sugar, flour, cinnamon, salt, nutmeg, and lemon juice.\n3. Place one pie crust in a pie dish. Fill with apple mixture. Cover with the second crust.\n4. Seal and flute edges. Cut slits in the top crust.\n5. Bake in the preheated oven for 45 minutes or until crust is golden brown. Allow to cool before serving.",
          "type": "assistant"
        }
      ],
      "started_at": "2025-07-24T17:40:21.098072Z",
      "completed_at": "2025-07-24T17:40:28.668180Z"
    }
  ]
}
```

I originally wanted to solve this by leveraging the session data in llama-stack to extract the attachment content, however because we pass the message as a string and not a list of `InterleavedContentItem`'s it directly appends the content to the message content string making it difficult to remove. 

This PR represents solving the issue in a **non-hacky** way but such that it doesn't fully meet the acceptance criteria of [LCORE-383](https://issues.redhat.com/browse/LCORE-383). Basically it just changes how we pass the `content` of the `UserMessage` to be a list of content items and not a string.

The issue with this however is that we wouldn't have any of the metadata that is passed originally along with the `attachment`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue [LCORE-383](https://issues.redhat.com/browse/LCORE-383)
- Closes [LCORE-383](https://issues.redhat.com/browse/LCORE-383)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
