### PR TITLE
Add tool calls to stored transcripts

### DIFF
--- a/src/utils/transcripts.py
+++ b/src/utils/transcripts.py
@@ -1,0 +1,86 @@
+"""Transcript handling.
+
+Transcripts are a log of individual query/response pairs that get
+stored on disk for later analysis
+"""
+
+from datetime import UTC, datetime
+import json
+import logging
+import os
+from pathlib import Path
+
+from configuration import configuration
+from models.requests import Attachment, QueryRequest
+from utils.suid import get_suid
+from utils.types import TurnSummary
+
+logger = logging.getLogger("utils.transcripts")
+
+
+def construct_transcripts_path(user_id: str, conversation_id: str) -> Path:
+    """Construct path to transcripts."""
+    # these two normalizations are required by Snyk as it detects
+    # this Path sanitization pattern
+    uid = os.path.normpath("/" + user_id).lstrip("/")
+    cid = os.path.normpath("/" + conversation_id).lstrip("/")
+    file_path = (
+        configuration.user_data_collection_configuration.transcripts_storage or ""
+    )
+    return Path(file_path, uid, cid)
+
+
+def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    user_id: str,
+    conversation_id: str,
+    model_id: str,
+    provider_id: str | None,
+    query_is_valid: bool,
+    query: str,
+    query_request: QueryRequest,
+    summary: TurnSummary,
+    rag_chunks: list[str],
+    truncated: bool,
+    attachments: list[Attachment],
+) -> None:
+    """Store transcript in the local filesystem.
+
+    Args:
+        user_id: The user ID (UUID).
+        conversation_id: The conversation ID (UUID).
+        query_is_valid: The result of the query validation.
+        query: The query (without attachments).
+        query_request: The request containing a query.
+        summary: Summary of the query/response turn.
+        rag_chunks: The list of `RagChunk` objects.
+        truncated: The flag indicating if the history was truncated.
+        attachments: The list of `Attachment` objects.
+    """
+    transcripts_path = construct_transcripts_path(user_id, conversation_id)
+    transcripts_path.mkdir(parents=True, exist_ok=True)
+
+    data_to_store = {
+        "metadata": {
+            "provider": provider_id,
+            "model": model_id,
+            "query_provider": query_request.provider,
+            "query_model": query_request.model,
+            "user_id": user_id,
+            "conversation_id": conversation_id,
+            "timestamp": datetime.now(UTC).isoformat(),
+        },
+        "redacted_query": query,
+        "query_is_valid": query_is_valid,
+        "llm_response": summary.llm_response,
+        "rag_chunks": rag_chunks,
+        "truncated": truncated,
+        "attachments": [attachment.model_dump() for attachment in attachments],
+        "tool_calls": [tc.model_dump() for tc in summary.tool_calls],
+    }
+
+    # stores feedback in a file under unique uuid
+    transcript_file_path = transcripts_path / f"{get_suid()}.json"
+    with open(transcript_file_path, "w", encoding="utf-8") as transcript_file:
+        json.dump(data_to_store, transcript_file)
+
+    logger.info("Transcript successfully stored at: %s", transcript_file_path)

--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -1,10 +1,13 @@
 """Common types for the project."""
 
-from typing import Optional
+from typing import Any, Optional
 
+from llama_stack_client.lib.agents.event_logger import interleaved_content_as_str
 from llama_stack_client.lib.agents.tool_parser import ToolParser
 from llama_stack_client.types.shared.completion_message import CompletionMessage
 from llama_stack_client.types.shared.tool_call import ToolCall
+from llama_stack_client.types.tool_execution_step import ToolExecutionStep
+from pydantic.main import BaseModel
 
 
 class Singleton(type):
@@ -35,3 +38,41 @@ class GraniteToolParser(ToolParser):
         if model_id and model_id.lower().startswith("granite"):
             return GraniteToolParser()
         return None
