### PR TITLE
Delay setup_model_metrics() until /metrics is called

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,7 +19,7 @@ RUN pip3.12 install uv
 COPY ${LSC_SOURCE_DIR}/src ./src
 COPY ${LSC_SOURCE_DIR}/pyproject.toml ${LSC_SOURCE_DIR}/LICENSE ${LSC_SOURCE_DIR}/README.md ${LSC_SOURCE_DIR}/uv.lock ./
 
-RUN uv sync --locked --no-install-project --no-dev
+RUN uv sync --locked --no-dev
 
 
 # Final image without uv package manager

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,9 @@ services:
       - lightspeednet
 
   lightspeed-stack:
-    image: quay.io/lightspeed-core/lightspeed-stack:latest
+    build:
+      context: .
+      dockerfile: Containerfile
     container_name: lightspeed-stack
     ports:
       - "8080:8080"

--- a/src/app/endpoints/metrics.py
+++ b/src/app/endpoints/metrics.py
@@ -7,10 +7,15 @@ from prometheus_client import (
     CONTENT_TYPE_LATEST,
 )
 
+from metrics.utils import setup_model_metrics
+
 router = APIRouter(tags=["metrics"])
 
 
 @router.get("/metrics", response_class=PlainTextResponse)
-def metrics_endpoint_handler(_request: Request) -> PlainTextResponse:
+async def metrics_endpoint_handler(_request: Request) -> PlainTextResponse:
     """Handle request to the /metrics endpoint."""
+    # Setup the model metrics if not already done. This is a one-time setup
+    # and will not be run again on subsequent calls to this endpoint
+    await setup_model_metrics()
     return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -10,7 +10,6 @@ from app import routers
 from configuration import configuration
 from log import get_logger
 import metrics
-from metrics.utils import setup_model_metrics
 from utils.common import register_mcp_servers_async
 import version
 
@@ -81,6 +80,4 @@ async def startup_event() -> None:
     logger.info("Registering MCP servers")
     await register_mcp_servers_async(logger, configuration.configuration)
     get_logger("app.endpoints.handlers")
-    logger.info("Setting up model metrics")
-    await setup_model_metrics()
     logger.info("App startup complete")

--- a/src/metrics/utils.py
+++ b/src/metrics/utils.py
@@ -4,12 +4,15 @@ from configuration import configuration
 from client import LlamaStackClientHolder, AsyncLlamaStackClientHolder
 from log import get_logger
 import metrics
+from utils.common import run_once_async
 
 logger = get_logger(__name__)
 
 
+@run_once_async
 async def setup_model_metrics() -> None:
     """Perform setup of all metrics related to LLM model and provider."""
+    logger.info("Setting up model metrics")
     model_list = []
     if configuration.llama_stack_configuration.use_as_library_client:
         model_list = await AsyncLlamaStackClientHolder().get_client().models.list()
@@ -48,3 +51,4 @@ async def setup_model_metrics() -> None:
                 model_name,
                 default_model_value,
             )
+    logger.info("Model metrics setup complete")

--- a/test.containerfile
+++ b/test.containerfile
@@ -17,7 +17,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 RUN uv -h
 
 RUN uv venv && \
-    uv pip install llama-stack \
+    uv pip install llama-stack==0.2.16 \
     fastapi \
     opentelemetry-sdk \
     opentelemetry-exporter-otlp \

--- a/tests/e2e/features/rest_api.feature
+++ b/tests/e2e/features/rest_api.feature
@@ -10,7 +10,7 @@ Feature: REST API tests
 
   Scenario: Check if service report proper readiness state
     Given the system is in default state
-     When I access REST API endpoint "readiness" using HTTP GET method
+     When I access endpoint "readiness" using HTTP GET method
      Then The status code of the response is 200
       And The body of the response has the following schema
           """
@@ -28,7 +28,7 @@ Feature: REST API tests
 
   Scenario: Check if service report proper liveness state
     Given the system is in default state
-     When I access REST API endpoint "liveness" using HTTP GET method
+     When I access endpoint "liveness" using HTTP GET method
      Then The status code of the response is 200
       And The body of the response has the following schema
           """

--- a/tests/unit/app/endpoints/test_metrics.py
+++ b/tests/unit/app/endpoints/test_metrics.py
@@ -3,15 +3,20 @@
 from app.endpoints.metrics import metrics_endpoint_handler
 
 
-def test_metrics_endpoint():
+async def test_metrics_endpoint(mocker):
     """Test the metrics endpoint handler."""
-    response = metrics_endpoint_handler(None)
+    mock_setup_metrics = mocker.patch(
+        "app.endpoints.metrics.setup_model_metrics", return_value=None
+    )
+    response = await metrics_endpoint_handler(None)
     assert response is not None
     assert response.status_code == 200
     assert "text/plain" in response.headers["Content-Type"]
 
     response_body = response.body.decode()
 
+    # Assert metrics were set up
+    mock_setup_metrics.assert_called_once()
     # Check if the response contains Prometheus metrics format
     assert "# TYPE ls_rest_api_calls_total counter" in response_body
     assert "# TYPE ls_response_duration_seconds histogram" in response_body


### PR DESCRIPTION
## Description

This patch moves the setup_model_metrics() from the service startup to the first time the /metrics endpoint is called. This speed up the lightspeed-stack service initialization and also make lightspeed-stack more resilient regarding service initialization order because it no longer requires llama-stack to be started first (as setup_model_metrics() tries to connect to llama-stack and fetch the list of models from it).

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reliability of metrics setup by ensuring model metrics are initialized only once before serving metrics data.
  * Updated container and deployment configuration to build the application image locally for streamlined development.

* **Bug Fixes**
  * Enhanced the `/metrics` endpoint to handle setup asynchronously, preventing redundant or repeated setup calls.

* **Tests**
  * Updated tests for the metrics endpoint to support asynchronous execution and verify correct setup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->