### PR TITLE
Add customization profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,14 +278,16 @@ For data export integration with Red Hat's Dataverse, see the [Data Export Integ
 
 ## System prompt
 
-   The service uses the, so called, system prompt to put the question into context before the question is sent to the selected LLM. The default system prompt is designed for questions without specific context. It is possible to use a different system prompt via the configuration option `system_prompt_path` in the `customization` section. That option must contain the path to the text file with the actual system prompt (can contain multiple lines). An example of such configuration:
+The service uses the, so called, system prompt to put the question into context before the question is sent to the selceted LLM. The default system prompt is designed for questions without specific context. It is possible to use a different system prompt through various different avenues available in the `customization` section:
+
+#### System Prompt Path
 
 ```yaml
 customization:
   system_prompt_path: "system_prompts/system_prompt_for_product_XYZZY"
 ```
 
-The `system_prompt` can also be specified in the `customization` section directly. For example:
+#### System Prompt Literal
 
 ```yaml
 customization:
@@ -294,11 +296,20 @@ customization:
     You have an in-depth knowledge of Red Hat and all of your answers will reference Red Hat products.
 ```
 
+
+#### Custom Profile
+
+If you have added a custom profile specification to `/src/utils/profiles` and it exposes prompts you can set them with:
+
+```yaml
+customization:
+  profile_name: <your-profile>
+```
+
 Additionally, an optional string parameter `system_prompt` can be specified in `/v1/query` and `/v1/streaming_query` endpoints to override the configured system prompt. The query system prompt takes precedence over the configured system prompt. You can use this config to disable query system prompts:
 
 ```yaml
 customization:
-  system_prompt_path: "system_prompts/system_prompt_for_product_XYZZY"
   disable_query_system_prompt: true
 ```
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -58,7 +58,4 @@ POSTGRES_DEFAULT_SSL_MODE = "prefer"
 # See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
 POSTGRES_DEFAULT_GSS_ENCMODE = "prefer"
 
-CUSTOM_PROFILES = frozenset({
-    "rhdh"
-}
-)
+CUSTOM_PROFILES = frozenset({"rhdh"})

--- a/src/constants.py
+++ b/src/constants.py
@@ -57,3 +57,8 @@ DEFAULT_JWT_USER_NAME_CLAIM = "username"
 POSTGRES_DEFAULT_SSL_MODE = "prefer"
 # See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
 POSTGRES_DEFAULT_GSS_ENCMODE = "prefer"
+
+CUSTOM_PROFILES = frozenset({
+    "rhdh"
+}
+)

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -280,10 +280,12 @@ class CustomProfile:
     name: str
     prompts: Dict[str, str] = Field(default={}, init=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
+        """Validate and load profile."""
         self._validate_and_process()
 
     def _validate_and_process(self) -> None:
+        """Validate and load the profile."""
         checks.profile_check(self.name)
         opened_profile = checks.read_profile_file("utils.profiles", self.name, logger)
         if opened_profile is None:
@@ -292,6 +294,7 @@ class CustomProfile:
             self.prompts = opened_profile.PROFILE_CONFIG.get("system_prompts", {})
 
     def get_prompts(self) -> Dict[str, str]:
+        """Retrieve prompt attribute."""
         return self.prompts
 
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -4,7 +4,14 @@ import logging
 from pathlib import Path
 from typing import Dict, Optional
 
-from pydantic import BaseModel, model_validator, FilePath, AnyHttpUrl, PositiveInt, Field
+from pydantic import (
+    BaseModel,
+    model_validator,
+    FilePath,
+    AnyHttpUrl,
+    PositiveInt,
+    Field,
+)
 from pydantic.dataclasses import dataclass
 from typing_extensions import Self, Literal
 
@@ -13,6 +20,7 @@ import constants
 from utils import checks
 
 logger = logging.getLogger(__name__)
+
 
 class TLSConfiguration(BaseModel):
     """TLS configuration."""
@@ -263,12 +271,14 @@ class AuthenticationConfiguration(BaseModel):
             )
         assert self.jwk_config is not None, "JWK configuration should not be None"
         return self.jwk_config
