### PR TITLE
Dump config operation does not need to connect to Llama Stack

### DIFF
--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -63,17 +63,28 @@ def main() -> None:
     logger.info(
         "Llama stack configuration: %s", configuration.llama_stack_configuration
     )
+
+    # -d or --dump-configuration CLI flags are used to dump the actual configuration
+    # to a JSON file w/o doing any other operation
+    if args.dump_configuration:
+        try:
+            configuration.configuration.dump()
+            logger.info("Configuration dumped to configuration.json")
+        except Exception as e:
+            logger.error("Failed to dump configuration: %s", e)
+            raise SystemExit(1) from e
+        return
+
     logger.info("Creating AsyncLlamaStackClient")
     asyncio.run(
         AsyncLlamaStackClientHolder().load(configuration.configuration.llama_stack)
     )
     client = AsyncLlamaStackClientHolder().get_client()
+
+    # check if the Llama Stack version is supported by the service
     asyncio.run(check_llama_stack_version(client))
 
-    if args.dump_configuration:
-        configuration.configuration.dump()
-    else:
-        start_uvicorn(configuration.service_configuration)
+    start_uvicorn(configuration.service_configuration)
     logger.info("Lightspeed stack finished")
 
 


### PR DESCRIPTION
## Description

Dump config operation does not need to connect to Llama Stack

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an immediate configuration dump mode: using -d/--dump-configuration now outputs the configuration as JSON and exits without starting the server or performing version checks, enabling faster config inspection for scripts/CI.
  * Ensured version checks run early during normal startup so the server only starts after compatibility is validated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->