### PR TITLE
LCORE-817: add new e2e tests for tools endpoint

### DIFF
--- a/tests/e2e/features/info.feature
+++ b/tests/e2e/features/info.feature
@@ -64,6 +64,62 @@ Feature: Info tests
          {"detail": {"response": "Unable to connect to Llama Stack", "cause": "Connection error."}}
       """
 
+  Scenario: Check if tools endpoint is working
+    Given The system is in default state
+     When I access REST API endpoint "tools" using HTTP GET method
+     Then The status code of the response is 200
+      And The response contains 2 tools listed for provider rag-runtime
+      And The body of the response has the following schema
+      """
+         {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "object",
+          "properties": {
+            "identifier": { "type": "string" },
+            "description": { "type": "string" },
+            "parameters": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "description": { "type": "string" },
+                  "name": { "type": "string" },
+                  "parameter_type": { "type": "string" },
+                  "required": { "type": "boolean" },
+                  "default": { "type": ["string", "null"] }
+                }
+              }
+            },
+            "provider_id": { "type": "string" },
+            "toolgroup_id": { "type": "string" },
+            "server_source": { "type": "string" },
+            "type": { "type": "string" }
+          }
+        }
+      """
+      And The body of the response has proper structure for provider rag-runtime
+      """
+      {
+        "identifier": "insert_into_memory",
+        "description": "Insert documents into memory",
+        "provider_id": "rag-runtime",
+        "toolgroup_id": "builtin::rag",
+        "server_source": "builtin",
+        "type": "tool"
+      }
+      """
+
+
+  Scenario: Check if tools endpoint reports error when llama-stack in unreachable
+    Given The system is in default state
+    And  The llama-stack connection is disrupted
+     When I access REST API endpoint "tools" using HTTP GET method
+     Then The status code of the response is 500
+      And The body of the response is the following
+      """
+         {"detail": {"response": "Unable to connect to Llama Stack", "cause": "Connection error."}}
+      """
+
   Scenario: Check if metrics endpoint is working
     Given The system is in default state
      When I access endpoint "metrics" using HTTP GET method

--- a/tests/e2e/features/steps/info.py
+++ b/tests/e2e/features/steps/info.py
@@ -1,5 +1,6 @@
 """Implementation of common test steps."""
 
+import json
 from behave import then  # pyright: ignore[reportAttributeAccessIssue]
 from behave.runner import Context
 
@@ -97,3 +98,64 @@ def check_shield_structure(context: Context) -> None:
     assert (
         found_shield["identifier"] == "llama-guard-shield"
     ), "identifier should be 'llama-guard-shield'"
+
+
+@then("The response contains {count:d} tools listed for provider {provider_name}")
+def check_tool_count(context: Context, count: int, provider_name: str) -> None:
+    """Check that the number of tools for defined provider is correct."""
+    response_json = context.response.json()
+    assert response_json is not None, "Response is not valid JSON"
+
+    assert "tools" in response_json, "Response missing 'tools' field"
+    tools = response_json["tools"]
+    assert len(tools) > 0, "Response has empty list of tools"
+
+    provider_tools = []
+
+    for tool in tools:
+        if tool["provider_id"] == provider_name:
+            provider_tools.append(tool)
+
+    assert len(provider_tools) == count
+
+
+@then("The body of the response has proper structure for provider {provider_name}")
+def check_tool_structure(context: Context, provider_name: str) -> None:
+    """Check that the first listed tool for defined provider has the correct structure."""
+    response_json = context.response.json()
+    assert response_json is not None, "Response is not valid JSON"
+
+    expected_json = json.loads(context.text)
+
+    assert "tools" in response_json, "Response missing 'tools' field"
+    tools = response_json["tools"]
+    assert len(tools) > 0, "Response has empty list of tools"
+
+    provider_tool = None
+
+    for tool in tools:
+        if tool["provider_id"] == provider_name:
+            provider_tool = tool
+            break
+
+    assert provider_tool is not None, "No tool found in response"
+
+    # Validate structure and values
+    assert (
+        provider_tool["identifier"] == expected_json["identifier"]
+    ), f"identifier should be {expected_json["identifier"]}, but was {provider_tool["identifier"]}"
+    assert (
+        provider_tool["description"] == expected_json["description"]
+    ), f"description should be {expected_json["description"]}"
+    assert (
+        provider_tool["provider_id"] == expected_json["provider_id"]
+    ), f"provider_id should be {expected_json["provider_id"]}"
+    assert (
+        provider_tool["toolgroup_id"] == expected_json["toolgroup_id"]
+    ), f"toolgroup_id should be {expected_json["toolgroup_id"]}"
+    assert (
+        provider_tool["server_source"] == expected_json["server_source"]
+    ), f"server_source should be {expected_json["server_source"]}"
+    assert (
+        provider_tool["type"] == expected_json["type"]
+    ), f"type should be {expected_json["type"]}"


### PR DESCRIPTION
## Description

add new e2e tests for tools endpoint

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [X] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-817
- Closes #LCORE-817

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test scenarios for the tools endpoint: successful retrieval (HTTP 200) validating two tools for a provider with a detailed JSON schema and example entry, and an error scenario (HTTP 500) when the backend is unreachable.
  * Added step validations for tool count and detailed tool structure (identifier, description, provider and group IDs, server source, type).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->