### PR TITLE
Remove nonsensical `user_id` filter

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -81,9 +81,7 @@ def persist_user_conversation_details(
     """Associate conversation to user in the database."""
     with get_session() as session:
         existing_conversation = (
-            session.query(UserConversation)
-            .filter_by(id=conversation_id, user_id=user_id)
-            .first()
+            session.query(UserConversation).filter_by(id=conversation_id).first()
         )
 
         if not existing_conversation:


### PR DESCRIPTION
## Description

When checking whether an existing conversation already exists before persisting user conversation details, the `user_id` filter is unnecessary - the `conversation_id` is already unique, and ownership has already been validated in prior steps.

This change removes the redundant `user_id` filter from the query.

Inspired by [this](https://github.com/lightspeed-core/lightspeed-stack/pull/476#issuecomment-3244669219) comment

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Tested manually. User conversations are still persisted correctly. Unit tests are still passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined conversation persistence to identify existing conversations by ID, ensuring consistent updates to metadata (last used model/provider, last activity time, message counts).
  - Creation of new conversations remains unchanged.
  - Expected impact: more reliable conversation history continuity across sessions; no visual changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->