### PR TITLE
[ISSUE-291] Fix setup_model_metrics() as a library

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -74,8 +74,6 @@ app_routes_paths = [
     if isinstance(route, (Mount, Route, WebSocketRoute))
 ]
 
-setup_model_metrics()
-
 
 @app.on_event("startup")
 async def startup_event() -> None:
@@ -83,4 +81,6 @@ async def startup_event() -> None:
     logger.info("Registering MCP servers")
     await register_mcp_servers_async(logger, configuration.configuration)
     get_logger("app.endpoints.handlers")
+    logger.info("Setting up model metrics")
+    await setup_model_metrics()
     logger.info("App startup complete")

--- a/src/metrics/utils.py
+++ b/src/metrics/utils.py
@@ -1,19 +1,24 @@
 """Utility functions for metrics handling."""
 
 from configuration import configuration
-from client import LlamaStackClientHolder
+from client import LlamaStackClientHolder, AsyncLlamaStackClientHolder
 from log import get_logger
 import metrics
 
 logger = get_logger(__name__)
 
 
-def setup_model_metrics() -> None:
+async def setup_model_metrics() -> None:
     """Perform setup of all metrics related to LLM model and provider."""
-    client = LlamaStackClientHolder().get_client()
+    model_list = []
+    if configuration.llama_stack_configuration.use_as_library_client:
+        model_list = await AsyncLlamaStackClientHolder().get_client().models.list()
+    else:
+        model_list = LlamaStackClientHolder().get_client().models.list()
+
     models = [
         model
-        for model in client.models.list()
+        for model in model_list
         if model.model_type == "llm"  # pyright: ignore[reportAttributeAccessIssue]
     ]
 

--- a/tests/unit/metrics/test_utis.py
+++ b/tests/unit/metrics/test_utis.py
@@ -3,7 +3,7 @@
 from metrics.utils import setup_model_metrics
 
 
-def test_setup_model_metrics(mocker):
+async def test_setup_model_metrics(mocker):
     """Test the setup_model_metrics function."""
 
     # Mock the LlamaStackAsLibraryClient
@@ -51,7 +51,7 @@ def test_setup_model_metrics(mocker):
         model_1,
     ]
 
-    setup_model_metrics()
+    await setup_model_metrics()
 
     # Check that the provider_model_configuration metric was set correctly
     # The default model should have a value of 1, others should be 0


### PR DESCRIPTION
## Description
Fix nested event loop error when setup_model_metrics() is called with llama-stack used as a library.

fixes: 291

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #291

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup by deferring model metrics setup until the startup phase, ensuring smoother initialization.
  * Enhanced logging with a new message indicating when model metrics are being set up.

* **Refactor**
  * Updated model metrics setup to use asynchronous operations for better performance and reliability.

* **Tests**
  * Updated related unit tests to support asynchronous execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->