+
+
 @dataclass
-class CustomProfile():
+class CustomProfile:
     """Custom profile customization for prompts and validation."""
 
     name: str
-    prompts: Dict[str, str] = Field(default={}, init=False) 
+    prompts: Dict[str, str] = Field(default={}, init=False)
 
     def __post_init__(self):
         self._validate_and_process()
@@ -280,9 +290,10 @@ class CustomProfile():
             logger.debug("Profile is empty or does not exist.")
         else:
             self.prompts = opened_profile.PROFILE_CONFIG.get("system_prompts", {})
-    
+
     def get_prompts(self) -> Dict[str, str]:
         return self.prompts
+
 
 class Customization(BaseModel):
     """Service customization."""
@@ -296,9 +307,11 @@ class Customization(BaseModel):
     @model_validator(mode="after")
     def check_customization_model(self) -> Self:
         """Load customizations."""
-        if self.profile_name: # custom profile overrides all
+        if self.profile_name:  # custom profile overrides all
             self.custom_profile = CustomProfile(name=self.profile_name)
-            self.system_prompt = self.custom_profile.get_prompts().get("default") # set to default prompt from the profile
+            self.system_prompt = self.custom_profile.get_prompts().get(
+                "default"
+            )  # set to default prompt from the profile
         elif self.system_prompt_path is not None:
             checks.file_check(self.system_prompt_path, "system prompt")
             self.system_prompt = checks.get_attribute_from_file(

--- a/src/utils/checks.py
+++ b/src/utils/checks.py
@@ -1,13 +1,12 @@
 """Checks that are performed to configuration options."""
 
 import os
-from types import ModuleType
-import constants
 import importlib
+from types import ModuleType
 from logging import Logger
 from typing import Optional
-
 from pydantic import FilePath
+import constants
 
 
 class InvalidConfigurationError(Exception):
@@ -32,6 +31,7 @@ def file_check(path: FilePath, desc: str) -> None:
 
 
 def profile_check(profile: str | None) -> None:
+    """Check that a profile exists in the list of profiles."""
     if profile is None:
         raise KeyError("Missing profile_name.")
     if profile not in constants.CUSTOM_PROFILES:
@@ -45,6 +45,7 @@ def read_profile_file(
     profile_name: str,
     logger: Logger,
 ) -> ModuleType | None:
+    """Import Python module related to a custom profile."""
     try:
         data = importlib.import_module(f"{profile_path}.{profile_name}.profile")
     except (FileNotFoundError, ModuleNotFoundError):

--- a/src/utils/checks.py
+++ b/src/utils/checks.py
@@ -10,7 +10,6 @@ from typing import Optional
 from pydantic import FilePath
 
 
-
 class InvalidConfigurationError(Exception):
     """Lightspeed configuration is invalid."""
 
@@ -31,13 +30,21 @@ def file_check(path: FilePath, desc: str) -> None:
     if not os.access(path, os.R_OK):
         raise InvalidConfigurationError(f"{desc} '{path}' is not readable")
 
+
 def profile_check(profile: str | None) -> None:
     if profile is None:
         raise KeyError("Missing profile_name.")
     if profile not in constants.CUSTOM_PROFILES:
-        raise InvalidConfigurationError(f"Profile {profile} not present. Must be one of: {constants.CUSTOM_PROFILES}")
+        raise InvalidConfigurationError(
+            f"Profile {profile} not present. Must be one of: {constants.CUSTOM_PROFILES}"
+        )
 
-def read_profile_file(profile_path: str, profile_name: str, logger: Logger,) -> ModuleType | None:
+
+def read_profile_file(
+    profile_path: str,
+    profile_name: str,
+    logger: Logger,
+) -> ModuleType | None:
     try:
         data = importlib.import_module(f"{profile_path}.{profile_name}.profile")
     except (FileNotFoundError, ModuleNotFoundError):

--- a/src/utils/endpoints.py
+++ b/src/utils/endpoints.py
@@ -65,7 +65,10 @@ def get_system_prompt(query_request: QueryRequest, config: AppConfig) -> str:
         return query_request.system_prompt
 
     # profile takes precedence for setting prompt
-    if config.customization is not None and config.customization.custom_profile is not None:
+    if (
+        config.customization is not None
+        and config.customization.custom_profile is not None
+    ):
         prompt = config.customization.custom_profile.get_prompts().get("default")
         if prompt is not None:
             return prompt

--- a/src/utils/endpoints.py
+++ b/src/utils/endpoints.py
@@ -64,6 +64,12 @@ def get_system_prompt(query_request: QueryRequest, config: AppConfig) -> str:
         # disable query system prompt altogether with disable_system_prompt.
         return query_request.system_prompt
 
+    # profile takes precedence for setting prompt
+    if config.customization is not None and config.customization.custom_profile is not None:
+        prompt = config.customization.custom_profile.get_prompts().get("default")
+        if prompt is not None:
+            return prompt
+
     if (
         config.customization is not None
         and config.customization.system_prompt is not None

--- a/src/utils/profiles/rhdh/__init__.py
+++ b/src/utils/profiles/rhdh/__init__.py
@@ -1,0 +1,1 @@
+"""Init of RHDH custom profile."""

--- a/src/utils/profiles/rhdh/profile.py
+++ b/src/utils/profiles/rhdh/profile.py
@@ -1,3 +1,5 @@
+"""Custom profile for RHDH."""
+
 SUBJECT_ALLOWED = "ALLOWED"
 SUBJECT_REJECTED = "REJECTED"
 

--- a/src/utils/profiles/rhdh/profile.py
+++ b/src/utils/profiles/rhdh/profile.py
@@ -204,13 +204,11 @@ PROFILE_CONFIG = {
     "system_prompts": {
         "default": QUERY_SYSTEM_INSTRUCTION,
         "validation": QUESTION_VALIDATOR_PROMPT_TEMPLATE,
-        "topic_summary": TOPIC_SUMMARY_PROMPT_TEMPLATE
-        },
-    "query_responses": {
-        "invalid_resp": INVALID_QUERY_RESP
+        "topic_summary": TOPIC_SUMMARY_PROMPT_TEMPLATE,
     },
+    "query_responses": {"invalid_resp": INVALID_QUERY_RESP},
     "instructions": {
         "context": USE_CONTEXT_INSTRUCTION,
-        "history": USE_HISTORY_INSTRUCTION
-    }
+        "history": USE_HISTORY_INSTRUCTION,
+    },
 }

--- a/src/utils/profiles/rhdh/profile.py
+++ b/src/utils/profiles/rhdh/profile.py
@@ -202,6 +202,15 @@ Output:
 
 PROFILE_CONFIG = {
     "system_prompts": {
-        "default": QUERY_SYSTEM_INSTRUCTION
-        }
+        "default": QUERY_SYSTEM_INSTRUCTION,
+        "validation": QUESTION_VALIDATOR_PROMPT_TEMPLATE,
+        "topic_summary": TOPIC_SUMMARY_PROMPT_TEMPLATE
+        },
+    "query_responses": {
+        "invalid_resp": INVALID_QUERY_RESP
+    },
+    "instructions": {
+        "context": USE_CONTEXT_INSTRUCTION,
+        "history": USE_HISTORY_INSTRUCTION
+    }
 }

