### PR TITLE
Fix example run.yaml

### DIFF
--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -69,8 +69,9 @@ providers:
       checkpoint_format: huggingface
       device: cpu
       distributed_backend: null
+      dpo_output_dir: .llama/distributions/ollama
     provider_id: huggingface
-    provider_type: inline::huggingface
+    provider_type: inline::huggingface-gpu
   safety:
   - config:
       excluded_categories: []


### PR DESCRIPTION
## Description

Fix example run.yaml. The current version fails with
```
    raise ValueError(f"Provider `{provider.provider_type}` is not available for API `{api}`")
ValueError: Provider `inline::huggingface` is not available for API `Api.post_training`
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable DPO output directory in post-training settings (dpo_output_dir), enabling users to choose where results are saved.
* **Chores**
  * Updated the example configuration to use the GPU-backed Hugging Face provider for post-training by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->