### PR TITLE
LCORE-574: Unit tests for PostgreSQL configuration + removed unused check

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -72,8 +72,6 @@ class PostgreSQLDatabaseConfiguration(BaseModel):
         """Check PostgreSQL configuration."""
         if self.port > 65535:
             raise ValueError("Port value should be less than 65536")
-        if self.ca_cert_path is not None and not self.ca_cert_path.exists():
-            raise ValueError(f"CA certificate file does not exist: {self.ca_cert_path}")
         return self
 
 

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -11,6 +11,8 @@ from constants import (
     AUTH_MOD_NOOP,
     AUTH_MOD_K8S,
     AUTH_MOD_JWK_TOKEN,
+    POSTGRES_DEFAULT_SSL_MODE,
+    POSTGRES_DEFAULT_GSS_ENCMODE,
 )
 
 from models.config import (
@@ -24,6 +26,7 @@ from models.config import (
     CORSConfiguration,
     ModelContextProtocolServer,
     InferenceConfiguration,
+    PostgreSQLDatabaseConfiguration,
 )
 
 from utils.checks import InvalidConfigurationError
@@ -867,3 +870,63 @@ def test_authentication_configuration_module_unsupported() -> None:
             k8s_ca_cert_path=None,
             k8s_cluster_api=None,
         )
+
+
+def test_postgresql_database_configuration() -> None:
+    """Test the PostgreSQLDatabaseConfiguration model."""
+    c = PostgreSQLDatabaseConfiguration(db="db", user="user", password="password")
+    assert c is not None
+    assert c.host == "localhost"
+    assert c.port == 5432
+    assert c.db == "db"
+    assert c.user == "user"
+    assert c.password == "password"
+    assert c.ssl_mode == POSTGRES_DEFAULT_SSL_MODE
+    assert c.gss_encmode == POSTGRES_DEFAULT_GSS_ENCMODE
+    assert c.namespace == "lightspeed-stack"
+    assert c.ca_cert_path is None
+
+
+def test_postgresql_database_configuration_port_setting(subtests) -> None:
+    """Test the PostgreSQLDatabaseConfiguration model."""
+    with subtests.test(msg="Correct port value"):
+        c = PostgreSQLDatabaseConfiguration(
+            db="db", user="user", password="password", port=1234
+        )
+        assert c is not None
+        assert c.port == 1234
+
+    with subtests.test(msg="Negative port value"):
+        with pytest.raises(ValidationError, match="Input should be greater than 0"):
+            PostgreSQLDatabaseConfiguration(
+                db="db", user="user", password="password", port=-1
+            )
+
+    with subtests.test(msg="Too big port value"):
+        with pytest.raises(ValueError, match="Port value should be less than 65536"):
+            PostgreSQLDatabaseConfiguration(
+                db="db", user="user", password="password", port=100000
+            )
+
+
+def test_postgresql_database_configuration_ca_cert_path(subtests) -> None:
+    """Test the PostgreSQLDatabaseConfiguration model."""
+    with subtests.test(msg="Path exists"):
+        c = PostgreSQLDatabaseConfiguration(
+            db="db",
+            user="user",
+            password="password",
+            port=1234,
+            ca_cert_path=Path("tests/configuration/server.crt"),
+        )
+        assert c.ca_cert_path == Path("tests/configuration/server.crt")
+
+    with subtests.test(msg="Path does not exist"):
+        with pytest.raises(ValidationError, match="Path does not point to a file"):
+            PostgreSQLDatabaseConfiguration(
+                db="db",
+                user="user",
+                password="password",
+                port=1234,
+                ca_cert_path=Path("not a file"),
+            )


### PR DESCRIPTION
## Description

LCORE-574: Unit tests for PostgreSQL configuration + removed unused check

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable PostgreSQL connection settings with sensible defaults (host, port, namespace).
  - Introduced default values for SSL mode and GSS encryption mode.

- Bug Fixes
  - Refined PostgreSQL configuration validation: improved port checks and adjusted CA certificate path handling to apply only when provided.

- Tests
  - Added unit tests covering PostgreSQL configuration defaults, port range validation, and CA certificate path behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->