### PR TITLE
LCORE-602: Fix unit-test warning

### DIFF
--- a/tests/unit/utils/auth_helpers.py
+++ b/tests/unit/utils/auth_helpers.py
@@ -19,7 +19,7 @@ def mock_authorization_resolvers(mocker: Any) -> None:
         "authorization.middleware.get_authorization_resolvers"
     )
     mock_role_resolver = AsyncMock()
-    mock_access_resolver = AsyncMock()
+    mock_access_resolver = Mock()
     mock_role_resolver.resolve_roles.return_value = set()
     mock_access_resolver.check_access.return_value = True
     # get_actions should be synchronous, not async


### PR DESCRIPTION
## Description

```
  .../assisted-chat/lightspeed-stack/src/authorization/middleware.py:91: RuntimeWarning: coroutine 'AsyncMockMixin._execute_mock_call' was never awaited
    if not access_resolver.check_access(action, user_roles):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

`mock_access_resolver` is created as an `AsyncMock`, which makes all its
methods async by default, but `AccessResolver` `check_access` is sync


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

LCORE-602

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated authorization test helpers to align synchronous/asynchronous behavior, improving reliability and reducing flakiness.
  - Refined mock configurations to better reflect expected roles, actions, and access outcomes in tests.
  - Minor improvements to test readability and maintainability.
  - No changes to application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->