### PR TITLE
LCORE-971: ensure that type hints are checked for integration tetss

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ PYTHON_REGISTRY = pypi
 run: ## Run the service locally
 	uv run src/lightspeed_stack.py
 
-
-
 test-unit: ## Run the unit tests
 	@echo "Running unit tests..."
 	@echo "Reports will be written to ${ARTIFACT_DIR}"
@@ -24,7 +22,7 @@ test-e2e: ## Run end to end tests for the service
 	script -q -e -c "uv run behave --color --format pretty --tags=-skip -D dump_errors=true @tests/e2e/test_list.txt"
 
 check-types: ## Checks type hints in sources
-	uv run mypy --explicit-package-bases --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --ignore-missing-imports --disable-error-code attr-defined src/ tests/unit
+	uv run mypy --explicit-package-bases --disallow-untyped-calls --disallow-untyped-defs --disallow-incomplete-defs --ignore-missing-imports --disable-error-code attr-defined src/ tests/unit tests/integration
 
 security-check: ## Check the project for security issues
 	bandit -c pyproject.toml -r src tests


### PR DESCRIPTION
## Description

LCORE-971: ensure that type hints are checked for integration tetss

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-971


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test execution configuration to include integration tests in the test scope.
  * Expanded type checking to cover integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->