### PR TITLE
feat(rlsapi): add method to combine request inputs

### DIFF
--- a/src/models/rlsapi/requests.py
+++ b/src/models/rlsapi/requests.py
@@ -174,3 +174,27 @@ class RlsapiV1InferRequest(ConfigurationBase):
         if not stripped:
             raise ValueError("Question cannot be empty or whitespace-only")
         return stripped
+
+    def get_input_source(self) -> str:
+        """Combine all non-empty input sources into a single string.
+
+        Joins question, stdin, attachment contents, and terminal output with double
+        newlines, in priority order. Empty sources are omitted.
+
+        Priority order:
+            1. question
+            2. stdin
+            3. attachment contents
+            4. terminal output
+
+        Returns:
+            The combined input string with sources separated by double newlines.
+        """
+        # pylint: disable=no-member  # Pydantic fields are dynamic
+        parts = [
+            self.question,
+            self.context.stdin,
+            self.context.attachments.contents,
+            self.context.terminal.output,
+        ]
+        return "\n\n".join(part for part in parts if part)


### PR DESCRIPTION
## Description

Adds input handling for the rlsapi v1 interface. Joins non-empty sources (question, stdin, attachment, terminal) with double newlines for LLM inference.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Existing unit tests should be sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds consolidated input assembly that merges multiple input sources into a single prioritized input string, preserving content formatting.

* **Tests**
  * Introduces comprehensive unit tests covering combinations of input sources, multiline content preservation, and explicit priority ordering validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->