### PR TITLE
LCORE-423: Add a section how to run lightspeed-stack image on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,17 @@ podman compose up --build
 # Access llama-stack at http://localhost:8321
 ```
 
+#### macOS (arm64)
+
+Emulation of platform amd64 will not work with `podman compose up --build` command.
+
+Instead run the docker command:
+
+```bash
+# Start both services
+docker compose up --build
+```
+
 ### Llama-Stack as Library (Library Mode)
 
 When embedding llama-stack directly in the container, use the existing `Containerfile` directly (this will not build the llama stack service in a separate container). First modify the `lightspeed-stack.yaml` config to use llama stack in library mode.
@@ -620,7 +631,7 @@ podman run \
   my-lightspeed-core:latest
 ```
 
-For macosx users:
+#### macOS
 ```bash
 podman run \
   -p 8080:8080 \


### PR DESCRIPTION
## Description

Edit README file to fix macOS image building guide

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # 423
- Closes # 423

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
I have tested image building and run on macOS Tahoe 26.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded macOS-specific documentation for ARM64 architecture with clarified guidance differentiating Docker Compose and Podman Compose compatibility, including notes about emulation considerations on macOS systems
  * Reorganized Library Mode section with a dedicated formal macOS header to improve documentation structure, navigation, and clarity for macOS users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->