### PR TITLE
LCORE-803: Bump-up LCORE to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/badge/license-Apache-blue)](https://github.com/lightspeed-core/lightspeed-stack/blob/main/LICENSE)
 [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/)
 [![Required Python version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Flightspeed-core%2Flightspeed-stack%2Frefs%2Fheads%2Fmain%2Fpyproject.toml)](https://www.python.org/)
-[![Tag](https://img.shields.io/github/v/tag/lightspeed-core/lightspeed-stack)](https://github.com/lightspeed-core/lightspeed-stack/releases/tag/0.2.0)
+[![Tag](https://img.shields.io/github/v/tag/lightspeed-core/lightspeed-stack)](https://github.com/lightspeed-core/lightspeed-stack/releases/tag/0.3.0)
 
 Lightspeed Core Stack (LCS) is an AI-powered assistant that provides answers to product questions using backend LLM services, agents, and RAG databases.
  

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13,7 +13,7 @@
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "0.2.0"
+        "version": "0.3.0"
     },
     "servers": [
         {

--- a/src/version.py
+++ b/src/version.py
@@ -9,4 +9,4 @@
 # [tool.pdm.version]
 # source = "file"
 # path = "src/version.py"
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/tests/e2e/features/info.feature
+++ b/tests/e2e/features/info.feature
@@ -17,7 +17,7 @@ Feature: Info tests
     Given The system is in default state
      When I access REST API endpoint "info" using HTTP GET method
      Then The status code of the response is 200
-      And The body of the response has proper name Lightspeed Core Service (LCS) and version 0.2.0
+      And The body of the response has proper name Lightspeed Core Service (LCS) and version 0.3.0
       And The body of the response has llama-stack version 0.2.22
 
   Scenario: Check if info endpoint reports error when llama-stack connection is not working


### PR DESCRIPTION
## Description

LCORE-803: Bump-up LCORE to 0.3.0

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [x] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-803


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application and API version to 0.3.0.
* **Documentation**
  * Updated README badge to reflect version 0.3.0.
  * OpenAPI specification now reports version 0.3.0.
* **Tests**
  * Updated end-to-end tests to expect version 0.3.0.

No functional or behavioral changes; this release aligns versioning across the app, documentation, and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->