### PR TITLE
LCORE-739: added return type to unit tests

### DIFF
--- a/tests/unit/metrics/test_utis.py
+++ b/tests/unit/metrics/test_utis.py
@@ -3,7 +3,7 @@
 from metrics.utils import setup_model_metrics, update_llm_token_count_from_turn
 
 
-async def test_setup_model_metrics(mocker):
+async def test_setup_model_metrics(mocker) -> None:
     """Test the setup_model_metrics function."""
 
     # Mock the LlamaStackAsLibraryClient
@@ -76,7 +76,7 @@ async def test_setup_model_metrics(mocker):
     )
 
 
-def test_update_llm_token_count_from_turn(mocker):
+def test_update_llm_token_count_from_turn(mocker) -> None:
     """Test the update_llm_token_count_from_turn function."""
     mocker.patch("metrics.utils.Tokenizer.get_instance")
     mock_formatter_class = mocker.patch("metrics.utils.ChatFormat")

--- a/tests/unit/utils/test_common.py
+++ b/tests/unit/utils/test_common.py
@@ -18,7 +18,7 @@ from models.config import (
 
 
 @pytest.mark.asyncio
-async def test_register_mcp_servers_empty_list(mocker):
+async def test_register_mcp_servers_empty_list(mocker) -> None:
     """Test register_mcp_servers with empty MCP servers list."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -49,7 +49,7 @@ async def test_register_mcp_servers_empty_list(mocker):
 
 
 @pytest.mark.asyncio
-async def test_register_mcp_servers_single_server_not_registered(mocker):
+async def test_register_mcp_servers_single_server_not_registered(mocker) -> None:
     """Test register_mcp_servers with single MCP server that is not yet registered."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -94,7 +94,7 @@ async def test_register_mcp_servers_single_server_not_registered(mocker):
 
 
 @pytest.mark.asyncio
-async def test_register_mcp_servers_single_server_already_registered(mocker):
+async def test_register_mcp_servers_single_server_already_registered(mocker) -> None:
     """Test register_mcp_servers with single MCP server that is already registered."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -132,7 +132,7 @@ async def test_register_mcp_servers_single_server_already_registered(mocker):
 
 
 @pytest.mark.asyncio
-async def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
+async def test_register_mcp_servers_multiple_servers_mixed_registration(mocker) -> None:
     """Test register_mcp_servers with multiple MCP servers - some registered, some not."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -194,7 +194,7 @@ async def test_register_mcp_servers_multiple_servers_mixed_registration(mocker):
 
 
 @pytest.mark.asyncio
-async def test_register_mcp_servers_with_custom_provider(mocker):
+async def test_register_mcp_servers_with_custom_provider(mocker) -> None:
     """Test register_mcp_servers with MCP server using custom provider."""
     # Mock the logger
     mock_logger = Mock(spec=Logger)
@@ -235,7 +235,7 @@ async def test_register_mcp_servers_with_custom_provider(mocker):
 
 
 @pytest.mark.asyncio
-async def test_register_mcp_servers_async_with_library_client(mocker):
+async def test_register_mcp_servers_async_with_library_client(mocker) -> None:
     """
     Test that `register_mcp_servers_async` correctly registers MCP
     servers when using the library client configuration.


### PR DESCRIPTION
## Description

LCORE-739: added return type to unit tests

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-739


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added explicit None return type annotations across multiple unit and async tests to align with stricter typing and improve readability and static analysis.
  * Standardized test function signatures for consistency and maintainability.
  * No changes to logic, control flow, or behavior; test outcomes remain the same.
  * No new dependencies introduced; this is a non-functional, code-quality update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->