### PR TITLE
LCORE-755: Fixed feedback endpoint responds correctly without sentiment and empty user_feedback

### DIFF
--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -377,7 +377,7 @@ class FeedbackRequest(BaseModel):
         """Ensure that at least one form of feedback is provided."""
         if (
             self.sentiment is None
-            and self.user_feedback is None
+            and (self.user_feedback is None or self.user_feedback == "")
             and self.categories is None
         ):
             raise ValueError(

--- a/tests/e2e/features/feedback.feature
+++ b/tests/e2e/features/feedback.feature
@@ -291,3 +291,30 @@ Feature: feedback endpoint API tests
                     }
         }
         """
+
+  Scenario: Check if feedback endpoint fails when only empty string user_feedback is provided
+    Given The system is in default state
+    And A new conversation is initialized
+    And The feedback is enabled
+     When I submit the following feedback for the conversation created before
+        """
+        {
+            "user_question": "Sample Question",
+            "llm_response": "Sample Response",
+            "user_feedback": ""
+        }
+        """
+     Then The status code of the response is 422
+     And the body of the response has the following structure
+        """
+        {
+            "detail": [{
+                        "type": "value_error", 
+                        "loc": ["body"], 
+                        "msg": "Value error, At least one form of feedback must be provided: 'sentiment', 'user_feedback', or 'categories'",
+                        "input": {
+                            "user_feedback": ""
+                        }
+                    }]           
+        }
+        """

--- a/tests/unit/models/requests/test_feedback_request.py
+++ b/tests/unit/models/requests/test_feedback_request.py
@@ -182,3 +182,17 @@ class TestFeedbackRequest:
                 llm_response="Test response",
                 categories="invalid_type",  # Should be list, not string
             )
+
+    def test_empty_user_feedback_not_sufficient(self) -> None:
+        """Test that an empty string for user_feedback is treated as no feedback."""
+        with pytest.raises(
+            ValueError, match="At least one form of feedback must be provided"
+        ):
+            FeedbackRequest(
+                conversation_id="123e4567-e89b-12d3-a456-426614174000",
+                user_question="What is feedback?",
+                llm_response="Some LLM response.",
+                user_feedback="",  # Empty string should trigger validation error
+                sentiment=None,
+                categories=None,
+            )


### PR DESCRIPTION
## Description

This PR updates the FeedbackRequest model validator to treat empty strings for user_feedback as invalid, ensuring that at least one form of feedback (sentiment, user_feedback, or categories) must be provided.

It adds a unit test for this case and a corresponding e2e test for endpoint validation.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement


## Related Tickets & Documents

- Related Issue # [LCORE-755](https://issues.redhat.com/browse/LCORE-755)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feedback validation to require at least one form of feedback: sentiment, feedback text, or categories. Empty feedback submissions will no longer be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->