### PR TITLE
LCORE-793: Refactored status codes and response models for v1/conversations

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -693,39 +693,11 @@
                 "operationId": "get_conversations_list_endpoint_handler_v1_conversations_get",
                 "responses": {
                     "200": {
-                        "description": "Successful Response",
+                        "description": "List of conversations retrieved successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ConversationsListResponse"
-                                }
-                            }
-                        },
-                        "conversations": [
-                            {
-                                "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                                "created_at": "2024-01-01T00:00:00Z",
-                                "last_message_at": "2024-01-01T00:05:00Z",
-                                "last_used_model": "gemini/gemini-1.5-flash",
-                                "last_used_provider": "gemini",
-                                "message_count": 5
-                            },
-                            {
-                                "conversation_id": "456e7890-e12b-34d5-a678-901234567890",
-                                "created_at": "2024-01-01T01:00:00Z",
-                                "last_message_at": "2024-01-01T01:02:00Z",
-                                "last_used_model": "gemini/gemini-2.0-flash",
-                                "last_used_provider": "gemini",
-                                "message_count": 2
-                            }
-                        ]
-                    },
-                    "400": {
-                        "description": "Missing or invalid credentials provided by client",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/UnauthorizedResponse"
                                 }
                             }
                         }
@@ -741,10 +713,13 @@
                         }
                     },
                     "503": {
-                        "description": "Service Unavailable",
-                        "detail": {
-                            "response": "Unable to connect to Llama Stack",
-                            "cause": "Connection error."
+                        "description": "Service unavailable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                                }
+                            }
                         }
                     }
                 }
@@ -771,38 +746,21 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful Response",
+                        "description": "Conversation retrieved successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ConversationResponse"
                                 }
                             }
-                        },
-                        "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                        "chat_history": [
-                            {
-                                "messages": [
-                                    {
-                                        "content": "Hi",
-                                        "type": "user"
-                                    },
-                                    {
-                                        "content": "Hello!",
-                                        "type": "assistant"
-                                    }
-                                ],
-                                "started_at": "2024-01-01T00:00:00Z",
-                                "completed_at": "2024-01-01T00:00:05Z"
-                            }
-                        ]
+                        }
                     },
                     "400": {
-                        "description": "Missing or invalid credentials provided by client",
+                        "description": "Invalid request",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/UnauthorizedResponse"
+                                    "$ref": "#/components/schemas/BadRequestResponse"
                                 }
                             }
                         }
@@ -817,19 +775,35 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Client does not have permission to access conversation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccessDeniedResponse"
+                                }
+                            }
+                        }
+                    },
                     "404": {
-                        "detail": {
-                            "response": "Conversation not found",
-                            "cause": "The specified conversation ID does not exist."
-                        },
-                        "description": "Not Found"
+                        "description": "Conversation not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFoundResponse"
+                                }
+                            }
+                        }
                     },
                     "503": {
-                        "detail": {
-                            "response": "Unable to connect to Llama Stack",
-                            "cause": "Connection error."
-                        },
-                        "description": "Service Unavailable"
+                        "description": "Service unavailable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
                         "description": "Validation Error",
@@ -863,24 +837,21 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful Response",
+                        "description": "Conversation deleted successfully",
                         "content": {
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ConversationDeleteResponse"
                                 }
                             }
-                        },
-                        "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                        "success": true,
-                        "message": "Conversation deleted successfully"
+                        }
                     },
                     "400": {
-                        "description": "Missing or invalid credentials provided by client",
+                        "description": "Invalid request",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/UnauthorizedResponse"
+                                    "$ref": "#/components/schemas/BadRequestResponse"
                                 }
                             }
                         }
@@ -895,19 +866,35 @@
                             }
                         }
                     },
