### PR TITLE
LCORE-287: fixed field descriptions

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -267,7 +267,7 @@
                         },
                         "llama_stack": {
                             "url": "http://localhost:8321",
-                            "api_key": "xyzzy",
+                            "api_key": "*****",
                             "use_as_library_client": false
                         },
                         "user_data_collection": {
@@ -935,9 +935,12 @@
                     },
                     "skip_userid_check": {
                         "type": "boolean",
-                        "title": "Skip User Id Check",
+                        "title": "Skip Userid Check",
                         "description": "Whether to skip the user ID check",
-                        "examples": [true, false]
+                        "examples": [
+                            true,
+                            false
+                        ]
                     }
                 },
                 "type": "object",
@@ -947,12 +950,12 @@
                     "skip_userid_check"
                 ],
                 "title": "AuthorizedResponse",
-                "description": "Model representing a response to an authorization request.\n\nAttributes:\n    user_id: The ID of the logged in user.\n    username: The name of the logged in user.",
+                "description": "Model representing a response to an authorization request.\n\nAttributes:\n    user_id: The ID of the logged in user.\n    username: The name of the logged in user.\n    skip_userid_check: Whether to skip the user ID check.",
                 "examples": [
                     {
+                        "skip_userid_check": false,
                         "user_id": "123e4567-e89b-12d3-a456-426614174000",
-                        "username": "user1",
-                        "skip_userid_check": false
+                        "username": "user1"
                     }
                 ]
             },
@@ -1015,27 +1018,17 @@
                         "$ref": "#/components/schemas/UserDataCollection"
                     },
                     "database": {
-                        "$ref": "#/components/schemas/DatabaseConfiguration",
-                        "default": {
-                            "sqlite": {
-                                "db_path": "/tmp/lightspeed-stack.db"
-                            }
-                        }
+                        "$ref": "#/components/schemas/DatabaseConfiguration"
                     },
                     "mcp_servers": {
                         "items": {
                             "$ref": "#/components/schemas/ModelContextProtocolServer"
                         },
                         "type": "array",
-                        "title": "Mcp Servers",
-                        "default": []
+                        "title": "Mcp Servers"
                     },
                     "authentication": {
-                        "$ref": "#/components/schemas/AuthenticationConfiguration",
-                        "default": {
-                            "module": "noop",
-                            "skip_tls_verification": false
-                        }
+                        "$ref": "#/components/schemas/AuthenticationConfiguration"
                     },
                     "authorization": {
                         "anyOf": [
@@ -1058,8 +1051,7 @@
                         ]
                     },
                     "inference": {
-                        "$ref": "#/components/schemas/InferenceConfiguration",
-                        "default": {}
+                        "$ref": "#/components/schemas/InferenceConfiguration"
                     }
                 },
                 "additionalProperties": false,
@@ -1655,7 +1647,7 @@
                     "llama_stack_version"
                 ],
                 "title": "InfoResponse",
-                "description": "Model representing a response to an info request.\n\nAttributes:\n    name: Service name.\n    service_version: Service version.\n    llama_stack_version: Llama Stack version.\n\nExample:\n    ```python\n    info_response = InfoResponse(\n        name=\"Lightspeed Stack\",\n        service_version=\"1.0.0\",\n        llama_stack_version=\"0.2.18\",\n    )\n    ```",
+                "description": "Model representing a response to an info request.\n\nAttributes:\n    name: Service name.\n    service_version: Service version.\n    llama_stack_version: Llama Stack version.\n\nExample:\n    ```python\n    info_response = InfoResponse(\n        name=\"Lightspeed Stack\",\n        service_version=\"1.0.0\",\n        llama_stack_version=\"0.2.19\",\n    )\n    ```",
                 "examples": [
                     {
                         "llama_stack_version": "1.0.0",
@@ -1684,12 +1676,7 @@
                         "title": "Url"
                     },
                     "jwt_configuration": {
-                        "$ref": "#/components/schemas/JwtConfiguration",
-                        "default": {
-                            "user_id_claim": "user_id",
-                            "username_claim": "username",
-                            "role_rules": []
-                        }
+                        "$ref": "#/components/schemas/JwtConfiguration"
                     }
                 },
                 "additionalProperties": false,
