### PR TITLE
LCORE-759: Updated response dicts for feedback endpoints

### DIFF
--- a/src/app/endpoints/feedback.py
+++ b/src/app/endpoints/feedback.py
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/feedback", tags=["feedback"])
 feedback_status_lock = threading.Lock()
 
 # Response for the feedback endpoint
-feedback_response: dict[int | str, dict[str, Any]] = {
+feedback_post_response: dict[int | str, dict[str, Any]] = {
     200: {
         "description": "Feedback received and stored",
         "model": FeedbackResponse,
@@ -47,6 +47,32 @@ feedback_response: dict[int | str, dict[str, Any]] = {
         "description": "User feedback can not be stored",
         "model": ErrorResponse,
     },
+}
+
+feedback_put_response: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": "Feedback status successfully updated",
+        "model": FeedbackStatusUpdateResponse,
+    },
+    400: {
+        "description": "Missing or invalid credentials provided by client",
+        "model": UnauthorizedResponse,
+    },
+    401: {
+        "description": "Missing or invalid credentials provided by client",
+        "model": UnauthorizedResponse,
+    },
+    403: {
+        "description": "Client does not have permission to access resource",
+        "model": ForbiddenResponse,
+    },
+}
+
+feedback_get_response: dict[int | str, dict[str, Any]] = {
+    200: {
+        "description": "Feedback status successfully retrieved",
+        "model": StatusResponse,
+    }
 }
 
 
@@ -83,7 +109,7 @@ async def assert_feedback_enabled(_request: Request) -> None:
         )
 
 
-@router.post("", responses=feedback_response)
+@router.post("", responses=feedback_post_response)
 @authorize(Action.FEEDBACK)
 async def feedback_endpoint_handler(
     feedback_request: FeedbackRequest,
@@ -161,7 +187,7 @@ def store_feedback(user_id: str, feedback: dict) -> None:
     logger.info("Feedback stored successfully at %s", feedback_file_path)
 
 
-@router.get("/status")
+@router.get("/status", responses=feedback_get_response)
 def feedback_status() -> StatusResponse:
     """
     Handle feedback status requests.
@@ -179,7 +205,7 @@ def feedback_status() -> StatusResponse:
     )
 
 
-@router.put("/status")
+@router.put("/status", responses=feedback_put_response)
 @authorize(Action.ADMIN)
 async def update_feedback_status(
     feedback_update_request: FeedbackStatusUpdateRequest,

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -1140,3 +1140,32 @@ class ForbiddenResponse(UnauthorizedResponse):
             ]
         }
     }
+
+
+class InvalidFeedbackStoragePathResponse(AbstractErrorResponse):
+    """500 Internal Error - Invalid feedback storage path."""
+
+    def __init__(self, storage_path: str):
+        """Initialize an InvalidFeedbackStoragePathResponse for feedback storage failures."""
+        super().__init__(
+            detail=DetailModel(
+                response="Failed to store feedback",
+                cause=f"Invalid feedback storage path: {storage_path}",
+            )
+        )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "detail": {
+                        "response": "Failed to store feedback",
+                        "cause": (
+                            "Invalid feedback storage path: "
+                            "/var/app/data/feedbacks/invalid_path"
+                        ),
+                    }
+                }
+            ]
+        }
+    }

--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -145,6 +145,8 @@ def before_feature(context: Context, feature: Feature) -> None:
         restart_container("lightspeed-stack")
 
     if "Feedback" in feature.tags:
+        context.hostname = os.getenv("E2E_LSC_HOSTNAME", "localhost")
+        context.port = os.getenv("E2E_LSC_PORT", "8080")
         context.feedback_conversations = []
 
 
@@ -156,7 +158,6 @@ def after_feature(context: Context, feature: Feature) -> None:
         remove_config_backup(context.default_config_backup)
 
     if "Feedback" in feature.tags:
-        print(context.feedback_conversations)
         for conversation_id in context.feedback_conversations:
             url = f"http://{context.hostname}:{context.port}/v1/conversations/{conversation_id}"
             headers = context.auth_headers if hasattr(context, "auth_headers") else {}

--- a/tests/e2e/features/feedback.feature
+++ b/tests/e2e/features/feedback.feature
@@ -260,7 +260,25 @@ Feature: feedback endpoint API tests
      And The body of the response is the following
         """
         {
-            "detail": "No Authorization header found"            
+            "detail": {
+                        "cause": "Missing or invalid credentials provided by client",
+                        "response": "Unauthorized"
+            }
+        }
+        """
+
+  Scenario: Check if update feedback status endpoint is not working when not authorized
+    Given The system is in default state
+    And I remove the auth header
+     When The feedback is enabled
+     Then The status code of the response is 400
+     And The body of the response is the following
+        """
+        {
+            "detail": {
+                        "cause": "Missing or invalid credentials provided by client",
+                        "response": "Unauthorized"
+            }
         }
         """
 

--- a/tests/e2e/features/steps/feedback.py
+++ b/tests/e2e/features/steps/feedback.py
@@ -17,7 +17,6 @@ def enable_feedback(context: Context) -> None:
     assert context is not None
     payload = {"status": True}
     access_feedback_put_endpoint(context, payload)
-    assert context.response.status_code == 200, "Enabling feedback was unsuccessful"
 
 
 @step("The feedback is disabled")  # type: ignore
@@ -26,7 +25,6 @@ def disable_feedback(context: Context) -> None:
     assert context is not None
     payload = {"status": False}
     access_feedback_put_endpoint(context, payload)
-    assert context.response.status_code == 200, "Disabling feedback was unsuccessful"
 
 
 @when("I update feedback status with")  # type: ignore


### PR DESCRIPTION
## Description

This commit updates the feedback response dictionaries, adds an end-to-end test verifying a 400 status code for the PUT endpoint, and fixes a bug in the existing e2e tests.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement


## Related Tickets & Documents

- Related Issue # [LCORE-759](https://issues.redhat.com/browse/LCORE-759)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unauthorized feedback error to return structured, clearer error details.
  * Added a specific error response for failures to store feedback (invalid storage path).

* **Improvements**
  * Aligned feedback API response declarations for POST/GET/PUT endpoints for consistency.

* **Tests**
  * E2E tests: environment-driven host/port configuration added and assertions adjusted for feedback status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->