### PR TITLE
LCORE-261: Add RH identity header auth

### DIFF
--- a/examples/lightspeed-stack-rh-identity.yaml
+++ b/examples/lightspeed-stack-rh-identity.yaml
@@ -1,0 +1,23 @@
+name: Red Hat Identity Authentication Example
+service:
+  host: localhost
+  port: 8080
+  auth_enabled: true
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  use_as_library_client: false
+  url: http://localhost:8321
+authentication:
+  module: "rh-identity"
+  rh_identity_config:
+    # Option 1: Single entitlement validation
+    required_entitlements: ["rhel"]
+
+    # Option 2: Multiple entitlements validation - ALL required (uncomment to use, comment out option 1)
+    # required_entitlements:
+    #   - "rhel"
+    #   - "ansible"
+
+    # Option 3: No validation - omit required_entitlements field (comment out both options above)

--- a/src/authentication/__init__.py
+++ b/src/authentication/__init__.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import constants
-from authentication import jwk_token, k8s, noop, noop_with_token
+from authentication import jwk_token, k8s, noop, noop_with_token, rh_identity
 from authentication.interface import AuthInterface
 from configuration import LogicError, configuration
 
@@ -44,6 +44,14 @@ def get_auth_dependency(
         case constants.AUTH_MOD_JWK_TOKEN:
             return jwk_token.JwkTokenAuthDependency(
                 configuration.authentication_configuration.jwk_configuration,
+                virtual_path=virtual_path,
+            )
+        case constants.AUTH_MOD_RH_IDENTITY:
+            rh_identity_config = (
+                configuration.authentication_configuration.rh_identity_configuration
+            )
+            return rh_identity.RHIdentityAuthDependency(
+                required_entitlements=rh_identity_config.required_entitlements,
                 virtual_path=virtual_path,
             )
         case _:

--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -1,0 +1,250 @@
+"""Red Hat Identity header authentication for FastAPI endpoints.
+
+This module provides authentication via the x-rh-identity header, supporting both
+User and System identity types with optional entitlement validation.
+"""
+
+import base64
+import json
+import logging
+from typing import Optional
+
+from fastapi import HTTPException, Request
+
+from authentication.interface import AuthInterface, AuthTuple
+from constants import DEFAULT_VIRTUAL_PATH, NO_USER_TOKEN
+
+logger = logging.getLogger(__name__)
+
+
+class RHIdentityData:
+    """Extracts and validates Red Hat Identity header data.
+
+    Supports two identity types:
+    - User: Console users with user_id, username, is_org_admin
+    - System: Certificate-authenticated RHEL systems with cn as identifier
+    """
+
+    def __init__(
+        self,
+        identity_data: dict,
+        required_entitlements: Optional[list[str]] = None,
+    ) -> None:
+        """Initialize RH Identity data extractor.
+
+        Args:
+            identity_data: Decoded JSON from x-rh-identity header
+            required_entitlements: Service entitlements to validate (optional)
+
+        Raises:
+            HTTPException: If validation fails (400 for format errors, 403 for entitlements)
+        """
+        self.identity_data = identity_data
+        self.required_entitlements = required_entitlements or []
+        self._validate_structure()
+
+    def _validate_structure(self) -> None:
+        """Validate the identity data structure.
+
+        Raises:
+            HTTPException: 400 if required fields are missing
+        """
+        if (
+            "identity" not in self.identity_data
+            or self.identity_data["identity"] is None
+        ):
+            raise HTTPException(status_code=400, detail="Missing 'identity' field")
+
+        identity = self.identity_data["identity"]
+        if "type" not in identity:
+            raise HTTPException(status_code=400, detail="Missing identity 'type' field")
+
+        identity_type = identity["type"]
+        if identity_type == "User":
+            if "user" not in identity:
+                raise HTTPException(
+                    status_code=400, detail="Missing 'user' field for User type"
+                )
+            user = identity["user"]
+            if "user_id" not in user:
+                raise HTTPException(
+                    status_code=400, detail="Missing 'user_id' in user data"
+                )
+            if "username" not in user:
+                raise HTTPException(
+                    status_code=400, detail="Missing 'username' in user data"
+                )
+        elif identity_type == "System":
+            if "system" not in identity:
+                raise HTTPException(
+                    status_code=400, detail="Missing 'system' field for System type"
+                )
+            system = identity["system"]
+            if "cn" not in system:
+                raise HTTPException(
+                    status_code=400, detail="Missing 'cn' in system data"
+                )
+            if "account_number" not in identity:
+                raise HTTPException(
+                    status_code=400, detail="Missing 'account_number' for System type"
+                )
+        else:
+            raise HTTPException(
+                status_code=400, detail=f"Unsupported identity type: {identity_type}"
+            )
+
+    def _get_identity_type(self) -> str:
+        """Get the identity type (User or System).
+
+        Returns:
+            Identity type string
+        """
+        return self.identity_data["identity"]["type"]
+
+    def get_user_id(self) -> str:
+        """Extract user ID based on identity type.
+
+        Returns:
+            User ID (user.user_id for User type, system.cn for System type)
+        """
+        identity = self.identity_data["identity"]
+
+        if self._get_identity_type() == "User":
+            return identity["user"]["user_id"]
+        return identity["system"]["cn"]
+
+    def get_username(self) -> str:
+        """Extract username based on identity type.
+
+        Returns:
+            Username (user.username for User type, account_number for System type)
+        """
+        identity = self.identity_data["identity"]
+
+        if self._get_identity_type() == "User":
+            return identity["user"]["username"]
+        return identity["account_number"]
+
+    def has_entitlement(self, service: str) -> bool:
+        """Check if user has a specific service entitlement.
+
+        Args:
+            service: Service name to check (e.g., "rhel", "ansible", "openshift")
+
+        Returns:
+            True if user has the entitlement and is_entitled is True
+        """
+        entitlements = self.identity_data.get("entitlements", {})
+        service_entitlement = entitlements.get(service, {})
+        return service_entitlement.get("is_entitled", False)
+
+    def has_entitlements(self, services: list[str]) -> bool:
+        """Check if user has ALL specified service entitlements.
+
+        Args:
+            services: List of service names to check
+
+        Returns:
+            True if user has ALL entitlements in the list
+        """
+        return all(self.has_entitlement(service) for service in services)
+
+    def validate_entitlements(self) -> None:
+        """Validate required entitlements based on configuration.
+
+        Raises:
+            HTTPException: 403 if required entitlements are missing
+        """
+        if not self.required_entitlements:
+            return  # No validation required
+
+        missing = [s for s in self.required_entitlements if not self.has_entitlement(s)]
+        if missing:
+            entitlement_word = "entitlement" if len(missing) == 1 else "entitlements"
+            raise HTTPException(
+                status_code=403,
+                detail=f"Missing required {entitlement_word}: {', '.join(missing)}",
+            )
+
+
+class RHIdentityAuthDependency(AuthInterface):  # pylint: disable=too-few-public-methods
+    """Red Hat Identity header authentication dependency for FastAPI.
+
+    Authenticates requests using the x-rh-identity header with base64-encoded JSON.
+    Supports both User and System identity types with optional entitlement validation.
+    """
+
+    def __init__(
+        self,
+        required_entitlements: Optional[list[str]] = None,
+        virtual_path: str = DEFAULT_VIRTUAL_PATH,
+    ) -> None:
+        """Initialize RH Identity authentication dependency.
+
+        Args:
+            required_entitlements: Services to require (ALL must be present)
+            virtual_path: Virtual path for authorization checks
+        """
+        self.required_entitlements = required_entitlements
+        self.virtual_path = virtual_path
+        self.skip_userid_check = False
+
+    async def __call__(self, request: Request) -> AuthTuple:
+        """Validate FastAPI request for RH Identity authentication.
+
+        Args:
+            request: The FastAPI request object
+
+        Returns:
+            AuthTuple: (user_id, username, skip_userid_check, token)
+
+        Raises:
+            HTTPException:
+                - 401: Missing x-rh-identity header
+                - 400: Invalid base64, invalid JSON, or missing required fields
+                - 403: Missing required entitlements
+        """
+        # Extract header
+        identity_header = request.headers.get("x-rh-identity")
+        if not identity_header:
+            logger.warning("Missing x-rh-identity header")
+            raise HTTPException(status_code=401, detail="Missing x-rh-identity header")
+
+        # Decode base64
+        try:
+            decoded_bytes = base64.b64decode(identity_header, validate=True)
+            decoded_str = decoded_bytes.decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            logger.warning("Invalid base64 in x-rh-identity header: %s", exc)
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid base64 encoding in x-rh-identity header",
+            ) from exc
+
+        # Parse JSON
+        try:
+            identity_data = json.loads(decoded_str)
+        except json.JSONDecodeError as exc:
+            logger.warning("Invalid JSON in x-rh-identity header: %s", exc)
+            raise HTTPException(
+                status_code=400, detail="Invalid JSON in x-rh-identity header"
+            ) from exc
+
+        # Extract and validate identity
+        rh_identity = RHIdentityData(
+            identity_data,
+            required_entitlements=self.required_entitlements,
+        )
+
+        # Validate entitlements if configured
+        rh_identity.validate_entitlements()
+
+        # Extract user data
+        user_id = rh_identity.get_user_id()
+        username = rh_identity.get_username()
+
+        logger.debug(
+            "RH Identity authenticated: user_id=%s, username=%s", user_id, username
+        )
+
+        return user_id, username, self.skip_userid_check, NO_USER_TOKEN

