### PR TITLE
Store the model ID without the provider ID in DB

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -183,7 +183,7 @@ async def query_endpoint_handler(
     try:
         # try to get Llama Stack client
         client = AsyncLlamaStackClientHolder().get_client()
-        model_id, provider_id = select_model_and_provider_id(
+        llama_stack_model_id, model_id, provider_id = select_model_and_provider_id(
             await client.models.list(),
             *evaluate_model_hints(
                 user_conversation=user_conversation, query_request=query_request
@@ -191,7 +191,7 @@ async def query_endpoint_handler(
         )
         response, conversation_id = await retrieve_response(
             client,
-            model_id,
+            llama_stack_model_id,
             query_request,
             token,
             mcp_headers=mcp_headers,
@@ -239,7 +239,7 @@ async def query_endpoint_handler(
 
 def select_model_and_provider_id(
     models: ModelListResponse, model_id: str | None, provider_id: str | None
-) -> tuple[str, str]:
+) -> tuple[str, str, str]:
     """Select the model ID and provider ID based on the request or available models."""
     # If model_id and provider_id are provided in the request, use them
 
@@ -268,7 +268,7 @@ def select_model_and_provider_id(
             model_id = model.identifier
             provider_id = model.provider_id
             logger.info("Selected model: %s", model)
-            return model_id, provider_id
+            return model_id, model_id, provider_id
         except (StopIteration, AttributeError) as e:
             message = "No LLM model found in available models"
             logger.error(message)
@@ -297,7 +297,7 @@ def select_model_and_provider_id(
             },
         )
 
-    return llama_stack_model_id, provider_id
+    return llama_stack_model_id, model_id, provider_id
 
 
 def _is_inout_shield(shield: Shield) -> bool:

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -421,7 +421,7 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
     try:
         # try to get Llama Stack client
         client = AsyncLlamaStackClientHolder().get_client()
-        model_id, provider_id = select_model_and_provider_id(
+        llama_stack_model_id, model_id, provider_id = select_model_and_provider_id(
             await client.models.list(),
             *evaluate_model_hints(
                 user_conversation=user_conversation, query_request=query_request
@@ -429,7 +429,7 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
         )
         response, conversation_id = await retrieve_response(
             client,
-            model_id,
+            llama_stack_model_id,
             query_request,
             token,
             mcp_headers=mcp_headers,

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -132,7 +132,7 @@ async def _test_query_endpoint_handler(mocker, store_transcript_to_file=False):
     )
     mocker.patch(
         "app.endpoints.query.select_model_and_provider_id",
-        return_value=("fake_model_id", "fake_provider_id"),
+        return_value=("fake_model_id", "fake_model_id", "fake_provider_id"),
     )
     mocker.patch(
         "app.endpoints.query.is_transcripts_enabled",
@@ -214,11 +214,12 @@ def test_select_model_and_provider_id_from_request(mocker):
     )
 
     # Assert the model and provider from request take precedence from the configuration one
-    model_id, provider_id = select_model_and_provider_id(
+    llama_stack_model_id, model_id, provider_id = select_model_and_provider_id(
         model_list, query_request.model, query_request.provider
     )
 
-    assert model_id == "provider2/model2"
+    assert llama_stack_model_id == "provider2/model2"
+    assert model_id == "model2"
     assert provider_id == "provider2"
 
 
@@ -249,12 +250,13 @@ def test_select_model_and_provider_id_from_configuration(mocker):
         query="What is OpenStack?",
     )
 
-    model_id, provider_id = select_model_and_provider_id(
+    llama_stack_model_id, model_id, provider_id = select_model_and_provider_id(
         model_list, query_request.model, query_request.provider
     )
 
     # Assert that the default model and provider from the configuration are returned
-    assert model_id == "default_provider/default_model"
+    assert llama_stack_model_id == "default_provider/default_model"
+    assert model_id == "default_model"
     assert provider_id == "default_provider"
 
 
@@ -274,12 +276,13 @@ def test_select_model_and_provider_id_first_from_list(mocker):
 
     query_request = QueryRequest(query="What is OpenStack?")
 
-    model_id, provider_id = select_model_and_provider_id(
+    llama_stack_model_id, model_id, provider_id = select_model_and_provider_id(
         model_list, query_request.model, query_request.provider
     )
 
     # Assert return the first available LLM model when no model/provider is
     # specified in the request or in the configuration
+    assert llama_stack_model_id == "first_model"
     assert model_id == "first_model"
     assert provider_id == "provider1"
 
@@ -1135,7 +1138,7 @@ async def test_auth_tuple_unpacking_in_query_endpoint_handler(mocker):
 
     mocker.patch(
         "app.endpoints.query.select_model_and_provider_id",
-        return_value=("test_model", "test_provider"),
+        return_value=("test_model", "test_model", "test_provider"),
     )
     mocker.patch("app.endpoints.query.is_transcripts_enabled", return_value=False)
     # Mock database operations
@@ -1174,7 +1177,7 @@ async def test_query_endpoint_handler_no_tools_true(mocker):
     )
     mocker.patch(
         "app.endpoints.query.select_model_and_provider_id",
-        return_value=("fake_model_id", "fake_provider_id"),
+        return_value=("fake_model_id", "fake_model_id", "fake_provider_id"),
     )
     mocker.patch("app.endpoints.query.is_transcripts_enabled", return_value=False)
     # Mock database operations
@@ -1213,7 +1216,7 @@ async def test_query_endpoint_handler_no_tools_false(mocker):
     )
     mocker.patch(
         "app.endpoints.query.select_model_and_provider_id",
-        return_value=("fake_model_id", "fake_provider_id"),
+        return_value=("fake_model_id", "fake_model_id", "fake_provider_id"),
     )
     mocker.patch("app.endpoints.query.is_transcripts_enabled", return_value=False)
     # Mock database operations

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -265,7 +265,7 @@ async def _test_streaming_query_endpoint_handler(mocker, store_transcript=False)
     )
     mocker.patch(
         "app.endpoints.streaming_query.select_model_and_provider_id",
-        return_value=("fake_model_id", "fake_provider_id"),
+        return_value=("fake_model_id", "fake_model_id", "fake_provider_id"),
     )
     mocker.patch(
         "app.endpoints.streaming_query.is_transcripts_enabled",
@@ -1279,7 +1279,7 @@ async def test_auth_tuple_unpacking_in_streaming_query_endpoint_handler(mocker):
 
     mocker.patch(
         "app.endpoints.streaming_query.select_model_and_provider_id",
-        return_value=("test_model", "test_provider"),
+        return_value=("test_model", "test_model", "test_provider"),
     )
     mocker.patch(
         "app.endpoints.streaming_query.is_transcripts_enabled", return_value=False
@@ -1325,7 +1325,7 @@ async def test_streaming_query_endpoint_handler_no_tools_true(mocker):
     )
     mocker.patch(
         "app.endpoints.streaming_query.select_model_and_provider_id",
-        return_value=("fake_model_id", "fake_provider_id"),
+        return_value=("fake_model_id", "fake_model_id", "fake_provider_id"),
     )
     mocker.patch(
         "app.endpoints.streaming_query.is_transcripts_enabled", return_value=False
@@ -1372,7 +1372,7 @@ async def test_streaming_query_endpoint_handler_no_tools_false(mocker):
     )
     mocker.patch(
         "app.endpoints.streaming_query.select_model_and_provider_id",
-        return_value=("fake_model_id", "fake_provider_id"),
+        return_value=("fake_model_id", "fake_model_id", "fake_provider_id"),
     )
     mocker.patch(
         "app.endpoints.streaming_query.is_transcripts_enabled", return_value=False


### PR DESCRIPTION
## Description

In 3f7ed75e0e46766301dfbf622de3bfd0debb0736 we accidentally stored the model ID as "\<provider\>/\<model\>", which is not what we want. We want to store the model ID as is, so we can re-use it later when the user omits it, without string manipulation.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

3f7ed75e0e46766301dfbf622de3bfd0debb0736

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Modified unit tests. Made sure omitting the model ID and provider ID when giving the conversation ID actually works now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None; no user-facing changes.

- Refactor
  - Improved model selection to use a provider-qualified model identifier for response retrieval in query and streaming endpoints while preserving existing identifiers for logging and persistence.
  - No changes to public APIs.

- Tests
  - Updated unit tests to unpack and validate the new triple return (qualified model ID, model ID, provider ID).
  - Adjusted mocks and assertions to cover the qualified model identifier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->