### PR TITLE
update store transcript function

### DIFF
--- a/src/utils/transcripts.py
+++ b/src/utils/transcripts.py
@@ -5,6 +5,7 @@ stored on disk for later analysis
 """
 
 from datetime import UTC, datetime
+import fcntl
 import json
 import logging
 import os
@@ -12,22 +13,20 @@ from pathlib import Path
 
 from configuration import configuration
 from models.requests import Attachment, QueryRequest
-from utils.suid import get_suid
 from utils.types import TurnSummary
 
 logger = logging.getLogger("utils.transcripts")
 
 
-def construct_transcripts_path(user_id: str, conversation_id: str) -> Path:
+def construct_transcripts_path(user_id: str) -> Path:
     """Construct path to transcripts."""
     # these two normalizations are required by Snyk as it detects
     # this Path sanitization pattern
     uid = os.path.normpath("/" + user_id).lstrip("/")
-    cid = os.path.normpath("/" + conversation_id).lstrip("/")
     file_path = (
         configuration.user_data_collection_configuration.transcripts_storage or ""
     )
-    return Path(file_path, uid, cid)
+    return Path(file_path, uid)
 
 
 def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
@@ -45,9 +44,14 @@ def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-
 ) -> None:
     """Store transcript in the local filesystem.
 
+    All turns for a single conversation are stored in the same file,
+    named after the conversation_id.
+
     Args:
         user_id: The user ID (UUID).
         conversation_id: The conversation ID (UUID).
+        model_id: The model ID.
+        provider_id: The provider ID.
         query_is_valid: The result of the query validation.
         query: The query (without attachments).
         query_request: The request containing a query.
@@ -56,17 +60,18 @@ def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-
         truncated: The flag indicating if the history was truncated.
         attachments: The list of `Attachment` objects.
     """
-    transcripts_path = construct_transcripts_path(user_id, conversation_id)
+    transcripts_path = construct_transcripts_path(user_id)
     transcripts_path.mkdir(parents=True, exist_ok=True)
 
-    data_to_store = {
+    # Use conversation_id as filename instead of random UUID
+    transcript_file_path = transcripts_path / f"{conversation_id}.json"
+    # Prepare turn data
+    turn_data = {
         "metadata": {
             "provider": provider_id,
             "model": model_id,
             "query_provider": query_request.provider,
             "query_model": query_request.model,
-            "user_id": user_id,
-            "conversation_id": conversation_id,
             "timestamp": datetime.now(UTC).isoformat(),
         },
         "redacted_query": query,
@@ -78,9 +83,39 @@ def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-
         "tool_calls": [tc.model_dump() for tc in summary.tool_calls],
     }
 
-    # stores feedback in a file under unique uuid
-    transcript_file_path = transcripts_path / f"{get_suid()}.json"
-    with open(transcript_file_path, "w", encoding="utf-8") as transcript_file:
-        json.dump(data_to_store, transcript_file)
+    # Use file locking to handle concurrent writes safely
+    with open(transcript_file_path, "a+", encoding="utf-8") as transcript_file:
+        fcntl.flock(transcript_file.fileno(), fcntl.LOCK_EX)
+        try:
+            # Move to beginning to read existing content
+            transcript_file.seek(0)
+            file_content = transcript_file.read()
+            if file_content.strip():
+                # File has existing content, load it
+                transcript_file.seek(0)
+                conversation_data = json.load(transcript_file)
+            else:
+                # First turn for this conversation
+                conversation_data = {
+                    "conversation_metadata": {
+                        "conversation_id": conversation_id,
+                        "user_id": user_id,
+                        "created_at": datetime.now(UTC).isoformat(),
+                        "last_updated": datetime.now(UTC).isoformat(),
+                    },
+                    "turns": [],
+                }
+            # Add new turn
+            conversation_data["turns"].append(turn_data)
+            conversation_data["conversation_metadata"]["last_updated"] = datetime.now(
+                UTC
+            ).isoformat()
 
-    logger.info("Transcript successfully stored at: %s", transcript_file_path)
+            # Write updated data back to file
+            transcript_file.seek(0)
+            transcript_file.truncate()
+            json.dump(conversation_data, transcript_file, indent=2)
+        finally:
+            fcntl.flock(transcript_file.fileno(), fcntl.LOCK_UN)
+
+    logger.info("Transcript turn successfully stored at: %s", transcript_file_path)


### PR DESCRIPTION
## Description

the old way how LCS stores transcripts,  each conversation turn got stored in a separate json file with a random uuid, is hard to determine the order or match with  turns from session data

update the  store transcript function to have all conversation turns for a single conversation_id stored under the same file. `tmp_storage/{user_id}/{conversation_id}.json`. It will be much more easier to locate the transcript file and also easier to extract particular information from the transcripts.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
