### PR TITLE
fix(agents): remove non-existent AsyncAgent.initialize() calls

### DIFF
--- a/src/utils/endpoints.py
+++ b/src/utils/endpoints.py
@@ -355,7 +355,6 @@ async def get_agent(
         tool_parser=None if no_tools else GraniteToolParser.get_parser(model_id),
         enable_session_persistence=True,  # type: ignore[call-arg]
     )
-    await agent.initialize()  # type: ignore[attr-defined]
 
     if existing_agent_id and conversation_id:
         logger.debug("Existing conversation ID: %s", conversation_id)
@@ -412,7 +411,6 @@ async def get_temp_agent(
         # type: ignore[call-arg]  # Temporary agent doesn't need persistence
         # enable_session_persistence=False,
     )
-    await agent.initialize()  # type: ignore[attr-defined]
 
     # Generate new IDs for the temporary agent
     # conversation_id = agent.agent_id


### PR DESCRIPTION
## Description

Remove calls to `AsyncAgent.initialize()` in `get_agent()` and `get_temp_agent()` functions. This method does not exist in llama-stack-client 0.3.5 and causes `AttributeError` at runtime.

The agent does not require explicit initialization - `create_session()` works without it.

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude
- Generated by: N/A

## Related Tickets & Documents

- Related Issue # N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

1. Start lightspeed-stack with llama-stack as library mode
2. Make a request to any endpoint that uses `get_agent()` or `get_temp_agent()`
3. Verify no `AttributeError: 'AsyncAgent' object has no attribute 'initialize'` is raised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal agent initialization process for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->