### PR TITLE
RSPEED-2288: fix(auth): add rh-identity support to authorization middleware

### DIFF
--- a/src/authorization/middleware.py
+++ b/src/authorization/middleware.py
@@ -64,6 +64,17 @@ def get_authorization_resolvers() -> Tuple[RolesResolver, AccessResolver]:
                 GenericAccessResolver(authorization_cfg.access_rules),
             )
 
+        case constants.AUTH_MOD_RH_IDENTITY:
+            # rh-identity uses access rules for authorization, but doesn't extract
+            # roles from the identity header - all authenticated users get the "*" role
+            if len(authorization_cfg.access_rules) == 0:
+                return NoopRolesResolver(), NoopAccessResolver()
+
+            return (
+                NoopRolesResolver(),
+                GenericAccessResolver(authorization_cfg.access_rules),
+            )
+
         case _:
             response = InternalServerErrorResponse.generic()
             raise HTTPException(**response.model_dump())


### PR DESCRIPTION
## Description

The authorization middleware's `match` statement didn't handle the `rh-identity` authentication module. When using rh-identity auth with `access_rules` configured, requests fell through to the default case which raised `InternalServerError` (HTTP 500) on every protected endpoint.

This adds a case for `constants.AUTH_MOD_RH_IDENTITY` that:
- Uses `NoopRolesResolver` (all authenticated users get the `*` role)
- Applies `GenericAccessResolver` with configured `access_rules`
- Falls back to `NoopAccessResolver` if no `access_rules` are configured

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude Code
- Generated by: N/A

## Related Tickets & Documents

- Related Issue # N/A
- Closes # N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

1. Configure lightspeed-stack with rh-identity authentication:
   ```yaml
   authentication:
     module: "rh-identity"
     rh_identity_config:
       required_entitlements: ["rhel"]
   
   authorization:
     access_rules:
       - role: "*"
         actions: ["info", "rlsapi_v1_infer"]
   ```

2. Start the service and make a request with a valid `x-rh-identity` header

3. **Before fix**: Request returns HTTP 500 Internal Server Error
4. **After fix**: Request is properly authorized and returns expected response

The fix was verified by running an end-to-end test with rh-identity auth against the `/liveness` endpoint, which now correctly returns HTTP 200 instead of HTTP 500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization behavior for RH Identity authentication module to ensure consistent access rule resolution when configurations are empty or populated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->