### PR TITLE
adds optional no_tools parameter on /query to skip all tool calling

### DIFF
--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -58,6 +58,7 @@ async def get_agent(
     available_input_shields: list[str],
     available_output_shields: list[str],
     conversation_id: str | None,
+    no_tools: bool = False,
 ) -> tuple[AsyncAgent, str]:
     """Get existing agent or create a new one with session persistence."""
     if conversation_id is not None:
@@ -76,7 +77,7 @@ async def get_agent(
         instructions=system_prompt,
         input_shields=available_input_shields if available_input_shields else [],
         output_shields=available_output_shields if available_output_shields else [],
-        tool_parser=GraniteToolParser.get_parser(model_id),
+        tool_parser=None if no_tools else GraniteToolParser.get_parser(model_id),
         enable_session_persistence=True,
     )
     conversation_id = await agent.create_session(get_suid())
@@ -532,41 +533,53 @@ async def retrieve_response(
         available_input_shields,
         available_output_shields,
         query_request.conversation_id,
+        query_request.no_tools or False,
     )
 
-    # preserve compatibility when mcp_headers is not provided
-    if mcp_headers is None:
+    # bypass tools and MCP servers if no_tools is True
+    if query_request.no_tools:
         mcp_headers = {}
+        agent.extra_headers = {}
+        toolgroups = None
+    else:
+        # preserve compatibility when mcp_headers is not provided
+        if mcp_headers is None:
+            mcp_headers = {}
 
-    mcp_headers = handle_mcp_headers_with_toolgroups(mcp_headers, configuration)
+        mcp_headers = handle_mcp_headers_with_toolgroups(mcp_headers, configuration)
 
-    if not mcp_headers and token:
-        for mcp_server in configuration.mcp_servers:
-            mcp_headers[mcp_server.url] = {
-                "Authorization": f"Bearer {token}",
-            }
+        if not mcp_headers and token:
+            for mcp_server in configuration.mcp_servers:
+                mcp_headers[mcp_server.url] = {
+                    "Authorization": f"Bearer {token}",
+                }
 
-    agent.extra_headers = {
-        "X-LlamaStack-Provider-Data": json.dumps(
-            {
-                "mcp_headers": mcp_headers,
-            }
-        ),
-    }
+        agent.extra_headers = {
+            "X-LlamaStack-Provider-Data": json.dumps(
+                {
+                    "mcp_headers": mcp_headers,
+                }
+            ),
+        }
+
+        logger.debug("Session ID: %s", conversation_id)
+        vector_db_ids = [
+            vector_db.identifier for vector_db in await client.vector_dbs.list()
+        ]
+        toolgroups = (get_rag_toolgroups(vector_db_ids) or []) + [
+            mcp_server.name for mcp_server in configuration.mcp_servers
+        ]
+        # Convert empty list to None for consistency with existing behavior
+        if not toolgroups:
+            toolgroups = None
 
     logger.debug("Session ID: %s", conversation_id)
-    vector_db_ids = [
-        vector_db.identifier for vector_db in await client.vector_dbs.list()
-    ]
-    toolgroups = (get_rag_toolgroups(vector_db_ids) or []) + [
-        mcp_server.name for mcp_server in configuration.mcp_servers
-    ]
     response = await agent.create_turn(
         messages=[UserMessage(role="user", content=query_request.query)],
         session_id=conversation_id,
         documents=query_request.get_documents(),
         stream=True,
-        toolgroups=toolgroups or None,
+        toolgroups=toolgroups,
     )
 
     return response, conversation_id

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -69,6 +69,7 @@ class QueryRequest(BaseModel):
         model: The optional model.
         system_prompt: The optional system prompt.
         attachments: The optional attachments.
+        no_tools: Whether to bypass all tools and MCP servers (default: False).
 
     Example:
         ```python
@@ -82,6 +83,7 @@ class QueryRequest(BaseModel):
     model: Optional[str] = None
     system_prompt: Optional[str] = None
     attachments: Optional[list[Attachment]] = None
+    no_tools: Optional[bool] = False
     # media_type is not used in 'lightspeed-stack' that only supports application/json.
     # the field is kept here to enable compatibility with 'road-core' clients.
     media_type: Optional[str] = None
@@ -97,6 +99,7 @@ class QueryRequest(BaseModel):
                     "provider": "openai",
                     "model": "model-name",
                     "system_prompt": "You are a helpful assistant",
+                    "no_tools": False,
                     "attachments": [
                         {
                             "attachment_type": "log",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents
There were no related issues or anything. This was just randomly discussed in Slack so I decided to give it a whirl.

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
There are tests that were written to validate that the parameter (or its absence) works, and the existing tests still work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new option to disable all tools and MCP server integration for both standard and streaming query endpoints by setting a `no_tools` flag in requests.

* **Bug Fixes**
  * Improved default handling to ensure backward compatibility when the new option is not specified.

* **Tests**
  * Added comprehensive tests to verify correct behavior when the new option is enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->