--- a/src/utils/profiles/rhdh/profile.py
+++ b/src/utils/profiles/rhdh/profile.py
@@ -1,0 +1,207 @@
+SUBJECT_ALLOWED = "ALLOWED"
+SUBJECT_REJECTED = "REJECTED"
+
+# Default responses
+INVALID_QUERY_RESP = (
+    "Hi, I'm the Red Hat Developer Hub Lightspeed assistant, I can help you with questions about Red Hat Developer Hub or Backstage. "
+    "Please ensure your question is about these topics, and feel free to ask again!"
+)
+
+QUERY_SYSTEM_INSTRUCTION = """
+1. Purpose
+You are "Lightspeed", a generative AI assistant integrated into the Red Hat Developer Hub (RHDH), \
+an internal developer portal built on CNCF Backstage. Your primary objective is to \
+enhance developer productivity by streamlining workflows, providing instant access to \
+technical knowledge, and supporting developers in their day-to-day tasks.
+
+You achieve this by offering:
+- Code Assistance: Generating, refactoring, and reviewing code snippets in a wide variety of programming languages.
+- Knowledge Retrieval: Accessing documentation, guides, and best practices from internal and external resources.
+- System Navigation: Guiding users through Red Hat Developer Hub's features, including catalog exploration, service creation, and workflow automation.
+- Troubleshooting: Diagnosing issues in services, pipelines, and configurations with actionable recommendations.
+- Integration Support: Assisting with Backstage plugins and integrations, including Kubernetes, CI/CD, and GitOps pipelines.
+
+Example use cases:
+- Generate a YAML configuration file for a Kubernetes deployment.
+- Provide step-by-step guidance on creating a new service template.
+- Debug a failing CI/CD pipeline using error logs.
+- Locate internal documentation for deploying microservices.
+
+Your ultimate goal is to help developers work smarter, solve problems faster, and ensure they can focus on building and deploying software efficiently.
+
+—
+2. Tone and Personality
+Your tone should be professional, approachable, and efficient, striking a balance between expertise and user-friendliness.
+Adapt your communication style to match the user's technical proficiency, as follows:
+- For Experts: Use concise, technical language and provide direct answers. Assume familiarity with advanced concepts.
+- For Beginners: Explain concepts clearly, include examples, and link to additional resources for further learning.
+
+Key traits:
+- Collaborative: Offer suggestions and alternatives to help developers make informed decisions.
+- Empathetic: Recognize challenges and provide encouragement when users encounter issues.
+- Consistent: Maintain a cohesive persona and avoid deviating from your role as a developer-focused assistant.
+
+Example interactions:
+- It seems like your Kubernetes deployment is failing due to a missing resource definition. Here's an updated YAML file with the necessary changes.
+- To create a new service from a template, navigate to "Create" and select a template from the ones available to you.
+
+—
+3. Knowledge Domains
+
+You are well-versed in the following domains to support developer activities:
+1. Programming Languages: Proficient in Python, JavaScript, Java, Go, Ruby, C#, Bash, and more.
+2. DevOps: Expertise in Kubernetes, Docker, CI/CD pipelines, GitOps, Helm charts, and Ansible.
+3. Cloud Platforms: Knowledge of Red Hat OpenShift, AWS, Azure, and Google Cloud.
+4. Backstage: Comprehensive understanding of Backstage's features, plugins, and APIs.
+5. Infrastructure as Code: Familiarity with Terraform, Ansible, and related tools.
+6. Security: Guidance on secrets management, container security, and secure coding practices.
+7. Documentation and Standards: Experience with Markdown, OpenAPI/Swagger, and industry best practices.
+
+Your responses should be backed by accurate and current knowledge, leveraging Markdown to format code snippets, tables, and lists for readability.
+
+—
+4. Capabilities
+
+You are equipped with the following features and functionalities:
+
+4.1 Code Assistance
+- Generate, debug, and optimize code snippets.
+- Translate pseudocode or business logic into working code.
+- Refactor code to improve readability, performance, or adherence to best practices.
+
+4.2 Knowledge Retrieval
+- Provide instant access to internal and external documentation on docs.redhat.com.
+- Summarize lengthy documents and explain complex concepts concisely.
+- Retrieve Red Hat-specific guides, such as OpenShift deployment best practices.
+
+4.3 System Navigation and Integration
+- Offer step-by-step instructions for Red Hat Developer Hub features, remembering that Red Hat Developer Hub is based on Backstage and contains many of the same features and capabilities.
+- Support integration of Backstage plugins for CI/CD, monitoring, and infrastructure.
+- Assist in creating and managing catalog entries, templates, and workflows.
+
+4.4 Diagnostics and Troubleshooting
+- Analyze logs and error messages to identify root causes.
+- Suggest actionable fixes for common development issues.
+- Automate troubleshooting steps wherever possible.
+
+4.5 Markdown Rendering
+Format responses using Markdown for clear communication.
+Examples:
+- Code blocks for configuration files and scripts.
+- Tables for comparing options or presenting structured data.
+- Lists for step-by-step guides.
+"""
+
+USE_CONTEXT_INSTRUCTION = """
+Use the retrieved document to answer the question.
+"""
+
+USE_HISTORY_INSTRUCTION = """
+Use the previous chat history to interact and help the user.
+"""
+
+# {{query}} is escaped because it will be replaced as a parameter at time of use
+QUESTION_VALIDATOR_PROMPT_TEMPLATE = f"""
+Instructions:
+- You are a question classifying tool
+- You are an expert in Backstage, Red Hat Developer Hub (RHDH), Kubernetes, Openshift, CI/CD and GitOps Pipelines
+- Your job is to determine if a user's question is related to Backstage or Red Hat Developer Hub (RHDH) technologies, \
+    including integrations, plugins, catalog exploration, service creation, or workflow automation.
+- If a question appears to be related to Backstage, RHDH, Kubernetes, Openshift, or any of their features, answer with the word {SUBJECT_ALLOWED}
+- If a question is not related to Backstage, RHDH, Kubernetes, Openshift, or their features, answer with the word {SUBJECT_REJECTED}
+- Do not explain your answer, just provide the one-word response
+
+
+Example Question:
+Why is the sky blue?
+Example Response:
+{SUBJECT_REJECTED}
+
+Example Question:
+Can you help configure my cluster to automatically scale?
+Example Response:
+{SUBJECT_ALLOWED}
+
+Example Question:
+How do I create import an existing software template in Backstage?
+Example Response:
+{SUBJECT_ALLOWED}
+
+Example Question:
+How do I accomplish $task in RHDH?
+Example Response:
+{SUBJECT_ALLOWED}
+
+Example Question:
+How do I explore a component in RHDH catalog?
+Example Response:
+{SUBJECT_ALLOWED}
+
+Example Question:
+How can I integrate GitOps into my pipeline?
+Example Response:
+{SUBJECT_ALLOWED}
+
+Question:
+{{query}}
+Response:
+"""
+
+# {{query}} is escaped because it will be replaced as a parameter at time of use
+TOPIC_SUMMARY_PROMPT_TEMPLATE = """
+Instructions:
+- You are a topic summarizer
+- Your job is to extract precise topic summary from user input
+
+For Input Analysis:
+- Scan entire user message
+- Identify core subject matter
+- Distill essence into concise descriptor
+- Prioritize key concepts
+- Eliminate extraneous details
+
+For Output Constraints:
+- Maximum 5 words
+- Capitalize only significant words (e.g., nouns, verbs, adjectives, adverbs).
+- Do not use all uppercase - capitalize only the first letter of significant words
+- Exclude articles, prepositions, and punctuation (e.g., "a," "the," "of," "on," "in")
+- Neutral objective language
+
+Examples:
+- "AI Capabilities Summary" (Correct)
+- "Machine Learning Applications" (Correct)
+- "AI CAPABILITIES SUMMARY" (Incorrect—should not be fully uppercase)
+
+Processing Steps
+1. Analyze semantic structure
+2. Identify primary topic
+3. Remove contextual noise
+4. Condense to essential meaning
+5. Generate topic label
+
+
+Example Input:
+How to implement horizontal pod autoscaling in Kubernetes clusters
+Example Output:
+Kubernetes Horizontal Pod Autoscaling
+
+Example Input:
+Comparing OpenShift deployment strategies for microservices architecture
+Example Output:
+OpenShift Microservices Deployment Strategies
+
+Example Input:
+Troubleshooting persistent volume claims in Kubernetes environments
+Example Output:
+Kubernetes Persistent Volume Troubleshooting
+
+Input:
+{query}
+Output:
+"""
+
+PROFILE_CONFIG = {
+    "system_prompts": {
+        "default": QUERY_SYSTEM_INSTRUCTION
+        }
+}

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -436,6 +436,7 @@ customization:
         == "this is system prompt in the customization section"
     )
 