@@ -1796,7 +1783,9 @@
                     "api_key": {
                         "anyOf": [
                             {
-                                "type": "string"
+                                "type": "string",
+                                "format": "password",
+                                "writeOnly": true
                             },
                             {
                                 "type": "null"
@@ -1919,7 +1908,9 @@
                     },
                     "password": {
                         "type": "string",
-                        "title": "Password"
+                        "format": "password",
+                        "title": "Password",
+                        "writeOnly": true
                     },
                     "namespace": {
                         "anyOf": [
@@ -2303,23 +2294,10 @@
                         "default": true
                     },
                     "tls_config": {
-                        "$ref": "#/components/schemas/TLSConfiguration",
-                        "default": {}
+                        "$ref": "#/components/schemas/TLSConfiguration"
                     },
                     "cors": {
-                        "$ref": "#/components/schemas/CORSConfiguration",
-                        "default": {
-                            "allow_origins": [
-                                "*"
-                            ],
-                            "allow_credentials": false,
-                            "allow_methods": [
-                                "*"
-                            ],
-                            "allow_headers": [
-                                "*"
-                            ]
-                        }
+                        "$ref": "#/components/schemas/CORSConfiguration"
                     }
                 },
                 "additionalProperties": false,

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -397,8 +397,8 @@ Returns:
 | Status Code | Description | Component |
 |-------------|-------------|-----------|
 | 200 | The user is logged-in and authorized to access OLS | [AuthorizedResponse](#authorizedresponse) |
-| 400 | Missing or invalid credentials provided by client for noop and noop-with-token | [UnauthorizedResponse](#unauthorizedresponse) |
-| 401 | Missing or invalid credentials provided by client for k8s | [UnauthorizedResponse](#unauthorizedresponse) |
+| 400 | Missing or invalid credentials provided by client for the noop and noop-with-token authentication modules | [UnauthorizedResponse](#unauthorizedresponse) |
+| 401 | Missing or invalid credentials provided by client for the k8s authentication module | [UnauthorizedResponse](#unauthorizedresponse) |
 | 403 | User is not authorized | [ForbiddenResponse](#forbiddenresponse) |
 ## GET `/metrics`
 
@@ -510,13 +510,14 @@ Model representing a response to an authorization request.
 Attributes:
     user_id: The ID of the logged in user.
     username: The name of the logged in user.
+    skip_userid_check: Whether to skip the user ID check.
 
 
 | Field | Type | Description |
 |-------|------|-------------|
 | user_id | string | User ID, for example UUID |
 | username | string | User name |
-| skip_userid_check | bool | Whether to skip user_id check |
+| skip_userid_check | boolean | Whether to skip the user ID check |
 
 
 ## CORSConfiguration
@@ -893,7 +894,7 @@ Example:
     info_response = InfoResponse(
         name="Lightspeed Stack",
         service_version="1.0.0",
-        llama_stack_version="0.2.18",
+        llama_stack_version="0.2.19",
     )
     ```
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -397,8 +397,8 @@ Returns:
 | Status Code | Description | Component |
 |-------------|-------------|-----------|
 | 200 | The user is logged-in and authorized to access OLS | [AuthorizedResponse](#authorizedresponse) |
-| 400 | Missing or invalid credentials provided by client for noop and noop-with-token | [UnauthorizedResponse](#unauthorizedresponse) |
-| 401 | Missing or invalid credentials provided by client for k8s | [UnauthorizedResponse](#unauthorizedresponse) |
+| 400 | Missing or invalid credentials provided by client for the noop and noop-with-token authentication modules | [UnauthorizedResponse](#unauthorizedresponse) |
+| 401 | Missing or invalid credentials provided by client for the k8s authentication module | [UnauthorizedResponse](#unauthorizedresponse) |
 | 403 | User is not authorized | [ForbiddenResponse](#forbiddenresponse) |
 ## GET `/metrics`
 
@@ -510,14 +510,14 @@ Model representing a response to an authorization request.
 Attributes:
     user_id: The ID of the logged in user.
     username: The name of the logged in user.
-    skip_userid_check: Whether to skip user_id check
+    skip_userid_check: Whether to skip the user ID check.
 
 
 | Field | Type | Description |
 |-------|------|-------------|
 | user_id | string | User ID, for example UUID |
 | username | string | User name |
-| skip_userid_check | bool | skip user_id check |
+| skip_userid_check | boolean | Whether to skip the user ID check |
 
 
 ## CORSConfiguration
@@ -884,7 +884,7 @@ Example:
     info_response = InfoResponse(
         name="Lightspeed Stack",
         service_version="1.0.0",
-        llama_stack_version="0.2.18",
+        llama_stack_version="0.2.19",
     )
     ```
 

--- a/src/app/endpoints/authorized.py
+++ b/src/app/endpoints/authorized.py
@@ -20,12 +20,12 @@ authorized_responses: dict[int | str, dict[str, Any]] = {
         "model": AuthorizedResponse,
     },
     400: {
-        "description": "Missing or invalid credentials provided by client for the noop and"
+        "description": "Missing or invalid credentials provided by client for the noop and "
         "noop-with-token authentication modules",
         "model": UnauthorizedResponse,
     },
     401: {
-        "description": "Missing or invalid credentials provided by client for the"
+        "description": "Missing or invalid credentials provided by client for the "
         "k8s authentication module",
         "model": UnauthorizedResponse,
     },


### PR DESCRIPTION
## Description

LCORE-287: fixed field descriptions

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added skip_userid_check (boolean) to AuthorizedResponse.

- Documentation
  - OpenAPI examples now mask sensitive api_key values.
  - Password-like fields (e.g., api_key, database password) marked as write-only with password format to improve client/UI handling.
  - Clarified 400/401 error descriptions to reference specific authentication modules.
  - Configuration schemas now reference dedicated components instead of inlined defaults; minor title/metadata tweaks.
  - Updated example llama_stack_version to 0.2.19.

- Bug Fixes
  - Corrected truncated error descriptions to display full text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->