### PR TITLE
Replace json.loads with ast.literal_eval

### DIFF
--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -1,9 +1,9 @@
 """Handler for REST API call to provide answer to streaming query."""
 
+import ast
 import json
-import logging
 import re
-from json import JSONDecodeError
+import logging
 from typing import Any, AsyncIterator, Iterator
 
 from cachetools import TTLCache  # type: ignore
@@ -362,12 +362,12 @@ def _handle_tool_execution_event(
                                 summary = summary[:newline_pos]
                         for match in METADATA_PATTERN.findall(text_content_item.text):
                             try:
-                                meta = json.loads(match.replace("'", '"'))
+                                meta = ast.literal_eval(match)
                                 if "document_id" in meta:
                                     metadata_map[meta["document_id"]] = meta
-                            except JSONDecodeError:
+                            except Exception:  # pylint: disable=broad-except
                                 logger.debug(
-                                    "JSONDecodeError was thrown in processing %s",
+                                    "An exception was thrown in processing %s",
                                     match,
                                 )
 

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -55,11 +55,13 @@ BEGIN of knowledge_search tool results.
 """,
     """Result 1
 Content: ABC
-Metadata: {'docs_url': 'https://example.com/doc1', 'title': 'Doc1', 'document_id': 'doc-1'}
+Metadata: {'docs_url': 'https://example.com/doc1', 'title': 'Doc1', 'document_id': 'doc-1', \
+'source': None}
 """,
     """Result 2
 Content: ABC
-Metadata: {'docs_url': 'https://example.com/doc2', 'title': 'Doc2', 'document_id': 'doc-2'}
+Metadata: {'docs_url': 'https://example.com/doc2', 'title': 'Doc2', 'document_id': 'doc-2', \
+'source': None}
 """,
     """END of knowledge_search tool results.
 """,
@@ -67,7 +69,8 @@ Metadata: {'docs_url': 'https://example.com/doc2', 'title': 'Doc2', 'document_id
     # and it is not picked as a referenced document.
     """Result 3
 Content: ABC
-Metadata: {'docs_url': 'https://example.com/doc3', 'Title': 'Doc3', 'document_id': 'doc-3'}
+Metadata: {'docs_url': 'https://example.com/doc3', 'Title': 'Doc3', 'document_id': 'doc-3', \
+'source': None}
 """,
     """The above results were retrieved to help answer the user\'s query: "Sample Query".
 Use them as supporting information only in answering this query.


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
**This was found an issue while testing with llama-stack 0.2.16.**

The logic for supporting referenced documents in streaming mode (#183) had an issue.  When an empty metadata is included, the knowledge search log includes strings like:
```
'source': None,
```
the logic attempts to convert this to JSON syntax by replacing double quotes to single ones, but
```
"source": None,
```
is not correct in JSON syntax (`None` should be replaced with `null`).

I will resolve this issue by using `ast.literal_eval()` instead of `json.loads()`, which is currently used.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of metadata parsing in streaming queries to reduce errors and enhance reliability.

* **Tests**
  * Updated test data for knowledge search results to include an additional metadata field for more comprehensive coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->