### PR TITLE
Run GH workflows on pull_request main branch only

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -1,8 +1,9 @@
 name: Bandit security scanner
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   bandit:

--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,8 +1,9 @@
 name: Black
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   black:

--- a/.github/workflows/check_dependencies.yaml
+++ b/.github/workflows/check_dependencies.yaml
@@ -1,8 +1,9 @@
 name: Check dependencies
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   check_dependencies:

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,8 +1,9 @@
 name: Integration tests
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   integration_tests:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,8 +1,9 @@
 name: Type checks
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   mypy:

--- a/.github/workflows/outdated_dependencies.yaml
+++ b/.github/workflows/outdated_dependencies.yaml
@@ -1,8 +1,9 @@
 name: List outdated dependencies
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   list_outdated_dependencies:

--- a/.github/workflows/pydocstyle.yaml
+++ b/.github/workflows/pydocstyle.yaml
@@ -1,8 +1,9 @@
 name: Pydocstyle
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   pydocstyle:

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -1,8 +1,9 @@
 name: Python linter
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   pylint:

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -1,8 +1,9 @@
 name: Pyright
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   pyright:

--- a/.github/workflows/radon.yaml
+++ b/.github/workflows/radon.yaml
@@ -1,8 +1,9 @@
 name: Radon
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   radon:

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,8 +1,9 @@
 name: Ruff
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   ruff:

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,8 +1,9 @@
 name: Shell check
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   shellcheck:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,8 +1,9 @@
 name: Unit tests
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - main
 
 jobs:
   unit_tests:


### PR DESCRIPTION
## Description

This changes the linters, unit-tests and integration-tests to run the GH workflows on pull_request, main branch only because that's all that matters.

I hope and pray we are not pushing things directly into the branches without a PR.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [x] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configurations so that automated checks now run only on pull requests targeting the "main" branch. Workflows will no longer run on push events or on pull requests to other branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->