### PR TITLE
[LCORE-702] Add e2e tests for error status codes for the /query endpoint

### DIFF
--- a/tests/e2e/features/query.feature
+++ b/tests/e2e/features/query.feature
@@ -64,6 +64,26 @@ Feature: Query endpoint API tests
       }
       """
 
+  Scenario: Check if LLM responds to sent question with error when bearer token is missing
+    Given The system is in default state
+    And I set the Authorization header to Bearer
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Write a simple code for reversing string", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+      Then The status code of the response is 401
+      And The body of the response contains No token found in Authorization header
+
+  Scenario: Check if LLM responds to sent question with error when model does not exist
+    Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Write a simple code for reversing string", "model": "does-not-exist", "provider": "does-not-exist"}
+    """
+      Then The status code of the response is 404
+      And The body of the response contains Model not found
+
   Scenario: Check if LLM responds to sent question with error when attempting to access conversation
     Given The system is in default state
      And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.5
- Generated by: Claude Opus 4.5

## Related Tickets & Documents

- Related Issue https://issues.redhat.com/browse/LCORE-702
- Closes https://issues.redhat.com/browse/LCORE-702

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end error handling coverage with two new scenarios: missing authorization token (401) and non-existent model (404), augmenting existing invalid-authentication tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->