### PR TITLE
LCORE-642: better run.yaml structure

### DIFF
--- a/run.yaml
+++ b/run.yaml
@@ -27,15 +27,17 @@ metadata_store:
   type: sqlite
 providers:
   files:
-  - config:
+  - provider_id: localfs
+    provider_type: inline::localfs
+    config:
       storage_dir: /tmp/llama-stack-files
       metadata_store:
         type: sqlite
         db_path: .llama/distributions/ollama/files_metadata.db
-    provider_id: localfs
-    provider_type: inline::localfs
   agents:
-  - config:
+  - provider_id: meta-reference
+    provider_type: inline::meta-reference
+    config:
       persistence_store:
         db_path: .llama/distributions/ollama/agents_store.db
         namespace: null
@@ -43,31 +45,29 @@ providers:
       responses_store:
         db_path: .llama/distributions/ollama/responses_store.db
         type: sqlite
-    provider_id: meta-reference
-    provider_type: inline::meta-reference
   datasetio:
-  - config:
+  - provider_id: huggingface
+    provider_type: remote::huggingface
+    config:
       kvstore:
         db_path: .llama/distributions/ollama/huggingface_datasetio.db
         namespace: null
         type: sqlite
-    provider_id: huggingface
-    provider_type: remote::huggingface
-  - config:
+  - provider_id: localfs
+    provider_type: inline::localfs
+    config:
       kvstore:
         db_path: .llama/distributions/ollama/localfs_datasetio.db
         namespace: null
         type: sqlite
-    provider_id: localfs
-    provider_type: inline::localfs
   eval:
-  - config:
+  - provider_id: meta-reference
+    provider_type: inline::meta-reference
+    config:
       kvstore:
         db_path: .llama/distributions/ollama/meta_reference_eval.db
         namespace: null
         type: sqlite
-    provider_id: meta-reference
-    provider_type: inline::meta-reference
   inference:
     - provider_id: sentence-transformers # Can be any embedding provider
       provider_type: inline::sentence-transformers
@@ -77,36 +77,36 @@ providers:
       config:
         api_key: ${env.OPENAI_API_KEY}
   post_training:
-  - config:
+  - provider_id: huggingface
+    provider_type: inline::huggingface-gpu
+    config:
       checkpoint_format: huggingface
       device: cpu
       distributed_backend: null
       dpo_output_dir: "."
-    provider_id: huggingface
-    provider_type: inline::huggingface-gpu
   safety:
-  - config:
-      excluded_categories: []
-    provider_id: llama-guard
+  - provider_id: llama-guard
     provider_type: inline::llama-guard
+    config:
+      excluded_categories: []
   scoring:
-  - config: {}
-    provider_id: basic
+  - provider_id: basic
     provider_type: inline::basic
-  - config: {}
-    provider_id: llm-as-judge
+    config: {}
+  - provider_id: llm-as-judge
     provider_type: inline::llm-as-judge
-  - config:
-      openai_api_key: '********'
-    provider_id: braintrust
+    config: {}
+  - provider_id: braintrust
     provider_type: inline::braintrust
+    config:
+      openai_api_key: '********'
   telemetry:
-  - config:
+  - provider_id: meta-reference
+    provider_type: inline::meta-reference
+    config:
       service_name: 'lightspeed-stack-telemetry'
       sinks: sqlite
       sqlite_db_path: .llama/distributions/ollama/trace_store.db
-    provider_id: meta-reference
-    provider_type: inline::meta-reference
   tool_runtime:
     - provider_id: model-context-protocol
       provider_type: remote::model-context-protocol
@@ -115,13 +115,13 @@ providers:
       provider_type: inline::rag-runtime
       config: {}
   vector_io:
-  - config:
+  - provider_id: faiss
+    provider_type: inline::faiss # Or preferred vector DB
+    config:
       kvstore:
         db_path: .llama/distributions/ollama/faiss_store.db # Location of vector database
         namespace: null
         type: sqlite
-    provider_id: faiss
-    provider_type: inline::faiss # Or preferred vector DB
 scoring_fns: []
 server:
   auth: null
@@ -138,15 +138,15 @@ vector_dbs:
     embedding_dimension: 768
     provider_id: faiss
 models:
-  - metadata:
-      embedding_dimension: 768 # Depends on chosen model
-    model_id: sentence-transformers/all-mpnet-base-v2 # Example embedding model
+  - model_id: sentence-transformers/all-mpnet-base-v2 # Example embedding model
+    model_type: embedding
     provider_id: sentence-transformers
     provider_model_id: sentence-transformers/all-mpnet-base-v2 # Location of embedding model
-    model_type: embedding
+    metadata:
+      embedding_dimension: 768 # Depends on chosen model
   - model_id: gpt-4-turbo
-    provider_id: openai
     model_type: llm
+    provider_id: openai
     provider_model_id: gpt-4-turbo
 
 tool_groups:


### PR DESCRIPTION
## Description

LCORE-642: better `run.yaml` structure

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized configuration to explicit provider blocks across all sections for consistency and easier management.
  * Updated model definitions to use model_id/model_type and centralized embedding metadata.
  * Consolidated Braintrust/OpenAI credentials within the provider configuration.
  * Switched vector configuration to a FAISS provider and aligned references accordingly.
  * Removed redundant inline configs and aligned related sections.

* **Chores**
  * Migrated run configuration to the new provider-based structure with no expected functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->