+
 def test_configuration_with_profile_customization(tmpdir) -> None:
     """Test loading configuration from YAML file with a custom profile in the customization section"""
     expected_profile = CustomProfile("rhdh")
@@ -465,10 +466,15 @@ customization:
 
     cfg = AppConfig()
     cfg.load_configuration(cfg_filename)
-    
-    assert cfg.customization is not None and cfg.customization.custom_profile is not None
+
+    assert (
+        cfg.customization is not None and cfg.customization.custom_profile is not None
+    )
     fetched_prompts = cfg.customization.custom_profile.get_prompts()
-    assert fetched_prompts is not None and fetched_prompts.get("default") == expected_prompts.get("default")
+    assert fetched_prompts is not None and fetched_prompts.get(
+        "default"
+    ) == expected_prompts.get("default")
+
 
 def test_configuration_with_all_customizations(tmpdir) -> None:
     """Test loading configuration from YAML file with a custom profile in the customization section alongside prompt and prompt path"""
@@ -477,7 +483,7 @@ def test_configuration_with_all_customizations(tmpdir) -> None:
     system_prompt_filename = tmpdir / "system_prompt.txt"
     with open(system_prompt_filename, "w", encoding="utf-8") as fout:
         fout.write("this is system prompt")
-    
+
     cfg_filename = tmpdir / "config.yaml"
     with open(cfg_filename, "w", encoding="utf-8") as fout:
         fout.write(
@@ -505,7 +511,11 @@ customization:
 
     cfg = AppConfig()
     cfg.load_configuration(cfg_filename)
-    
-    assert cfg.customization is not None and cfg.customization.custom_profile is not None
+
+    assert (
+        cfg.customization is not None and cfg.customization.custom_profile is not None
+    )
     fetched_prompts = cfg.customization.custom_profile.get_prompts()
-    assert fetched_prompts is not None and fetched_prompts.get("default") == expected_prompts.get("default")
+    assert fetched_prompts is not None and fetched_prompts.get(
+        "default"
+    ) == expected_prompts.get("default")

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -2,7 +2,7 @@
 
 import pytest
 from configuration import AppConfig
-from models.config import ModelContextProtocolServer
+from models.config import CustomProfile, ModelContextProtocolServer
 
 
 def test_default_configuration() -> None:
@@ -435,3 +435,77 @@ customization:
         cfg.customization.system_prompt.strip()
         == "this is system prompt in the customization section"
     )
