### PR TITLE
LCORE-336: Regenerate OpenAPI schema

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -397,11 +397,22 @@
                             }
                         },
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                        "session_data": {
-                            "session_id": "123e4567-e89b-12d3-a456-426614174000",
-                            "turns": [],
-                            "started_at": "2024-01-01T00:00:00Z"
-                        }
+                        "chat_history": [
+                            {
+                                "messages": [
+                                    {
+                                        "content": "Hi",
+                                        "type": "user"
+                                    },
+                                    {
+                                        "content": "Hello!",
+                                        "type": "assistant"
+                                    }
+                                ],
+                                "started_at": "2024-01-01T00:00:00Z",
+                                "completed_at": "2024-01-01T00:00:05Z"
+                            }
+                        ]
                     },
                     "404": {
                         "detail": {


### PR DESCRIPTION
## Description

LCORE-336: Regenerate OpenAPI schema

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API documentation for conversation details to replace the "session_data" object with a new "chat_history" array, providing a clearer representation of conversation history with message groups and timing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->