### PR TITLE
LCORE-650: update Llama Stack version in documentation and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ version = "0.1.0"
 description = "Llama Stack runner"
 authors = []
 dependencies = [
-    "llama-stack==0.2.20",
+    "llama-stack==0.2.21",
     "fastapi>=0.115.12",
     "opentelemetry-sdk>=1.34.0",
     "opentelemetry-exporter-otlp>=1.34.0",

--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -390,7 +390,7 @@ cp examples/run.yaml /tmp/llama-stack-server
     The output should be in this form:
     ```json
     {
-      "version": "0.2.20"
+      "version": "0.2.21"
     }
     ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -24,7 +24,7 @@ It is possible to run Lightspeed Core Stack service with Llama Stack "embedded" 
 1. Add and install all required dependencies
     ```bash
     uv add \
-    "llama-stack==0.2.20" \
+    "llama-stack==0.2.21" \
     "fastapi>=0.115.12" \
     "opentelemetry-sdk>=1.34.0" \
     "opentelemetry-exporter-otlp>=1.34.0" \

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2153,7 +2153,7 @@
                     "llama_stack_version"
                 ],
                 "title": "InfoResponse",
-                "description": "Model representing a response to an info request.\n\nAttributes:\n    name: Service name.\n    service_version: Service version.\n    llama_stack_version: Llama Stack version.\n\nExample:\n    ```python\n    info_response = InfoResponse(\n        name=\"Lightspeed Stack\",\n        service_version=\"1.0.0\",\n        llama_stack_version=\"0.2.20\",\n    )\n    ```",
+                "description": "Model representing a response to an info request.\n\nAttributes:\n    name: Service name.\n    service_version: Service version.\n    llama_stack_version: Llama Stack version.\n\nExample:\n    ```python\n    info_response = InfoResponse(\n        name=\"Lightspeed Stack\",\n        service_version=\"1.0.0\",\n        llama_stack_version=\"0.2.21\",\n    )\n    ```",
                 "examples": [
                     {
                         "llama_stack_version": "1.0.0",

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1011,7 +1011,7 @@ Example:
     info_response = InfoResponse(
         name="Lightspeed Stack",
         service_version="1.0.0",
-        llama_stack_version="0.2.20",
+        llama_stack_version="0.2.21",
     )
     ```
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -1011,7 +1011,7 @@ Example:
     info_response = InfoResponse(
         name="Lightspeed Stack",
         service_version="1.0.0",
-        llama_stack_version="0.2.20",
+        llama_stack_version="0.2.21",
     )
     ```
 

--- a/examples/pyproject.llamastack.toml
+++ b/examples/pyproject.llamastack.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Default template for PDM package"
 authors = []
 dependencies = [
-    "llama-stack==0.2.20",
+    "llama-stack==0.2.21",
     "fastapi>=0.115.12",
     "opentelemetry-sdk>=1.34.0",
     "opentelemetry-exporter-otlp>=1.34.0",

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -164,7 +164,7 @@ class InfoResponse(BaseModel):
         info_response = InfoResponse(
             name="Lightspeed Stack",
             service_version="1.0.0",
-            llama_stack_version="0.2.20",
+            llama_stack_version="0.2.21",
         )
         ```
     """


### PR DESCRIPTION
## Description

LCORE-650: update Llama Stack version in documentation and examples

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references to llama-stack to version 0.2.21 across getting started, deployment, and output/API examples.
  * Improved OpenAPI description formatting for clearer line breaks and refreshed example values.
  * Minor formatting cleanups to enhance readability; no behavioral or API changes.

* **Chores**
  * Aligned example project configuration to depend on llama-stack 0.2.21 for consistency with documentation and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->