### PR TITLE
Fixes llama-stack model-id

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -216,10 +216,12 @@ def select_model_and_provider_id(
                 },
             ) from e
 
+    llama_stack_model_id = f"{provider_id}/{model_id}"
     # Validate that the model_id and provider_id are in the available models
     logger.debug("Searching for model: %s, provider: %s", model_id, provider_id)
     if not any(
-        m.identifier == model_id and m.provider_id == provider_id for m in models
+        m.identifier == llama_stack_model_id and m.provider_id == provider_id
+        for m in models
     ):
         message = f"Model {model_id} from provider {provider_id} not found in available models"
         logger.error(message)
@@ -231,7 +233,7 @@ def select_model_and_provider_id(
             },
         )
 
-    return model_id, provider_id
+    return llama_stack_model_id, provider_id
 
 
 def _is_inout_shield(shield: Shield) -> bool:

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -191,10 +191,16 @@ def test_select_model_and_provider_id_from_request(mocker):
     )
 
     model_list = [
-        mocker.Mock(identifier="model1", model_type="llm", provider_id="provider1"),
-        mocker.Mock(identifier="model2", model_type="llm", provider_id="provider2"),
         mocker.Mock(
-            identifier="default_model", model_type="llm", provider_id="default_provider"
+            identifier="provider1/model1", model_type="llm", provider_id="provider1"
+        ),
+        mocker.Mock(
+            identifier="provider2/model2", model_type="llm", provider_id="provider2"
+        ),
+        mocker.Mock(
+            identifier="default_provider/default_model",
+            model_type="llm",
+            provider_id="default_provider",
         ),
     ]
 
@@ -206,7 +212,7 @@ def test_select_model_and_provider_id_from_request(mocker):
     # Assert the model and provider from request take precedence from the configuration one
     model_id, provider_id = select_model_and_provider_id(model_list, query_request)
 
-    assert model_id == "model2"
+    assert model_id == "provider2/model2"
     assert provider_id == "provider2"
 
 
@@ -222,9 +228,13 @@ def test_select_model_and_provider_id_from_configuration(mocker):
     )
 
     model_list = [
-        mocker.Mock(identifier="model1", model_type="llm", provider_id="provider1"),
         mocker.Mock(
-            identifier="default_model", model_type="llm", provider_id="default_provider"
+            identifier="provider1/model1", model_type="llm", provider_id="provider1"
+        ),
+        mocker.Mock(
+            identifier="default_provider/default_model",
+            model_type="llm",
+            provider_id="default_provider",
         ),
     ]
 
@@ -236,7 +246,7 @@ def test_select_model_and_provider_id_from_configuration(mocker):
     model_id, provider_id = select_model_and_provider_id(model_list, query_request)
 
     # Assert that the default model and provider from the configuration are returned
-    assert model_id == "default_model"
+    assert model_id == "default_provider/default_model"
     assert provider_id == "default_provider"
 
 


### PR DESCRIPTION

## Description
Fixes llama-stack model-id introduced with version 0.2.16, This allows lightspeed-stack to preserve its interface and any configuration and clients to remain compatible.

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [X] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection and validation by using fully qualified model identifiers combining provider and model names.

* **Tests**
  * Updated tests to verify the use of fully qualified model identifiers in model selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->