### PR TITLE
LCORE-583: print all Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,6 @@ help: ## Show this help screen
 	@echo ''
 	@echo 'Available targets are:'
 	@echo ''
-	@grep -E '^[ a-zA-Z0-9_.-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	@grep -E '^[ a-zA-Z0-9_./-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-33s\033[0m %s\n", $$1, $$2}'
 	@echo ''

--- a/README.md
+++ b/README.md
@@ -567,6 +567,9 @@ format                            Format the code into unified format
 schema                            Generate OpenAPI schema file
 openapi-doc                       Generate OpenAPI documentation
 requirements.txt                  Generate requirements.txt file containing hashes for all non-devel packages
+docs/config.puml                  Generate PlantUML class diagram for configuration
+docs/config.png                   Generate an image with configuration graph
+docs/config.svg                   Generate an SVG with configuration graph
 shellcheck                        Run shellcheck
 verify                            Run all linters
 distribution-archives             Generate distribution archives to be uploaded into Python registry


### PR DESCRIPTION
## Description

LCORE-583: print all Makefile targets

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Improved Makefile help output to list targets that include path separators, making all documentation-related tasks visible. No changes to build behavior.
* Documentation
  * Added README entries for new documentation targets:
    * docs/config.puml – generate PlantUML class diagram for configuration.
    * docs/config.png – generate an image of the configuration graph.
    * docs/config.svg – generate an SVG of the configuration graph.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->