### PR TITLE
Use async for model metrics initialization

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -74,12 +74,11 @@ app_routes_paths = [
     if isinstance(route, (Mount, Route, WebSocketRoute))
 ]
 
-setup_model_metrics()
-
 
 @app.on_event("startup")
 async def startup_event() -> None:
-    """Perform logger setup on service startup."""
+    """Perform logger setup and other initializations on service startup."""
+    await setup_model_metrics()
     logger.info("Registering MCP servers")
     await register_mcp_servers_async(logger, configuration.configuration)
     get_logger("app.endpoints.handlers")

--- a/src/metrics/utils.py
+++ b/src/metrics/utils.py
@@ -1,19 +1,19 @@
 """Utility functions for metrics handling."""
 
 from configuration import configuration
-from client import LlamaStackClientHolder
+from client import AsyncLlamaStackClientHolder
 from log import get_logger
 import metrics
 
 logger = get_logger(__name__)
 
 
-def setup_model_metrics() -> None:
+async def setup_model_metrics() -> None:
     """Perform setup of all metrics related to LLM model and provider."""
-    client = LlamaStackClientHolder().get_client()
+    client = AsyncLlamaStackClientHolder().get_client()
     models = [
         model
-        for model in client.models.list()
+        for model in await client.models.list()
         if model.model_type == "llm"  # pyright: ignore[reportAttributeAccessIssue]
     ]
 


### PR DESCRIPTION
## Description

`LlamaStackClientHolder` is sync, but internally within llama-stack it glues into the async client, by instantiating its own event loop. This somehow interferes with the async event loop of uvicorn:

<details>
<summary>Traceback</summary>

```
Traceback (most recent call last):
  File "/app-root/src/lightspeed_stack.py", line 91, in <module>
    main()
  File "/app-root/src/lightspeed_stack.py", line 86, in main
    start_uvicorn(configuration.service_configuration)
  File "/app-root/src/runners/uvicorn.py", line 20, in start_uvicorn
    uvicorn.run(
  File "/app-root/.venv/lib64/python3.12/site-packages/uvicorn/main.py", line 580, in run
    server.run()
  File "/app-root/.venv/lib64/python3.12/site-packages/uvicorn/server.py", line 67, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/app-root/.venv/lib64/python3.12/site-packages/uvicorn/server.py", line 71, in serve
    await self._serve(sockets)
  File "/app-root/.venv/lib64/python3.12/site-packages/uvicorn/server.py", line 78, in _serve
    config.load()
  File "/app-root/.venv/lib64/python3.12/site-packages/uvicorn/config.py", line 436, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app-root/.venv/lib64/python3.12/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/app-root/src/app/main.py", line 77, in <module>
    setup_model_metrics()
  File "/app-root/src/metrics/utils.py", line 16, in setup_model_metrics
    for model in client.models.list()
                 ^^^^^^^^^^^^^^^^^^^^
  File "/app-root/.venv/lib64/python3.12/site-packages/llama_stack_client/resources/models.py", line 93, in list
    return self._get(
           ^^^^^^^^^^
  File "/app-root/.venv/lib64/python3.12/site-packages/llama_stack_client/_base_client.py", line 1178, in get
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app-root/llama-stack/llama_stack/distribution/library_client.py", line 177, in request
    result = loop.run_until_complete(self.async_client.request(*args, **kwargs))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 667, in run_until_complete
    self._check_running()
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 628, in _check_running
    raise RuntimeError(
RuntimeError: Cannot run the event loop while another loop is running
sys:1: RuntimeWarning: coroutine 'AsyncLlamaStackAsLibraryClient.request' was never awaited
```
</details>

Not sure why this was not caught earlier, maybe it only happens when running llama-stack in library mode?

I've changed the `setup_model_metrics` function to be async and use `AsyncLlamaStackClientHolder` instead of `LlamaStackClientHolder`. It also means we should call it from `startup_event`

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

I've ran it manually in the same setup where the error occurs and made sure the error no longer occurs