### PR TITLE
LCORE-892: updated conversation cache loading logic + added missing tests for conversation cache settings

### DIFF
--- a/src/configuration.py
+++ b/src/configuration.py
@@ -144,7 +144,7 @@ class AppConfig:
         return self._configuration.database
 
     @property
-    def conversation_cache(self) -> Cache | None:
+    def conversation_cache(self) -> Cache:
         """Return the conversation cache."""
         if self._configuration is None:
             raise LogicError("logic error: configuration is not loaded")


### PR DESCRIPTION
## Description

LCORE-892: updated conversation cache loading logic + added missing tests for conversation cache settings

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-892


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Accessing the conversation cache now errors clearly if the app configuration hasn't been loaded, preventing silent failures.

* **New Features**
  * Conversation cache always provides a usable cache instance and supports configurable storage backends (SQLite and in-memory) via configuration.

* **Tests**
  * Added tests validating cache backend selection and the new error behavior when configuration is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->