### PR TITLE
Drop obsolete query_is_valid

### DIFF
--- a/docs/user_data_collection.md
+++ b/docs/user_data_collection.md
@@ -98,7 +98,6 @@ Each transcript file contains:
     "timestamp": "2024-01-01T12:00:00Z"
   },
   "redacted_query": "What is Kubernetes?",
-  "query_is_valid": true,
   "llm_response": "Kubernetes is an open-source container orchestration system...",
   "rag_chunks": [],
   "truncated": false,

--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -312,7 +312,6 @@ async def query_endpoint_handler(  # pylint: disable=R0914
                 conversation_id=conversation_id,
                 model_id=model_id,
                 provider_id=provider_id,
-                query_is_valid=True,  # TODO(lucasagomes): implement as part of query validation
                 query=query_request.query,
                 query_request=query_request,
                 summary=summary,

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -839,7 +839,6 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals,t
                     conversation_id=conversation_id,
                     model_id=model_id,
                     provider_id=provider_id,
-                    query_is_valid=True,  # TODO(lucasagomes): implement as part of query validation
                     query=query_request.query,
                     query_request=query_request,
                     summary=summary,

--- a/src/utils/transcripts.py
+++ b/src/utils/transcripts.py
@@ -42,7 +42,6 @@ def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-
     conversation_id: str,
     model_id: str,
     provider_id: str | None,
-    query_is_valid: bool,
     query: str,
     query_request: QueryRequest,
     summary: TurnSummary,
@@ -55,7 +54,6 @@ def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-
     Args:
         user_id: The user ID (UUID).
         conversation_id: The conversation ID (UUID).
-        query_is_valid: The result of the query validation.
         query: The query (without attachments).
         query_request: The request containing a query.
         summary: Summary of the query/response turn.
@@ -79,7 +77,6 @@ def store_transcript(  # pylint: disable=too-many-arguments,too-many-positional-
             "timestamp": datetime.now(UTC).isoformat(),
         },
         "redacted_query": query,
-        "query_is_valid": query_is_valid,
         "llm_response": summary.llm_response,
         "rag_chunks": rag_chunks,
         "truncated": truncated,

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -240,7 +240,6 @@ async def _test_query_endpoint_handler(
             conversation_id=conversation_id,
             model_id="fake_model_id",
             provider_id="fake_provider_id",
-            query_is_valid=True,
             query=query,
             query_request=query_request,
             summary=summary,

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -363,7 +363,6 @@ async def _test_streaming_query_endpoint_handler(mocker, store_transcript=False)
             conversation_id="00000000-0000-0000-0000-000000000000",
             model_id="fake_model_id",
             provider_id="fake_provider_id",
-            query_is_valid=True,
             query=query,
             query_request=query_request,
             summary=TurnSummary(

--- a/tests/unit/utils/test_transcripts.py
+++ b/tests/unit/utils/test_transcripts.py
@@ -80,7 +80,6 @@ def test_store_transcript(mocker):
             )
         ],
     )
-    query_is_valid = True
     rag_chunks = []
     truncated = False
     attachments = []
@@ -90,7 +89,6 @@ def test_store_transcript(mocker):
         conversation_id,
         model,
         provider,
-        query_is_valid,
         query,
         query_request,
         summary,
@@ -113,7 +111,6 @@ def test_store_transcript(mocker):
                 "timestamp": mocker.ANY,
             },
             "redacted_query": query,
-            "query_is_valid": query_is_valid,
             "llm_response": summary.llm_response,
             "rag_chunks": rag_chunks,
             "truncated": truncated,


### PR DESCRIPTION
## Description

Drop obsolete query_is_valid. It is a compatibility item for OLS, but has no use for that.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated transcript data structure documentation to reflect simplified schema.

* **Refactor**
  * Streamlined transcript storage by removing validation flag parameter from query handling and storage layers.

* **Tests**
  * Updated unit tests to align with revised transcript storage interface across query and streaming endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->