### PR TITLE
LCORE-534: Mitigate CVE GHSA-wj6h-64fc-37mp - remove python-ecdsa

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -27,6 +27,13 @@ COPY ${LSC_SOURCE_DIR}/pyproject.toml ${LSC_SOURCE_DIR}/LICENSE ${LSC_SOURCE_DIR
 # Bundle additional dependencies for library mode.
 RUN uv sync --locked --no-dev --group llslibdev
 
+# Explicitly remove some packages to mitigate some CVEs
+# - GHSA-wj6h-64fc-37mp: python-ecdsa package won't fix it upstream.
+#   This package is required by python-jose. python-jose supports multiple
+#   backends. By default it uses python-cryptography package instead of
+#   python-ecdsa. It is safe to remove python-ecdsa package.
+RUN uv pip uninstall ecdsa
+
 # Final image without uv package manager
 FROM registry.access.redhat.com/ubi9/python-312-minimal
 ARG APP_ROOT=/app-root


### PR DESCRIPTION
## Description

LCORE-534: Mitigate CVE GHSA-wj6h-64fc-37mp - remove python-ecdsa

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
