### PR TITLE
LCORE-411: add token usage metrics

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -24,6 +24,7 @@ from client import AsyncLlamaStackClientHolder
 from configuration import configuration
 from app.database import get_session
 import metrics
+from metrics.utils import update_llm_token_count_from_turn
 import constants
 from authorization.middleware import authorize
 from models.config import Action
@@ -218,6 +219,7 @@ async def query_endpoint_handler(
             query_request,
             token,
             mcp_headers=mcp_headers,
+            provider_id=provider_id,
         )
         # Update metrics for the LLM call
         metrics.llm_calls_total.labels(provider_id, model_id).inc()
@@ -387,12 +389,14 @@ def is_input_shield(shield: Shield) -> bool:
     return _is_inout_shield(shield) or not is_output_shield(shield)
 
 
-async def retrieve_response(  # pylint: disable=too-many-locals,too-many-branches
+async def retrieve_response(  # pylint: disable=too-many-locals,too-many-branches,too-many-arguments
     client: AsyncLlamaStackClient,
     model_id: str,
     query_request: QueryRequest,
     token: str,
     mcp_headers: dict[str, dict[str, str]] | None = None,
+    *,
+    provider_id: str = "",
 ) -> tuple[TurnSummary, str]:
     """
     Retrieve response from LLMs and agents.
@@ -411,6 +415,7 @@ async def retrieve_response(  # pylint: disable=too-many-locals,too-many-branche
 
     Parameters:
         model_id (str): The identifier of the LLM model to use.
+        provider_id (str): The identifier of the LLM provider to use.
         query_request (QueryRequest): The user's query and associated metadata.
         token (str): The authentication token for authorization.
         mcp_headers (dict[str, dict[str, str]], optional): Headers for multi-component processing.
@@ -509,6 +514,10 @@ async def retrieve_response(  # pylint: disable=too-many-locals,too-many-branche
         ),
         tool_calls=[],
     )
+
+    # Update token count metrics for the LLM call
+    model_label = model_id.split("/", 1)[1] if "/" in model_id else model_id
+    update_llm_token_count_from_turn(response, model_label, provider_id, system_prompt)
 
     # Check for validation errors in the response
     steps = response.steps or []

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -46,6 +46,14 @@ def dummy_request() -> Request:
     return req
 
 
+def mock_metrics(mocker):
+    """Helper function to mock metrics operations for query endpoints."""
+    mocker.patch(
+        "app.endpoints.query.update_llm_token_count_from_turn",
+        return_value=None,
+    )
+
+
 def mock_database_operations(mocker):
     """Helper function to mock database operations for query endpoints."""
     mocker.patch(
@@ -443,6 +451,7 @@ async def test_retrieve_response_no_returned_message(prepare_agent_mocks, mocker
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -474,6 +483,7 @@ async def test_retrieve_response_message_without_content(prepare_agent_mocks, mo
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -506,6 +516,7 @@ async def test_retrieve_response_vector_db_available(prepare_agent_mocks, mocker
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -544,6 +555,7 @@ async def test_retrieve_response_no_available_shields(prepare_agent_mocks, mocke
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -593,6 +605,7 @@ async def test_retrieve_response_one_available_shield(prepare_agent_mocks, mocke
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -645,6 +658,7 @@ async def test_retrieve_response_two_available_shields(prepare_agent_mocks, mock
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -699,6 +713,7 @@ async def test_retrieve_response_four_available_shields(prepare_agent_mocks, moc
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -755,6 +770,7 @@ async def test_retrieve_response_with_one_attachment(prepare_agent_mocks, mocker
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?", attachments=attachments)
     model_id = "fake_model_id"
@@ -809,6 +825,7 @@ async def test_retrieve_response_with_two_attachments(prepare_agent_mocks, mocke
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?", attachments=attachments)
     model_id = "fake_model_id"
@@ -864,6 +881,7 @@ async def test_retrieve_response_with_mcp_servers(prepare_agent_mocks, mocker):
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -933,6 +951,7 @@ async def test_retrieve_response_with_mcp_servers_empty_token(
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -994,6 +1013,7 @@ async def test_retrieve_response_with_mcp_servers_and_mcp_headers(
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
     model_id = "fake_model_id"
@@ -1090,6 +1110,7 @@ async def test_retrieve_response_shield_violation(prepare_agent_mocks, mocker):
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?")
 
@@ -1326,6 +1347,7 @@ async def test_retrieve_response_no_tools_bypasses_mcp_and_rag(
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?", no_tools=True)
     model_id = "fake_model_id"
@@ -1376,6 +1398,7 @@ async def test_retrieve_response_no_tools_false_preserves_functionality(
         "app.endpoints.query.get_agent",
         return_value=(mock_agent, "fake_conversation_id", "fake_session_id"),
     )
+    mock_metrics(mocker)
 
     query_request = QueryRequest(query="What is OpenStack?", no_tools=False)
     model_id = "fake_model_id"

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -58,6 +58,14 @@ def mock_database_operations(mocker):
     mocker.patch("app.endpoints.streaming_query.persist_user_conversation_details")
 
 
+def mock_metrics(mocker):
+    """Helper function to mock metrics operations for streaming query endpoints."""
+    mocker.patch(
+        "app.endpoints.streaming_query.update_llm_token_count_from_turn",
+        return_value=None,
+    )
+
+
 SAMPLE_KNOWLEDGE_SEARCH_RESULTS = [
     """knowledge_search tool found 2 chunks:
 BEGIN of knowledge_search tool results.
@@ -346,12 +354,14 @@ async def _test_streaming_query_endpoint_handler(mocker, store_transcript=False)
 @pytest.mark.asyncio
 async def test_streaming_query_endpoint_handler(mocker):
     """Test the streaming query endpoint handler with transcript storage disabled."""
+    mock_metrics(mocker)
     await _test_streaming_query_endpoint_handler(mocker, store_transcript=False)
 
 
 @pytest.mark.asyncio
 async def test_streaming_query_endpoint_handler_store_transcript(mocker):
     """Test the streaming query endpoint handler with transcript storage enabled."""
+    mock_metrics(mocker)
     await _test_streaming_query_endpoint_handler(mocker, store_transcript=True)
 
 


### PR DESCRIPTION
## Description

record metrics of tokens sent to LLM provider and those received from LLM provider. 

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-411](https://issues.redhat.com/browse/LCORE-411)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.

call the query or streaming_query endpoint and check the metrics `llm_token_received_total` and `llm_token_sent_total`

- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved token usage metrics with provider attribution across both standard and streaming queries for more accurate reporting.
  * Integrated per-turn token counting without altering user-facing behavior.

* **Tests**
  * Added unit tests validating token counting logic.
  * Updated query and streaming endpoint tests to mock metrics updates, ensuring stable and focused test runs.

* **Note**
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->