### PR TITLE
LCORE-502: unlock OpenAI package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "authlib>=1.6.0",
     # OpenAPI exporter
     "email-validator>=2.2.0",
-    "openai==1.99.9",
+    "openai>=1.99.9",
     # Used by database interface
     "sqlalchemy>=2.0.42",
     # Used by Llama Stack version checker

--- a/uv.lock
+++ b/uv.lock
@@ -1368,7 +1368,7 @@ requires-dist = [
     { name = "kubernetes", specifier = ">=30.1.0" },
     { name = "llama-stack", specifier = "==0.2.19" },
     { name = "llama-stack-client", specifier = "==0.2.19" },
-    { name = "openai", specifier = "==1.99.9" },
+    { name = "openai", specifier = ">=1.99.9" },
     { name = "prometheus-client", specifier = ">=0.22.1" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "semver", specifier = "<4.0.0" },


### PR DESCRIPTION
## Description

LCORE-502: unlock OpenAI package version

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Relaxed OpenAI SDK dependency to allow versions 1.99.9 and above, improving forward compatibility and reducing upgrade friction.
  * Enables quicker adoption of security patches and performance improvements from newer SDK releases without requiring additional app updates.
  * No user-facing changes; existing functionality and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->