### PR TITLE
Add resolved model/provider to transcripts

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -205,6 +205,8 @@ async def query_endpoint_handler(
             store_transcript(
                 user_id=user_id,
                 conversation_id=conversation_id,
+                model_id=model_id,
+                provider_id=provider_id,
                 query_is_valid=True,  # TODO(lucasagomes): implement as part of query validation
                 query=query_request.query,
                 query_request=query_request,
@@ -456,6 +458,8 @@ def construct_transcripts_path(user_id: str, conversation_id: str) -> Path:
 def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     user_id: str,
     conversation_id: str,
+    model_id: str,
+    provider_id: str | None,
     query_is_valid: bool,
     query: str,
     query_request: QueryRequest,
@@ -482,8 +486,10 @@ def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-
 
     data_to_store = {
         "metadata": {
-            "provider": query_request.provider,
-            "model": query_request.model,
+            "provider": provider_id,
+            "model": model_id,
+            "query_provider": query_request.provider,
+            "query_model": query_request.model,
             "user_id": user_id,
             "conversation_id": conversation_id,
             "timestamp": datetime.now(UTC).isoformat(),

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -464,6 +464,8 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
                 store_transcript(
                     user_id=user_id,
                     conversation_id=conversation_id,
+                    model_id=model_id,
+                    provider_id=provider_id,
                     query_is_valid=True,  # TODO(lucasagomes): implement as part of query validation
                     query=query_request.query,
                     query_request=query_request,

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -159,6 +159,8 @@ async def _test_query_endpoint_handler(mocker, store_transcript_to_file=False):
         mock_transcript.assert_called_once_with(
             user_id="mock_user_id",
             conversation_id=conversation_id,
+            model_id="fake_model_id",
+            provider_id="fake_provider_id",
             query_is_valid=True,
             query=query,
             query_request=query_request,
@@ -1045,6 +1047,8 @@ def test_store_transcript(mocker):
     store_transcript(
         user_id,
         conversation_id,
+        model,
+        provider,
         query_is_valid,
         query,
         query_request,
@@ -1058,8 +1062,10 @@ def test_store_transcript(mocker):
     mock_json.dump.assert_called_once_with(
         {
             "metadata": {
-                "provider": query_request.provider,
-                "model": query_request.model,
+                "provider": "fake-provider",
+                "model": "fake-model",
+                "query_provider": query_request.provider,
+                "query_model": query_request.model,
                 "user_id": user_id,
                 "conversation_id": conversation_id,
                 "timestamp": mocker.ANY,

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -318,6 +318,8 @@ async def _test_streaming_query_endpoint_handler(mocker, store_transcript=False)
         mock_transcript.assert_called_once_with(
             user_id="mock_user_id",
             conversation_id="test_conversation_id",
+            model_id="fake_model_id",
+            provider_id="fake_provider_id",
             query_is_valid=True,
             query=query,
             query_request=query_request,


### PR DESCRIPTION
This makes it easier to analyze differences between models.

Before it would only add the model/provider if it was customized in the query.

## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement



## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
Generate some transcripts and see if the new fields are there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Transcripts now include both the actual model and provider used and the originally requested model/provider for standard and streaming queries.
  - Transcript details (query, response, RAG chunks, truncation, attachments) remain unchanged aside from the added identifiers.
  - Applies when transcript logging is enabled; no changes to query behavior or results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->