### PR TITLE
LCORE-637: Bundle jq and patch with the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ USER root
 RUN dnf --disablerepo="*" --enablerepo="ubi-9-appstream-rpms" --enablerepo="ubi-9-baseos-rpms" install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs gcc
 
 # Install uv package manager
-RUN pip3.12 install "uv==0.8.11"
+RUN pip3.12 install "uv==0.8.15"
 
 # Add explicit files and directories
 # (avoid accidental inclusion of local directories or env files or credentials)
@@ -57,7 +57,12 @@ COPY --from=builder /app-root/LICENSE /licenses/
 # Add uv to final image for derived images to add additional dependencies
 # with command:
 # $ uv pip install <dependency>
-RUN pip3.12 install "uv==0.8.11"
+RUN pip3.12 install "uv==0.8.15"
+
+USER root
+
+# Additional tools for derived images
+RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs jq patch
 
 # Add executables from .venv to system PATH
 ENV PATH="/app-root/.venv/bin:$PATH"


### PR DESCRIPTION
## Description

LCORE-637: Bundle jq and patch with the image

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image to use uv 0.8.15 in both build and runtime stages (was 0.8.11).
  * Added jq and patch to the runtime image so those command-line tools are available.
  * Result: Consistent package manager version across stages and additional CLI utilities present in the image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->