### PR TITLE
LCORE-446: Use uv tool to build and upload distribution archives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,10 +81,10 @@ verify: ## Run all linters
 
 distribution-archives: ## Generate distribution archives to be uploaded into Python registry
 	rm -rf dist
-	pdm run python -m build
+	uv run python -m build
 
 upload-distribution-archives: ## Upload distribution archives into Python registry
-	pdm run python -m twine upload --repository ${PYTHON_REGISTRY} dist/*
+	uv run python -m twine upload --repository ${PYTHON_REGISTRY} dist/*
 
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'


### PR DESCRIPTION
## Description

LCORE-446: Use `uv` tool to build and upload distribution archives

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-446


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and upload commands to use a new tool for running Python scripts during distribution and upload processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->