### PR TITLE
LCORE-1012: do not use assert in production code

### DIFF
--- a/src/app/database.py
+++ b/src/app/database.py
@@ -117,13 +117,19 @@ def initialize_database() -> None:
             logger.info("Initialize SQLite database")
             sqlite_config = db_config.config
             logger.debug("Configuration: %s", sqlite_config)
-            assert isinstance(sqlite_config, SQLiteDatabaseConfiguration)
+            if not isinstance(sqlite_config, SQLiteDatabaseConfiguration):
+                raise TypeError(
+                    f"Expected SQLiteDatabaseConfiguration, got {type(sqlite_config)}"
+                )
             engine = _create_sqlite_engine(sqlite_config, **create_engine_kwargs)
         case "postgres":
             logger.info("Initialize PostgreSQL database")
             postgres_config = db_config.config
             logger.debug("Configuration: %s", postgres_config)
-            assert isinstance(postgres_config, PostgreSQLDatabaseConfiguration)
+            if not isinstance(postgres_config, PostgreSQLDatabaseConfiguration):
+                raise TypeError(
+                    f"Expected PostgreSQLDatabaseConfiguration, got {type(postgres_config)}"
+                )
             engine = _create_postgres_engine(postgres_config, **create_engine_kwargs)
 
     session_local = sessionmaker(autocommit=False, autoflush=False, bind=engine)


### PR DESCRIPTION
## Description

LCORE-1012: do not use `assert` in production code

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue #LCORE-1012
