### PR TITLE
LCORE-643: don't store None value in boolean CLI option

### DIFF
--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -31,7 +31,7 @@ def create_argument_parser() -> ArgumentParser:
         dest="verbose",
         help="make it verbose",
         action="store_true",
-        default=None,
+        default=False,
     )
     parser.add_argument(
         "-d",
@@ -39,7 +39,7 @@ def create_argument_parser() -> ArgumentParser:
         dest="dump_configuration",
         help="dump actual configuration into JSON file and quit",
         action="store_true",
-        default=None,
+        default=False,
     )
     parser.add_argument(
         "-c",


### PR DESCRIPTION
## Description

LCORE-643: don't store `None` value in boolean CLI option

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The --verbose and --dump-configuration command-line options now default to off when not provided.
  * Values are consistently boolean, eliminating edge cases from None defaults and improving reliability in checks and automation.
  * Existing usage remains unchanged: pass the flag to enable.
  * No changes to public interfaces or other behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->