### PR TITLE
LCORE-1094: Rag chunks are not parsed

### DIFF
--- a/tests/integration/endpoints/test_query_v2_integration.py
+++ b/tests/integration/endpoints/test_query_v2_integration.py
@@ -347,6 +347,7 @@ async def test_query_v2_endpoint_with_tool_calls(
     mock_result.file_id = "doc-1"
     mock_result.filename = "ansible-docs.txt"
     mock_result.score = 0.95
+    mock_result.text = "Ansible is an open-source automation tool..."
     mock_result.attributes = {
         "doc_url": "https://example.com/ansible-docs.txt",
         "link": "https://example.com/ansible-docs.txt",


### PR DESCRIPTION
## Description

Added parsing of rag_chunks, then added them to TurnSummary to store the rag chunks in the transcript.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue # LCORE-1094
- Closes # LCORE-1094

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Set up LCS with a rag db, called the rag and checked that the transcript stores the rag chunks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responses now extract and attach RAG chunks (content, source, relevance) from tool results so conversation summaries include source-attributed snippets.
* **Bug Fixes**
  * Retrieval flow now populates referenced RAG chunks instead of leaving them empty, improving source visibility.
* **Tests**
  * Integration and unit tests updated to exercise richer response structures and validate RAG chunk extraction and referenced-doc listings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->