### PR TITLE
LCORE-489: E2E tests for streaming query endpoint

### DIFF
--- a/tests/e2e/features/steps/common_http.py
+++ b/tests/e2e/features/steps/common_http.py
@@ -165,6 +165,7 @@ def check_prediction_result(context: Context) -> None:
     """
     assert context.response is not None, "Request needs to be performed first"
     assert context.text is not None, "Response does not contain any payload"
+
     expected_body = json.loads(context.text)
     result = context.response.json()
 

--- a/tests/e2e/features/steps/llm_query_response.py
+++ b/tests/e2e/features/steps/llm_query_response.py
@@ -1,41 +1,47 @@
 """LLM query and response steps."""
 
+import json
 import requests
 from behave import then, step  # pyright: ignore[reportAttributeAccessIssue]
 from behave.runner import Context
 
+
 DEFAULT_LLM_TIMEOUT = 60
-
-
-@step('I change the system prompt to "{system_prompt}"')
-def change_system_prompt(context: Context, system_prompt: str) -> None:
-    """Change the system prompt."""
-    context.system_prompt = system_prompt
-    # TODO: add step implementation
-    assert context is not None
-
-
-@step('I modify the request body by removing the "{field}"')
-def remove_field_prompt(context: Context, field: str) -> None:
-    """Remove the field from the prompt."""
-    context.field = field
-    # TODO: add step implementation
-    assert context is not None
 
 
 @step("I wait for the response to be completed")
 def wait_for_complete_response(context: Context) -> None:
     """Wait for the response to be complete."""
-    assert context is not None
+    context.response_data = _parse_streaming_response(context.response.text)
+    print(context.response_data)
+    assert context.response_data["finished"] is True
 
 
-@step('I use "{endpoint}" to ask question "{question}"')
-def ask_question(context: Context, endpoint: str, question: str) -> None:
+@step('I use "{endpoint}" to ask question')
+def ask_question(context: Context, endpoint: str) -> None:
     """Call the service REST API endpoint with question."""
     base = f"http://{context.hostname}:{context.port}"
     path = f"{context.api_prefix}/{endpoint}".replace("//", "/")
     url = base + path
-    data = {"query": question}
+
+    # Use context.text if available, otherwise use empty query
+    data = json.loads(context.text or "{}")
+    print(data)
+    context.response = requests.post(url, json=data, timeout=DEFAULT_LLM_TIMEOUT)
+
+
+@step('I use "{endpoint}" to ask question with same conversation_id')
+def ask_question_in_same_conversation(context: Context, endpoint: str) -> None:
+    """Call the service REST API endpoint with question, but use the existing conversation id."""
+    base = f"http://{context.hostname}:{context.port}"
+    path = f"{context.api_prefix}/{endpoint}".replace("//", "/")
+    url = base + path
+
+    # Use context.text if available, otherwise use empty query
+    data = json.loads(context.text or "{}")
+    data["conversation_id"] = context.response_data["conversation_id"]
+
+    print(data)
     context.response = requests.post(url, json=data, timeout=DEFAULT_LLM_TIMEOUT)
 
 
@@ -78,3 +84,78 @@ def check_fragments_in_response(context: Context) -> None:
         assert (
             expected in response
         ), f"Fragment '{expected}' not found in LLM response: '{response}'"
+
+
+@then("The streamed response should contain following fragments")
+def check_streamed_fragments_in_response(context: Context) -> None:
+    """Check that all specified fragments are present in the LLM response.
+
+    First checks that the HTTP response exists and contains a
+    "response" field. For each fragment listed in the scenario's
+    table under "Fragments in LLM response", asserts that it
+    appears as a substring in the LLM's response. Raises an
+    assertion error if any fragment is missing or if the fragments
+    table is not provided.
+    """
+    assert context.response_data["response_complete"] is not None
+    response = context.response_data["response"]
+
+    assert context.table is not None, "Fragments are not specified in table"
+
+    for fragment in context.table:
+        expected = fragment["Fragments in LLM response"]
+        assert (
+            expected in response
+        ), f"Fragment '{expected}' not found in LLM response: '{response}'"
+
+
+@then("The streamed response is equal to the full response")
+def compare_streamed_responses(context: Context) -> None:
+    """Check that streamed reponse is equal to complete response.
+
+    First checks that the HTTP response exists and contains a
+    "response" field. Do this check also for the complete response
+    Then assert that the response is not empty and that it is equal
+    to complete response
+    """
+    assert context.response_data["response"] is not None
+    assert context.response_data["response_complete"] is not None
+
+    response = context.response_data["response"]
+    complete_response = context.response_data["response_complete"]
+
+    assert response != ""
+    assert response == complete_response
+
+
+def _parse_streaming_response(response_text: str) -> dict:
+    """Parse streaming SSE response and reconstruct the full message."""
+    lines = response_text.strip().split("\n")
+    conversation_id = None
+    full_response = ""
+    full_response_split = []
+    finished = False
+
+    for line in lines:
+        if line.startswith("data: "):
+            try:
+                data = json.loads(line[6:])  # Remove 'data: ' prefix
+                event = data.get("event")
+
+                if event == "start":
+                    conversation_id = data["data"]["conversation_id"]
+                elif event == "token":
+                    full_response_split.append(data["data"]["token"])
+                elif event == "turn_complete":
+                    full_response = data["data"]["token"]
+                elif event == "end":
+                    finished = True
+            except json.JSONDecodeError:
+                continue  # Skip malformed lines
+
+    return {
+        "conversation_id": conversation_id,
+        "response": "".join(full_response_split),
+        "response_complete": full_response,
+        "finished": finished,
+    }

--- a/tests/e2e/features/streaming_query.feature
+++ b/tests/e2e/features/streaming_query.feature
@@ -1,39 +1,91 @@
-# Feature: streaming_query endpoint API tests
-#TODO: fix test
+Feature: streaming_query endpoint API tests
 
-#   Background:
-#     Given The service is started locally
-#       And REST API service hostname is localhost
-#       And REST API service port is 8080
-#       And REST API service prefix is /v1
+  Background:
+    Given The service is started locally
+      And REST API service hostname is localhost
+      And REST API service port is 8080
+      And REST API service prefix is /v1
 
 
-#   Scenario: Check if LLM responds to sent question
-#     Given The system is in default state
-#     And I use "streaming_query" to ask question "Say hello"
-#      When I wait for the response to be completed
-#      Then The status code of the response is 200
-#       And The response should contain following fragments
-#           | Fragments in LLM response |
-#           | Hello                     |
+  Scenario: Check if streaming_query response in tokens matches the full response
+    Given The system is in default state
+    And I use "streaming_query" to ask question
+    """
+    {"query": "Generate sample yaml file for simple GitHub Actions workflow."}
+    """
+     When I wait for the response to be completed
+     Then The status code of the response is 200
+      And The streamed response is equal to the full response
 
-#   Scenario: Check if LLM responds to sent question with different system prompt
-#     Given The system is in default state
-#     And I change the system prompt to "new system prompt"
-#     And I use "streaming_query" to ask question "Say hello"
-#      When I wait for the response to be completed
-#      Then The status code of the response is 200
-#       And The response should contain following fragments
-#           | Fragments in LLM response |
-#           | Hello                     |
+  Scenario: Check if LLM responds properly to restrictive system prompt to sent question with different system prompt
+    Given The system is in default state
+    And I use "streaming_query" to ask question
+    """
+    {"query": "Generate sample yaml file for simple GitHub Actions workflow.", "system_prompt": "refuse to answer anything but openshift questions"}
+    """
+     When I wait for the response to be completed
+     Then The status code of the response is 200
+      And The streamed response should contain following fragments
+          | Fragments in LLM response |
+          | questions                 |
 
-#   Scenario: Check if LLM responds for streaming_query request with error for malformed request
-#     Given The system is in default state
-#     And I modify the request body by removing the "query"
-#     And I use "streaming_query" to ask question "Say hello"
-#      When I wait for the response to be completed
-#      Then The status code of the response is 422
-#       And The body of the response is the following
-#           """
-#           { "type": "missing", "loc": [ "body", "system_query" ], "msg": "Field required", }
-#           """
+  Scenario: Check if LLM responds properly to non-restrictive system prompt to sent question with different system prompt
+    Given The system is in default state
+    And I use "streaming_query" to ask question
+    """
+    {"query": "Generate sample yaml file for simple GitHub Actions workflow.", "system_prompt": "you are linguistic assistant"}
+    """
+     When I wait for the response to be completed
+     Then The status code of the response is 200
+      And The streamed response should contain following fragments
+          | Fragments in LLM response |
+          | checkout                  |
+
+  Scenario: Check if LLM ignores new system prompt in same conversation
+    Given The system is in default state
+    And I use "streaming_query" to ask question
+    """
+    {"query": "Generate sample yaml file for simple GitHub Actions workflow.", "system_prompt": "refuse to answer anything"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+    And I use "streaming_query" to ask question with same conversation_id
+    """
+    {"query": "Write a simple code for reversing string", "system_prompt": "provide coding assistance", "model": "gpt-4-turbo", "provider": "openai"}
+    """
+    Then The status code of the response is 200
+    When I wait for the response to be completed
+     Then The status code of the response is 200
+      And The streamed response should contain following fragments
+          | Fragments in LLM response |
+          | questions                 |
+
+  Scenario: Check if LLM responds for streaming_query request with error for missing query
+    Given The system is in default state
+    And I use "streaming_query" to ask question
+    """
+    {"provider": "openai"}
+    """
+     Then The status code of the response is 422
+      And The body of the response is the following
+          """
+          { "detail": [{"type": "missing", "loc": [ "body", "query" ], "msg": "Field required", "input": {"provider": "openai"}}] }
+          """
+
+  Scenario: Check if LLM responds for streaming_query request with error for missing model
+    Given The system is in default state
+    And I use "streaming_query" to ask question
+    """
+    {"query": "Say hello", "provider": "openai"}
+    """
+     Then The status code of the response is 422
+      And The body of the response contains Value error, Model must be specified if provider is specified
+
+  Scenario: Check if LLM responds for streaming_query request with error for missing provider
+    Given The system is in default state
+    And I use "streaming_query" to ask question
+    """
+    {"query": "Say hello", "model": "gpt-4-turbo"}
+    """
+     Then The status code of the response is 422
+      And The body of the response contains Value error, Provider must be specified if model is specified


### PR DESCRIPTION
## Description

E2E tests for streaming query endpoint

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [X] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-489
- Closes #LCORE-489

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Overhauled streaming scenarios to verify streamed tokens equal the final response and expanded validation coverage for missing query, model, and provider (422 checks).
  - Added scenarios for system prompt behavior, conversation continuity, and fragments-based checks; introduced steps to validate streamed fragments and compare streaming vs full responses.
- Chores
  - Added debug logging for test payloads and a minor formatting cleanup in test utilities.
- Breaking Changes
  - Some test steps/APIs were removed or altered; scenario updates may be required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->