### PR TITLE
Add rlsapi v1 infer request/response models

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -804,6 +804,8 @@ class Action(str, Enum):
     INFO = "info"
     # Allow overriding model/provider via request
     MODEL_OVERRIDE = "model_override"
+    # RHEL Lightspeed rlsapi v1 compatibility - stateless inference (no history/RAG)
+    RLSAPI_V1_INFER = "rlsapi_v1_infer"
 
 
 class AccessRule(ConfigurationBase):

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -1,6 +1,6 @@
 """Models for REST API requests."""
 
-from typing import Optional, Self
+from typing import Any, Optional, Self
 from enum import Enum
 
 from pydantic import BaseModel, model_validator, field_validator, Field
@@ -527,4 +527,39 @@ class ConversationUpdateRequest(BaseModel):
     )
 
     # Reject unknown fields
+    model_config = {"extra": "forbid"}
+
+
+class RlsapiV1InferRequest(BaseModel):
+    """RHEL Lightspeed rlsapi v1 /infer request - flexible context as dict.
+
+    Attributes:
+        question: User question string
+        context: Optional context dictionary with flexible fields
+            (system_info, terminal_output, stdin, attachments, etc)
+
+    Example:
+        ```python
+        request = RlsapiV1InferRequest(
+            question="How do I list files?",
+            context={"system_info": "RHEL 9.3", "terminal_output": "bash: command not found"}
+        )
+        ```
+    """
+
+    question: str = Field(..., description="User question")
+    context: Optional[dict[str, Any]] = Field(
+        None,
+        description=(
+            "Optional context "
+            "(system_info, terminal_output, stdin, attachments, etc)"
+        ),
+        examples=[
+            {
+                "system_info": "RHEL 9.3",
+                "terminal_output": "bash: command not found",
+                "stdin": "user input",
+            }
+        ],
+    )
     model_config = {"extra": "forbid"}

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -1941,6 +1941,33 @@ class InternalServerErrorResponse(AbstractErrorResponse):
         )
 
 
+class RlsapiV1InferResponse(AbstractSuccessfulResponse):
+    """RHEL Lightspeed rlsapi v1 /infer response.
+
+    Attributes:
+        data: Dictionary containing response text and request_id
+    """
+
+    data: dict[str, Any] = Field(
+        ...,
+        description="Response data containing text and request_id",
+    )
+
+    model_config = {
+        "extra": "forbid",
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "data": {
+                        "text": "To list files in Linux, use the `ls` command.",
+                        "request_id": "01JDKR8N7QW9ZMXVGK3PB5TQWZ",
+                    }
+                }
+            ]
+        },
+    }
+
+
 class ServiceUnavailableResponse(AbstractErrorResponse):
     """503 Backend Unavailable."""
 

--- a/tests/unit/authentication/test_api_key_token.py
+++ b/tests/unit/authentication/test_api_key_token.py
@@ -71,7 +71,9 @@ async def test_api_key_with_token_auth_dependency_no_token(
         await dependency(request)
 
     assert exc_info.value.status_code == 401
-    assert exc_info.value.detail["cause"] == "No Authorization header found"
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["cause"] == "No Authorization header found"
 
 
 async def test_api_key_with_token_auth_dependency_no_bearer(
@@ -94,7 +96,9 @@ async def test_api_key_with_token_auth_dependency_no_bearer(
         await dependency(request)
 
     assert exc_info.value.status_code == 401
-    assert exc_info.value.detail["cause"] == "No token found in Authorization header"
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["cause"] == "No token found in Authorization header"
 
 
 async def test_api_key_with_token_auth_dependency_invalid(


### PR DESCRIPTION
## Description

Adding the basic set of pydantic models in preparation for adding the RHEL Lightspeed rlsapi v1 API endpoint.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Existing tests should work fine. More testing will be added as the endpoint is added in a subsequent PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added support for RLS API v1 inference endpoint with corresponding request and response models for question + optional context.

* **Tests**
  - Improved authentication tests to assert structured error detail objects for clearer failure diagnostics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->