### PR TITLE
Support configuration env variable replacement

### DIFF
--- a/src/configuration.py
+++ b/src/configuration.py
@@ -3,6 +3,10 @@
 import logging
 from typing import Any, Optional
 
+# We want to support environment variable replacement in the configuration
+# similarly to how it is done in llama-stack, so we use their function directly
+from llama_stack.core.stack import replace_env_vars
+
 import yaml
 from models.config import (
     Configuration,
@@ -15,6 +19,7 @@ from models.config import (
     InferenceConfiguration,
     DatabaseConfiguration,
 )
+
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +43,7 @@ class AppConfig:
         """Load configuration from YAML file."""
         with open(filename, encoding="utf-8") as fin:
             config_dict = yaml.safe_load(fin)
+            config_dict = replace_env_vars(config_dict)
             logger.info("Loaded configuration: %s", config_dict)
             self.init_from_dict(config_dict)
 


### PR DESCRIPTION
We want to support environment variable replacement in the configuration similarly to how it is done in llama-stack.

Example use case / motivation:

The config, which since 3f7ed75e0e46766301dfbf622de3bfd0debb0736 can contain a password to a database, requires users to move their entire config to a Kubernetes secret, as it now contains sensitive information, rather than a configmap. If instead we supported environment variable replacement, users could keep their config in a configmap and just set the password in a secret as k8s allows you to load secret values as environment variables in pods.

Since users of lightspeed-stack are already familiar with the syntax for environment variable replacement from llama-stack, we can use the same function from llama-stack to handle this.



## Description

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Checked that it works. Since it's a borrowed function, testing seems unnecessary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now support environment variable placeholders. You can reference variables (e.g., ${DB_PASSWORD}, ${API_URL}) in your YAML config, and they will be substituted from your environment at load time.
  * Works transparently with existing configurations—no changes to keys or structure required. This helps keep sensitive or environment-specific values out of your config files while preserving current behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->