+                    "403": {
+                        "description": "Client does not have permission to access conversation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AccessDeniedResponse"
+                                }
+                            }
+                        }
+                    },
                     "404": {
-                        "detail": {
-                            "response": "Conversation not found",
-                            "cause": "The specified conversation ID does not exist."
-                        },
-                        "description": "Not Found"
+                        "description": "Conversation not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotFoundResponse"
+                                }
+                            }
+                        }
                     },
                     "503": {
-                        "detail": {
-                            "response": "Unable to connect to Llama Stack",
-                            "cause": "Connection error."
-                        },
-                        "description": "Service Unavailable"
+                        "description": "Service unavailable",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceUnavailableResponse"
+                                }
+                            }
+                        }
                     },
                     "422": {
                         "description": "Validation Error",
@@ -1323,6 +1310,27 @@
     },
     "components": {
         "schemas": {
+            "AccessDeniedResponse": {
+                "properties": {
+                    "detail": {
+                        "$ref": "#/components/schemas/DetailModel"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "detail"
+                ],
+                "title": "AccessDeniedResponse",
+                "description": "403 Access Denied - User does not have permission to perform the action.",
+                "examples": [
+                    {
+                        "detail": {
+                            "cause": "User 6789 does not have permission to access conversation with ID 123e4567-e89b-12d3-a456-426614174000.",
+                            "response": "Access denied"
+                        }
+                    }
+                ]
+            },
             "AccessRule": {
                 "properties": {
                     "role": {
@@ -1606,6 +1614,27 @@
                         "skip_userid_check": false,
                         "user_id": "123e4567-e89b-12d3-a456-426614174000",
                         "username": "user1"
+                    }
+                ]
+            },
+            "BadRequestResponse": {
+                "properties": {
+                    "detail": {
+                        "$ref": "#/components/schemas/DetailModel"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "detail"
+                ],
+                "title": "BadRequestResponse",
+                "description": "400 Bad Request - Invalid resource identifier.",
+                "examples": [
+                    {
+                        "detail": {
+                            "cause": "Conversation ID 123e4567-e89b-12d3-a456-426614174000 has invalid format",
+                            "response": "Invalid conversation ID format"
+                        }
                     }
                 ]
             },
@@ -2284,6 +2313,27 @@
                 "title": "DatabaseConfiguration",
                 "description": "Database configuration."
             },
+            "DetailModel": {
+                "properties": {
+                    "response": {
+                        "type": "string",
+                        "title": "Response",
+                        "description": "Short summary of the error"
+                    },
+                    "cause": {
+                        "type": "string",
+                        "title": "Cause",
+                        "description": "Detailed explanation of what caused the error"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "response",
+                    "cause"
+                ],
+                "title": "DetailModel",
+                "description": "Nested detail model for error responses."
+            },
             "ErrorResponse": {
                 "properties": {
                     "detail": {
@@ -2527,12 +2577,7 @@
             "ForbiddenResponse": {
                 "properties": {
                     "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "description": "Details about the authorization issue",
-                        "examples": [
-                            "Missing or invalid credentials provided by client"
-                        ]
+                        "$ref": "#/components/schemas/DetailModel"
                     }
                 },
                 "type": "object",
@@ -2540,10 +2585,13 @@
                     "detail"
                 ],
                 "title": "ForbiddenResponse",
-                "description": "Model representing response for forbidden access.",
+                "description": "403 Forbidden - User does not have access to this resource.",
                 "examples": [
                     {
-                        "detail": "Forbidden: User is not authorized to access this resource"
+                        "detail": {
+                            "cause": "User 42 is not allowed to access conversation with ID 123e4567-e89b-12d3-a456-426614174000.",
+                            "response": "Access denied"
+                        }
                     }
                 ]
             },
@@ -2933,6 +2981,27 @@
                 ],
                 "title": "ModelsResponse",
                 "description": "Model representing a response to models request."
+            },
+            "NotFoundResponse": {
+                "properties": {
+                    "detail": {
+                        "$ref": "#/components/schemas/DetailModel"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "detail"
+                ],
+                "title": "NotFoundResponse",
+                "description": "404 Not Found - Resource does not exist.",
+                "examples": [
+                    {
+                        "detail": {
+                            "cause": "Conversation with ID 123e4567-e89b-12d3-a456-426614174000 does not exist.",
+                            "response": "Conversation not found"
+                        }
+                    }
+                ]
             },
             "PostgreSQLDatabaseConfiguration": {
                 "properties": {
@@ -3695,6 +3764,27 @@
                 "title": "ServiceConfiguration",
                 "description": "Service configuration."
             },
+            "ServiceUnavailableResponse": {
+                "properties": {
+                    "detail": {
+                        "$ref": "#/components/schemas/DetailModel"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "detail"
+                ],
+                "title": "ServiceUnavailableResponse",
+                "description": "503 Backend Unavailable - Unable to reach backend service.",
+                "examples": [
+                    {
+                        "detail": {
+                            "cause": "Connection error while trying to reach Llama Stack API.",
+                            "response": "Unable to connect to Llama Stack"
+                        }
+                    }
+                ]
+            },
             "ShieldsResponse": {
                 "properties": {
                     "shields": {
@@ -3882,12 +3972,7 @@
             "UnauthorizedResponse": {
                 "properties": {
                     "detail": {
-                        "type": "string",
-                        "title": "Detail",
-                        "description": "Details about the authorization issue",
-                        "examples": [
-                            "Missing or invalid credentials provided by client"
-                        ]
+                        "$ref": "#/components/schemas/DetailModel"
                     }
                 },
                 "type": "object",
@@ -3895,10 +3980,13 @@
                     "detail"
                 ],
                 "title": "UnauthorizedResponse",
-                "description": "Model representing response for missing or invalid credentials.",
+                "description": "401 Unauthorized - Missing or invalid credentials.",
                 "examples": [
                     {
-                        "detail": "Unauthorized: No auth header found"
+                        "detail": {
+                            "cause": "Missing or invalid credentials provided by client",
+                            "response": "Unauthorized"
+                        }
                     }
                 ]
             },

--- a/tests/e2e/features/conversations.feature
+++ b/tests/e2e/features/conversations.feature
@@ -114,7 +114,7 @@ Feature: conversations endpoint API tests
     Given The system is in default state
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
      When I use REST API conversation endpoint with conversation_id "abcdef" using HTTP GET method
-     Then The status code of the response is 422
+     Then The status code of the response is 400
 
   Scenario: Check if conversations/{conversation_id} GET endpoint fails when llama-stack is unavailable
     Given The system is in default state
@@ -153,10 +153,11 @@ Feature: conversations endpoint API tests
     Given The system is in default state
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
      When I use REST API conversation endpoint with conversation_id "abcdef" using HTTP DELETE method
-     Then The status code of the response is 422
+     Then The status code of the response is 400
 
   Scenario: Check if conversations DELETE endpoint fails when the conversation does not exist
     Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
      When I use REST API conversation endpoint with conversation_id "12345678-abcd-0000-0123-456789abcdef" using HTTP DELETE method
      Then The status code of the response is 404
 

--- a/tests/e2e/features/query.feature
+++ b/tests/e2e/features/query.feature
@@ -68,8 +68,8 @@ Feature: Query endpoint API tests
      """
      {"conversation_id": "123e4567-e89b-12d3-a456-426614174000", "query": "Write a simple code for reversing string"}
      """
-      Then The status code of the response is 403
-      And The body of the response contains User is not authorized to access this resource
+      Then The status code of the response is 404
+      And The body of the response contains Conversation not found
 
 Scenario: Check if LLM responds for query request with error for missing query
     Given The system is in default state

--- a/tests/integration/test_openapi_json.py
+++ b/tests/integration/test_openapi_json.py
@@ -66,7 +66,7 @@ def test_servers_section_present(spec: dict):
         ("/v1/feedback", "post", {"200", "401", "403", "500", "422"}),
         ("/v1/feedback/status", "get", {"200"}),
         ("/v1/feedback/status", "put", {"200", "422"}),
-        ("/v1/conversations", "get", {"200", "400", "401", "503"}),
+        ("/v1/conversations", "get", {"200", "401", "503"}),
         (
             "/v1/conversations/{conversation_id}",
             "get",

--- a/tests/unit/app/endpoints/test_conversations.py
+++ b/tests/unit/app/endpoints/test_conversations.py
@@ -1,4 +1,4 @@
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name, too-many-lines
 
 """Unit tests for the /conversations REST API endpoints."""
 
@@ -13,6 +13,7 @@ from app.endpoints.conversations import (
     simplify_session_data,
 )
 from models.config import Action
+from models.database.conversations import UserConversation
 from models.responses import (
     ConversationResponse,
     ConversationDeleteResponse,
@@ -178,6 +179,19 @@ def expected_chat_history_fixture():
     ]
 
 
+@pytest.fixture(name="mock_conversation")
+def mock_conversation_fixture():
+    """Create a mock UserConversation object for testing."""
+    mock_conv = UserConversation()
+    mock_conv.id = VALID_CONVERSATION_ID
+    mock_conv.user_id = "another_user"  # Different from test auth
+    mock_conv.message_count = 2
+    mock_conv.last_used_model = "mock-model"
+    mock_conv.last_used_provider = "mock-provider"
+    mock_conv.topic_summary = "Mock topic"
+    return mock_conv
+
+
 class TestSimplifySessionData:
     """Test cases for the simplify_session_data function."""
 
@@ -295,7 +309,8 @@ class TestGetConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock AsyncLlamaStackClientHolder to raise APIConnectionError
         mock_client = mocker.AsyncMock()
@@ -324,7 +339,8 @@ class TestGetConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock AsyncLlamaStackClientHolder to raise NotFoundError
         mock_client = mocker.AsyncMock()
@@ -345,7 +361,7 @@ class TestGetConversationEndpoint:
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "Conversation not found" in exc_info.value.detail["response"]
-        assert "could not be retrieved" in exc_info.value.detail["cause"]
+        assert "does not exist" in exc_info.value.detail["cause"]
         assert VALID_CONVERSATION_ID in exc_info.value.detail["cause"]
 
     @pytest.mark.asyncio
@@ -356,7 +372,8 @@ class TestGetConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock AsyncLlamaStackClientHolder to raise a general exception
         mock_client = mocker.AsyncMock()
@@ -380,6 +397,93 @@ class TestGetConversationEndpoint:
         )
 
     @pytest.mark.asyncio
+    async def test_get_conversation_forbidden(
+        self, mocker, setup_configuration, dummy_request, mock_conversation
+    ):
+        """Test forbidden access when user lacks permission to read conversation."""
+        mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
+        mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
+        mocker.patch(
+            "app.endpoints.conversations.retrieve_conversation",
+            return_value=mock_conversation,
+        )
+        mocker.patch(
+            "authorization.resolvers.NoopAccessResolver.get_actions",
+            return_value=set(Action.GET_CONVERSATION),
+        )  # Reduce user's permissions to access only their conversations
+
+        mock_row = mocker.Mock()
+        mock_row.user_id = "different_user_id"
+
+        # Mock the SQLAlchemy-like session
+        mock_session = mocker.MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            mock_row
+        )
+
+        mock_session.__enter__.return_value = mock_session
+        mock_session.__exit__.return_value = None
+
+        mocker.patch("utils.endpoints.get_session", return_value=mock_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_conversation_endpoint_handler(
+                request=dummy_request,
+                conversation_id=VALID_CONVERSATION_ID,
+                auth=MOCK_AUTH,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+        expected = (
+            f"User {MOCK_AUTH[0]} does not have permission "
+            f"to read conversation with ID {VALID_CONVERSATION_ID}."
+        )
+        assert expected in exc_info.value.detail["cause"]
+
+    @pytest.mark.asyncio
+    async def test_get_others_conversations_allowed_for_authorized_user(
+        self,
+        mocker,
+        setup_configuration,
+        mock_conversation,
+        dummy_request,
+        mock_session_data,
+    ):  # pylint: disable=too-many-arguments, too-many-positional-arguments
+        """Test allowed access to another user's conversation for authorized user."""
+        mocker.patch(
+            "authorization.resolvers.NoopAccessResolver.get_actions",
+            return_value={Action.GET_CONVERSATION, Action.READ_OTHERS_CONVERSATIONS},
+        )  # Allow user to access other users' conversations
+        mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
+        mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
+        mocker.patch(
+            "app.endpoints.conversations.retrieve_conversation",
+            return_value=mock_conversation,
+        )
+
+        mock_client = mocker.AsyncMock()
+        mock_client.agents.session.list.return_value = mocker.Mock(
+            data=[mock_session_data]
+        )
+
+        mock_session_retrieve_result = mocker.Mock()
+        mock_session_retrieve_result.model_dump.return_value = mock_session_data
+        mock_client.agents.session.retrieve.return_value = mock_session_retrieve_result
+
+        mock_client_holder = mocker.patch(
+            "app.endpoints.conversations.AsyncLlamaStackClientHolder"
+        )
+        mock_client_holder.return_value.get_client.return_value = mock_client
+        response = await get_conversation_endpoint_handler(
+            request=dummy_request,
+            conversation_id=VALID_CONVERSATION_ID,
+            auth=MOCK_AUTH,
+        )
+
+        assert response.conversation_id == VALID_CONVERSATION_ID
+        assert hasattr(response, "chat_history")
+
+    @pytest.mark.asyncio
     async def test_successful_conversation_retrieval(
         self,
         mocker,
@@ -392,7 +496,8 @@ class TestGetConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock AsyncLlamaStackClientHolder
         mock_client = mocker.AsyncMock()
@@ -469,7 +574,8 @@ class TestDeleteConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock AsyncLlamaStackClientHolder to raise APIConnectionError
         mock_client = mocker.AsyncMock()
@@ -497,7 +603,8 @@ class TestDeleteConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock AsyncLlamaStackClientHolder to raise NotFoundError
         mock_client = mocker.AsyncMock()
@@ -518,7 +625,7 @@ class TestDeleteConversationEndpoint:
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
         assert "Conversation not found" in exc_info.value.detail["response"]
-        assert "could not be deleted" in exc_info.value.detail["cause"]
+        assert "does not exist" in exc_info.value.detail["cause"]
         assert VALID_CONVERSATION_ID in exc_info.value.detail["cause"]
 
     @pytest.mark.asyncio
@@ -529,7 +636,8 @@ class TestDeleteConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock AsyncLlamaStackClientHolder to raise a general exception
         mock_client = mocker.AsyncMock()
@@ -556,6 +664,93 @@ class TestDeleteConversationEndpoint:
         )
 
     @pytest.mark.asyncio
+    async def test_delete_conversation_forbidden(
+        self, mocker, setup_configuration, dummy_request, mock_conversation
+    ):
+        """Test forbidden deletion when user lacks permission to delete conversation."""
+        mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
+        mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
+        mocker.patch(
+            "app.endpoints.conversations.retrieve_conversation",
+            return_value=mock_conversation,
+        )
+        mocker.patch(
+            "authorization.resolvers.NoopAccessResolver.get_actions",
+            return_value=set(Action.DELETE_CONVERSATION),
+        )  # Reduce user's permissions to delete only their conversations
+
+        mock_row = mocker.Mock()
+        mock_row.user_id = "different_user_id"
+
+        # Mock the SQLAlchemy-like session
+        mock_session = mocker.MagicMock()
+        mock_session.query.return_value.filter.return_value.first.return_value = (
+            mock_row
+        )
+
+        mock_session.__enter__.return_value = mock_session
+        mock_session.__exit__.return_value = None
+
+        mocker.patch("utils.endpoints.get_session", return_value=mock_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_conversation_endpoint_handler(
+                request=dummy_request,
+                conversation_id=VALID_CONVERSATION_ID,
+                auth=MOCK_AUTH,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_403_FORBIDDEN
+        expected = (
+            f"User {MOCK_AUTH[0]} does not have permission "
+            f"to delete conversation with ID {VALID_CONVERSATION_ID}."
+        )
+        assert expected in exc_info.value.detail["cause"]
+
+    @pytest.mark.asyncio
+    async def test_delete_others_conversations_allowed_for_authorized_user(
+        self, mocker, setup_configuration, mock_conversation, dummy_request
+    ):
+        """Test allowed deletion of another user's conversation for authorized user."""
+        mocker.patch(
+            "authorization.resolvers.NoopAccessResolver.get_actions",
+            return_value={
+                Action.DELETE_OTHERS_CONVERSATIONS,
+                Action.DELETE_CONVERSATION,
+            },
+        )  # Allow user to detele other users' conversations
+
+        mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
+        mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
+        mocker.patch(
+            "app.endpoints.conversations.retrieve_conversation",
+            return_value=mock_conversation,
+        )
+
+        mock_client = mocker.AsyncMock()
+        mock_client.agents.session.list.return_value.data = [
+            {"session_id": VALID_CONVERSATION_ID}
+        ]
+        mock_client.agents.session.delete.return_value = None
+        mocker.patch(
+            "app.endpoints.conversations.AsyncLlamaStackClientHolder.get_client",
+            return_value=mock_client,
+        )
+
+        mocker.patch(
+            "app.endpoints.conversations.delete_conversation", return_value=None
+        )
+        response = await delete_conversation_endpoint_handler(
+            request=dummy_request,
+            conversation_id=VALID_CONVERSATION_ID,
+            auth=MOCK_AUTH,
+        )
+
+        assert response.success is True
+        assert response.conversation_id == VALID_CONVERSATION_ID
+        assert "deleted successfully" in response.response
+
+    @pytest.mark.asyncio
     async def test_successful_conversation_deletion(
         self, mocker, setup_configuration, dummy_request
     ):
@@ -563,7 +758,8 @@ class TestDeleteConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations.configuration", setup_configuration)
         mocker.patch("app.endpoints.conversations.check_suid", return_value=True)
-        mocker.patch("app.endpoints.conversations.validate_conversation_ownership")
+        mocker.patch("app.endpoints.conversations.can_access_conversation")
+        mocker.patch("app.endpoints.conversations.retrieve_conversation")
 
         # Mock the delete_conversation function
         mocker.patch("app.endpoints.conversations.delete_conversation")

--- a/tests/unit/models/responses/test_unauthorized_response.py
+++ b/tests/unit/models/responses/test_unauthorized_response.py
@@ -1,23 +1,21 @@
 """Unit tests for UnauthorizedResponse model."""
 
-import pytest
-
-from pydantic import ValidationError
-
-from models.responses import UnauthorizedResponse
+from models.responses import UnauthorizedResponse, DetailModel
 
 
 class TestUnauthorizedResponse:
     """Test cases for the UnauthorizedResponse model."""
 
-    def test_constructor(self) -> None:
-        """Test the UnauthorizedResponse constructor."""
-        ur = UnauthorizedResponse(
-            detail="Missing or invalid credentials provided by client"
-        )
-        assert ur.detail == "Missing or invalid credentials provided by client"
+    def test_constructor_without_user_id(self) -> None:
+        """Test UnauthorizedResponse when user_id is not provided."""
+        ur = UnauthorizedResponse()
+        assert isinstance(ur.detail, DetailModel)
+        assert ur.detail.response == "Unauthorized"
+        assert ur.detail.cause == "Missing or invalid credentials provided by client"
 
-    def test_constructor_fields_required(self) -> None:
-        """Test the UnauthorizedResponse constructor."""
-        with pytest.raises(ValidationError):
-            _ = UnauthorizedResponse()  # pyright: ignore
+    def test_constructor_with_user_id(self) -> None:
+        """Test UnauthorizedResponse when user_id is provided."""
+        ur = UnauthorizedResponse(user_id="user_123")
+        assert isinstance(ur.detail, DetailModel)
+        assert ur.detail.response == "Unauthorized"
+        assert ur.detail.cause == "User user_123 is unauthorized"


### PR DESCRIPTION
## Description

Fix GET and DELETE conversation endpoints to return correct HTTP status codes.
Update conversations response models with structured detail field including response and cause.
Update endpoint docstrings, OpenAPI specification; unit, integration and e2e tests.

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [x] Integration tests improvement
- [x] End to end tests improvement


## Related Tickets & Documents

- Related Issue # [LCORE-793](https://issues.redhat.com/browse/LCORE-793)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized, nested error payloads and new error types (Not Found, Access Denied, Bad Request, Service Unavailable) with refined Unauthorized/Forbidden semantics.
  * Conversation responses now include simplified chat/session history for clearer output.

* **Bug Fixes**
  * Malformed input now returns 400 instead of 422.
  * More consistent permission-based access control with clearer 403/404 behavior.

* **Tests**
  * Updated and added tests to match new error formats and access-control responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->