### PR TITLE
LCORE-433: Support for all OpenAPI metadata

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,13 +2,25 @@
     "openapi": "3.1.0",
     "info": {
         "title": "Lightspeed Core Service (LCS) service - OpenAPI",
+        "summary": "Lightspeed Core Service (LCS) service API specification.",
         "description": "Lightspeed Core Service (LCS) service API specification.",
+        "contact": {
+            "name": "Pavel Tisnovsky",
+            "url": "https://github.com/tisnik/",
+            "email": "ptisnovs@redhat.com"
+        },
         "license": {
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
         },
         "version": "0.1.3"
     },
+    "servers": [
+        {
+            "url": "http://localhost:8080/",
+            "description": "Locally running service"
+        }
+    ],
     "paths": {
         "/": {
             "get": {

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -7,6 +7,7 @@ Lightspeed Core Service (LCS) service API specification.
 
 | URL | Description |
 |-----|-------------|
+| http://localhost:8080/ | Locally running service |
 
 
 # 🛠️ APIs

--- a/docs/output.md
+++ b/docs/output.md
@@ -7,6 +7,7 @@ Lightspeed Core Service (LCS) service API specification.
 
 | URL | Description |
 |-----|-------------|
+| http://localhost:8080/ | Locally running service |
 
 
 # 🛠️ APIs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "authlib>=1.6.0",
     "openai==1.99.1",
     "sqlalchemy>=2.0.42",
+    "email-validator>=2.2.0",
 ]
 
 [tool.pyright]

--- a/scripts/generate_openapi_schema.py
+++ b/scripts/generate_openapi_schema.py
@@ -67,11 +67,14 @@ if __name__ == "__main__":
     # retrieve OpenAPI schema via initialized app
     open_api = get_openapi(
         title=app.title,
+        summary=app.summary,
         version=app.version,
         openapi_version=app.openapi_version,
         description=app.description,
         routes=app.routes,
         license_info=app.license_info,
+        servers=app.servers,
+        contact=app.contact,
     )
 
     # dump the schema into file

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -23,12 +23,21 @@ service_name = configuration.configuration.name
 
 app = FastAPI(
     title=f"{service_name} service - OpenAPI",
+    summary=f"{service_name} service API specification.",
     description=f"{service_name} service API specification.",
     version=version.__version__,
+    contact={
+        "name": "Pavel Tisnovsky",
+        "url": "https://github.com/tisnik/",
+        "email": "ptisnovs@redhat.com",
+    },
     license_info={
         "name": "Apache 2.0",
         "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
     },
+    servers=[
+        {"url": "http://localhost:8080/", "description": "Locally running service"}
+    ],
 )
 
 app.add_middleware(

--- a/uv.lock
+++ b/uv.lock
@@ -531,6 +531,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -558,6 +567,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967, upload-time = "2024-06-20T11:30:30.034Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631", size = 33521, upload-time = "2024-06-20T11:30:28.248Z" },
 ]
 
 [[package]]
@@ -1068,6 +1090,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "authlib" },
     { name = "cachetools" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "kubernetes" },
     { name = "llama-stack" },
@@ -1130,6 +1153,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.14" },
     { name = "authlib", specifier = ">=1.6.0" },
     { name = "cachetools", specifier = ">=6.1.0" },
+    { name = "email-validator", specifier = ">=2.2.0" },
     { name = "fastapi", specifier = ">=0.115.6" },
     { name = "kubernetes", specifier = ">=30.1.0" },
     { name = "llama-stack", specifier = "==0.2.17" },


### PR DESCRIPTION
## Description

LCORE-433: Support for all OpenAPI metadata

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-433


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * OpenAPI spec now includes a concise API summary and maintainer contact details.
  * Added a local development server (http://localhost:8080/) to the Servers list and Base URL tables.
  * No changes to endpoints, schemas, or responses.

* **Chores**
  * Added email-validator as a project dependency.
  * Updated OpenAPI schema generation to include the new metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->