### PR TITLE
LCORE-390: authentication configuration is not optional

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -292,9 +292,7 @@ class Configuration(BaseModel):
     user_data_collection: UserDataCollection
     database: DatabaseConfiguration = DatabaseConfiguration()
     mcp_servers: list[ModelContextProtocolServer] = []
-    authentication: Optional[AuthenticationConfiguration] = (
-        AuthenticationConfiguration()
-    )
+    authentication: AuthenticationConfiguration = AuthenticationConfiguration()
     customization: Optional[Customization] = None
     inference: InferenceConfiguration = InferenceConfiguration()
 

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -614,6 +614,53 @@ def test_dump_configuration_with_more_mcp_servers(tmp_path) -> None:
         ]
 
 
+def test_authentication_configuration_in_config() -> None:
+    """Test the authentication configuration in main config."""
+    cfg = Configuration(
+        name="test_name",
+        service=ServiceConfiguration(),
+        llama_stack=LlamaStackConfiguration(
+            use_as_library_client=True,
+            library_client_config_path="tests/configuration/run.yaml",
+        ),
+        user_data_collection=UserDataCollection(
+            feedback_enabled=False, feedback_storage=None
+        ),
+        mcp_servers=[],
+    )
+    assert cfg.authentication is not None
+    assert cfg.authentication.module == AUTH_MOD_NOOP
+    assert cfg.authentication.skip_tls_verification is False
+    assert cfg.authentication.k8s_ca_cert_path is None
+    assert cfg.authentication.k8s_cluster_api is None
+
+    cfg2 = Configuration(
+        name="test_name",
+        service=ServiceConfiguration(),
+        llama_stack=LlamaStackConfiguration(
+            use_as_library_client=True,
+            library_client_config_path="tests/configuration/run.yaml",
+        ),
+        user_data_collection=UserDataCollection(
+            feedback_enabled=False, feedback_storage=None
+        ),
+        mcp_servers=[],
+        authentication=AuthenticationConfiguration(
+            module=AUTH_MOD_K8S,
+            skip_tls_verification=True,
+            k8s_ca_cert_path="tests/configuration/server.crt",
+            k8s_cluster_api=None,
+        ),
+    )
+    assert cfg2.authentication is not None
+    assert cfg2.authentication.module == AUTH_MOD_K8S
+    assert cfg2.authentication.skip_tls_verification is True
+    assert cfg2.authentication.k8s_ca_cert_path == Path(
+        "tests/configuration/server.crt"
+    )
+    assert cfg2.authentication.k8s_cluster_api is None
+
+
 def test_authentication_configuration() -> None:
     """Test the AuthenticationConfiguration constructor."""
 


### PR DESCRIPTION
## Description

LCORE-390: authentication configuration is not optional

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-390


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configuration now always includes a default authentication setup, removing the possibility of missing/None authentication. This ensures predictable behavior without manual initialization.
- Tests
  - Added unit tests validating default authentication values and custom authentication overrides within Configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->