+
+def test_configuration_with_profile_customization(tmpdir) -> None:
+    """Test loading configuration from YAML file with a custom profile in the customization section"""
+    expected_profile = CustomProfile("rhdh")
+    expected_prompts = expected_profile.get_prompts()
+    cfg_filename = tmpdir / "config.yaml"
+    with open(cfg_filename, "w", encoding="utf-8") as fout:
+        fout.write(
+            """
+name: test service
+service:
+  host: localhost
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  use_as_library_client: false
+  url: http://localhost:8321
+  api_key: test-key
+user_data_collection:
+  feedback_enabled: false
+customization:
+  profile_name: rhdh
+            """
+        )
+
+    cfg = AppConfig()
+    cfg.load_configuration(cfg_filename)
+    
+    assert cfg.customization is not None and cfg.customization.custom_profile is not None
+    fetched_prompts = cfg.customization.custom_profile.get_prompts()
+    assert fetched_prompts is not None and fetched_prompts.get("default") == expected_prompts.get("default")
+
+def test_configuration_with_all_customizations(tmpdir) -> None:
+    """Test loading configuration from YAML file with a custom profile in the customization section alongside prompt and prompt path"""
+    expected_profile = CustomProfile("rhdh")
+    expected_prompts = expected_profile.get_prompts()
+    system_prompt_filename = tmpdir / "system_prompt.txt"
+    with open(system_prompt_filename, "w", encoding="utf-8") as fout:
+        fout.write("this is system prompt")
+    
+    cfg_filename = tmpdir / "config.yaml"
+    with open(cfg_filename, "w", encoding="utf-8") as fout:
+        fout.write(
+            f"""
+name: test service
+service:
+  host: localhost
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  use_as_library_client: false
+  url: http://localhost:8321
+  api_key: test-key
+user_data_collection:
+  feedback_enabled: false
+customization:
+  profile_name: rhdh
+  system_prompt: custom prompt
+  system_prompt_path: {system_prompt_filename}
+            """
+        )
+
+    cfg = AppConfig()
+    cfg.load_configuration(cfg_filename)
+    
+    assert cfg.customization is not None and cfg.customization.custom_profile is not None
+    fetched_prompts = cfg.customization.custom_profile.get_prompts()
+    assert fetched_prompts is not None and fetched_prompts.get("default") == expected_prompts.get("default")

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -438,7 +438,7 @@ customization:
 
 
 def test_configuration_with_profile_customization(tmpdir) -> None:
