### PR TITLE
[RHDHPAI-1150] create /v1/shields endpoint

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -123,6 +123,40 @@
                 }
             }
         },
+        "/v1/shields": {
+            "get": {
+                "tags": [
+                    "shields"
+                ],
+                "summary": "Shields Endpoint Handler",
+                "description": "Handle requests to the /shields endpoint.\n\nProcess GET requests to the /shields endpoint, returning a list of available\nshields from the Llama Stack service.\n\nRaises:\n    HTTPException: If unable to connect to the Llama Stack server or if\n    shield retrieval fails for any reason.\n\nReturns:\n    ShieldsResponse: An object containing the list of available shields.",
+                "operationId": "shields_endpoint_handler_v1_shields_get",
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ShieldsResponse"
+                                }
+                            }
+                        },
+                        "shields": [
+                            {
+                                "identifier": "lightspeed_question_validity-shield",
+                                "provider_resource_id": "lightspeed_question_validity-shield",
+                                "provider_id": "lightspeed_question_validity",
+                                "type": "shield",
+                                "params": {}
+                            }
+                        ]
+                    },
+                    "500": {
+                        "description": "Connection to Llama Stack is broken"
+                    }
+                }
+            }
+        },
         "/v1/query": {
             "post": {
                 "tags": [
@@ -1082,6 +1116,7 @@
                     "delete_conversation",
                     "feedback",
                     "get_models",
+                    "get_shields",
                     "get_metrics",
                     "get_config",
                     "info",
@@ -2989,6 +3024,34 @@
                 "type": "object",
                 "title": "ServiceConfiguration",
                 "description": "Service configuration."
+            },
+            "ShieldsResponse": {
+                "properties": {
+                    "shields": {
+                        "items": {
+                            "additionalProperties": true,
+                            "type": "object"
+                        },
+                        "type": "array",
+                        "title": "Shields",
+                        "description": "List of shields available",
+                        "examples": [
+                            {
+                                "identifier": "lightspeed_question_validity-shield",
+                                "params": {},
+                                "provider_id": "lightspeed_question_validity",
+                                "provider_resource_id": "lightspeed_question_validity-shield",
+                                "type": "shield"
+                            }
+                        ]
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "shields"
+                ],
+                "title": "ShieldsResponse",
+                "description": "Model representing a response to shields request."
             },
             "StatusResponse": {
                 "properties": {

--- a/src/app/endpoints/shields.py
+++ b/src/app/endpoints/shields.py
@@ -1,0 +1,96 @@
+"""Handler for REST API call to list available shields."""
+
+import logging
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.params import Depends
+from llama_stack_client import APIConnectionError
+
+from authentication import get_auth_dependency
+from authentication.interface import AuthTuple
+from authorization.middleware import authorize
+from client import AsyncLlamaStackClientHolder
+from configuration import configuration
+from models.config import Action
+from models.responses import ShieldsResponse
+from utils.endpoints import check_configuration_loaded
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["shields"])
+
+
+shields_responses: dict[int | str, dict[str, Any]] = {
+    200: {
+        "shields": [
+            {
+                "identifier": "lightspeed_question_validity-shield",
+                "provider_resource_id": "lightspeed_question_validity-shield",
+                "provider_id": "lightspeed_question_validity",
+                "type": "shield",
+                "params": {},
+            }
+        ]
+    },
+    500: {"description": "Connection to Llama Stack is broken"},
+}
+
+
+@router.get("/shields", responses=shields_responses)
+@authorize(Action.GET_SHIELDS)
+async def shields_endpoint_handler(
+    request: Request,
+    auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
+) -> ShieldsResponse:
+    """
+    Handle requests to the /shields endpoint.
+
+    Process GET requests to the /shields endpoint, returning a list of available
+    shields from the Llama Stack service.
+
+    Raises:
+        HTTPException: If unable to connect to the Llama Stack server or if
+        shield retrieval fails for any reason.
+
+    Returns:
+        ShieldsResponse: An object containing the list of available shields.
+    """
+    # Used only by the middleware
+    _ = auth
+
+    # Nothing interesting in the request
+    _ = request
+
+    check_configuration_loaded(configuration)
+
+    llama_stack_configuration = configuration.llama_stack_configuration
+    logger.info("Llama stack config: %s", llama_stack_configuration)
+
+    try:
+        # try to get Llama Stack client
+        client = AsyncLlamaStackClientHolder().get_client()
+        # retrieve shields
+        shields = await client.shields.list()
+        s = [dict(s) for s in shields]
+        return ShieldsResponse(shields=s)
+
+    # connection to Llama Stack server
+    except APIConnectionError as e:
+        logger.error("Unable to connect to Llama Stack: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "response": "Unable to connect to Llama Stack",
+                "cause": str(e),
+            },
+        ) from e
+    # any other exception that can occur during shield listing
+    except Exception as e:
+        logger.error("Unable to retrieve list of shields: %s", e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={
+                "response": "Unable to retrieve list of shields",
+                "cause": str(e),
+            },
+        ) from e

--- a/src/app/routers.py
+++ b/src/app/routers.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from app.endpoints import (
     info,
     models,
+    shields,
     root,
     query,
     health,
@@ -27,6 +28,7 @@ def include_routers(app: FastAPI) -> None:
     app.include_router(root.router)
     app.include_router(info.router, prefix="/v1")
     app.include_router(models.router, prefix="/v1")
+    app.include_router(shields.router, prefix="/v1")
     app.include_router(query.router, prefix="/v1")
     app.include_router(streaming_query.router, prefix="/v1")
     app.include_router(config.router, prefix="/v1")

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -358,6 +358,7 @@ class Action(str, Enum):
     DELETE_CONVERSATION = "delete_conversation"
     FEEDBACK = "feedback"
     GET_MODELS = "get_models"
+    GET_SHIELDS = "get_shields"
     GET_METRICS = "get_metrics"
     GET_CONFIG = "get_config"
 

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -36,6 +36,24 @@ class ModelsResponse(BaseModel):
     )
 
 
+class ShieldsResponse(BaseModel):
+    """Model representing a response to shields request."""
+
+    shields: list[dict[str, Any]] = Field(
+        ...,
+        description="List of shields available",
+        examples=[
+            {
+                "identifier": "lightspeed_question_validity-shield",
+                "provider_resource_id": "lightspeed_question_validity-shield",
+                "provider_id": "lightspeed_question_validity",
+                "type": "shield",
+                "params": {},
+            }
+        ],
+    )
+
+
 class RAGChunk(BaseModel):
     """Model representing a RAG chunk used in the response."""
 

--- a/tests/unit/app/endpoints/test_shields.py
+++ b/tests/unit/app/endpoints/test_shields.py
@@ -1,0 +1,365 @@
+"""Unit tests for the /shields REST API endpoint."""
+
+import pytest
+
+from fastapi import HTTPException, Request, status
+
+from llama_stack_client import APIConnectionError
+
+from app.endpoints.shields import shields_endpoint_handler
+from configuration import AppConfig
+from tests.unit.utils.auth_helpers import mock_authorization_resolvers
+
+
+@pytest.mark.asyncio
+async def test_shields_endpoint_handler_configuration_not_loaded(mocker):
+    """Test the shields endpoint handler if configuration is not loaded."""
+    mock_authorization_resolvers(mocker)
+
+    # simulate state when no configuration is loaded
+    mocker.patch(
+        "app.endpoints.shields.configuration",
+        return_value=mocker.Mock(),
+    )
+    mocker.patch("app.endpoints.shields.configuration", None)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer invalid-token")],
+        }
+    )
+    auth = ("user_id", "user_name", "token")
+
+    with pytest.raises(HTTPException) as e:
+        await shields_endpoint_handler(request=request, auth=auth)
+        assert e.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert e.detail["response"] == "Configuration is not loaded"
+
+
+@pytest.mark.asyncio
+async def test_shields_endpoint_handler_improper_llama_stack_configuration(mocker):
+    """Test the shields endpoint handler if Llama Stack configuration is not proper."""
+    mock_authorization_resolvers(mocker)
+
+    # configuration for tests
+    config_dict = {
+        "name": "test",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "test-key",
+            "url": "http://test.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "transcripts_enabled": False,
+        },
+        "mcp_servers": [],
+        "customization": None,
+        "authorization": {"access_rules": []},
+        "authentication": {"module": "noop"},
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+
+    mocker.patch(
+        "app.endpoints.shields.configuration",
+        return_value=None,
+    )
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer invalid-token")],
+        }
+    )
+    auth = ("test_user", "token", {})
+    with pytest.raises(HTTPException) as e:
+        await shields_endpoint_handler(request=request, auth=auth)
+        assert e.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert e.detail["response"] == "Llama stack is not configured"
+
+
+@pytest.mark.asyncio
+async def test_shields_endpoint_handler_configuration_loaded(mocker):
+    """Test the shields endpoint handler if configuration is loaded."""
+    mock_authorization_resolvers(mocker)
+
+    # configuration for tests
+    config_dict = {
+        "name": "foo",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "xyzzy",
+            "url": "http://x.y.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+        },
+        "customization": None,
+        "authorization": {"access_rules": []},
+        "authentication": {"module": "noop"},
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer invalid-token")],
+        }
+    )
+    auth = ("test_user", "token", {})
+
+    with pytest.raises(HTTPException) as e:
+        await shields_endpoint_handler(request=request, auth=auth)
+        assert e.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert e.detail["response"] == "Unable to connect to Llama Stack"
+
+
+@pytest.mark.asyncio
+async def test_shields_endpoint_handler_unable_to_retrieve_shields_list(mocker):
+    """Test the shields endpoint handler if configuration is loaded."""
+    mock_authorization_resolvers(mocker)
+
+    # configuration for tests
+    config_dict = {
+        "name": "foo",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "xyzzy",
+            "url": "http://x.y.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+        },
+        "customization": None,
+        "authorization": {"access_rules": []},
+        "authentication": {"module": "noop"},
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+
+    # Mock the LlamaStack client
+    mock_client = mocker.AsyncMock()
+    mock_client.shields.list.return_value = []
+    mock_lsc = mocker.patch("client.AsyncLlamaStackClientHolder.get_client")
+    mock_lsc.return_value = mock_client
+    mock_config = mocker.Mock()
+    mocker.patch("app.endpoints.shields.configuration", mock_config)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer invalid-token")],
+        }
+    )
+    auth = ("test_user", "token", {})
+    response = await shields_endpoint_handler(request=request, auth=auth)
+    assert response is not None
+
+
+@pytest.mark.asyncio
+async def test_shields_endpoint_llama_stack_connection_error(mocker):
+    """Test the shields endpoint when LlamaStack connection fails."""
+    mock_authorization_resolvers(mocker)
+
+    # configuration for tests
+    config_dict = {
+        "name": "foo",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "xyzzy",
+            "url": "http://x.y.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+        },
+        "customization": None,
+        "authorization": {"access_rules": []},
+        "authentication": {"module": "noop"},
+    }
+
+    # mock AsyncLlamaStackClientHolder to raise APIConnectionError
+    # when shields.list() method is called
+    mock_client = mocker.AsyncMock()
+    mock_client.shields.list.side_effect = APIConnectionError(request=None)
+    mock_client_holder = mocker.patch(
+        "app.endpoints.shields.AsyncLlamaStackClientHolder"
+    )
+    mock_client_holder.return_value.get_client.return_value = mock_client
+
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer invalid-token")],
+        }
+    )
+    auth = ("test_user", "token", {})
+
+    with pytest.raises(HTTPException) as e:
+        await shields_endpoint_handler(request=request, auth=auth)
+        assert e.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert e.detail["response"] == "Unable to connect to Llama Stack"
+
+
+@pytest.mark.asyncio
+async def test_shields_endpoint_handler_success_with_shields_data(mocker):
+    """Test the shields endpoint handler with successful response and shields data."""
+    mock_authorization_resolvers(mocker)
+
+    # configuration for tests
+    config_dict = {
+        "name": "foo",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "xyzzy",
+            "url": "http://x.y.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+        },
+        "customization": None,
+        "authorization": {"access_rules": []},
+        "authentication": {"module": "noop"},
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+
+    # Mock the LlamaStack client with sample shields data
+    mock_shields_data = [
+        {
+            "identifier": "lightspeed_question_validity-shield",
+            "provider_resource_id": "lightspeed_question_validity-shield",
+            "provider_id": "lightspeed_question_validity",
+            "type": "shield",
+            "params": {},
+        },
+        {
+            "identifier": "content_filter-shield",
+            "provider_resource_id": "content_filter-shield",
+            "provider_id": "content_filter",
+            "type": "shield",
+            "params": {"threshold": 0.8},
+        },
+    ]
+
+    mock_client = mocker.AsyncMock()
+    mock_client.shields.list.return_value = mock_shields_data
+    mock_lsc = mocker.patch("client.AsyncLlamaStackClientHolder.get_client")
+    mock_lsc.return_value = mock_client
+    mock_config = mocker.Mock()
+    mocker.patch("app.endpoints.shields.configuration", mock_config)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer invalid-token")],
+        }
+    )
+    auth = ("test_user", "token", {})
+    response = await shields_endpoint_handler(request=request, auth=auth)
+
+    assert response is not None
+    assert hasattr(response, "shields")
+    assert len(response.shields) == 2
+    assert response.shields[0]["identifier"] == "lightspeed_question_validity-shield"
+    assert response.shields[1]["identifier"] == "content_filter-shield"
+
+
+@pytest.mark.asyncio
+async def test_shields_endpoint_handler_general_exception(mocker):
+    """Test the shields endpoint handler when a general exception occurs."""
+    mock_authorization_resolvers(mocker)
+
+    # configuration for tests
+    config_dict = {
+        "name": "foo",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "xyzzy",
+            "url": "http://x.y.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+        },
+        "customization": None,
+        "authorization": {"access_rules": []},
+        "authentication": {"module": "noop"},
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+
+    # Mock the LlamaStack client to raise a general exception
+    mock_client = mocker.AsyncMock()
+    mock_client.shields.list.side_effect = Exception("General error")
+    mock_client_holder = mocker.patch(
+        "app.endpoints.shields.AsyncLlamaStackClientHolder"
+    )
+    mock_client_holder.return_value.get_client.return_value = mock_client
+    mock_config = mocker.Mock()
+    mocker.patch("app.endpoints.shields.configuration", mock_config)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer invalid-token")],
+        }
+    )
+    auth = ("test_user", "token", {})
+
+    with pytest.raises(HTTPException) as e:
+        await shields_endpoint_handler(request=request, auth=auth)
+        assert e.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert e.detail["response"] == "Unable to retrieve list of shields"
+        assert e.detail["cause"] == "General error"

