### PR TITLE
LCORE-784: Changing unsupported mime types to text/plain

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -18,6 +18,7 @@ from llama_stack_client.types.agents.turn import Turn
 from llama_stack_client.types.agents.turn_create_params import (
     Toolgroup,
     ToolgroupAgentToolGroupWithArgs,
+    Document,
 )
 from llama_stack_client.types.model_list_response import ModelListResponse
 from llama_stack_client.types.shared.interleaved_content_item import TextContentItem
@@ -692,10 +693,20 @@ async def retrieve_response(  # pylint: disable=too-many-locals,too-many-branche
         if not toolgroups:
             toolgroups = None
 
+    # TODO: LCORE-881 - Remove if Llama Stack starts to support these mime types
+    documents: list[Document] = [
+        (
+            {"content": doc["content"], "mime_type": "text/plain"}
+            if doc["mime_type"].lower() in ("application/json", "application/xml")
+            else doc
+        )
+        for doc in query_request.get_documents()
+    ]
+
     response = await agent.create_turn(
         messages=[UserMessage(role="user", content=query_request.query)],
         session_id=session_id,
-        documents=query_request.get_documents(),
+        documents=documents,
         stream=False,
         toolgroups=toolgroups,
     )

--- a/tests/e2e/features/query.feature
+++ b/tests/e2e/features/query.feature
@@ -114,3 +114,29 @@ Scenario: Check if LLM responds for query request with error for missing query
     """
      Then The status code of the response is 500
       And The body of the response contains Unable to connect to Llama Stack
+
+  Scenario: Check if LLM responds properly when XML and JSON attachments are sent
+    Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+    When I use "query" to ask question with authorization header
+    """
+    {
+      "query": "Say hello",
+      "attachments": [
+        {
+          "attachment_type": "configuration",
+          "content": "<note><to>User</to><from>System</from><message>Hello</message></note>",
+          "content_type": "application/xml"
+        },
+        {
+          "attachment_type": "configuration",
+          "content": "{\"foo\": \"bar\"}",
+          "content_type": "application/json"
+        }
+      ],
+      "model": "{MODEL}", 
+      "provider": "{PROVIDER}",
+      "system_prompt": "You are a helpful assistant"
+    }
+    """
+    Then The status code of the response is 200

--- a/tests/e2e/features/streaming_query.feature
+++ b/tests/e2e/features/streaming_query.feature
@@ -89,3 +89,29 @@ Feature: streaming_query endpoint API tests
     """
      Then The status code of the response is 422
       And The body of the response contains Value error, Provider must be specified if model is specified
+
+  Scenario: Check if LLM responds properly when XML and JSON attachments are sent
+    Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {
+      "query": "Say hello",
+      "attachments": [
+        {
+          "attachment_type": "configuration",
+          "content": "<note><to>User</to><from>System</from><message>Hello</message></note>",
+          "content_type": "application/xml"
+        },
+        {
+          "attachment_type": "configuration",
+          "content": "{\"foo\": \"bar\"}",
+          "content_type": "application/json"
+        }
+      ],
+      "model": "{MODEL}", 
+      "provider": "{PROVIDER}",
+      "system_prompt": "You are a helpful assistant"
+    }
+    """
+    Then The status code of the response is 200


### PR DESCRIPTION
## Description

This pull request temporarily converts application/json and application/xml MIME types to text/plain to prevent errors with the current Llama Stack implementation. This workaround will be removed once Llama Stack supports these MIME types.
Added e2e tests checking the successful response status if concerned attachment types are passed to query.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement


## Related Tickets & Documents

- Related Issue # [LCORE-784](https://issues.redhat.com/browse/LCORE-784)
- Closes # [LCORE-881](https://issues.redhat.com/browse/LCORE-881)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for XML and JSON file attachments in query requests
  * Attachments are now automatically normalized for improved LLM processing compatibility

* **Tests**
  * Added test coverage for XML and JSON attachment handling in both standard and streaming query modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->