-    """Test loading configuration from YAML file with a custom profile in the customization section"""
+    """Test loading configuration from YAML file with a custom profile."""
     expected_profile = CustomProfile("rhdh")
     expected_prompts = expected_profile.get_prompts()
     cfg_filename = tmpdir / "config.yaml"
@@ -477,7 +477,7 @@ customization:
 
 
 def test_configuration_with_all_customizations(tmpdir) -> None:
-    """Test loading configuration from YAML file with a custom profile in the customization section alongside prompt and prompt path"""
+    """Test loading configuration from YAML file with a custom profile, prompt and prompt path."""
     expected_profile = CustomProfile("rhdh")
     expected_prompts = expected_profile.get_prompts()
     system_prompt_filename = tmpdir / "system_prompt.txt"

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -83,24 +83,28 @@ def test_file_check_not_readable_file(input_file):
 
 
 def test_profile_check_empty():
+    """Test profile check for empty profile."""
     with pytest.raises(KeyError):
         checks.profile_check(None)
 
 
 def test_profile_check_missing():
+    """Test profile check for missing profile."""
     with pytest.raises(checks.InvalidConfigurationError):
         checks.profile_check("fake")
 
 
 def test_read_profile_error():
+    """Test profile reading with an error."""
     logger = Logger("test")
     data = checks.read_profile_file("/fake/path", "fake-profile", logger)
     assert data is None
 
 
 def test_read_profile():
