### PR TITLE
feat(rlsapi): implement LLM integration for v1 /infer endpoint

### DIFF
--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -93,6 +93,7 @@ async def retrieve_simple_response(question: str) -> str:
 
     Raises:
         APIConnectionError: If the Llama Stack service is unreachable.
+        HTTPException: 503 if no model is configured.
     """
     client = AsyncLlamaStackClientHolder().get_client()
     model_id = _get_default_model_id()

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -58,7 +58,9 @@ def mock_llm_response_fixture(
     mock_turn = mocker.Mock()
     mock_turn.output_message = mock_output_message
     mock_turn.steps = []
-    mock_agent.create_turn.return_value = mock_turn
+
+    # Use AsyncMock for async method
+    mock_agent.create_turn = mocker.AsyncMock(return_value=mock_turn)
 
     # Mock get_temp_agent to return our mock agent
     mocker.patch(
@@ -86,7 +88,9 @@ def mock_empty_llm_response_fixture(
     mock_turn = mocker.Mock()
     mock_turn.output_message = None
     mock_turn.steps = []
-    mock_agent.create_turn.return_value = mock_turn
+
+    # Use AsyncMock for async method
+    mock_agent.create_turn = mocker.AsyncMock(return_value=mock_turn)
 
     # Mock get_temp_agent to return our mock agent
     mocker.patch(


### PR DESCRIPTION
## Description

Wire up the /infer endpoint to Llama Stack for actual inference of RHEL Lightspeed requests:

- Handle empty LLM responses with fallback message
- Include request_id in all log statements for tracing

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue RSPEED-2229

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

No changes to how tests are run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced placeholder inference with live LLM retrieval for user queries.
  * Added request/response logging and session-aware retrieval to improve reliability.

* **Bug Fixes**
  * Returns HTTP 503 with a service-unavailable payload when the LLM backend is unreachable.
  * Provides a fallback response when the LLM yields no content.
  * Strips whitespace and validates blank questions before processing.

* **Tests**
  * Expanded unit tests covering default model resolution, successful and empty LLM outputs, API errors, and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->