### PR TITLE
LCORE-298: SQLite conversation cache

### DIFF
--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -16,7 +16,7 @@ class Cache(ABC):
     read or modify other users conversations.
     """
 
-    # separator between parts of compond key
+    # separator between parts of compound key
     COMPOUND_KEY_SEPARATOR = ":"
 
     @staticmethod

--- a/src/cache/sqlite_cache.py
+++ b/src/cache/sqlite_cache.py
@@ -1,6 +1,11 @@
 """Cache that uses SQLite to store cached values."""
 
+from time import time
+
+import sqlite3
+
 from cache.cache import Cache
+from cache.cache_error import CacheError
 from models.cache_entry import CacheEntry
 from models.config import SQLiteDatabaseConfiguration
 from log import get_logger
@@ -10,22 +15,130 @@ logger = get_logger("cache.sqlite_cache")
 
 
 class SQLiteCache(Cache):
-    """Cache that uses SQLite to store cached values."""
+    """Cache that uses SQLite to store cached values.
+
+    The cache itself is stored in following table:
+
+    ```
+         Column      |            Type             | Nullable |
+    -----------------+-----------------------------+----------+
+     user_id         | text                        | not null |
+     conversation_id | text                        | not null |
+     created_at      | int                         | not null |
+     query           | text                        |          |
+     response        | text                        |          |
+     provider        | text                        |          |
+     model           | text                        |          |
+    Indexes:
+        "cache_pkey" PRIMARY KEY, btree (user_id, conversation_id, created_at)
+        "cache_key_key" UNIQUE CONSTRAINT, btree (key)
+        "timestamps" btree (updated_at)
+    Access method: heap
+    ```
+    """
+
+    CREATE_CACHE_TABLE = """
+        CREATE TABLE IF NOT EXISTS cache (
+            user_id         text NOT NULL,
+            conversation_id text NOT NULL,
+            created_at      int NOT NULL,
+            query           text,
+            response        text,
+            provider        text,
+            model           text,
+            PRIMARY KEY(user_id, conversation_id, created_at)
+        );
+        """
+
+    CREATE_INDEX = """
+        CREATE INDEX IF NOT EXISTS timestamps
+            ON cache (created_at)
+        """
+
+    SELECT_CONVERSATION_HISTORY_STATEMENT = """
+        SELECT query, response, provider, model
+          FROM cache
+         WHERE user_id=? AND conversation_id=?
+         ORDER BY created_at
+        """
+
+    INSERT_CONVERSATION_HISTORY_STATEMENT = """
+        INSERT INTO cache(user_id, conversation_id, created_at, query, response, provider, model)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """
+
+    QUERY_CACHE_SIZE = """
+        SELECT count(*) FROM cache;
+        """
+
+    DELETE_SINGLE_CONVERSATION_STATEMENT = """
+        DELETE FROM cache
+         WHERE user_id=? AND conversation_id=?
+        """
+
+    LIST_CONVERSATIONS_STATEMENT = """
+        SELECT DISTINCT conversation_id
+          FROM cache
+         WHERE user_id=?
+         ORDER BY created_at DESC
+    """
 
     def __init__(self, config: SQLiteDatabaseConfiguration) -> None:
         """Create a new instance of SQLite cache."""
         self.sqlite_config = config
 
+        # initialize connection to DB
+        self.connect()
+        # self.capacity = config.max_entries
+
+    # pylint: disable=W0201
     def connect(self) -> None:
         """Initialize connection to database."""
         logger.info("Connecting to storage")
+        # make sure the connection will have known state
+        # even if SQLite is not alive
+        self.connection = None
+        config = self.sqlite_config
+        try:
+            self.connection = sqlite3.connect(database=config.db_path)
+            self.initialize_cache()
+        except Exception as e:
+            if self.connection is not None:
+                self.connection.close()
+            logger.exception("Error initializing SQLite cache:\n%s", e)
+            raise
+        self.connection.autocommit = True
 
     def connected(self) -> bool:
         """Check if connection to cache is alive."""
-        return True
+        if self.connection is None:
+            logger.warning("Not connected, need to reconnect later")
+            return False
+        try:
+            cursor = self.connection.cursor()
+            cursor.execute("SELECT 1")
+            logger.info("Connection to storage is ok")
+            return True
+        except Exception as e:
+            logger.error("Disconnected from storage: %s", e)
+            return False
 
     def initialize_cache(self) -> None:
-        """Initialize cache."""
+        """Initialize cache - clean it up etc."""
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("Initialize_cache: cache is disconnected")
+
+        cursor = self.connection.cursor()
+
+        logger.info("Initializing table for cache")
+        cursor.execute(SQLiteCache.CREATE_CACHE_TABLE)
+
+        logger.info("Initializing index for cache")
+        cursor.execute(SQLiteCache.CREATE_INDEX)
+
+        cursor.close()
+        self.connection.commit()
 
     @connection
     def get(
@@ -39,11 +152,30 @@ class SQLiteCache(Cache):
             skip_user_id_check: Skip user_id suid check.
 
         Returns:
-            Empty list.
+            The value associated with the key, or None if not found.
         """