--- a/tests/unit/app/test_routers.py
+++ b/tests/unit/app/test_routers.py
@@ -12,6 +12,7 @@ from app.endpoints import (
     root,
     info,
     models,
+    shields,
     query,
     health,
     config,
@@ -61,10 +62,11 @@ def test_include_routers() -> None:
     include_routers(app)
 
     # are all routers added?
-    assert len(app.routers) == 12
+    assert len(app.routers) == 13
     assert root.router in app.get_routers()
     assert info.router in app.get_routers()
     assert models.router in app.get_routers()
+    assert shields.router in app.get_routers()
     assert query.router in app.get_routers()
     assert streaming_query.router in app.get_routers()
     assert config.router in app.get_routers()
@@ -81,10 +83,11 @@ def test_check_prefixes() -> None:
     include_routers(app)
 
     # are all routers added?
-    assert len(app.routers) == 12
+    assert len(app.routers) == 13
     assert app.get_router_prefix(root.router) == ""
     assert app.get_router_prefix(info.router) == "/v1"
     assert app.get_router_prefix(models.router) == "/v1"
+    assert app.get_router_prefix(shields.router) == "/v1"
     assert app.get_router_prefix(query.router) == "/v1"
     assert app.get_router_prefix(streaming_query.router) == "/v1"
     assert app.get_router_prefix(config.router) == "/v1"


### PR DESCRIPTION
## Description

for issue https://issues.redhat.com/browse/RHDHPAI-1150

add `/v1/shields` endpoint to list llama-stack enabled shields. 
also added tests for the new endpoint


<img width="818" height="593" alt="Screenshot 2025-10-06 at 11 42 32 AM" src="https://github.com/user-attachments/assets/a5342e7b-37be-4cef-9a5f-003c113815da" />

without shield being registered:

<img width="493" height="390" alt="Screenshot 2025-10-06 at 11 53 45 AM" src="https://github.com/user-attachments/assets/be145c69-f26a-4fe0-a01c-83e9a8fefca5" />


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new GET /v1/shields endpoint to list available shields.
  - Responses now support a shields list via a new ShieldsResponse payload.
- Documentation
  - OpenAPI spec updated with the /v1/shields path, ShieldsResponse schema, and example payloads.
  - Action list extended to include get_shields; /v1/models examples optionally reference shields.
- Tests
  - Added unit tests covering successful retrieval, configuration errors, and connection failures for the shields endpoint.
  - Updated router tests to include and validate the new shields route and prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->