### PR TITLE
Allow authorization header to be omitted

### DIFF
--- a/src/auth/interface.py
+++ b/src/auth/interface.py
@@ -9,11 +9,15 @@ from abc import ABC, abstractmethod
 
 from fastapi import Request
 
+from constants import DEFAULT_USER_NAME, DEFAULT_USER_UID, NO_USER_TOKEN
+
 UserID = str
 UserName = str
 Token = str
 
 AuthTuple = tuple[UserID, UserName, Token]
+
+NO_AUTH_TUPLE: AuthTuple = (DEFAULT_USER_UID, DEFAULT_USER_NAME, NO_USER_TOKEN)
 
 
 class AuthInterface(ABC):  # pylint: disable=too-few-public-methods

--- a/src/auth/jwk_token.py
+++ b/src/auth/jwk_token.py
@@ -19,7 +19,7 @@ import aiohttp
 from constants import (
     DEFAULT_VIRTUAL_PATH,
 )
-from auth.interface import AuthInterface
+from auth.interface import NO_AUTH_TUPLE, AuthInterface, AuthTuple
 from auth.utils import extract_user_token
 from models.config import JwkConfiguration
 
@@ -120,10 +120,12 @@ class JwkTokenAuthDependency(AuthInterface):  # pylint: disable=too-few-public-m
         self.virtual_path: str = virtual_path
         self.config: JwkConfiguration = config
 
-    async def __call__(self, request: Request) -> tuple[str, str, str]:
+    async def __call__(self, request: Request) -> AuthTuple:
         """Authenticate the JWT in the headers against the keys from the JWK url."""
-        user_token = extract_user_token(request.headers)
+        if not request.headers.get("Authorization"):
+            return NO_AUTH_TUPLE
 
+        user_token = extract_user_token(request.headers)
         jwk_set = await get_jwk_set(str(self.config.url))
 
         try:

--- a/src/authorization/resolvers.py
+++ b/src/authorization/resolvers.py
@@ -9,6 +9,7 @@ from jsonpath_ng import parse
 
 from auth.interface import AuthTuple
 from models.config import JwtRoleRule, AccessRule, JsonPathOperator, Action
+import constants
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +72,10 @@ class JwtRolesResolver(RolesResolver):  # pylint: disable=too-few-public-methods
     def _get_claims(auth: AuthTuple) -> dict[str, Any]:
         """Get the JWT claims from the auth tuple."""
         _, _, token = auth
+        if token == constants.NO_USER_TOKEN:
+            # No claims for guests
+            return {}
+
         jwt_claims = json.loads(token)
 
         if not jwt_claims:

--- a/tests/unit/auth/test_jwk_token.py
+++ b/tests/unit/auth/test_jwk_token.py
@@ -12,6 +12,7 @@ from pydantic import AnyHttpUrl
 from authlib.jose import JsonWebKey, JsonWebToken
 
 from auth.jwk_token import JwkTokenAuthDependency, _jwk_cache
+from constants import DEFAULT_USER_NAME, DEFAULT_USER_UID, NO_USER_TOKEN
 from models.config import JwkConfiguration, JwtConfiguration
 
 TEST_USER_ID = "test-user-123"
@@ -267,11 +268,11 @@ async def test_no_auth_header(
 
     dependency = JwkTokenAuthDependency(default_jwk_configuration)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await dependency(no_token_request)
+    user_id, username, token_claims = await dependency(no_token_request)
 
-    assert exc_info.value.status_code == 400
-    assert exc_info.value.detail == "No Authorization header found"
+    assert user_id == DEFAULT_USER_UID
+    assert username == DEFAULT_USER_NAME
+    assert token_claims == NO_USER_TOKEN
 
 
 async def test_no_bearer(


### PR DESCRIPTION
## Description

Endpoints configured for the anybody (`*`) role should work without an Authorization header.

This change allows requests without the header to be processed, returning a default user identity, which will obviously receive the anybody role (`*`) (because everyone receives it), so if the configuration allows particular endpoints to be reachable by the `*` role, guests (no auth header) users will be authorized to use it.

This is good for the readiness/liveness endpoints

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unauthenticated requests without an Authorization header are now treated as “guest” access instead of returning an error.
  * Guest requests use a default user identity and carry no JWT claims, allowing public endpoints to function without authentication while maintaining restricted permissions.
* **Tests**
  * Updated unit tests to validate guest behavior for missing Authorization headers and ensure consistent handling of default user identity and empty claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->