### PR TITLE
fix: streaming_query: empty conversation ID

### DIFF
--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -399,7 +399,7 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
     user_id, _user_name, token = auth
 
     user_conversation: UserConversation | None = None
-    if query_request.conversation_id is not None:
+    if query_request.conversation_id:
         user_conversation = validate_conversation_ownership(
             user_id=user_id, conversation_id=query_request.conversation_id
         )


### PR DESCRIPTION
## Description

The query endpoint would treat an empty conversation ID as not provided,
but the streaming query endpoint would treat it as if it were an ID
(which doesn't belong to anyone, so it would fail).

Align the behavior of the streaming query endpoint with the query
endpoint, so when users provide a "conversation_id" with an empty
string, it will be as if they didn't provide it at all.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted conversation ID handling in streaming queries: validation now occurs only when a non-empty ID is provided.
  - Prevents unintended 403 errors for requests with empty or missing conversation IDs; valid, non-empty IDs continue to be checked as before.
  - Requests with empty strings or other falsy IDs are treated as having no conversation context.
  - No changes to streaming behavior or response format beyond this validation refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->