-        # just check if user_id and conversation_id are UUIDs
-        super().construct_key(user_id, conversation_id, skip_user_id_check)
-        return []
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("get: cache is disconnected")
+
+        cursor = self.connection.cursor()
+        cursor.execute(
+            self.SELECT_CONVERSATION_HISTORY_STATEMENT, (user_id, conversation_id)
+        )
+        conversation_entries = cursor.fetchall()
+        cursor.close()
+
+        result = []
+        for conversation_entry in conversation_entries:
+            cache_entry = CacheEntry(
+                query=conversation_entry[0],
+                response=conversation_entry[1],
+                provider=conversation_entry[2],
+                model=conversation_entry[3],
+            )
+            result.append(cache_entry)
+
+        return result
 
     @connection
     def insert_or_append(
@@ -62,8 +194,25 @@ class SQLiteCache(Cache):
             skip_user_id_check: Skip user_id suid check.
 
         """
-        # just check if user_id and conversation_id are UUIDs
-        super().construct_key(user_id, conversation_id, skip_user_id_check)
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("insert_or_append: cache is disconnected")
+
+        cursor = self.connection.cursor()
+        cursor.execute(
+            self.INSERT_CONVERSATION_HISTORY_STATEMENT,
+            (
+                user_id,
+                conversation_id,
+                time(),
+                cache_entry.query,
+                cache_entry.response,
+                cache_entry.provider,
+                cache_entry.model,
+            ),
+        )
+        cursor.close()
+        self.connection.commit()
 
     @connection
     def delete(
@@ -77,11 +226,20 @@ class SQLiteCache(Cache):
             skip_user_id_check: Skip user_id suid check.
 
         Returns:
-            bool: True in all cases.
+            bool: True if the conversation was deleted, False if not found.
 
         """
-        # just check if user_id and conversation_id are UUIDs
-        super().construct_key(user_id, conversation_id, skip_user_id_check)
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("delete: cache is disconnected")
+
+        cursor = self.connection.cursor()
+        cursor.execute(
+            self.DELETE_SINGLE_CONVERSATION_STATEMENT,
+            (user_id, conversation_id),
+        )
+        cursor.close()
+        self.connection.commit()
         return True
 
     @connection
@@ -93,16 +251,24 @@ class SQLiteCache(Cache):
             skip_user_id_check: Skip user_id suid check.
 
         Returns:
-            An empty list.
+            A list of conversation ids from the cache
 
         """
-        super()._check_user_id(user_id, skip_user_id_check)
-        return []
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("list: cache is disconnected")
+
+        cursor = self.connection.cursor()
+        cursor.execute(self.LIST_CONVERSATIONS_STATEMENT, (user_id,))
+        conversations = cursor.fetchall()
+        cursor.close()
+
+        return [conversation[0] for conversation in conversations]
 
     def ready(self) -> bool:
         """Check if the cache is ready.
 
         Returns:
-            True in all cases.
+            True if the cache is ready, False otherwise.
         """
         return True

--- a/tests/unit/cache/test_cache_factory.py
+++ b/tests/unit/cache/test_cache_factory.py
@@ -48,11 +48,12 @@ def postgres_cache_config():
     )
 
 
-@pytest.fixture(scope="module", name="sqlite_cache_config_fixture")
-def sqlite_cache_config():
+@pytest.fixture(name="sqlite_cache_config_fixture")
+def sqlite_cache_config(tmpdir):
     """Fixture containing initialized instance of SQLite cache."""
+    db_path = str(tmpdir / "test.sqlite")
     return ConversationCacheConfiguration(
-        type=CACHE_TYPE_SQLITE, sqlite=SQLiteDatabaseConfiguration(db_path="foo")
+        type=CACHE_TYPE_SQLITE, sqlite=SQLiteDatabaseConfiguration(db_path=db_path)
     )
 
 
@@ -99,10 +100,11 @@ def test_conversation_cache_sqlite(sqlite_cache_config_fixture):
     assert isinstance(cache, SQLiteCache)
 
 
-def test_conversation_cache_sqlite_improper_config():
+def test_conversation_cache_sqlite_improper_config(tmpdir):
     """Check if memory cache configuration is checked in cache factory."""
+    db_path = str(tmpdir / "test.sqlite")
     cc = ConversationCacheConfiguration(
-        type=CACHE_TYPE_SQLITE, sqlite=SQLiteDatabaseConfiguration(db_path="foo")
+        type=CACHE_TYPE_SQLITE, sqlite=SQLiteDatabaseConfiguration(db_path=db_path)
     )
     # simulate improper configuration (can not be done directly as model checks this)
     cc.sqlite = None

--- a/tests/unit/cache/test_sqlite_cache.py
+++ b/tests/unit/cache/test_sqlite_cache.py
@@ -1,0 +1,245 @@
+"""Unit tests for SQLite cache implementation."""
+
+import pytest
+from pathlib import Path
+
+from cache.cache_error import CacheError
+from models.config import SQLiteDatabaseConfiguration
+from models.cache_entry import CacheEntry
+from cache.sqlite_cache import SQLiteCache
+from utils import suid
+
+USER_ID_1 = suid.get_suid()
+USER_ID_2 = suid.get_suid()
+CONVERSATION_ID_1 = suid.get_suid()
+CONVERSATION_ID_2 = suid.get_suid()
+cache_entry_1 = CacheEntry(
+    query="user message1", response="AI message1", provider="foo", model="bar"
+)
+cache_entry_2 = CacheEntry(
+    query="user message2", response="AI message2", provider="foo", model="bar"
+)
+
+
+class CursorMock:
+    """Mock class for simulating DB cursor exceptions."""
+
+    def __init__(self):
+        pass
+
+    def execute(self, str):
+        raise Exception("can not SELECT")
+
+
+class ConnectionMock:
+    """Mock class for connection."""
+
+    def __init__(self):
+        pass
+
+    def cursor(self):
+        return CursorMock()
+
+
+def create_cache(path):
+    """Create the cache instance."""
+    db_path = str(path / "test.sqlite")
+    cc = SQLiteDatabaseConfiguration(db_path=db_path)
+    return SQLiteCache(cc)
+
+
+def test_cache_initialization(tmpdir):
+    """Test the get operation when DB is not connected."""
+    cache = create_cache(tmpdir)
+    assert cache is not None
+    assert cache.connection is not None
+
+
+def test_cache_initialization_wrong_connection():
+    """Test the get operation when DB can not be connected."""
+    with pytest.raises(Exception, match="unable to open database file"):
+        _ = create_cache(Path("/foo/bar/baz"))
+
+
+def test_connected_when_connected(tmpdir):
+    """Test the connected() method."""
+    # cache should be connected by default
+    cache = create_cache(tmpdir)
+    assert cache.connected() is True
+
+
+def test_connected_when_disconnected(tmpdir):
+    """Test the connected() method."""
+    # simulate disconnected cache
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    assert cache.connected() is False
+
+
+def test_connected_when_connection_error(tmpdir):
+    """Test the connected() method."""
+    # simulate connection error
+    cache = create_cache(tmpdir)
+    cache.connection = ConnectionMock()
+    assert cache.connection is not None
+    assert cache.connected() is False
+
+
+def test_initialize_cache_when_connected(tmpdir):
+    """Test the initialize_cache()."""
+    cache = create_cache(tmpdir)
+    # should not fail
+    cache.initialize_cache()
+
+
+def test_initialize_cache_when_disconnected(tmpdir):
+    """Test the initialize_cache()."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.initialize_cache()
+
+
+def test_get_operation_when_disconnected(tmpdir):
+    """Test the get() method."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    # no operation for @connection decorator
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.get(USER_ID_1, CONVERSATION_ID_1, False)
+
+
+def test_get_operation_when_connected(tmpdir):
+    """Test the get() method."""
+    cache = create_cache(tmpdir)
+
+    # should not fail
+    lst = cache.get(USER_ID_1, CONVERSATION_ID_1, False)
+    assert lst == []
+
+
+def test_insert_or_append_when_disconnected(tmpdir):
+    """Test the insert_or_append() method."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    # no operation for @connection decorator
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_1, False)
+
+
+def test_insert_or_append_operation_when_connected(tmpdir):
+    """Test the insert_or_append() method."""
+    cache = create_cache(tmpdir)
+
+    # should not fail
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_1, False)
+
+
+def test_delete_operation_when_disconnected(tmpdir):
+    """Test the delete() method."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    # no operation for @connection decorator
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.delete(USER_ID_1, CONVERSATION_ID_1, False)
+
+
+def test_delete_operation_when_connected(tmpdir):
+    """Test the delete() method."""
+    cache = create_cache(tmpdir)
+
+    # should not fail
+    deleted = cache.delete(USER_ID_1, CONVERSATION_ID_1, False)
+    assert deleted is True
+
+
+def test_list_operation_when_disconnected(tmpdir):
+    """Test the list() method."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    # no operation for @connection decorator
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.list(USER_ID_1, False)
+
+
+def test_list_operation_when_connected(tmpdir):
+    """Test the list() method."""
+    cache = create_cache(tmpdir)
+
+    # should not fail
+    lst = cache.list(USER_ID_1, False)
+    assert lst == []
+
+
+def test_ready_method(tmpdir):
+    """Test the ready() method."""
+    cache = create_cache(tmpdir)
+
+    # should not fail
+    ready = cache.ready()
+    assert ready is True
+
+
+def test_get_operation_after_insert_or_append(tmpdir):
+    """Test the get() method called after insert_or_append() one."""
+    cache = create_cache(tmpdir)
+
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_1, False)
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_2, False)
+
+    lst = cache.get(USER_ID_1, CONVERSATION_ID_1, False)
+    assert lst[0] == cache_entry_1
+    assert lst[1] == cache_entry_2
+
+
+def test_get_operation_after_delete(tmpdir):
+    """Test the get() method called after delete() one."""
+    cache = create_cache(tmpdir)
+
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_1, False)
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_2, False)
+
+    deleted = cache.delete(USER_ID_1, CONVERSATION_ID_1, False)
+
+    lst = cache.get(USER_ID_1, CONVERSATION_ID_1, False)
+    assert lst == []
+
+
+def test_multiple_ids(tmpdir):
+    """Test the get() method called after delete() one."""
+    cache = create_cache(tmpdir)
+
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_1, False)
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_2, False)
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_2, cache_entry_1, False)
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_2, cache_entry_2, False)
+    cache.insert_or_append(USER_ID_2, CONVERSATION_ID_1, cache_entry_1, False)
+    cache.insert_or_append(USER_ID_2, CONVERSATION_ID_1, cache_entry_2, False)
+    cache.insert_or_append(USER_ID_2, CONVERSATION_ID_2, cache_entry_1, False)
+    cache.insert_or_append(USER_ID_2, CONVERSATION_ID_2, cache_entry_2, False)
+
+    deleted = cache.delete(USER_ID_1, CONVERSATION_ID_1, False)
+
+    lst = cache.get(USER_ID_1, CONVERSATION_ID_1, False)
+    assert lst == []
+
+    lst = cache.get(USER_ID_1, CONVERSATION_ID_2, False)
+    assert lst[0] == cache_entry_1
+    assert lst[1] == cache_entry_2
+
+    lst = cache.get(USER_ID_2, CONVERSATION_ID_1, False)
+    assert lst[0] == cache_entry_1
+    assert lst[1] == cache_entry_2
+
+    lst = cache.get(USER_ID_2, CONVERSATION_ID_2, False)
+    assert lst[0] == cache_entry_1
+    assert lst[1] == cache_entry_2


### PR DESCRIPTION
## Description

LCORE-298: SQLite conversation cache

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a working SQLite-backed cache with automatic setup, connection lifecycle, and operations to insert, retrieve multiple entries, delete conversations, and list conversations.
- Bug Fixes
  - Improved handling of disconnected state, enforced deletion semantics, returned accurate retrievals, and clarified readiness/error behavior.
- Tests
  - Added comprehensive unit tests for init, connectivity, CRUD and error scenarios; updated fixtures to use per-test temporary DB paths.
- Style
  - Fixed a typo in a comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->