### PR TITLE
LCORE-487: Fix /conversations endpoint 

### DIFF
--- a/src/app/endpoints/conversations.py
+++ b/src/app/endpoints/conversations.py
@@ -134,7 +134,13 @@ async def get_conversation_endpoint_handler(
     try:
         client = AsyncLlamaStackClientHolder().get_client()
 
-        session_data = (await client.agents.session.list(agent_id=agent_id)).data[0]
+        agent_sessions = (await client.agents.session.list(agent_id=agent_id)).data
+        session_id = str(agent_sessions[0].get("session_id"))
+
+        session_response = await client.agents.session.retrieve(
+            agent_id=agent_id, session_id=session_id
+        )
+        session_data = session_response.model_dump()
 
         logger.info("Successfully retrieved conversation %s", conversation_id)
 

--- a/tests/unit/app/endpoints/test_conversations.py
+++ b/tests/unit/app/endpoints/test_conversations.py
@@ -305,6 +305,12 @@ class TestGetConversationEndpoint:
         mock_client.agents.session.list.return_value = mocker.Mock(
             data=[mock_session_data]
         )
+
+        # Mock session.retrieve to return an object with model_dump() method
+        mock_session_retrieve_result = mocker.Mock()
+        mock_session_retrieve_result.model_dump.return_value = mock_session_data
+        mock_client.agents.session.retrieve.return_value = mock_session_retrieve_result
+
         mock_client_holder = mocker.patch(
             "app.endpoints.conversations.AsyncLlamaStackClientHolder"
         )


### PR DESCRIPTION
## Description

The `/conversations` endpoint was returning an empty chat history when there should have been messages in the history. I think that the upgraded version of llama-stack broke the `GET /v1/agents/{agent_id}/sessions` endpoint so that the turns are no longer returned in the response. This fix instead uses both the `GET /v1/agents/{agent_id}/sessions` (`list()`) to get the `session_id` and then uses the `GET /v1/agents/{agent_id}/sessions/{session_id}` (`retrieve()`) to then get the `session_data`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue [LCORE-487](https://issues.redhat.com/browse/LCORE-487)
- Closes [LCORE-487](https://issues.redhat.com/browse/LCORE-487)

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of conversation session retrieval to ensure accurate session details are returned.

* **Tests**
  * Enhanced unit tests to better simulate session retrieval and validate correct data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->