### PR TITLE
LCORE-395: config endpoint should not leak secrets

### DIFF
--- a/src/app/database.py
+++ b/src/app/database.py
@@ -59,7 +59,7 @@ def _create_postgres_engine(
 ) -> Engine:
     """Create PostgreSQL database engine."""
     postgres_url = (
-        f"postgresql://{config.user}:{config.password}@"
+        f"postgresql://{config.user}:{config.password.get_secret_value()}@"
         f"{config.host}:{config.port}/{config.db}"
         f"?sslmode={config.ssl_mode}&gssencmode={config.gss_encmode}"
     )

--- a/src/app/endpoints/config.py
+++ b/src/app/endpoints/config.py
@@ -36,7 +36,7 @@ get_config_responses: dict[int | str, dict[str, Any]] = {
         },
         "llama_stack": {
             "url": "http://localhost:8321",
-            "api_key": "xyzzy",
+            "api_key": "*****",
             "use_as_library_client": False,
             "library_client_config_path": None,
         },

--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -176,10 +176,8 @@ async def query_endpoint_handler(
     # Enforce RBAC: optionally disallow overriding model/provider in requests
     validate_model_provider_override(query_request, request.state.authorized_actions)
 
-    # log Llama Stack configuration, but without sensitive information
-    llama_stack_config = configuration.llama_stack_configuration.model_copy()
-    llama_stack_config.api_key = "********"
-    logger.info("Llama stack config: %s", llama_stack_config)
+    # log Llama Stack configuration
+    logger.info("Llama stack config: %s", configuration.llama_stack_configuration)
 
     user_id, _, token = auth
 

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -552,10 +552,8 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
     # Enforce RBAC: optionally disallow overriding model/provider in requests
     validate_model_provider_override(query_request, request.state.authorized_actions)
 
-    # log Llama Stack configuration, but without sensitive information
-    llama_stack_config = configuration.llama_stack_configuration.model_copy()
-    llama_stack_config.api_key = "********"
-    logger.info("Llama stack config: %s", llama_stack_config)
+    # log Llama Stack configuration
+    logger.info("Llama stack config: %s", configuration.llama_stack_configuration)
 
     user_id, _user_name, token = auth
 

--- a/src/client.py
+++ b/src/client.py
@@ -38,7 +38,12 @@ class AsyncLlamaStackClientHolder(metaclass=Singleton):
         else:
             logger.info("Using Llama stack running as a service")
             self._lsc = AsyncLlamaStackClient(
-                base_url=llama_stack_config.url, api_key=llama_stack_config.api_key
+                base_url=llama_stack_config.url,
+                api_key=(
+                    llama_stack_config.api_key.get_secret_value()
+                    if llama_stack_config.api_key is not None
+                    else None
+                ),
             )
 
     def get_client(self) -> AsyncLlamaStackClient:

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -16,6 +16,7 @@ from pydantic import (
     FilePath,
     AnyHttpUrl,
     PositiveInt,
+    SecretStr,
 )
 from typing_extensions import Self, Literal
 
@@ -80,7 +81,7 @@ class PostgreSQLDatabaseConfiguration(ConfigurationBase):
     port: PositiveInt = 5432
     db: str
     user: str
-    password: str
+    password: SecretStr
     namespace: Optional[str] = "lightspeed-stack"
     ssl_mode: str = constants.POSTGRES_DEFAULT_SSL_MODE
     gss_encmode: str = constants.POSTGRES_DEFAULT_GSS_ENCMODE
@@ -167,7 +168,7 @@ class LlamaStackConfiguration(ConfigurationBase):
     """Llama stack configuration."""
 
     url: Optional[str] = None
-    api_key: Optional[str] = None
+    api_key: Optional[SecretStr] = None
     use_as_library_client: Optional[bool] = None
     library_client_config_path: Optional[str] = None
 

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -58,7 +58,7 @@ def test_loading_proper_configuration(configuration_filename: str) -> None:
     ls_config = cfg.llama_stack_configuration
     assert ls_config.use_as_library_client is False
     assert ls_config.url == "http://localhost:8321"
-    assert ls_config.api_key == "xyzzy"
+    assert ls_config.api_key.get_secret_value() == "xyzzy"
 
     # check 'user_data_collection' section
     udc_config = cfg.user_data_collection_configuration

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -537,6 +537,18 @@ def test_dump_configuration(tmp_path) -> None:
         user_data_collection=UserDataCollection(
             feedback_enabled=False, feedback_storage=None
         ),
+        database=DatabaseConfiguration(
+            sqlite=None,
+            postgres=PostgreSQLDatabaseConfiguration(
+                db="lightspeed_stack",
+                user="ls_user",
+                password="ls_password",
+                port=5432,
+                ca_cert_path=None,
+                ssl_mode="require",
+                gss_encmode="disable",
+            ),
+        ),
         mcp_servers=[],
         customization=None,
         inference=InferenceConfiguration(
@@ -601,8 +613,8 @@ def test_dump_configuration(tmp_path) -> None:
             },
             "llama_stack": {
                 "url": None,
-                "api_key": "whatever",
                 "use_as_library_client": True,
+                "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
             },
             "user_data_collection": {
@@ -625,8 +637,18 @@ def test_dump_configuration(tmp_path) -> None:
                 "default_model": "default_model",
             },
             "database": {
-                "sqlite": {"db_path": "/tmp/lightspeed-stack.db"},
-                "postgres": None,
+                "sqlite": None,
+                "postgres": {
+                    "host": "localhost",
+                    "port": 5432,
+                    "db": "lightspeed_stack",
+                    "user": "ls_user",
+                    "password": "**********",
+                    "ssl_mode": "require",
+                    "gss_encmode": "disable",
+                    "namespace": "lightspeed-stack",
+                    "ca_cert_path": None,
+                },
             },
             "authorization": None,
         }
@@ -980,7 +1002,7 @@ def test_postgresql_database_configuration() -> None:
     assert c.port == 5432
     assert c.db == "db"
     assert c.user == "user"
-    assert c.password == "password"
+    assert c.password.get_secret_value() == "password"
     assert c.ssl_mode == POSTGRES_DEFAULT_SSL_MODE
     assert c.gss_encmode == POSTGRES_DEFAULT_GSS_ENCMODE
     assert c.namespace == "lightspeed-stack"

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -83,7 +83,7 @@ def test_init_from_dict() -> None:
     assert cfg.configuration.name == "foo"
 
     # check for llama_stack_configuration subsection
-    assert cfg.llama_stack_configuration.api_key == "xyzzy"
+    assert cfg.llama_stack_configuration.api_key.get_secret_value() == "xyzzy"
     assert cfg.llama_stack_configuration.url == "http://x.y.com:1234"
     assert cfg.llama_stack_configuration.use_as_library_client is False
 


### PR DESCRIPTION
## Description

Right now in assisted-chat we're blocking the config endpoint completely, even for employees, because it leaks secrets like:

- database password
- llama stack api key

This change makes sure those secrets are not included in the serialized configuration. This way we can open up the config endpoint to employees again (still not the public, because it contains things like system prompt, which we would like to keep private).

## Type of change

- [ ] Refactor
- [x] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #
LCORE-395

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Adjusted unit-tests and checked manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Configuration export now shows a richer PostgreSQL section (host, port, database, user, SSL options, namespace, CA cert) for improved clarity.

- Bug Fixes / Security
  - Secrets (API keys, DB passwords) are now represented as secure secret types and are redacted in exported configuration views; note logging behavior related to API keys was adjusted—please review logging/config for sensitive data exposure.

- Tests
  - Unit and integration tests updated to validate the new serialization and secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->