+
+
+class ToolCallSummary(BaseModel):
+    """Represents a tool call for data collection.
+
+    Use our own tool call model to keep things consistent across llama
+    upgrades or if we used something besides llama in the future.
+    """
+
+    # ID of the call itself
+    id: str
+    # Name of the tool used
+    name: str
+    # Arguments to the tool call
+    args: str | dict[Any, Any]
+    response: str | None
+
+
+class TurnSummary(BaseModel):
+    """Summary of a turn in llama stack."""
+
+    llm_response: str
+    tool_calls: list[ToolCallSummary]
+
+    def append_tool_calls_from_llama(self, tec: ToolExecutionStep) -> None:
+        """Append the tool calls from a llama tool execution step."""
+        calls_by_id = {tc.call_id: tc for tc in tec.tool_calls}
+        responses_by_id = {tc.call_id: tc for tc in tec.tool_responses}
+        for call_id, tc in calls_by_id.items():
+            resp = responses_by_id.get(call_id)
+            self.tool_calls.append(
+                ToolCallSummary(
+                    id=call_id,
+                    name=tc.tool_name,
+                    args=tc.arguments,
+                    response=interleaved_content_as_str(resp.content) if resp else None,
+                )
+            )

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -44,6 +44,7 @@ from app.endpoints.streaming_query import (
 
 from models.requests import QueryRequest, Attachment
 from models.config import ModelContextProtocolServer
+from utils.types import ToolCallSummary, TurnSummary
 
 MOCK_AUTH = ("mock_user_id", "mock_username", "mock_token")
 
@@ -218,7 +219,7 @@ async def _test_streaming_query_endpoint_handler(mocker, store_transcript=False)
                         step_type="tool_execution",
                         tool_responses=[
                             ToolResponse(
-                                call_id="c1",
+                                call_id="t1",
                                 tool_name="knowledge_search",
                                 content=[
                                     TextContentItem(text=s, type="text")
@@ -323,7 +324,17 @@ async def _test_streaming_query_endpoint_handler(mocker, store_transcript=False)
             query_is_valid=True,
             query=query,
             query_request=query_request,
-            response="LLM answer",
+            summary=TurnSummary(
+                llm_response="LLM answer",
+                tool_calls=[
+                    ToolCallSummary(
+                        id="t1",
+                        name="knowledge_search",
+                        args={},
+                        response=" ".join(SAMPLE_KNOWLEDGE_SEARCH_RESULTS),
+                    )
+                ],
+            ),
             attachments=[],
             rag_chunks=[],
             truncated=False,

--- a/tests/unit/utils/test_transcripts.py
+++ b/tests/unit/utils/test_transcripts.py
@@ -1,0 +1,127 @@
+"""Unit tests for functions defined in utils.transcripts module."""
+
+from configuration import AppConfig
+from models.requests import QueryRequest
+
+from utils.transcripts import (
+    construct_transcripts_path,
+    store_transcript,
+)
+from utils.types import ToolCallSummary, TurnSummary
+
+
+def test_construct_transcripts_path(mocker):
+    """Test the construct_transcripts_path function."""
+
+    config_dict = {
+        "name": "test",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "test-key",
+            "url": "http://test.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "transcripts_storage": "/tmp/transcripts",
+        },
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+    # Update configuration for this test
+    mocker.patch("utils.transcripts.configuration", cfg)
+
+    user_id = "user123"
+    conversation_id = "123e4567-e89b-12d3-a456-426614174000"
+
+    path = construct_transcripts_path(user_id, conversation_id)
+
+    assert (
+        str(path) == "/tmp/transcripts/user123/123e4567-e89b-12d3-a456-426614174000"
+    ), "Path should be constructed correctly"
+
+
+def test_store_transcript(mocker):
+    """Test the store_transcript function."""
+
+    mocker.patch("builtins.open", mocker.mock_open())
+    mocker.patch(
+        "utils.transcripts.construct_transcripts_path",
+        return_value=mocker.MagicMock(),
+    )
+
+    # Mock the JSON to assert the data is stored correctly
+    mock_json = mocker.patch("utils.transcripts.json")
+
+    # Mock parameters
+    user_id = "user123"
+    conversation_id = "123e4567-e89b-12d3-a456-426614174000"
+    query = "What is OpenStack?"
+    model = "fake-model"
+    provider = "fake-provider"
+    query_request = QueryRequest(query=query, model=model, provider=provider)
+    summary = TurnSummary(
+        llm_response="LLM answer",
+        tool_calls=[
+            ToolCallSummary(
+                id="123",
+                name="test-tool",
+                args="testing",
+                response="tool response",
+            )
+        ],
+    )
+    query_is_valid = True
+    rag_chunks = []
+    truncated = False
+    attachments = []
+
+    store_transcript(
+        user_id,
+        conversation_id,
+        model,
+        provider,
+        query_is_valid,
+        query,
+        query_request,
+        summary,
+        rag_chunks,
+        truncated,
+        attachments,
+    )
+
+    # Assert that the transcript was stored correctly
+    mock_json.dump.assert_called_once_with(
+        {
+            "metadata": {
+                "provider": "fake-provider",
+                "model": "fake-model",
+                "query_provider": query_request.provider,
+                "query_model": query_request.model,
+                "user_id": user_id,
+                "conversation_id": conversation_id,
+                "timestamp": mocker.ANY,
+            },
+            "redacted_query": query,
+            "query_is_valid": query_is_valid,
+            "llm_response": summary.llm_response,
+            "rag_chunks": rag_chunks,
+            "truncated": truncated,
+            "attachments": attachments,
+            "tool_calls": [
+                {
+                    "id": "123",
+                    "name": "test-tool",
+                    "args": "testing",
+                    "response": "tool response",
+                }
+            ],
+        },
+        mocker.ANY,
+    )


### PR DESCRIPTION
Also moved all of the transcript handling to its own module as it grew a bit with this.

Added a `TurnSummary` type in order to encapsulate both the llm's text response as well as the tool calls. This can be expanded in the future if other turn data is needed in either the transcripts or elsewhere.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Ran this locally with assisted-chat instance. Saw the tool calls in the transcripts when I made a query to list all my clusters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queries (streaming and non‑streaming) now return structured turn summaries that include the assistant response plus detailed tool‑call activity.

* **Refactor**
  * Transcript storage centralized to a shared utility and now persists the richer turn summaries with metadata, attachments, RAG chunks, and truncation info.

* **Tests**
  * Unit tests updated to assert on structured TurnSummary objects and verify transcript persistence and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->