### PR TITLE
fix constant hostname in e2e tests

### DIFF
--- a/tests/e2e/features/authorized_noop.feature
+++ b/tests/e2e/features/authorized_noop.feature
@@ -2,8 +2,6 @@ Feature: Authorized endpoint API tests for the noop authentication module
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
   Scenario: Check if the authorized endpoint works fine when user_id and auth header are not provided 

--- a/tests/e2e/features/authorized_noop_token.feature
+++ b/tests/e2e/features/authorized_noop_token.feature
@@ -3,8 +3,6 @@ Feature: Authorized endpoint API tests for the noop-with-token authentication mo
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
   Scenario: Check if the authorized endpoint fails when user_id and auth header are not provided 

--- a/tests/e2e/features/conversations.feature
+++ b/tests/e2e/features/conversations.feature
@@ -3,8 +3,6 @@ Feature: conversations endpoint API tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
 

--- a/tests/e2e/features/feedback.feature
+++ b/tests/e2e/features/feedback.feature
@@ -4,8 +4,6 @@ Feature: feedback endpoint API tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
       And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
 

--- a/tests/e2e/features/health.feature
+++ b/tests/e2e/features/health.feature
@@ -3,8 +3,6 @@ Feature: REST API tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
 

--- a/tests/e2e/features/info.feature
+++ b/tests/e2e/features/info.feature
@@ -3,8 +3,6 @@ Feature: Info tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
   Scenario: Check if the OpenAPI endpoint works as expected

--- a/tests/e2e/features/query.feature
+++ b/tests/e2e/features/query.feature
@@ -3,8 +3,6 @@ Feature: Query endpoint API tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
   Scenario: Check if LLM responds properly to restrictive system prompt to sent question with different system prompt

--- a/tests/e2e/features/rest_api.feature
+++ b/tests/e2e/features/rest_api.feature
@@ -3,8 +3,6 @@ Feature: REST API tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
   Scenario: Check if the OpenAPI endpoint works as expected

--- a/tests/e2e/features/smoketests.feature
+++ b/tests/e2e/features/smoketests.feature
@@ -3,8 +3,6 @@ Feature: Smoke tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
 

--- a/tests/e2e/features/steps/common.py
+++ b/tests/e2e/features/steps/common.py
@@ -2,12 +2,17 @@
 
 from behave import given  # pyright: ignore[reportAttributeAccessIssue]
 from behave.runner import Context
+import os
 
 
 @given("The service is started locally")
 def service_is_started_locally(context: Context) -> None:
     """Check the service status."""
     assert context is not None
+    context.hostname = os.getenv("E2E_LSC_HOSTNAME", "localhost")
+    context.port = os.getenv("E2E_LSC_PORT", "8080")
+    context.hostname_llama = os.getenv("E2E_LLAMA_HOSTNAME", "localhost")
+    context.port_llama = os.getenv("E2E_LLAMA_PORT", "8321")
 
 
 @given("The system is in default state")

--- a/tests/e2e/features/streaming_query.feature
+++ b/tests/e2e/features/streaming_query.feature
@@ -2,8 +2,6 @@ Feature: streaming_query endpoint API tests
 
   Background:
     Given The service is started locally
-      And REST API service hostname is localhost
-      And REST API service port is 8080
       And REST API service prefix is /v1
 
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [X] End to end tests improvement


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Tests** 
  * Refactored end-to-end test configuration to use environment variables instead of hard-coded values, enabling greater flexibility in test environments while maintaining backward compatibility with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->