### PR TITLE
LCORE-636: split config Customization unit tests

### DIFF
--- a/tests/unit/models/config/test_customization.py
+++ b/tests/unit/models/config/test_customization.py
@@ -1,0 +1,64 @@
+"""Unit tests for Customization model."""
+
+import pytest
+
+from pydantic import ValidationError
+
+from models.config import Customization
+
+
+def test_service_customization(subtests) -> None:
+    """Check the service customization class."""
+    with subtests.test(msg="System prompt is enabled"):
+        c = Customization()
+        assert c is not None
+        assert c.disable_query_system_prompt is False
+        assert c.system_prompt_path is None
+        assert c.system_prompt is None
+
+    with subtests.test(msg="System prompt is disabled"):
+        c = Customization(disable_query_system_prompt=True)
+        assert c is not None
+        assert c.disable_query_system_prompt is True
+        assert c.system_prompt_path is None
+        assert c.system_prompt is None
+
+    with subtests.test(
+        msg="Disabled overrides provided path, but the prompt is still loaded"
+    ):
+        c = Customization(
+            disable_query_system_prompt=True,
+            system_prompt_path="tests/configuration/system_prompt.txt",
+        )
+        assert c.system_prompt is not None
+        # check that the system prompt has been loaded from the provided file
+        assert c.system_prompt == "This is system prompt."
+        # but it is still disabled
+        assert c.disable_query_system_prompt is True
+
+
+def test_service_customization_wrong_system_prompt_path() -> None:
+    """Check the service customization class."""
+    with pytest.raises(ValidationError, match="Path does not point to a file"):
+        _ = Customization(system_prompt_path="/path/does/not/exists")
+
+
+def test_service_customization_correct_system_prompt_path(subtests) -> None:
+    """Check the service customization class."""
+    with subtests.test(msg="One line system prompt"):
+        # pass a file containing system prompt
+        c = Customization(system_prompt_path="tests/configuration/system_prompt.txt")
+        assert c is not None
+        # check that the system prompt has been loaded from the provided file
+        assert c.system_prompt == "This is system prompt."
+
+    with subtests.test(msg="Multi line system prompt"):
+        # pass a file containing system prompt
+        c = Customization(
+            system_prompt_path="tests/configuration/multiline_system_prompt.txt"
+        )
+        assert c is not None
+        # check that the system prompt has been loaded from the provided file
+        assert "You are OpenShift Lightspeed" in c.system_prompt
+        assert "Here are your instructions" in c.system_prompt
+        assert "Here are some basic facts about OpenShift" in c.system_prompt

--- a/tests/unit/models/test_config.py
+++ b/tests/unit/models/test_config.py
@@ -35,7 +35,6 @@ from models.config import (
     PostgreSQLDatabaseConfiguration,
     SQLiteDatabaseConfiguration,
     DatabaseConfiguration,
-    Customization,
 )
 
 
@@ -1165,60 +1164,3 @@ def test_jwt_role_rule_invalid_regexp() -> None:
             roles=["admin", "user"],
             operator=JsonPathOperator.MATCH,
         )
-
-
-def test_service_customization(subtests) -> None:
-    """Check the service customization class."""
-    with subtests.test(msg="System prompt is enabled"):
-        c = Customization()
-        assert c is not None
-        assert c.disable_query_system_prompt is False
-        assert c.system_prompt_path is None
-        assert c.system_prompt is None
-
-    with subtests.test(msg="System prompt is disabled"):
-        c = Customization(disable_query_system_prompt=True)
-        assert c is not None
-        assert c.disable_query_system_prompt is True
-        assert c.system_prompt_path is None
-        assert c.system_prompt is None
-
-    with subtests.test(
-        msg="Disabled overrides provided path, but the prompt is still loaded"
-    ):
-        c = Customization(
-            disable_query_system_prompt=True,
-            system_prompt_path="tests/configuration/system_prompt.txt",
-        )
-        assert c.system_prompt is not None
-        # check that the system prompt has been loaded from the provided file
-        assert c.system_prompt == "This is system prompt."
-        # but it is still disabled
-        assert c.disable_query_system_prompt is True
-
-
-def test_service_customization_wrong_system_prompt_path() -> None:
-    """Check the service customization class."""
-    with pytest.raises(ValidationError, match="Path does not point to a file"):
-        _ = Customization(system_prompt_path="/path/does/not/exists")
-
-
-def test_service_customization_correct_system_prompt_path(subtests) -> None:
-    """Check the service customization class."""
-    with subtests.test(msg="One line system prompt"):
-        # pass a file containing system prompt
-        c = Customization(system_prompt_path="tests/configuration/system_prompt.txt")
-        assert c is not None
-        # check that the system prompt has been loaded from the provided file
-        assert c.system_prompt == "This is system prompt."
-
-    with subtests.test(msg="Multi line system prompt"):
-        # pass a file containing system prompt
-        c = Customization(
-            system_prompt_path="tests/configuration/multiline_system_prompt.txt"
-        )
-        assert c is not None
-        # check that the system prompt has been loaded from the provided file
-        assert "You are OpenShift Lightspeed" in c.system_prompt
-        assert "Here are your instructions" in c.system_prompt
-        assert "Here are some basic facts about OpenShift" in c.system_prompt


### PR DESCRIPTION
## Description

LCORE-636: split config Customization unit tests

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added comprehensive unit tests for customization behavior, including system prompt loading, toggling, multiline handling, and validation of invalid paths.
- Chores
  - Removed deprecated customization export from the configuration API to streamline the surface area. This may affect integrations that relied on the removed export; no changes to runtime app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->