### PR TITLE
LCORE-380: Lock Llama-stack to version 0.2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "fastapi>=0.115.6",
     "uvicorn>=0.34.3",
     "kubernetes>=30.1.0",
-    "llama-stack>=0.2.13",
+    "llama-stack==0.2.14",
     "rich>=14.0.0",
     "cachetools>=6.1.0",
     "prometheus-client>=0.22.1",

--- a/uv.lock
+++ b/uv.lock
@@ -899,7 +899,7 @@ requires-dist = [
     { name = "cachetools", specifier = ">=6.1.0" },
     { name = "fastapi", specifier = ">=0.115.6" },
     { name = "kubernetes", specifier = ">=30.1.0" },
-    { name = "llama-stack", specifier = ">=0.2.13" },
+    { name = "llama-stack", specifier = "==0.2.14" },
     { name = "prometheus-client", specifier = ">=0.22.1" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "starlette", specifier = ">=0.47.1" },


### PR DESCRIPTION
## Description

LCORE-380: Lock Llama-stack to version 0.2.14

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-380


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version requirement for a core dependency to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->