### PR TITLE
(nit) Missing assert in integration tests

### DIFF
--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -58,6 +58,7 @@ def test_loading_proper_configuration(configuration_filename: str) -> None:
     ls_config = cfg.llama_stack_configuration
     assert ls_config.use_as_library_client is False
     assert ls_config.url == "http://localhost:8321"
+    assert ls_config.api_key is not None
     assert ls_config.api_key.get_secret_value() == "xyzzy"
 
     # check 'user_data_collection' section


### PR DESCRIPTION
## Description

(nit) Missing assert in integration tests

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Strengthened configuration tests by asserting the presence of an API key in the LLAMA stack configuration, while continuing to validate correct secret retrieval. This improves test coverage and confidence in configuration integrity, enhancing CI signal and helping prevent silent misconfigurations. No changes to user-facing behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->