### PR TITLE
implement persistence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Lightspeed Core Stack (LCS) is an AI-powered assistant that provides answers to 
     * [Llama Stack as client library](#llama-stack-as-client-library)
     * [System prompt](#system-prompt)
     * [Safety Shields](#safety-shields)
+    * [Persistence Configuration](#persistence-configuration)
+        * [Database Setup](#database-setup)
+        * [Migration Support](#migration-support)
 * [Usage](#usage)
     * [Make targets](#make-targets)
     * [Running Linux container image](#running-linux-container-image)
@@ -57,11 +60,23 @@ Overall architecture with all main parts is displayed below:
 
 Lightspeed Core Stack is based on the FastAPI framework (Uvicorn). The service is split into several parts described below.
 
+## Persistence Layer
+
+The service includes a robust persistence layer that replaces the in-memory conversation mapping with PostgreSQL-based storage.
+
+See more information in [persistence.md](docs/persistence.md).
+
+
 # Prerequisites
 
 * Python 3.12, or 3.13
     - please note that currently Python 3.14 is not officially supported
     - all sources are made (backward) compatible with Python 3.12; it is checked on CI
+
+* PostgreSQL (for persistence features)
+    - Required for conversation persistence
+    - Supports connection pooling and SSL
+    - Can be run locally or in cloud
 
 # Installation
 
@@ -71,6 +86,13 @@ Installation steps depends on operation system. Please look at instructions for 
 - [Linux installation](https://lightspeed-core.github.io/lightspeed-stack/installation_linux)
 - [macOS installation](https://lightspeed-core.github.io/lightspeed-stack/installation_macos)
 
+## Additional Dependencies for Persistence
+
+If you plan to use the persistence features, install the additional dependencies:
+
+```bash
+pip install sqlalchemy psycopg2-binary alembic
+```
 
 # Configuration
 

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,101 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python-dateutil library that can be
+# installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version number format
+version_num_format = %04d
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses
+# os.pathsep. If this key is omitted entirely, it falls back to the legacy
+# behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+version_path_separator = os
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = postgresql://postgres:your-password-here@localhost:5432/lightspeed_stack
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,319 @@
+# Conversation Persistence Implementation
+
+This document describes the implementation of persistent conversation storage for Lightspeed Core Stack (LCS), replacing the in-memory conversation mapping with PostgreSQL-based persistence.
+
+## Overview
+
+The persistence implementation provides:
+- **Persistent conversation storage** in PostgreSQL
+- **Agent state persistence** for rehydration
+- **Multi-replica support** through shared database
+- **Automatic conversation history** tracking
+- **Configurable retention policies**
+
+## Architecture
+
+### Database Schema
+
+The persistence layer uses three main tables:
+
+1. **`conversations`** - Stores conversation metadata
+   - `conversation_id` (UUID, Primary Key)
+   - `user_id` (UUID, indexed)
+   - `agent_id` (UUID, indexed)
+   - `model_id` (String)
+   - `system_prompt` (Text)
+   - `created_at` (DateTime)
+   - `updated_at` (DateTime)
+   - `status` (String, indexed)
+   - `metadata` (JSONB)
+
+2. **`conversation_turns`** - Stores individual conversation turns
+   - `turn_id` (UUID, Primary Key)
+   - `conversation_id` (UUID, Foreign Key)
+   - `turn_number` (Integer)
+   - `input_messages` (JSONB)
+   - `output_message` (JSONB)
+   - `started_at` (DateTime)
+   - `completed_at` (DateTime)
+   - `metadata` (JSONB)
+
+3. **`agent_states`** - Stores agent configuration and state
+   - `agent_id` (UUID, Primary Key)
+   - `conversation_id` (UUID, Foreign Key, Unique)
+   - `agent_config` (JSONB)
+   - `current_state` (JSONB)
+   - `created_at` (DateTime)
+   - `updated_at` (DateTime)
+
+### Service Layer
+
+The implementation includes several service classes:
+
+- **`DatabaseService`** - Handles database connections and session management
+- **`ConversationPersistenceService`** - Manages conversation CRUD operations
+- **`AgentStatePersistenceService`** - Manages agent state persistence
+- **`PersistentAgentManager`** - Coordinates agent lifecycle with persistence
+- **`PersistenceManager`** - Main coordinator for all persistence operations
+
+## Configuration
+
+### Basic Configuration
+
+Add the following to your `lightspeed-stack.yaml`:
+
+```yaml
+persistence:
+  type: "postgresql"
+  database:
+    host: "localhost"
+    port: 5432
+    name: "lightspeed_stack"
+    username: "postgres"
+    password: "your-password-here"
+    ssl_mode: "prefer"
+    pool_size: 20
+    max_overflow: 30
+    pool_timeout: 30
+    pool_recycle: 3600
+  agent_cache_max_size: 1000
+  agent_cache_ttl_seconds: 3600
+  enable_rehydration: true
+  conversation_retention_days: 90
+  enable_archival: false
+```
+
+### Configuration Options
+
+- **`type`**: Database type (currently only "postgresql" supported)
+- **`database`**: PostgreSQL connection configuration
+- **`agent_cache_max_size`**: Maximum number of agents in memory cache
+- **`agent_cache_ttl_seconds`**: Time-to-live for cached agents
+- **`enable_rehydration`**: Whether to enable agent rehydration from database
+- **`conversation_retention_days`**: Days to keep conversations before cleanup
+- **`enable_archival`**: Whether to enable conversation archival (future feature)
+
+## Database Setup
+
+### 1. Install Dependencies
+
+```bash
+pip install sqlalchemy psycopg2-binary alembic
+```
+
+### 2. Create Database
+
+```sql
+CREATE DATABASE lightspeed_stack;
+CREATE USER lightspeed_user WITH PASSWORD 'your-password';
+GRANT ALL PRIVILEGES ON DATABASE lightspeed_stack TO lightspeed_user;
+```
+
+### 3. Run Migrations
+
+```bash
+# Initialize Alembic (first time only)
+alembic init migrations
+
+# Create initial migration
+alembic revision --autogenerate -m "Initial migration"
+
+# Apply migrations
+alembic upgrade head
+```
+
+## Usage
+
+### Automatic Initialization
+
+The persistence layer is automatically initialized during application startup if configured:
+
+```python
+# In src/lightspeed_stack.py
+def initialize_persistence() -> None:
+    """Initialize persistence layer if configured."""
+    if configuration.persistence_configuration:
+        try:
+            from app.endpoints.query import initialize_persistent_agent_manager
+            initialize_persistent_agent_manager()
+            logger.info("Persistence layer initialized successfully")
+        except Exception as e:
+            logger.error("Failed to initialize persistence layer: %s", e)
+```
+
+### Manual Usage
+
+```python
+from services.persistence import PersistenceManager
+from models.config import PersistenceConfiguration
+
+# Create configuration
+config = PersistenceConfiguration(
+    type="postgresql",
+    database=DatabaseConfiguration(
+        host="localhost",
+        port=5432,
+        name="lightspeed_stack",
+        username="postgres",
+        password="password"
+    )
+)
+
+# Initialize persistence manager
+persistence_manager = PersistenceManager(config)
+persistence_manager.initialize()
+
+# Use services
+conversation_service = persistence_manager.get_conversation_service()
+agent_state_service = persistence_manager.get_agent_state_service()
+```
+
+## API Changes
+
+### Query Endpoint
+
+The `/query` endpoint now:
+- Stores conversation turns in persistent storage
+- Supports agent rehydration from database
+- Maintains backward compatibility with in-memory cache
+
+### Conversations Endpoint
+
+The `/conversations/{conversation_id}` endpoint now:
+- Retrieves conversations from persistent storage first
+- Falls back to llama-stack session retrieval
+- Supports conversation deletion from persistent storage
+
+## Multi-Replica Support
+
+The persistence implementation supports multiple LCS replicas by:
+
+1. **Shared Database**: All replicas connect to the same PostgreSQL database
+2. **Connection Pooling**: Each replica maintains its own connection pool
+3. **Session Independence**: Agent sessions are independent across replicas
+4. **Consistent State**: Database ensures consistent conversation state
+
+## Monitoring and Maintenance
+
+### Database Monitoring
+
+Monitor the following metrics:
+- Connection pool utilization
+- Query performance
+- Database size and growth
+- Index usage
+
+### Cleanup Operations
+
+The system includes automatic cleanup capabilities:
+
+```python
+# Clean up old conversations
+persistent_manager.cleanup_old_conversations()
+```
+
+### Backup Strategy
+
+Implement regular PostgreSQL backups:
+- Full database backups
+- Point-in-time recovery
+- Transaction log backups
+
+## Migration from In-Memory
+
+### Gradual Migration
+
+The implementation supports gradual migration:
+
+1. **Dual Mode**: Both persistent and in-memory storage are supported
+2. **Fallback**: If persistence fails, the system falls back to in-memory
+3. **Configuration**: Enable persistence via configuration
+
+### Data Migration
+
+To migrate existing conversations:
+
+```python
+# Export existing conversations
+# Import to persistent storage
+# Update configuration to enable persistence
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Connection Errors**
+   - Check database connectivity
+   - Verify credentials
+   - Check firewall settings
+
+2. **Performance Issues**
+   - Monitor connection pool usage
+   - Check database indexes
+   - Review query performance
+
+3. **Data Consistency**
+   - Check for duplicate conversations
+   - Verify agent state consistency
+   - Monitor transaction logs
+
+### Logging
+
+Enable debug logging for persistence operations:
+
+```python
+import logging
+logging.getLogger("services.persistence").setLevel(logging.DEBUG)
+```
+
+## Future Enhancements
+
+1. **MongoDB Support**: Add MongoDB as an alternative database
+2. **Firestore Support**: Add Google Firestore support
+3. **Archival**: Implement conversation archival to cheaper storage
+4. **Compression**: Add conversation data compression
+5. **Analytics**: Add conversation analytics and reporting
+6. **Encryption**: Add field-level encryption for sensitive data
+
+## Testing
+
+### Unit Tests
+
+```bash
+pytest tests/test_persistence.py
+```
+
+### Integration Tests
+
+```bash
+# Start PostgreSQL container
+docker run -d --name postgres-test -e POSTGRES_PASSWORD=test -p 5432:5432 postgres:15
+
+# Run integration tests
+pytest tests/test_integration_persistence.py
+```
+
+### Performance Tests
+
+```bash
+# Run performance benchmarks
+pytest tests/test_performance_persistence.py
+```
+
+## Security Considerations
+
+1. **Database Security**
+   - Use SSL connections
+   - Implement proper access controls
+   - Regular security updates
+
+2. **Data Protection**
+   - Encrypt sensitive data
+   - Implement data retention policies
+   - Audit access logs
+
+3. **Network Security**
+   - Use VPN for database connections
+   - Implement network segmentation
+   - Monitor network traffic 

--- a/lightspeed-stack.yaml
+++ b/lightspeed-stack.yaml
@@ -30,3 +30,21 @@ user_data_collection:
     connection_timeout_seconds: 30
 authentication:
   module: "noop"
+persistence:
+  type: "postgresql"
+  database:
+    host: "localhost"
+    port: 5432
+    name: "lightspeed_stack"
+    username: "postgres"
+    password: "your-password-here"
+    ssl_mode: "prefer"
+    pool_size: 20
+    max_overflow: 30
+    pool_timeout: 30
+    pool_recycle: 3600
+  agent_cache_max_size: 1000
+  agent_cache_ttl_seconds: 3600
+  enable_rehydration: true
+  conversation_retention_days: 90
+  enable_archival: false 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,88 @@
+"""Alembic environment configuration."""
+
+import logging
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# Import your models here
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from models.persistence import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = Base.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online() 

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"} 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "starlette>=0.47.1",
     "aiohttp>=3.12.14",
     "authlib>=1.6.0",
+    "sqlalchemy>=2.0.0",
+    "psycopg2-binary>=2.9.0",
+    "alembic>=1.13.0",
 ]
 
 [tool.pyright]

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -13,6 +13,7 @@ from models.config import (
     ModelContextProtocolServer,
     AuthenticationConfiguration,
     InferenceConfiguration,
+    PersistenceConfiguration,
 )
 
 logger = logging.getLogger(__name__)
@@ -112,6 +113,14 @@ class AppConfig:
             self._configuration is not None
         ), "logic error: configuration is not loaded"
         return self._configuration.inference
+
+    @property
+    def persistence_configuration(self) -> Optional[PersistenceConfiguration]:
+        """Return persistence configuration."""
+        assert (
+            self._configuration is not None
+        ), "logic error: configuration is not loaded"
+        return self._configuration.persistence
 
 
 configuration: AppConfig = AppConfig()

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -58,6 +58,19 @@ def create_argument_parser() -> ArgumentParser:
     return parser
 
 
+def initialize_persistence() -> None:
+    """Initialize persistence layer if configured."""
+    if configuration.persistence_configuration:
+        try:
+            from app.endpoints.query import initialize_persistent_agent_manager
+            initialize_persistent_agent_manager()
+            logger.info("Persistence layer initialized successfully")
+        except Exception as e:
+            logger.error("Failed to initialize persistence layer: %s", e)
+    else:
+        logger.info("No persistence configuration found, skipping persistence initialization")
+
+
 def main() -> None:
     """Entry point to the web service."""
     logger.info("Lightspeed stack startup")
@@ -75,6 +88,9 @@ def main() -> None:
     asyncio.run(
         AsyncLlamaStackClientHolder().load(configuration.configuration.llama_stack)
     )
+
+    # Initialize persistence layer
+    initialize_persistence()
 
     if args.dump_configuration:
         configuration.configuration.dump()

--- a/src/models/persistence.py
+++ b/src/models/persistence.py
@@ -1,0 +1,133 @@
+"""Database models for conversation persistence."""
+
+import uuid
+from datetime import datetime, UTC
+from typing import Any, Optional
+
+from sqlalchemy import (
+    Column, String, DateTime, Integer, Text, JSON, Boolean, 
+    ForeignKey, Index, UniqueConstraint
+)
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
+from pydantic import BaseModel
+
+Base = declarative_base()
+
+
+class Conversation(Base):
+    """Database model for conversations."""
+    
+    __tablename__ = "conversations"
+    
+    conversation_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    agent_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    model_id = Column(String(255), nullable=False)
+    system_prompt = Column(Text)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    status = Column(String(50), default="active", index=True)
+    metadata = Column(JSONB)
+    
+    # Relationships
+    turns = relationship("ConversationTurn", back_populates="conversation", cascade="all, delete-orphan")
+    agent_state = relationship("AgentState", back_populates="conversation", uselist=False, cascade="all, delete-orphan")
+    
+    __table_args__ = (
+        Index("idx_conversations_user_created", "user_id", "created_at"),
+        Index("idx_conversations_agent_updated", "agent_id", "updated_at"),
+    )
+
+
+class ConversationTurn(Base):
+    """Database model for conversation turns."""
+    
+    __tablename__ = "conversation_turns"
+    
+    turn_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.conversation_id"), nullable=False, index=True)
+    turn_number = Column(Integer, nullable=False)
+    input_messages = Column(JSONB, nullable=False)
+    output_message = Column(JSONB)
+    started_at = Column(DateTime(timezone=True))
+    completed_at = Column(DateTime(timezone=True))
+    metadata = Column(JSONB)
+    
+    # Relationships
+    conversation = relationship("Conversation", back_populates="turns")
+    
+    __table_args__ = (
+        Index("idx_turns_conversation_number", "conversation_id", "turn_number"),
+        UniqueConstraint("conversation_id", "turn_number", name="uq_conversation_turn_number"),
+    )
+
+
+class AgentState(Base):
+    """Database model for agent state persistence."""
+    
+    __tablename__ = "agent_states"
+    
+    agent_id = Column(UUID(as_uuid=True), primary_key=True)
+    conversation_id = Column(UUID(as_uuid=True), ForeignKey("conversations.conversation_id"), nullable=False, unique=True)
+    agent_config = Column(JSONB, nullable=False)
+    current_state = Column(JSONB)
+    created_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at = Column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    
+    # Relationships
+    conversation = relationship("Conversation", back_populates="agent_state")
+
+
+# Pydantic models for API responses
+class ConversationResponse(BaseModel):
+    """Pydantic model for conversation response."""
+    
+    conversation_id: uuid.UUID
+    user_id: uuid.UUID
+    agent_id: uuid.UUID
+    model_id: str
+    system_prompt: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    status: str
+    metadata: Optional[dict[str, Any]] = None
+    turns: list["ConversationTurnResponse"] = []
+    
+    class Config:
+        from_attributes = True
+
+
+class ConversationTurnResponse(BaseModel):
+    """Pydantic model for conversation turn response."""
+    
+    turn_id: uuid.UUID
+    conversation_id: uuid.UUID
+    turn_number: int
+    input_messages: dict[str, Any]
+    output_message: Optional[dict[str, Any]] = None
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    metadata: Optional[dict[str, Any]] = None
+    
+    class Config:
+        from_attributes = True
+
+
+class AgentStateResponse(BaseModel):
+    """Pydantic model for agent state response."""
+    
+    agent_id: uuid.UUID
+    conversation_id: uuid.UUID
+    agent_config: dict[str, Any]
+    current_state: Optional[dict[str, Any]] = None
+    created_at: datetime
+    updated_at: datetime
+    
+    class Config:
+        from_attributes = True
+
+
+# Update forward references
+ConversationResponse.model_rebuild() 

--- a/src/services/agent_manager.py
+++ b/src/services/agent_manager.py
@@ -1,0 +1,301 @@
+"""Persistent agent manager service."""
+
+import logging
+import uuid
+from typing import Any, Optional, Tuple
+
+from cachetools import TTLCache
+from llama_stack_client.lib.agents.agent import Agent
+from llama_stack_client import LlamaStackClient
+
+from configuration import configuration
+from services.persistence import PersistenceManager
+from utils.suid import get_suid
+from utils.types import GraniteToolParser
+
+logger = logging.getLogger(__name__)
+
+
+class PersistentAgentManager:
+    """Manages agents with persistent storage and rehydration capabilities."""
+    
+    def __init__(self, persistence_manager: PersistenceManager):
+        """Initialize persistent agent manager."""
+        self.persistence_manager = persistence_manager
+        self.conversation_service = persistence_manager.get_conversation_service()
+        self.agent_state_service = persistence_manager.get_agent_state_service()
+        
+        # In-memory cache for active agents (with TTL)
+        config = persistence_manager.config
+        self.agent_cache = TTLCache(
+            maxsize=config.agent_cache_max_size,
+            ttl=config.agent_cache_ttl_seconds
+        )
+        
+        logger.info("Persistent agent manager initialized")
+    
+    def get_or_create_agent(
+        self,
+        client: LlamaStackClient,
+        model_id: str,
+        system_prompt: str,
+        available_input_shields: list[str],
+        available_output_shields: list[str],
+        conversation_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ) -> Tuple[Agent, str]:
+        """Get existing agent or create a new one with session persistence."""
+        
+        # Convert string IDs to UUIDs
+        conversation_uuid = None
+        user_uuid = None
+        
+        if conversation_id:
+            try:
+                conversation_uuid = uuid.UUID(conversation_id)
+            except ValueError:
+                logger.error("Invalid conversation ID format: %s", conversation_id)
+                raise ValueError(f"Invalid conversation ID format: {conversation_id}")
+        
+        if user_id:
+            try:
+                user_uuid = uuid.UUID(user_id)
+            except ValueError:
+                logger.error("Invalid user ID format: %s", user_id)
+                raise ValueError(f"Invalid user ID format: {user_id}")
+        
+        # Check in-memory cache first
+        if conversation_id and conversation_id in self.agent_cache:
+            logger.debug("Reusing existing agent from cache: %s", conversation_id)
+            return self.agent_cache[conversation_id], conversation_id
+        
+        # Try to rehydrate from database
+        if conversation_uuid and self.persistence_manager.config.enable_rehydration:
+            agent = self._rehydrate_agent(client, conversation_uuid, model_id, system_prompt)
+            if agent:
+                logger.debug("Rehydrated agent from database: %s", conversation_id)
+                self.agent_cache[conversation_id] = agent
+                return agent, conversation_id
+        
+        # Create new agent
+        logger.debug("Creating new agent")
+        agent = Agent(
+            client,
+            model=model_id,
+            instructions=system_prompt,
+            input_shields=available_input_shields if available_input_shields else [],
+            output_shields=available_output_shields if available_output_shields else [],
+            tool_parser=GraniteToolParser.get_parser(model_id),
+            enable_session_persistence=True,
+        )
+        
+        # Create session
+        new_conversation_id = agent.create_session(get_suid())
+        logger.debug("Created new agent and conversation_id: %s", new_conversation_id)
+        
+        # Store in cache
+        self.agent_cache[new_conversation_id] = agent
+        
+        # Persist to database
+        if user_uuid:
+            self._persist_conversation(
+                conversation_id=new_conversation_id,
+                user_id=user_uuid,
+                agent_id=agent.agent_id,
+                model_id=model_id,
+                system_prompt=system_prompt,
+                agent=agent,
+            )
+        
+        return agent, new_conversation_id
+    
+    def _rehydrate_agent(
+        self,
+        client: LlamaStackClient,
+        conversation_id: uuid.UUID,
+        model_id: str,
+        system_prompt: str,
+    ) -> Optional[Agent]:
+        """Rehydrate agent from persistent storage."""
+        try:
+            # Get conversation from database
+            conversation = self.conversation_service.get_conversation(conversation_id)
+            if not conversation:
+                logger.debug("No conversation found for ID: %s", conversation_id)
+                return None
+            
+            # Get agent state
+            agent_state = self.agent_state_service.get_agent_state_by_conversation(conversation_id)
+            if not agent_state:
+                logger.debug("No agent state found for conversation: %s", conversation_id)
+                return None
+            
+            # Create agent with stored configuration
+            agent_config = agent_state.agent_config
+            agent = Agent(
+                client,
+                model=agent_config.get("model_id", model_id),
+                instructions=agent_config.get("system_prompt", system_prompt),
+                input_shields=agent_config.get("input_shields", []),
+                output_shields=agent_config.get("output_shields", []),
+                tool_parser=GraniteToolParser.get_parser(agent_config.get("model_id", model_id)),
+                enable_session_persistence=True,
+            )
+            
+            # Restore session (this would need to be implemented in llama-stack)
+            # For now, we'll create a new session but keep the conversation_id
+            # TODO: Implement session restoration in llama-stack
+            logger.info("Rehydrated agent for conversation: %s", conversation_id)
+            return agent
+            
+        except Exception as e:
+            logger.error("Failed to rehydrate agent for conversation %s: %s", conversation_id, e)
+            return None
+    
+    def _persist_conversation(
+        self,
+        conversation_id: str,
+        user_id: uuid.UUID,
+        agent_id: str,
+        model_id: str,
+        system_prompt: str,
+        agent: Agent,
+    ) -> None:
+        """Persist conversation and agent state to database."""
+        try:
+            conversation_uuid = uuid.UUID(conversation_id)
+            agent_uuid = uuid.UUID(agent_id)
+            
+            # Create conversation record
+            self.conversation_service.create_conversation(
+                conversation_id=conversation_uuid,
+                user_id=user_id,
+                agent_id=agent_uuid,
+                model_id=model_id,
+                system_prompt=system_prompt,
+                metadata={
+                    "created_by": "persistent_agent_manager",
+                    "agent_type": "Agent",
+                },
+            )
+            
+            # Save agent state
+            agent_config = {
+                "model_id": model_id,
+                "system_prompt": system_prompt,
+                "input_shields": agent.input_shields,
+                "output_shields": agent.output_shields,
+                "tool_parser": str(type(agent.tool_parser)),
+            }
+            
+            self.agent_state_service.save_agent_state(
+                agent_id=agent_uuid,
+                conversation_id=conversation_uuid,
+                agent_config=agent_config,
+                current_state=None,  # TODO: Implement agent state serialization
+            )
+            
+            logger.info("Persisted conversation and agent state: %s", conversation_id)
+            
+        except Exception as e:
+            logger.error("Failed to persist conversation %s: %s", conversation_id, e)
+            # Don't raise - persistence failure shouldn't break the flow
+    
+    def add_conversation_turn(
+        self,
+        conversation_id: str,
+        turn_number: int,
+        input_messages: list[dict[str, Any]],
+        output_message: Optional[dict[str, Any]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Add a turn to the conversation in persistent storage."""
+        try:
+            conversation_uuid = uuid.UUID(conversation_id)
+            
+            self.conversation_service.add_conversation_turn(
+                conversation_id=conversation_uuid,
+                turn_number=turn_number,
+                input_messages=input_messages,
+                output_message=output_message,
+                metadata=metadata,
+            )
+            
+            logger.debug("Added turn %d to conversation %s", turn_number, conversation_id)
+            
+        except Exception as e:
+            logger.error("Failed to add turn to conversation %s: %s", conversation_id, e)
+            # Don't raise - persistence failure shouldn't break the flow
+    
+    def get_conversation_id_to_agent_id_mapping(self) -> dict[str, str]:
+        """Get the mapping of conversation IDs to agent IDs from persistent storage."""
+        try:
+            # This is a simplified implementation
+            # In a real implementation, you might want to cache this mapping
+            # or implement a more efficient query
+            mapping = {}
+            
+            # For now, we'll return an empty mapping
+            # The actual implementation would query the database
+            # and build the mapping from conversation and agent state records
+            
+            return mapping
+            
+        except Exception as e:
+            logger.error("Failed to get conversation to agent mapping: %s", e)
+            return {}
+    
+    def cleanup_old_conversations(self) -> None:
+        """Clean up old conversations based on retention policy."""
+        try:
+            retention_days = self.persistence_manager.config.conversation_retention_days
+            # TODO: Implement cleanup logic
+            logger.info("Cleanup of old conversations not yet implemented")
+            
+        except Exception as e:
+            logger.error("Failed to cleanup old conversations: %s", e)
+    
+    def get_conversation_history(self, conversation_id: str) -> Optional[list[dict[str, Any]]]:
+        """Get conversation history from persistent storage."""
+        try:
+            conversation_uuid = uuid.UUID(conversation_id)
+            turns = self.conversation_service.get_conversation_turns(conversation_uuid)
+            
+            history = []
+            for turn in turns:
+                turn_data = {
+                    "turn_number": turn.turn_number,
+                    "input_messages": turn.input_messages,
+                    "output_message": turn.output_message,
+                    "started_at": turn.started_at.isoformat() if turn.started_at else None,
+                    "completed_at": turn.completed_at.isoformat() if turn.completed_at else None,
+                    "metadata": turn.metadata,
+                }
+                history.append(turn_data)
+            
+            return history
+            
+        except Exception as e:
+            logger.error("Failed to get conversation history for %s: %s", conversation_id, e)
+            return None
+    
+    def delete_conversation(self, conversation_id: str) -> bool:
+        """Delete conversation from persistent storage."""
+        try:
+            conversation_uuid = uuid.UUID(conversation_id)
+            
+            # Remove from cache
+            if conversation_id in self.agent_cache:
+                del self.agent_cache[conversation_id]
+            
+            # Soft delete from database
+            success = self.conversation_service.delete_conversation(conversation_uuid)
+            
+            if success:
+                logger.info("Deleted conversation: %s", conversation_id)
+            
+            return success
+            
+        except Exception as e:
+            logger.error("Failed to delete conversation %s: %s", conversation_id, e)
+            return False 

--- a/src/services/persistence.py
+++ b/src/services/persistence.py
@@ -1,0 +1,370 @@
+"""Database service layer for conversation persistence."""
+
+import logging
+import uuid
+from datetime import datetime, UTC
+from typing import Any, Optional, List
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from sqlalchemy.pool import QueuePool
+
+from models.config import DatabaseConfiguration, PersistenceConfiguration
+from models.persistence import Base, Conversation, ConversationTurn, AgentState
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseService:
+    """Service for database operations."""
+    
+    def __init__(self, db_config: DatabaseConfiguration):
+        """Initialize database service with configuration."""
+        self.db_config = db_config
+        self.engine = None
+        self.SessionLocal = None
+        self._initialize_engine()
+    
+    def _initialize_engine(self) -> None:
+        """Initialize SQLAlchemy engine with connection pooling."""
+        # Build connection string
+        password_part = f":{self.db_config.password}" if self.db_config.password else ""
+        connection_string = (
+            f"postgresql://{self.db_config.username}{password_part}"
+            f"@{self.db_config.host}:{self.db_config.port}/{self.db_config.name}"
+        )
+        
+        # Create engine with connection pooling
+        self.engine = create_engine(
+            connection_string,
+            poolclass=QueuePool,
+            pool_size=self.db_config.pool_size,
+            max_overflow=self.db_config.max_overflow,
+            pool_timeout=self.db_config.pool_timeout,
+            pool_recycle=self.db_config.pool_recycle,
+            pool_pre_ping=True,
+            echo=False,  # Set to True for SQL debugging
+        )
+        
+        # Create session factory
+        self.SessionLocal = sessionmaker(
+            autocommit=False,
+            autoflush=False,
+            bind=self.engine
+        )
+        
+        logger.info("Database engine initialized with connection pooling")
+    
+    def create_tables(self) -> None:
+        """Create all database tables."""
+        try:
+            Base.metadata.create_all(bind=self.engine)
+            logger.info("Database tables created successfully")
+        except SQLAlchemyError as e:
+            logger.error("Failed to create database tables: %s", e)
+            raise
+    
+    def get_session(self) -> Session:
+        """Get a database session."""
+        return self.SessionLocal()
+    
+    def test_connection(self) -> bool:
+        """Test database connection."""
+        try:
+            with self.get_session() as session:
+                session.execute(text("SELECT 1"))
+                logger.info("Database connection test successful")
+                return True
+        except SQLAlchemyError as e:
+            logger.error("Database connection test failed: %s", e)
+            return False
+
+
+class ConversationPersistenceService:
+    """Service for conversation persistence operations."""
+    
+    def __init__(self, db_service: DatabaseService):
+        """Initialize conversation persistence service."""
+        self.db_service = db_service
+    
+    def create_conversation(
+        self,
+        conversation_id: uuid.UUID,
+        user_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        model_id: str,
+        system_prompt: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> Conversation:
+        """Create a new conversation."""
+        try:
+            with self.db_service.get_session() as session:
+                conversation = Conversation(
+                    conversation_id=conversation_id,
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    model_id=model_id,
+                    system_prompt=system_prompt,
+                    metadata=metadata,
+                )
+                session.add(conversation)
+                session.commit()
+                session.refresh(conversation)
+                logger.info("Created conversation %s", conversation_id)
+                return conversation
+        except IntegrityError as e:
+            logger.error("Failed to create conversation %s: %s", conversation_id, e)
+            raise
+        except SQLAlchemyError as e:
+            logger.error("Database error creating conversation %s: %s", conversation_id, e)
+            raise
+    
+    def get_conversation(self, conversation_id: uuid.UUID) -> Optional[Conversation]:
+        """Get conversation by ID."""
+        try:
+            with self.db_service.get_session() as session:
+                conversation = session.query(Conversation).filter(
+                    Conversation.conversation_id == conversation_id
+                ).first()
+                return conversation
+        except SQLAlchemyError as e:
+            logger.error("Database error getting conversation %s: %s", conversation_id, e)
+            raise
+    
+    def get_conversations_by_user(self, user_id: uuid.UUID, limit: int = 100) -> List[Conversation]:
+        """Get conversations for a user."""
+        try:
+            with self.db_service.get_session() as session:
+                conversations = session.query(Conversation).filter(
+                    Conversation.user_id == user_id,
+                    Conversation.status == "active"
+                ).order_by(Conversation.updated_at.desc()).limit(limit).all()
+                return conversations
+        except SQLAlchemyError as e:
+            logger.error("Database error getting conversations for user %s: %s", user_id, e)
+            raise
+    
+    def update_conversation(
+        self,
+        conversation_id: uuid.UUID,
+        **kwargs: Any,
+    ) -> Optional[Conversation]:
+        """Update conversation."""
+        try:
+            with self.db_service.get_session() as session:
+                conversation = session.query(Conversation).filter(
+                    Conversation.conversation_id == conversation_id
+                ).first()
+                
+                if not conversation:
+                    return None
+                
+                for key, value in kwargs.items():
+                    if hasattr(conversation, key):
+                        setattr(conversation, key, value)
+                
+                conversation.updated_at = datetime.now(UTC)
+                session.commit()
+                session.refresh(conversation)
+                logger.info("Updated conversation %s", conversation_id)
+                return conversation
+        except SQLAlchemyError as e:
+            logger.error("Database error updating conversation %s: %s", conversation_id, e)
+            raise
+    
+    def delete_conversation(self, conversation_id: uuid.UUID) -> bool:
+        """Delete conversation (soft delete by setting status to deleted)."""
+        try:
+            with self.db_service.get_session() as session:
+                conversation = session.query(Conversation).filter(
+                    Conversation.conversation_id == conversation_id
+                ).first()
+                
+                if not conversation:
+                    return False
+                
+                conversation.status = "deleted"
+                conversation.updated_at = datetime.now(UTC)
+                session.commit()
+                logger.info("Deleted conversation %s", conversation_id)
+                return True
+        except SQLAlchemyError as e:
+            logger.error("Database error deleting conversation %s: %s", conversation_id, e)
+            raise
+    
+    def add_conversation_turn(
+        self,
+        conversation_id: uuid.UUID,
+        turn_number: int,
+        input_messages: dict[str, Any],
+        output_message: Optional[dict[str, Any]] = None,
+        started_at: Optional[datetime] = None,
+        completed_at: Optional[datetime] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> ConversationTurn:
+        """Add a turn to a conversation."""
+        try:
+            with self.db_service.get_session() as session:
+                turn = ConversationTurn(
+                    conversation_id=conversation_id,
+                    turn_number=turn_number,
+                    input_messages=input_messages,
+                    output_message=output_message,
+                    started_at=started_at or datetime.now(UTC),
+                    completed_at=completed_at,
+                    metadata=metadata,
+                )
+                session.add(turn)
+                session.commit()
+                session.refresh(turn)
+                logger.info("Added turn %d to conversation %s", turn_number, conversation_id)
+                return turn
+        except IntegrityError as e:
+            logger.error("Failed to add turn %d to conversation %s: %s", turn_number, conversation_id, e)
+            raise
+        except SQLAlchemyError as e:
+            logger.error("Database error adding turn to conversation %s: %s", conversation_id, e)
+            raise
+    
+    def get_conversation_turns(self, conversation_id: uuid.UUID) -> List[ConversationTurn]:
+        """Get all turns for a conversation."""
+        try:
+            with self.db_service.get_session() as session:
+                turns = session.query(ConversationTurn).filter(
+                    ConversationTurn.conversation_id == conversation_id
+                ).order_by(ConversationTurn.turn_number).all()
+                return turns
+        except SQLAlchemyError as e:
+            logger.error("Database error getting turns for conversation %s: %s", conversation_id, e)
+            raise
+
+
+class AgentStatePersistenceService:
+    """Service for agent state persistence operations."""
+    
+    def __init__(self, db_service: DatabaseService):
+        """Initialize agent state persistence service."""
+        self.db_service = db_service
+    
+    def save_agent_state(
+        self,
+        agent_id: uuid.UUID,
+        conversation_id: uuid.UUID,
+        agent_config: dict[str, Any],
+        current_state: Optional[dict[str, Any]] = None,
+    ) -> AgentState:
+        """Save agent state."""
+        try:
+            with self.db_service.get_session() as session:
+                # Check if agent state already exists
+                existing_state = session.query(AgentState).filter(
+                    AgentState.agent_id == agent_id
+                ).first()
+                
+                if existing_state:
+                    # Update existing state
+                    existing_state.agent_config = agent_config
+                    existing_state.current_state = current_state
+                    existing_state.updated_at = datetime.now(UTC)
+                    session.commit()
+                    session.refresh(existing_state)
+                    logger.info("Updated agent state for agent %s", agent_id)
+                    return existing_state
+                else:
+                    # Create new state
+                    agent_state = AgentState(
+                        agent_id=agent_id,
+                        conversation_id=conversation_id,
+                        agent_config=agent_config,
+                        current_state=current_state,
+                    )
+                    session.add(agent_state)
+                    session.commit()
+                    session.refresh(agent_state)
+                    logger.info("Created agent state for agent %s", agent_id)
+                    return agent_state
+        except SQLAlchemyError as e:
+            logger.error("Database error saving agent state for agent %s: %s", agent_id, e)
+            raise
+    
+    def get_agent_state(self, agent_id: uuid.UUID) -> Optional[AgentState]:
+        """Get agent state by agent ID."""
+        try:
+            with self.db_service.get_session() as session:
+                agent_state = session.query(AgentState).filter(
+                    AgentState.agent_id == agent_id
+                ).first()
+                return agent_state
+        except SQLAlchemyError as e:
+            logger.error("Database error getting agent state for agent %s: %s", agent_id, e)
+            raise
+    
+    def get_agent_state_by_conversation(self, conversation_id: uuid.UUID) -> Optional[AgentState]:
+        """Get agent state by conversation ID."""
+        try:
+            with self.db_service.get_session() as session:
+                agent_state = session.query(AgentState).filter(
+                    AgentState.conversation_id == conversation_id
+                ).first()
+                return agent_state
+        except SQLAlchemyError as e:
+            logger.error("Database error getting agent state for conversation %s: %s", conversation_id, e)
+            raise
+    
+    def delete_agent_state(self, agent_id: uuid.UUID) -> bool:
+        """Delete agent state."""
+        try:
+            with self.db_service.get_session() as session:
+                agent_state = session.query(AgentState).filter(
+                    AgentState.agent_id == agent_id
+                ).first()
+                
+                if not agent_state:
+                    return False
+                
+                session.delete(agent_state)
+                session.commit()
+                logger.info("Deleted agent state for agent %s", agent_id)
+                return True
+        except SQLAlchemyError as e:
+            logger.error("Database error deleting agent state for agent %s: %s", agent_id, e)
+            raise
+
+
+class PersistenceManager:
+    """Main persistence manager that coordinates all persistence operations."""
+    
+    def __init__(self, persistence_config: PersistenceConfiguration):
+        """Initialize persistence manager."""
+        self.config = persistence_config
+        
+        if persistence_config.type == "postgresql" and persistence_config.database:
+            self.db_service = DatabaseService(persistence_config.database)
+            self.conversation_service = ConversationPersistenceService(self.db_service)
+            self.agent_state_service = AgentStatePersistenceService(self.db_service)
+        else:
+            raise ValueError("PostgreSQL persistence is required but not configured")
+    
+    def initialize(self) -> None:
+        """Initialize the persistence layer."""
+        try:
+            # Test database connection
+            if not self.db_service.test_connection():
+                raise RuntimeError("Database connection test failed")
+            
+            # Create tables if they don't exist
+            self.db_service.create_tables()
+            
+            logger.info("Persistence layer initialized successfully")
+        except Exception as e:
+            logger.error("Failed to initialize persistence layer: %s", e)
+            raise
+    
+    def get_conversation_service(self) -> ConversationPersistenceService:
+        """Get conversation persistence service."""
+        return self.conversation_service
+    
+    def get_agent_state_service(self) -> AgentStatePersistenceService:
+        """Get agent state persistence service."""
+        return self.agent_state_service 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,322 @@
+"""Tests for persistence implementation."""
+
+import pytest
+import uuid
+from datetime import datetime, UTC
+from unittest.mock import Mock, patch
+
+from models.config import DatabaseConfiguration, PersistenceConfiguration
+from services.persistence import (
+    DatabaseService,
+    ConversationPersistenceService,
+    AgentStatePersistenceService,
+    PersistenceManager,
+)
+from models.persistence import Conversation, ConversationTurn, AgentState
+
+
+class TestDatabaseService:
+    """Test database service functionality."""
+
+    def test_database_service_initialization(self):
+        """Test database service initialization."""
+        db_config = DatabaseConfiguration(
+            host="localhost",
+            port=5432,
+            name="test_db",
+            username="test_user",
+            password="test_password",
+        )
+        
+        service = DatabaseService(db_config)
+        assert service.db_config == db_config
+        assert service.engine is not None
+        assert service.SessionLocal is not None
+
+    def test_connection_string_building(self):
+        """Test connection string building."""
+        db_config = DatabaseConfiguration(
+            host="localhost",
+            port=5432,
+            name="test_db",
+            username="test_user",
+            password="test_password",
+        )
+        
+        service = DatabaseService(db_config)
+        # The connection string should be built correctly
+        assert service.db_config.host == "localhost"
+        assert service.db_config.port == 5432
+
+
+class TestConversationPersistenceService:
+    """Test conversation persistence service functionality."""
+
+    @pytest.fixture
+    def mock_db_service(self):
+        """Create a mock database service."""
+        mock_service = Mock()
+        mock_service.get_session.return_value.__enter__.return_value = Mock()
+        mock_service.get_session.return_value.__exit__.return_value = None
+        return mock_service
+
+    @pytest.fixture
+    def conversation_service(self, mock_db_service):
+        """Create conversation service with mock database."""
+        return ConversationPersistenceService(mock_db_service)
+
+    def test_create_conversation(self, conversation_service, mock_db_service):
+        """Test conversation creation."""
+        conversation_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        agent_id = uuid.uuid4()
+        
+        # Mock the session
+        mock_session = Mock()
+        mock_db_service.get_session.return_value.__enter__.return_value = mock_session
+        
+        # Mock the conversation object
+        mock_conversation = Mock()
+        mock_conversation.conversation_id = conversation_id
+        mock_session.add.return_value = None
+        mock_session.commit.return_value = None
+        mock_session.refresh.return_value = None
+        
+        result = conversation_service.create_conversation(
+            conversation_id=conversation_id,
+            user_id=user_id,
+            agent_id=agent_id,
+            model_id="test-model",
+            system_prompt="Test prompt",
+        )
+        
+        assert result is not None
+        mock_session.add.assert_called_once()
+        mock_session.commit.assert_called_once()
+
+
+class TestAgentStatePersistenceService:
+    """Test agent state persistence service functionality."""
+
+    @pytest.fixture
+    def mock_db_service(self):
+        """Create a mock database service."""
+        mock_service = Mock()
+        mock_service.get_session.return_value.__enter__.return_value = Mock()
+        mock_service.get_session.return_value.__exit__.return_value = None
+        return mock_service
+
+    @pytest.fixture
+    def agent_state_service(self, mock_db_service):
+        """Create agent state service with mock database."""
+        return AgentStatePersistenceService(mock_db_service)
+
+    def test_save_agent_state(self, agent_state_service, mock_db_service):
+        """Test agent state saving."""
+        agent_id = uuid.uuid4()
+        conversation_id = uuid.uuid4()
+        
+        # Mock the session
+        mock_session = Mock()
+        mock_db_service.get_session.return_value.__enter__.return_value = mock_session
+        
+        # Mock query result (no existing state)
+        mock_session.query.return_value.filter.return_value.first.return_value = None
+        
+        # Mock the agent state object
+        mock_agent_state = Mock()
+        mock_agent_state.agent_id = agent_id
+        mock_session.add.return_value = None
+        mock_session.commit.return_value = None
+        mock_session.refresh.return_value = None
+        
+        result = agent_state_service.save_agent_state(
+            agent_id=agent_id,
+            conversation_id=conversation_id,
+            agent_config={"model_id": "test-model"},
+            current_state={"status": "active"},
+        )
+        
+        assert result is not None
+        mock_session.add.assert_called_once()
+        mock_session.commit.assert_called_once()
+
+
+class TestPersistenceManager:
+    """Test persistence manager functionality."""
+
+    def test_persistence_manager_initialization(self):
+        """Test persistence manager initialization."""
+        config = PersistenceConfiguration(
+            type="postgresql",
+            database=DatabaseConfiguration(
+                host="localhost",
+                port=5432,
+                name="test_db",
+                username="test_user",
+                password="test_password",
+            )
+        )
+        
+        manager = PersistenceManager(config)
+        assert manager.config == config
+        assert manager.db_service is not None
+        assert manager.conversation_service is not None
+        assert manager.agent_state_service is not None
+
+    def test_persistence_manager_invalid_type(self):
+        """Test persistence manager with invalid type."""
+        config = PersistenceConfiguration(
+            type="invalid_type",
+            database=DatabaseConfiguration(
+                host="localhost",
+                port=5432,
+                name="test_db",
+                username="test_user",
+                password="test_password",
+            )
+        )
+        
+        with pytest.raises(ValueError, match="Unsupported persistence type"):
+            PersistenceManager(config)
+
+    def test_persistence_manager_missing_database(self):
+        """Test persistence manager with missing database config."""
+        config = PersistenceConfiguration(
+            type="postgresql",
+            database=None,
+        )
+        
+        with pytest.raises(ValueError, match="Database configuration is required"):
+            PersistenceManager(config)
+
+
+class TestDatabaseModels:
+    """Test database model definitions."""
+
+    def test_conversation_model(self):
+        """Test conversation model structure."""
+        conversation = Conversation(
+            conversation_id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            agent_id=uuid.uuid4(),
+            model_id="test-model",
+            system_prompt="Test prompt",
+            status="active",
+        )
+        
+        assert conversation.conversation_id is not None
+        assert conversation.user_id is not None
+        assert conversation.agent_id is not None
+        assert conversation.model_id == "test-model"
+        assert conversation.system_prompt == "Test prompt"
+        assert conversation.status == "active"
+
+    def test_conversation_turn_model(self):
+        """Test conversation turn model structure."""
+        turn = ConversationTurn(
+            conversation_id=uuid.uuid4(),
+            turn_number=1,
+            input_messages=[{"role": "user", "content": "Hello"}],
+            output_message={"role": "assistant", "content": "Hi there!"},
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+        )
+        
+        assert turn.conversation_id is not None
+        assert turn.turn_number == 1
+        assert len(turn.input_messages) == 1
+        assert turn.output_message is not None
+        assert turn.started_at is not None
+        assert turn.completed_at is not None
+
+    def test_agent_state_model(self):
+        """Test agent state model structure."""
+        agent_state = AgentState(
+            agent_id=uuid.uuid4(),
+            conversation_id=uuid.uuid4(),
+            agent_config={"model_id": "test-model", "system_prompt": "Test"},
+            current_state={"status": "active"},
+        )
+        
+        assert agent_state.agent_id is not None
+        assert agent_state.conversation_id is not None
+        assert agent_state.agent_config is not None
+        assert agent_state.current_state is not None
+
+
+class TestConfigurationValidation:
+    """Test configuration validation."""
+
+    def test_valid_database_configuration(self):
+        """Test valid database configuration."""
+        config = DatabaseConfiguration(
+            host="localhost",
+            port=5432,
+            name="test_db",
+            username="test_user",
+            password="test_password",
+            pool_size=20,
+            max_overflow=30,
+        )
+        
+        assert config.host == "localhost"
+        assert config.port == 5432
+        assert config.pool_size == 20
+        assert config.max_overflow == 30
+
+    def test_invalid_port(self):
+        """Test invalid port configuration."""
+        with pytest.raises(ValueError, match="Port value should be between 1 and 65535"):
+            DatabaseConfiguration(
+                host="localhost",
+                port=70000,  # Invalid port
+                name="test_db",
+                username="test_user",
+            )
+
+    def test_invalid_pool_size(self):
+        """Test invalid pool size configuration."""
+        with pytest.raises(ValueError, match="Pool size must be at least 1"):
+            DatabaseConfiguration(
+                host="localhost",
+                port=5432,
+                name="test_db",
+                username="test_user",
+                pool_size=0,  # Invalid pool size
+            )
+
+    def test_valid_persistence_configuration(self):
+        """Test valid persistence configuration."""
+        config = PersistenceConfiguration(
+            type="postgresql",
+            database=DatabaseConfiguration(
+                host="localhost",
+                port=5432,
+                name="test_db",
+                username="test_user",
+            ),
+            agent_cache_max_size=1000,
+            agent_cache_ttl_seconds=3600,
+            enable_rehydration=True,
+            conversation_retention_days=90,
+        )
+        
+        assert config.type == "postgresql"
+        assert config.agent_cache_max_size == 1000
+        assert config.agent_cache_ttl_seconds == 3600
+        assert config.enable_rehydration is True
+        assert config.conversation_retention_days == 90
+
+    def test_invalid_persistence_type(self):
+        """Test invalid persistence type."""
+        with pytest.raises(ValueError, match="Unsupported persistence type"):
+            PersistenceConfiguration(
+                type="invalid_type",
+                database=DatabaseConfiguration(
+                    host="localhost",
+                    port=5432,
+                    name="test_db",
+                    username="test_user",
+                ),
+            ) 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/MGMT-21299

This PR adds implementation of persistent conversation storage for Lightspeed Core Stack (LCS), replacing the in-memory conversation mapping with PostgreSQL-based persistence.

## Overview

The persistence implementation provides:
- **Persistent conversation storage** in PostgreSQL
- **Agent state persistence** for rehydration
- **Multi-replica support** through shared database
- **Automatic conversation history** tracking
- **Configurable retention policies**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced persistent conversation storage using PostgreSQL, enabling conversations and agent states to be saved and restored across sessions.
  * Added support for multi-replica deployments with shared database access and connection pooling.
  * Provided configuration options for persistence, including database settings, caching, retention, and archival.

* **Documentation**
  * Updated and expanded documentation to cover setup, configuration, migration, usage, monitoring, troubleshooting, and security for the new persistence layer.

* **Bug Fixes**
  * Improved error handling and logging for persistence-related operations.

* **Tests**
  * Added comprehensive unit tests for the persistence layer and configuration validation.

* **Chores**
  * Added new dependencies for database integration and migrations (SQLAlchemy, psycopg2-binary, Alembic).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->