### PR TITLE
Use AsyncLlamaStackClientHolder for /readiness endpoint.

### DIFF
--- a/src/app/endpoints/health.py
+++ b/src/app/endpoints/health.py
@@ -11,7 +11,7 @@ from typing import Any
 from llama_stack.providers.datatypes import HealthStatus
 
 from fastapi import APIRouter, status, Response
-from client import LlamaStackClientHolder
+from client import AsyncLlamaStackClientHolder
 from models.responses import (
     LivenessResponse,
     ReadinessResponse,
@@ -22,16 +22,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["health"])
 
 
-def get_providers_health_statuses() -> list[ProviderHealthStatus]:
+async def get_providers_health_statuses() -> list[ProviderHealthStatus]:
     """Check health of all providers.
 
     Returns:
         List of provider health statuses.
     """
     try:
-        client = LlamaStackClientHolder().get_client()
+        client = AsyncLlamaStackClientHolder().get_client()
 
-        providers = client.providers.list()
+        # providers = []
+        providers = await client.providers.list()
         logger.debug("Found %d providers", len(providers))
 
         health_results = [
@@ -69,9 +70,9 @@ get_readiness_responses: dict[int | str, dict[str, Any]] = {
 
 
 @router.get("/readiness", responses=get_readiness_responses)
-def readiness_probe_get_method(response: Response) -> ReadinessResponse:
+async def readiness_probe_get_method(response: Response) -> ReadinessResponse:
     """Ready status of service with provider health details."""
-    provider_statuses = get_providers_health_statuses()
+    provider_statuses = await get_providers_health_statuses()
 
     # Check if any provider is unhealthy (not counting not_implemented as unhealthy)
     unhealthy_providers = [

--- a/tests/unit/app/endpoints/test_health.py
+++ b/tests/unit/app/endpoints/test_health.py
@@ -12,7 +12,7 @@ from app.endpoints.health import (
 from models.responses import ProviderHealthStatus, ReadinessResponse
 
 
-def test_readiness_probe_fails_due_to_unhealthy_providers(mocker):
+async def test_readiness_probe_fails_due_to_unhealthy_providers(mocker):
     """Test the readiness endpoint handler fails when providers are unhealthy."""
     # Mock get_providers_health_statuses to return an unhealthy provider
     mock_get_providers_health_statuses = mocker.patch(
@@ -29,7 +29,7 @@ def test_readiness_probe_fails_due_to_unhealthy_providers(mocker):
     # Mock the Response object
     mock_response = Mock()
 
-    response = readiness_probe_get_method(mock_response)
+    response = await readiness_probe_get_method(mock_response)
 
     assert response.ready is False
     assert "test_provider" in response.reason
@@ -37,7 +37,7 @@ def test_readiness_probe_fails_due_to_unhealthy_providers(mocker):
     assert mock_response.status_code == 503
 
 
-def test_readiness_probe_success_when_all_providers_healthy(mocker):
+async def test_readiness_probe_success_when_all_providers_healthy(mocker):
     """Test the readiness endpoint handler succeeds when all providers are healthy."""
     # Mock get_providers_health_statuses to return healthy providers
     mock_get_providers_health_statuses = mocker.patch(
@@ -59,7 +59,7 @@ def test_readiness_probe_success_when_all_providers_healthy(mocker):
     # Mock the Response object
     mock_response = Mock()
 
-    response = readiness_probe_get_method(mock_response)
+    response = await readiness_probe_get_method(mock_response)
     assert response is not None
     assert isinstance(response, ReadinessResponse)
     assert response.ready is True
@@ -98,13 +98,13 @@ class TestProviderHealthStatus:
 class TestGetProvidersHealthStatuses:
     """Test cases for the get_providers_health_statuses function."""
 
-    def test_get_providers_health_statuses(self, mocker):
+    async def test_get_providers_health_statuses(self, mocker):
         """Test get_providers_health_statuses with healthy providers."""
         # Mock the imports
-        mock_lsc = mocker.patch("client.LlamaStackClientHolder.get_client")
+        mock_lsc = mocker.patch("client.AsyncLlamaStackClientHolder.get_client")
 
         # Mock the client and its methods
-        mock_client = mocker.Mock()
+        mock_client = mocker.AsyncMock()
         mock_lsc.return_value = mock_client
 
         # Mock providers.list() to return providers with health
@@ -136,7 +136,7 @@ class TestGetProvidersHealthStatuses:
         ]
 
         # Mock configuration
-        result = get_providers_health_statuses()
+        result = await get_providers_health_statuses()
 
         assert len(result) == 3
         assert result[0].provider_id == "provider1"
@@ -149,15 +149,15 @@ class TestGetProvidersHealthStatuses:
         assert result[2].status == HealthStatus.ERROR.value
         assert result[2].message == "Connection failed"
 
-    def test_get_providers_health_statuses_connection_error(self, mocker):
+    async def test_get_providers_health_statuses_connection_error(self, mocker):
         """Test get_providers_health_statuses when connection fails."""
         # Mock the imports
-        mock_lsc = mocker.patch("client.LlamaStackClientHolder.get_client")
+        mock_lsc = mocker.patch("client.AsyncLlamaStackClientHolder.get_client")
 
         # Mock get_llama_stack_client to raise an exception
         mock_lsc.side_effect = Exception("Connection error")
 
-        result = get_providers_health_statuses()
+        result = await get_providers_health_statuses()
 
         assert len(result) == 1
         assert result[0].provider_id == "unknown"


### PR DESCRIPTION
## Description

When multiple successive requests to `/readiness` are made in quick succession the endpoint fails.
```
ERROR    2025-08-04 15:37:13,630 app.endpoints.health:49 uncategorized: Failed to check providers health: This event loop is already running          
INFO:     127.0.0.1:37980 - "GET /readiness HTTP/1.1" 503 Service Unavailable
/home/manstis/workspaces/github/manstis/forks/lightspeed-stack/src/app/endpoints/health.py:50: RuntimeWarning: coroutine 'AsyncLlamaStackAsLibraryClient.request' was never awaited
  return [
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```
It is plausible this is an issue with `llama-stack`'s `LlamaStackAsLibraryClient` class.

Whilst it appears to be synchronous it's internal implementation uses `AsyncLlamaStackAsLibraryClient`.

This PR contains a workaround by using `AsyncLlamaStackClientHolder()`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

The problem can be replicated with this code snippet:
```
import requests

url = "http://localhost:8080/readiness"

def call():
    result = requests.get(url)
    print(result.text)


def main():
    import threading
    threads = []
    for _ in range(10):
        t = threading.Thread(target=call)
        threads.append(t)
    for t in threads:
        t.start()
    for t in threads:
        t.join()


if __name__ == "__main__":
    main()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated health check endpoints to use asynchronous operations for improved responsiveness.

* **Tests**
  * Converted health endpoint tests to support asynchronous behavior, ensuring compatibility with async updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->