### PR TITLE
LCORE-775: removed duplicated fields

### DIFF
--- a/src/app/endpoints/conversations_v2.py
+++ b/src/app/endpoints/conversations_v2.py
@@ -243,8 +243,6 @@ def transform_chat_message(entry: CacheEntry) -> dict[str, Any]:
     return {
         "provider": entry.provider,
         "model": entry.model,
-        "query": entry.query,
-        "response": entry.response,
         "messages": [
             {"content": entry.query, "type": "user"},
             {"content": entry.response, "type": "assistant"},

--- a/tests/unit/app/endpoints/test_conversations_v2.py
+++ b/tests/unit/app/endpoints/test_conversations_v2.py
@@ -1,0 +1,33 @@
+# pylint: disable=redefined-outer-name
+
+"""Unit tests for the /conversations REST API endpoints."""
+
+from app.endpoints.conversations_v2 import transform_chat_message
+
+from models.cache_entry import CacheEntry
+
+
+def test_transform_message() -> None:
+    """Test the transform_chat_message transformation function."""
+    entry = CacheEntry(
+        query="query", response="response", provider="provider", model="model"
+    )
+    transformed = transform_chat_message(entry)
+    assert transformed is not None
+
+    assert "provider" in transformed
+    assert transformed["provider"] == "provider"
+
+    assert "model" in transformed
+    assert transformed["model"] == "model"
+
+    assert "messages" in transformed
+    assert len(transformed["messages"]) == 2
+
+    message1 = transformed["messages"][0]
+    assert message1["type"] == "user"
+    assert message1["content"] == "query"
+
+    message2 = transformed["messages"][1]
+    assert message2["type"] == "assistant"
+    assert message2["content"] == "response"


### PR DESCRIPTION
## Description

LCORE-775: removed duplicated fields

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-775


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated conversations API response format: removed top-level "query" and "response" fields. Responses now include provider, model, and a messages array (first user content, then assistant content). Clients may need to adjust parsing.
* **Tests**
  * Added unit tests to validate the new response structure, ensuring provider/model are present and messages contain correctly ordered user and assistant entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->