### PR TITLE
LCORE-632: regenerated OpenAPI doc

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1597,7 +1597,11 @@
                 "properties": {
                     "conversation_id": {
                         "type": "string",
-                        "title": "Conversation Id"
+                        "title": "Conversation Id",
+                        "description": "Conversation ID (UUID)",
+                        "examples": [
+                            "c5260aec-4d82-4370-9fdf-05cf908b3f16"
+                        ]
                     },
                     "chat_history": {
                         "items": {
@@ -1605,7 +1609,24 @@
                             "type": "object"
                         },
                         "type": "array",
-                        "title": "Chat History"
+                        "title": "Chat History",
+                        "description": "The simplified chat history as a list of conversation turns",
+                        "examples": [
+                            {
+                                "completed_at": "2024-01-01T00:01:05Z",
+                                "messages": [
+                                    {
+                                        "content": "Hello",
+                                        "type": "user"
+                                    },
+                                    {
+                                        "content": "Hi there!",
+                                        "type": "assistant"
+                                    }
+                                ],
+                                "started_at": "2024-01-01T00:01:00Z"
+                            }
+                        ]
                     }
                 },
                 "type": "object",
@@ -1979,7 +2000,11 @@
                 "properties": {
                     "response": {
                         "type": "string",
-                        "title": "Response"
+                        "title": "Response",
+                        "description": "The response of the feedback request.",
+                        "examples": [
+                            "feedback received"
+                        ]
                     }
                 },
                 "type": "object",
@@ -2041,7 +2066,11 @@
                 "properties": {
                     "detail": {
                         "type": "string",
-                        "title": "Detail"
+                        "title": "Detail",
+                        "description": "Details about the authorization issue",
+                        "examples": [
+                            "Missing or invalid credentials provided by client"
+                        ]
                     }
                 },
                 "type": "object",
@@ -2715,6 +2744,7 @@
                         },
                         "type": "array",
                         "title": "Rag Chunks",
+                        "description": "List of RAG chunks used to generate the response",
                         "default": []
                     },
                     "tool_calls": {
@@ -2964,12 +2994,22 @@
                 "properties": {
                     "functionality": {
                         "type": "string",
-                        "title": "Functionality"
+                        "title": "Functionality",
+                        "description": "The functionality of the service",
+                        "examples": [
+                            "feedback"
+                        ]
                     },
                     "status": {
                         "additionalProperties": true,
                         "type": "object",
-                        "title": "Status"
+                        "title": "Status",
+                        "description": "The status of the service",
+                        "examples": [
+                            {
+                                "enabled": true
+                            }
+                        ]
                     }
                 },
                 "type": "object",
@@ -3071,7 +3111,11 @@
                 "properties": {
                     "detail": {
                         "type": "string",
-                        "title": "Detail"
+                        "title": "Detail",
+                        "description": "Details about the authorization issue",
+                        "examples": [
+                            "Missing or invalid credentials provided by client"
+                        ]
                     }
                 },
                 "type": "object",

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -760,8 +760,8 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| conversation_id | string |  |
-| chat_history | array |  |
+| conversation_id | string | Conversation ID (UUID) |
+| chat_history | array | The simplified chat history as a list of conversation turns |
 
 
 ## ConversationsListResponse
@@ -931,7 +931,7 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| response | string |  |
+| response | string | The response of the feedback request. |
 
 
 ## FeedbackStatusUpdateRequest
@@ -989,7 +989,7 @@ Model representing response for forbidden access.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| detail | string |  |
+| detail | string | Details about the authorization issue |
 
 
 ## HTTPValidationError
@@ -1247,7 +1247,7 @@ Attributes:
 |-------|------|-------------|
 | conversation_id |  | The optional conversation ID (UUID) |
 | response | string | Response from LLM |
-| rag_chunks | array |  |
+| rag_chunks | array | List of RAG chunks used to generate the response |
 | tool_calls |  | List of tool calls made during response generation |
 | referenced_documents | array | List of documents referenced in generating the response |
 
@@ -1363,8 +1363,8 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| functionality | string |  |
-| status | object |  |
+| functionality | string | The functionality of the service |
+| status | object | The status of the service |
 
 
 ## TLSConfiguration
@@ -1401,7 +1401,7 @@ Model representing response for missing or invalid credentials.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| detail | string |  |
+| detail | string | Details about the authorization issue |
 
 
 ## UserDataCollection

--- a/docs/output.md
+++ b/docs/output.md
@@ -760,8 +760,8 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| conversation_id | string |  |
-| chat_history | array |  |
+| conversation_id | string | Conversation ID (UUID) |
+| chat_history | array | The simplified chat history as a list of conversation turns |
 
 
 ## ConversationsListResponse
@@ -931,7 +931,7 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| response | string |  |
+| response | string | The response of the feedback request. |
 
 
 ## FeedbackStatusUpdateRequest
@@ -989,7 +989,7 @@ Model representing response for forbidden access.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| detail | string |  |
+| detail | string | Details about the authorization issue |
 
 
 ## HTTPValidationError
@@ -1247,7 +1247,7 @@ Attributes:
 |-------|------|-------------|
 | conversation_id |  | The optional conversation ID (UUID) |
 | response | string | Response from LLM |
-| rag_chunks | array |  |
+| rag_chunks | array | List of RAG chunks used to generate the response |
 | tool_calls |  | List of tool calls made during response generation |
 | referenced_documents | array | List of documents referenced in generating the response |
 
@@ -1363,8 +1363,8 @@ Example:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| functionality | string |  |
-| status | object |  |
+| functionality | string | The functionality of the service |
+| status | object | The status of the service |
 
 
 ## TLSConfiguration
@@ -1401,7 +1401,7 @@ Model representing response for missing or invalid credentials.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| detail | string |  |
+| detail | string | Details about the authorization issue |
 
 
 ## UserDataCollection


### PR DESCRIPTION
## Description

LCORE-632: regenerated OpenAPI doc

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-632


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded OpenAPI documentation with clearer field descriptions and example payloads across multiple request/response models.
  - Clarified conversation_id (UUID), chat_history structure, response/feedback fields, authorization detail messages, rag_chunks meaning, and status reporting.
  - Enhanced descriptions for health, configuration, and related endpoints to better convey usage and expectations.
  - Improved readability and consistency across reference docs.
  - No changes to API behavior or data structures; request/response formats remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->