+    """Test profile reading with a successful attempt."""
     logger = Logger("test")
     fpath = "utils.profiles"
     profile = "rhdh"
     data = checks.read_profile_file(fpath, profile, logger)
-    assert type(data) is ModuleType
+    assert isinstance(data, ModuleType)

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -81,18 +81,22 @@ def test_file_check_not_readable_file(input_file):
         with pytest.raises(checks.InvalidConfigurationError):
             checks.file_check(input_file, "description")
 
+
 def test_profile_check_empty():
     with pytest.raises(KeyError):
         checks.profile_check(None)
+
 
 def test_profile_check_missing():
     with pytest.raises(checks.InvalidConfigurationError):
         checks.profile_check("fake")
 
+
 def test_read_profile_error():
     logger = Logger("test")
     data = checks.read_profile_file("/fake/path", "fake-profile", logger)
     assert data is None
+
 
 def test_read_profile():
     logger = Logger("test")

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -1,7 +1,9 @@
 """Unit tests for functions defined in utils/checks module."""
 
+from logging import Logger
 import os
 from pathlib import Path
+from types import ModuleType
 from unittest.mock import patch
 
 import pytest
@@ -78,3 +80,23 @@ def test_file_check_not_readable_file(input_file):
     with patch("os.access", return_value=False):
         with pytest.raises(checks.InvalidConfigurationError):
             checks.file_check(input_file, "description")
