### PR TITLE
add timestamp to feedback status updates

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1534,11 +1534,12 @@
                     "status"
                 ],
                 "title": "FeedbackStatusUpdateResponse",
-                "description": "Model representing a response to a feedback status update request.\n\nAttributes:\n    status: The previous and current status of the service and who updated it.\n\nExample:\n    ```python\n    status_response = StatusResponse(\n        status={\n            \"previous_status\": true,\n            \"updated_status\": false,\n            \"updated_by\": \"user/test\"\n        },\n    )\n    ```",
+                "description": "Model representing a response to a feedback status update request.\n\nAttributes:\n    status: The previous and current status of the service and who updated it.\n\nExample:\n    ```python\n    status_response = StatusResponse(\n        status={\n            \"previous_status\": true,\n            \"updated_status\": false,\n            \"updated_by\": \"user/test\",\n            \"timestamp\": \"2023-03-15 12:34:56\"\n        },\n    )\n    ```",
                 "examples": [
                     {
                         "status": {
                             "previous_status": true,
+                            "timestamp": "2023-03-15 12:34:56",
                             "updated_by": "user/test",
                             "updated_status": false
                         }
@@ -1659,7 +1660,8 @@
                 "enum": [
                     "equals",
                     "contains",
-                    "in"
+                    "in",
+                    "match"
                 ],
                 "title": "JsonPathOperator",
                 "description": "Supported operators for JSONPath evaluation."

--- a/src/app/endpoints/feedback.py
+++ b/src/app/endpoints/feedback.py
@@ -208,11 +208,13 @@ async def update_feedback_status(
         updated_status = (
             configuration.user_data_collection_configuration.feedback_enabled
         )
+        current_time = str(datetime.now(UTC))
 
     return FeedbackStatusUpdateResponse(
         status={
             "previous_status": previous_status,
             "updated_status": updated_status,
             "updated_by": user_id,
+            "timestamp": current_time,
         }
     )

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -593,7 +593,8 @@ class FeedbackStatusUpdateResponse(BaseModel):
             status={
                 "previous_status": true,
                 "updated_status": false,
-                "updated_by": "user/test"
+                "updated_by": "user/test",
+                "timestamp": "2023-03-15 12:34:56"
             },
         )
         ```
@@ -610,6 +611,7 @@ class FeedbackStatusUpdateResponse(BaseModel):
                         "previous_status": True,
                         "updated_status": False,
                         "updated_by": "user/test",
+                        "timestamp": "2023-03-15 12:34:56",
                     },
                 }
             ]

--- a/tests/unit/app/endpoints/test_feedback.py
+++ b/tests/unit/app/endpoints/test_feedback.py
@@ -197,7 +197,7 @@ def test_store_feedback_on_io_error(mocker, feedback_request_data):
         store_feedback(user_id, feedback_request_data)
 
 
-async def test_update_feedback_status_different():
+async def test_update_feedback_status_different(mocker):
     """Test that update_feedback_status returns the correct status with an update."""
     configuration.user_data_collection_configuration.feedback_enabled = True
 
@@ -210,10 +210,11 @@ async def test_update_feedback_status_different():
         "previous_status": True,
         "updated_status": False,
         "updated_by": "test_user_id",
+        "timestamp": mocker.ANY,
     }
 
 
-async def test_update_feedback_status_no_change():
+async def test_update_feedback_status_no_change(mocker):
     """Test that update_feedback_status returns the correct status with no update."""
     configuration.user_data_collection_configuration.feedback_enabled = True
 
@@ -226,4 +227,5 @@ async def test_update_feedback_status_no_change():
         "previous_status": True,
         "updated_status": True,
         "updated_by": "test_user_id",
+        "timestamp": mocker.ANY,
     }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Adds a `timestamp` to the response when you update the feedback status via the `PUT` endpoint.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # N/A
- Closes # N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
