### PR TITLE
(nit) would be nice to have a simple cli to run lcore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ distribution = true
 source = "file"
 path = "src/version.py"
 
+[project.scripts]
+lightspeed-stack = "lightspeed_stack:main"
+
 [project.urls]
 Homepage = "https://github.com/lightspeed-core/lightspeed-stack"
 Issues = "https://github.com/lightspeed-core/lightspeed-stack/issues"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line entry point: lightspeed-stack. After installing or upgrading, you can launch the tool directly from your terminal with the lightspeed-stack command.
  * Simplifies execution by removing the need for python -m invocation; the command is available on your PATH after installation via standard package managers.
  * Enhances usability for scripts and automation by providing a consistent, single-command entry point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->