--- a/src/constants.py
+++ b/src/constants.py
@@ -100,6 +100,7 @@ AUTH_MOD_K8S = "k8s"
 AUTH_MOD_NOOP = "noop"
 AUTH_MOD_NOOP_WITH_TOKEN = "noop-with-token"
 AUTH_MOD_JWK_TOKEN = "jwk-token"
+AUTH_MOD_RH_IDENTITY = "rh-identity"
 # Supported authentication modules
 SUPPORTED_AUTHENTICATION_MODULES = frozenset(
     {
@@ -107,6 +108,7 @@ SUPPORTED_AUTHENTICATION_MODULES = frozenset(
         AUTH_MOD_NOOP,
         AUTH_MOD_NOOP_WITH_TOKEN,
         AUTH_MOD_JWK_TOKEN,
+        AUTH_MOD_RH_IDENTITY,
     }
 )
 DEFAULT_AUTHENTICATION_MODULE = AUTH_MOD_NOOP

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -409,6 +409,12 @@ class JwkConfiguration(ConfigurationBase):
     jwt_configuration: JwtConfiguration = Field(default_factory=JwtConfiguration)
 
 
+class RHIdentityConfiguration(ConfigurationBase):
+    """Red Hat Identity authentication configuration."""
+
+    required_entitlements: Optional[list[str]] = None
+
+
 class AuthenticationConfiguration(ConfigurationBase):
     """Authentication configuration."""
 
@@ -417,6 +423,7 @@ class AuthenticationConfiguration(ConfigurationBase):
     k8s_cluster_api: Optional[AnyHttpUrl] = None
     k8s_ca_cert_path: Optional[FilePath] = None
     jwk_config: Optional[JwkConfiguration] = None
+    rh_identity_config: Optional[RHIdentityConfiguration] = None
 
     @model_validator(mode="after")
     def check_authentication_model(self) -> Self:
@@ -434,6 +441,13 @@ class AuthenticationConfiguration(ConfigurationBase):
                     "JWK configuration must be specified when using JWK token authentication"
                 )
 
