### PR TITLE
Variable RAG DB setup for query, query v2, and streaming query

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -728,9 +728,14 @@ async def retrieve_response(  # pylint: disable=too-many-locals,too-many-branche
             ),
         }
 
-        vector_db_ids = [
-            vector_store.id for vector_store in (await client.vector_stores.list()).data
-        ]
+        # Use specified vector stores or fetch all available ones
+        if query_request.vector_store_ids:
+            vector_db_ids = query_request.vector_store_ids
+        else:
+            vector_db_ids = [
+                vector_store.id
+                for vector_store in (await client.vector_stores.list()).data
+            ]
         toolgroups = (get_rag_toolgroups(vector_db_ids) or []) + [
             mcp_server.name for mcp_server in configuration.mcp_servers
         ]

--- a/src/app/endpoints/query_v2.py
+++ b/src/app/endpoints/query_v2.py
@@ -743,10 +743,13 @@ async def prepare_tools_for_responses_api(
         return None
 
     toolgroups = []
-    # Get vector stores for RAG tools
-    vector_store_ids = [
-        vector_store.id for vector_store in (await client.vector_stores.list()).data
-    ]
+    # Get vector stores for RAG tools - use specified ones or fetch all
+    if query_request.vector_store_ids:
+        vector_store_ids = query_request.vector_store_ids
+    else:
+        vector_store_ids = [
+            vector_store.id for vector_store in (await client.vector_stores.list()).data
+        ]
 
     # Add RAG tools if vector stores are available
     rag_tools = get_rag_tools(vector_store_ids)

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -1088,9 +1088,14 @@ async def retrieve_response(
             ),
         }
 
-        vector_db_ids = [
-            vector_store.id for vector_store in (await client.vector_stores.list()).data
-        ]
+        # Use specified vector stores or fetch all available ones
+        if query_request.vector_store_ids:
+            vector_db_ids = query_request.vector_store_ids
+        else:
+            vector_db_ids = [
+                vector_store.id
+                for vector_store in (await client.vector_stores.list()).data
+            ]
         toolgroups = (get_rag_toolgroups(vector_db_ids) or []) + [
             mcp_server.name for mcp_server in configuration.mcp_servers
         ]

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -83,6 +83,7 @@ class QueryRequest(BaseModel):
         no_tools: Whether to bypass all tools and MCP servers (default: False).
         generate_topic_summary: Whether to generate topic summary for new conversations.
         media_type: The optional media type for response format (application/json or text/plain).
+        vector_store_ids: The optional list of specific vector store IDs to query for RAG.
 
     Example:
         ```python
@@ -159,6 +160,13 @@ class QueryRequest(BaseModel):
         examples=[MEDIA_TYPE_JSON, MEDIA_TYPE_TEXT],
     )
 
+    vector_store_ids: Optional[list[str]] = Field(
+        None,
+        description="Optional list of specific vector store IDs to query for RAG. "
+        "If not provided, all available vector stores will be queried.",
+        examples=["ocp_docs", "knowledge_base", "vector_db_1"],
+    )
+
     # provides examples for /docs endpoint
     model_config = {
         "extra": "forbid",
@@ -172,6 +180,7 @@ class QueryRequest(BaseModel):
                     "system_prompt": "You are a helpful assistant",
                     "no_tools": False,
                     "generate_topic_summary": True,
+                    "vector_store_ids": ["ocp_docs", "knowledge_base"],
                     "attachments": [
                         {
                             "attachment_type": "log",


### PR DESCRIPTION
## Description
Currently, the RAG implementation lacks granularity in retrieval. To improve response accuracy and support multi-tenant or multi-context use cases, we need the ability to dynamically select which knowledge base (Vector DB/Index) to query.
Added a new request param vector_store_ids for:
query, query_v2, and streaming_query endpoints

<!--- Describe your changes in detail -->


## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude code)
- Generated by: (Claude-4.5-Sonnet)

## Related Tickets & Documents

- Related Issue [LCORE-1067](https://issues.redhat.com/browse/LCORE-1067)
- Closes [LCORE-1067](https://issues.redhat.com/browse/LCORE-1067)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query requests now support optional vector store selection for RAG operations
  * Specify particular vector stores to query; defaults to all stores if not provided
  * Fully backward compatible with existing requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->