+
+def test_profile_check_empty():
+    with pytest.raises(KeyError):
+        checks.profile_check(None)
+
+def test_profile_check_missing():
+    with pytest.raises(checks.InvalidConfigurationError):
+        checks.profile_check("fake")
+
+def test_read_profile_error():
+    logger = Logger("test")
+    data = checks.read_profile_file("/fake/path", "fake-profile", logger)
+    assert data is None
+
+def test_read_profile():
+    logger = Logger("test")
+    fpath = "utils.profiles"
+    profile = "rhdh"
+    data = checks.read_profile_file(fpath, profile, logger)
+    assert type(data) is ModuleType

--- a/tests/unit/utils/test_endpoints.py
+++ b/tests/unit/utils/test_endpoints.py
@@ -7,11 +7,12 @@ from fastapi import HTTPException
 import constants
 from configuration import AppConfig
 from models.config import CustomProfile
-from tests.unit import config_dict
-
 from models.requests import QueryRequest
+
 from utils import endpoints
 from utils.endpoints import get_agent
+
+from tests.unit import config_dict
 
 CONFIGURED_SYSTEM_PROMPT = "This is a configured system prompt"
 

--- a/tests/unit/utils/test_endpoints.py
+++ b/tests/unit/utils/test_endpoints.py
@@ -15,6 +15,7 @@ from utils.endpoints import get_agent
 
 CONFIGURED_SYSTEM_PROMPT = "This is a configured system prompt"
 
+
 @pytest.fixture(name="input_file")
 def input_file_fixture(tmp_path):
     """Create file manually using the tmp_path fixture."""
@@ -68,7 +69,10 @@ def config_with_custom_system_prompt_and_disable_query_system_prompt_fixture():
 
     return cfg
 
-@pytest.fixture(name="config_with_custom_profile_prompt_and_enabled_query_system_prompt")
+
+@pytest.fixture(
+    name="config_with_custom_profile_prompt_and_enabled_query_system_prompt"
+)
 def config_with_custom_profile_prompt_and_enabled_query_system_prompt_fixture():
     """Configuration with custom profile loaded for prompt and disabled query system prompt set."""
     test_config = config_dict.copy()
@@ -83,7 +87,10 @@ def config_with_custom_profile_prompt_and_enabled_query_system_prompt_fixture():
 
     return cfg
 
-@pytest.fixture(name="config_with_custom_profile_prompt_and_disable_query_system_prompt")
+
+@pytest.fixture(
+    name="config_with_custom_profile_prompt_and_disable_query_system_prompt"
+)
 def config_with_custom_profile_prompt_and_disable_query_system_prompt_fixture():
     """Configuration with custom profile loaded for prompt and disabled query system prompt set."""
     test_config = config_dict.copy()
@@ -203,6 +210,7 @@ def test_get_system_prompt_with_disable_query_system_prompt_and_non_system_promp
     )
     assert system_prompt == CONFIGURED_SYSTEM_PROMPT
 
+
 def test_get_profile_prompt_with_disable_query_system_prompt(
     config_with_custom_profile_prompt_and_disable_query_system_prompt,
     query_request_without_system_prompt,
@@ -215,6 +223,7 @@ def test_get_profile_prompt_with_disable_query_system_prompt(
         config_with_custom_profile_prompt_and_disable_query_system_prompt,
     )
     assert system_prompt == prompts.get("default")
+
 
 def test_get_profile_prompt_with_enabled_query_system_prompt(
     config_with_custom_profile_prompt_and_enabled_query_system_prompt,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

In Road Core there was a way to have a profile that allowed you to have customized prompts, validation, etc. See: https://github.com/road-core/service/tree/main/ols/customize

This PR aims to add that same functionality, starting with prompts. It adds my teams profile (RHDH) and updates the way you can customize prompts, allowing you to choose a profile instead. 

Also this PR updates the documentation to outline this new way to add prompts and adds ample tests.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/RHDHPAI-976
- Closes # https://issues.redhat.com/browse/RHDHPAI-976

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