+        if self.module == constants.AUTH_MOD_RH_IDENTITY:
+            if self.rh_identity_config is None:
+                raise ValueError(
+                    "RH Identity configuration must be specified "
+                    "when using RH Identity authentication"
+                )
+
         return self
 
     @property
@@ -446,6 +460,17 @@ class AuthenticationConfiguration(ConfigurationBase):
         if self.jwk_config is None:
             raise ValueError("JWK configuration should not be None")
         return self.jwk_config
+
+    @property
+    def rh_identity_configuration(self) -> RHIdentityConfiguration:
+        """Return RH Identity configuration if the module is RH Identity."""
+        if self.module != constants.AUTH_MOD_RH_IDENTITY:
+            raise ValueError(
+                "RH Identity configuration is only available for RH Identity authentication module"
+            )
+        if self.rh_identity_config is None:
+            raise ValueError("RH Identity configuration should not be None")
+        return self.rh_identity_config
 
 
 @dataclass

--- a/tests/configuration/rh-identity-config.yaml
+++ b/tests/configuration/rh-identity-config.yaml
@@ -1,0 +1,17 @@
+name: RH Identity Test Configuration
+service:
+  host: localhost
+  port: 8080
+  auth_enabled: true
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  use_as_library_client: false
+  url: http://localhost:8321
+user_data_collection:
+  feedback_enabled: false
+authentication:
+  module: "rh-identity"
+  rh_identity_config:
+    required_entitlements: ["rhel"]

