### PR TITLE
fix(auth): Use token in `AuthTuple`

### DIFF
--- a/src/auth/jwk_token.py
+++ b/src/auth/jwk_token.py
@@ -1,7 +1,6 @@
 """Manage authentication flow for FastAPI endpoints with JWK based JWT auth."""
 
 import logging
-import json
 from asyncio import Lock
 from typing import Any, Callable
 
@@ -191,4 +190,4 @@ class JwkTokenAuthDependency(AuthInterface):  # pylint: disable=too-few-public-m
 
         logger.info("Successfully authenticated user %s (ID: %s)", username, user_id)
 
-        return user_id, username, json.dumps(claims)
+        return user_id, username, user_token

--- a/tests/unit/auth/test_jwk_token.py
+++ b/tests/unit/auth/test_jwk_token.py
@@ -3,8 +3,6 @@
 """Unit tests for functions defined in auth/jwk_token.py"""
 
 import time
-import json
-import base64
 
 import pytest
 from fastapi import HTTPException, Request
@@ -174,19 +172,12 @@ def set_auth_header(request: Request, token: str):
     request.scope["headers"] = new_headers
 
 
-def get_claims(token: str):
-    """Extract claims from a JWT token without validating it."""
-    payload = token.split(".")[1]
-    padded = payload + "=" * (-len(payload) % 4)
-    return json.loads(base64.urlsafe_b64decode(padded))
-
-
-def ensure_test_user_id_and_name(auth_tuple, token):
+def ensure_test_user_id_and_name(auth_tuple, expected_token):
     """Utility to ensure that the values in the auth tuple match the test values."""
-    user_id, username, token_claims = auth_tuple
+    user_id, username, token = auth_tuple
     assert user_id == TEST_USER_ID
     assert username == TEST_USER_NAME
-    assert json.loads(token_claims) == get_claims(token)
+    assert token == expected_token
 
 
 async def test_valid(

--- a/tests/unit/authorization/test_resolvers.py
+++ b/tests/unit/authorization/test_resolvers.py
@@ -1,7 +1,21 @@
 """Unit tests for the authorization resolvers."""
 
+import json
+import base64
+
 from authorization.resolvers import JwtRolesResolver, GenericAccessResolver
 from models.config import JwtRoleRule, AccessRule, JsonPathOperator, Action
+
+
+def claims_to_token(claims: dict) -> str:
+    """Convert JWT claims dictionary to a JSON string token."""
+
+    string_claims = json.dumps(claims)
+    b64_encoded_claims = (
+        base64.urlsafe_b64encode(string_claims.encode()).decode().rstrip("=")
+    )
+
+    return f"foo_header.{b64_encoded_claims}.foo_signature"
 
 
 class TestJwtRolesResolver:
@@ -33,7 +47,7 @@ class TestJwtRolesResolver:
         }
 
         # Mock auth tuple with JWT claims as third element
-        auth = ("user", "token", str(jwt_claims).replace("'", '"'))
+        auth = ("user", "token", claims_to_token(jwt_claims))
         roles = await jwt_resolver.resolve_roles(auth)
         assert "employee" in roles
 
@@ -57,7 +71,7 @@ class TestJwtRolesResolver:
         }
 
         # Mock auth tuple with JWT claims as third element
-        auth = ("user", "token", str(jwt_claims).replace("'", '"'))
+        auth = ("user", "token", claims_to_token(jwt_claims))
         roles = await jwt_resolver.resolve_roles(auth)
         assert len(roles) == 0
 


### PR DESCRIPTION
While implementing authz I've made the authentication module put the claims in the `AuthTuple` instead of putting the original token because I assumed the original token was unnecessary and I didn't want to make the authz module re-parse the token to get the claims.

That was a mistake, because we need to pass on the user token to the MCP server for it to validate the user's access. So this commit changes the `AuthTuple` to contain the original token instead of the claims.

The authz module has been updated to parse the claims from the token instead of receiving them as a JSON string. Somewhat hackily, since we don't want to re-verify the token signature, so we assume that the token has already been verified during authentication and just decode the claims from the middle section of the JWT token.


## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Adjusted unit-tests, tested that MCP now works correctly manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a JWT-based role resolver that derives user roles from token claims using configurable rules.
- Behavior Changes
  - Authentication now propagates the raw user token instead of parsed claims, while still validating user identity.
- Security
  - Introduced safer handling of JWT claims extraction for role evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->