--- a/tests/integration/test_rh_identity_integration.py
+++ b/tests/integration/test_rh_identity_integration.py
@@ -1,0 +1,109 @@
+"""Integration tests for Red Hat Identity authentication."""
+
+# pylint: disable=redefined-outer-name
+
+import base64
+import json
+import os
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from configuration import configuration
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create test client for FastAPI app with RH Identity config."""
+    # Save original env var if it exists
+    original_config = os.environ.get("LIGHTSPEED_STACK_CONFIG_PATH")
+
+    # Set config path before importing app
+    os.environ["LIGHTSPEED_STACK_CONFIG_PATH"] = (
+        "tests/configuration/rh-identity-config.yaml"
+    )
+
+    # Load the configuration
+    configuration.load_configuration("tests/configuration/rh-identity-config.yaml")
+
+    # Import app after configuration is loaded
+    from app.main import app  # pylint: disable=import-outside-toplevel
+
+    yield TestClient(app)
+
+    # Restore original env var
+    if original_config:
+        os.environ["LIGHTSPEED_STACK_CONFIG_PATH"] = original_config
+    else:
+        os.environ.pop("LIGHTSPEED_STACK_CONFIG_PATH", None)
+
+
+@pytest.fixture
+def user_identity_json() -> dict:
+    """Fixture providing valid User identity JSON."""
+    return {
+        "identity": {
+            "account_number": "123",
+            "org_id": "321",
+            "type": "User",
+            "user": {
+                "user_id": "test-user-123",
+                "username": "testuser@redhat.com",
+                "is_org_admin": False,
+            },
+        },
+        "entitlements": {
+            "rhel": {"is_entitled": True, "is_trial": False},
+            "ansible": {"is_entitled": True, "is_trial": False},
+            "openshift": {"is_entitled": False, "is_trial": True},
+        },
+    }
+
+
+@pytest.fixture
+def system_identity_json() -> dict:
+    """Fixture providing valid System identity JSON."""
+    return {
+        "identity": {
+            "account_number": "456",
+            "org_id": "654",
+            "type": "System",
+            "system": {"cn": "c87dcb4c-8af1-40dd-878e-60c744edddd0"},
+        },
+        "entitlements": {
+            "rhel": {"is_entitled": True, "is_trial": False},
+        },
+    }
+
+
+def encode_identity(identity_json: dict) -> str:
+    """Encode identity JSON to base64."""
+    json_str = json.dumps(identity_json)
+    return base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
+
+
+class TestRHIdentityIntegration:
+    """Integration test suite for RH Identity authentication."""
+
+    def test_valid_user_identity(
+        self, client: TestClient, user_identity_json: dict
+    ) -> None:
+        """Test successful request with valid User identity."""
+        headers = {"x-rh-identity": encode_identity(user_identity_json)}
+
+        response = client.get("/api/v1/conversations", headers=headers)
+
+        # Should succeed (200) or return empty conversations list
+        assert response.status_code in [200, 404]
+
+    def test_valid_system_identity(
+        self, client: TestClient, system_identity_json: dict
+    ) -> None:
+        """Test successful request with valid System identity."""
+        headers = {"x-rh-identity": encode_identity(system_identity_json)}
+
+        response = client.get("/api/v1/conversations", headers=headers)
+
+        # Should succeed (200) or return empty conversations list
+        assert response.status_code in [200, 404]

--- a/tests/unit/authentication/test_rh_identity.py
+++ b/tests/unit/authentication/test_rh_identity.py
@@ -1,0 +1,347 @@
+"""Unit tests for Red Hat Identity authentication module."""
+
+# pylint: disable=redefined-outer-name
+
+import base64
+import json
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+from fastapi import HTTPException, Request
+
+from authentication.rh_identity import RHIdentityAuthDependency, RHIdentityData
+from constants import NO_USER_TOKEN
+
+
+@pytest.fixture
+def user_identity_data() -> dict:
+    """Fixture providing valid User identity data."""
+    return {
+        "identity": {
+            "account_number": "123",
+            "org_id": "321",
+            "type": "User",
+            "user": {
+                "user_id": "abc123",
+                "username": "user@redhat.com",
+                "is_org_admin": False,
+            },
+        },
+        "entitlements": {
+            "rhel": {"is_entitled": True, "is_trial": False},
+            "ansible": {"is_entitled": True, "is_trial": False},
+            "openshift": {"is_entitled": False, "is_trial": True},
+        },
+    }
+
+
+@pytest.fixture
+def system_identity_data() -> dict:
+    """Fixture providing valid System identity data."""
+    return {
+        "identity": {
+            "account_number": "123",
+            "org_id": "321",
+            "type": "System",
+            "system": {"cn": "c87dcb4c-8af1-40dd-878e-60c744edddd0"},
+        },
+        "entitlements": {
+            "rhel": {"is_entitled": True, "is_trial": False},
+        },
+    }
+
+
+def create_auth_header(identity_data: dict) -> str:
+    """Helper to create base64-encoded x-rh-identity header value."""
+    json_str = json.dumps(identity_data)
+    return base64.b64encode(json_str.encode("utf-8")).decode("utf-8")
+
+
+def create_request_with_header(header_value: Optional[str]) -> Request:
+    """Helper to create mock Request with x-rh-identity header."""
+    request = Mock(spec=Request)
+    request.headers = {"x-rh-identity": header_value} if header_value else {}
+    return request
+
+
+class TestRHIdentityData:
+    """Test suite for RHIdentityData class."""
+
+    def test_user_type_extraction(self, user_identity_data: dict) -> None:
+        """Test extraction of User identity fields."""
+        rh_identity = RHIdentityData(user_identity_data)
+
+        assert rh_identity.get_user_id() == "abc123"
+        assert rh_identity.get_username() == "user@redhat.com"
+
+    def test_system_type_extraction(self, system_identity_data: dict) -> None:
+        """Test extraction of System identity fields."""
+        rh_identity = RHIdentityData(system_identity_data)
+
+        assert rh_identity.get_user_id() == "c87dcb4c-8af1-40dd-878e-60c744edddd0"
+        assert rh_identity.get_username() == "123"
+
+    @pytest.mark.parametrize(
+        "service,expected",
+        [
+            ("rhel", True),  # Entitled service
+            ("ansible", True),  # Entitled service
+            ("openshift", False),  # Not entitled (is_trial=True)
+            ("nonexistent", False),  # Missing service
+        ],
+    )
+    def test_has_entitlement(
+        self, user_identity_data: dict, service: str, expected: bool
+    ) -> None:
+        """Test has_entitlement returns correct result for various services."""
+        rh_identity = RHIdentityData(user_identity_data)
+        assert rh_identity.has_entitlement(service) is expected
+
+    @pytest.mark.parametrize(
+        "services,expected",
+        [
+            (["rhel", "ansible"], True),  # All entitled
+            (["rhel", "openshift"], False),  # One not entitled
+            (["openshift", "nonexistent"], False),  # None entitled
+        ],
+    )
+    def test_has_entitlements(
+        self, user_identity_data: dict, services: list[str], expected: bool
+    ) -> None:
+        """Test has_entitlements returns correct result for service lists."""
+        rh_identity = RHIdentityData(user_identity_data)
+        assert rh_identity.has_entitlements(services) is expected
+
+    @pytest.mark.parametrize(
+        "required_entitlements,should_raise,expected_error",
+        [
+            (["rhel"], False, None),  # Single valid
+            (["rhel", "ansible"], False, None),  # Multiple valid
+            (None, False, None),  # No requirements
+            ([], False, None),  # Empty list
+            (
+                ["openshift"],
+                True,
+                "Missing required entitlement: openshift",
+            ),  # Single missing
+            (
+                ["rhel", "ansible", "openshift"],
+                True,
+                "Missing required entitlement: openshift",
+            ),  # Multiple with one missing
+        ],
+    )
+    def test_validate_entitlements(
+        self,
+        user_identity_data: dict,
+        required_entitlements: Optional[list[str]],
+        should_raise: bool,
+        expected_error: Optional[str],
+    ) -> None:
+        """Test validate_entitlements with various requirement configurations."""
+        rh_identity = RHIdentityData(user_identity_data, required_entitlements)
+
+        if should_raise:
+            with pytest.raises(HTTPException) as exc_info:
+                rh_identity.validate_entitlements()
+            assert exc_info.value.status_code == 403
+            assert expected_error is not None
+            assert expected_error in str(exc_info.value.detail)
+        else:
+            # Should not raise
+            rh_identity.validate_entitlements()
+
+    @pytest.mark.parametrize(
+        "missing_field,expected_error",
+        [
+            ({"identity": None}, "Missing 'identity' field"),
+            ({"identity": {"org_id": "123"}}, "Missing identity 'type' field"),
+            (
+                {"identity": {"type": "User", "org_id": "123"}},
+                "Missing 'user' field for User type",
+            ),
+            (
+                {
+                    "identity": {
+                        "type": "User",
+                        "org_id": "123",
+                        "user": {"username": "test"},
+                    }
+                },
+                "Missing 'user_id' in user data",
+            ),
+            (
+                {
+                    "identity": {
+                        "type": "User",
+                        "org_id": "123",
+                        "user": {"user_id": "123"},
+                    }
+                },
+                "Missing 'username' in user data",
+            ),
+            (
+                {"identity": {"type": "System", "org_id": "123"}},
+                "Missing 'system' field for System type",
+            ),
+            (
+                {"identity": {"type": "System", "org_id": "123", "system": {}}},
+                "Missing 'cn' in system data",
+            ),
+            (
+                {
+                    "identity": {
+                        "type": "System",
+                        "org_id": "123",
+                        "system": {"cn": "test"},
+                    }
+                },
+                "Missing 'account_number' for System type",
+            ),
+        ],
+    )
+    def test_validation_failures(
+        self, missing_field: dict, expected_error: str
+    ) -> None:
+        """Test validation failures for various missing fields."""
+        with pytest.raises(HTTPException) as exc_info:
+            RHIdentityData(missing_field)
+
+        assert exc_info.value.status_code == 400
+        assert expected_error in str(exc_info.value.detail)
+
+    def test_unsupported_identity_type(self) -> None:
+        """Test validation fails with unsupported identity type."""
+        invalid_data = {"identity": {"type": "Unknown", "org_id": "123"}}
+
+        with pytest.raises(HTTPException) as exc_info:
+            RHIdentityData(invalid_data)
+
+        assert exc_info.value.status_code == 400
+        assert "Unsupported identity type: Unknown" in str(exc_info.value.detail)
+
+
+class TestRHIdentityAuthDependency:
+    """Test suite for RHIdentityAuthDependency class."""
+
+    @pytest.mark.asyncio
+    async def test_user_authentication_success(self, user_identity_data: dict) -> None:
+        """Test successful User authentication."""
+        auth_dep = RHIdentityAuthDependency()
+        header_value = create_auth_header(user_identity_data)
+        request = create_request_with_header(header_value)
+
+        user_id, username, _, _ = await auth_dep(request)
+
+        assert user_id == "abc123"
+        assert username == "user@redhat.com"
+
+    @pytest.mark.asyncio
+    async def test_system_authentication_success(
+        self, system_identity_data: dict
+    ) -> None:
+        """Test successful System authentication."""
+        auth_dep = RHIdentityAuthDependency()
+        header_value = create_auth_header(system_identity_data)
+        request = create_request_with_header(header_value)
+
+        user_id, username, skip_check, token = await auth_dep(request)
+
+        assert user_id == "c87dcb4c-8af1-40dd-878e-60c744edddd0"
+        assert username == "123"
+        assert skip_check is False
+        assert token == NO_USER_TOKEN
+
+    @pytest.mark.asyncio
+    async def test_missing_header(self) -> None:
+        """Test authentication fails when header is missing."""
+        auth_dep = RHIdentityAuthDependency()
+        request = create_request_with_header(None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_dep(request)
+
+        assert exc_info.value.status_code == 401
+        assert "Missing x-rh-identity header" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_invalid_base64(self) -> None:
+        """Test authentication fails with invalid base64."""
+        auth_dep = RHIdentityAuthDependency()
+        request = create_request_with_header("not-valid-base64!!!")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_dep(request)
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid base64 encoding" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_invalid_json(self) -> None:
+        """Test authentication fails with invalid JSON."""
+        auth_dep = RHIdentityAuthDependency()
+        invalid_json = base64.b64encode(b"not valid json").decode("utf-8")
+        request = create_request_with_header(invalid_json)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_dep(request)
+
+        assert exc_info.value.status_code == 400
+        assert "Invalid JSON" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "required_entitlements,should_raise,expected_error",
+        [
+            (["rhel"], False, None),  # Single valid
+            (["rhel", "ansible"], False, None),  # Multiple valid
+            (None, False, None),  # No requirements
+            (
+                ["openshift"],
+                True,
+                "Missing required entitlement: openshift",
+            ),  # Single missing
+            (
+                ["rhel", "ansible", "openshift"],
+                True,
+                "Missing required entitlement: openshift",
+            ),  # Multiple with one missing
+        ],
+    )
+    async def test_entitlement_validation(
+        self,
+        user_identity_data: dict,
+        required_entitlements: Optional[list[str]],
+        should_raise: bool,
+        expected_error: Optional[str],
+    ) -> None:
+        """Test authentication with various entitlement requirements."""
+        auth_dep = RHIdentityAuthDependency(required_entitlements=required_entitlements)
+        header_value = create_auth_header(user_identity_data)
+        request = create_request_with_header(header_value)
+
+        if should_raise:
+            with pytest.raises(HTTPException) as exc_info:
+                await auth_dep(request)
+            assert exc_info.value.status_code == 403
+            assert expected_error is not None
+            assert expected_error in str(exc_info.value.detail)
+        else:
+            user_id, username, _, _ = await auth_dep(request)
+            assert user_id == "abc123"
+            assert username == "user@redhat.com"
+
+    @pytest.mark.asyncio
+    async def test_no_entitlement_data(self, user_identity_data: dict) -> None:
+        """Test authentication succeeds when no entitlements are present in identity data."""
+        user_identity_data_no_entitlements = user_identity_data.copy()
+        user_identity_data_no_entitlements["entitlements"] = {}
+
+        auth_dep = RHIdentityAuthDependency()
+        header_value = create_auth_header(user_identity_data_no_entitlements)
+        request = create_request_with_header(header_value)
+
+        user_id, username, _, _ = await auth_dep(request)
+        assert user_id == "abc123"
+        assert username == "user@redhat.com"

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -148,6 +148,7 @@ def test_dump_configuration(tmp_path: Path) -> None:
                 "k8s_ca_cert_path": None,
                 "k8s_cluster_api": None,
                 "jwk_config": None,
+                "rh_identity_config": None,
             },
             "customization": None,
             "inference": {
@@ -446,6 +447,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "k8s_ca_cert_path": None,
                 "k8s_cluster_api": None,
                 "jwk_config": None,
+                "rh_identity_config": None,
             },
             "customization": None,
             "inference": {


### PR DESCRIPTION
## Description

Add support for receiving a base64-encoded JSON blob passed in by a load balancer in Red Hat Insights deployments. Handle authentication for users and systems with the ability to check that certain entitlements are in place for various products.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Related Tickets & Documents

- Related Issue # LSCORE-261

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

Testing this in production requires putting the deployment behind a load balancer in the Red Hat Insights environment, but you can also test it by providing a base64-encoded JSON string in the `x-rh-identity` header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Red Hat Identity authentication with entitlement-based access control and configuration support.
  * App now exposes RH Identity configuration option in runtime settings and dumped configuration.

* **Examples**
  * Added a ready-to-use example showing single, multiple (ALL), and no-entitlement validation options.

* **Tests**
  * Added comprehensive unit and integration tests covering RH Identity parsing, validation, and dependency behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->