### PR TITLE
[LCORE 704] Add e2e tests for /conversation endpoint error status codes

### DIFF
--- a/tests/e2e/features/conversations.feature
+++ b/tests/e2e/features/conversations.feature
@@ -45,6 +45,13 @@ Feature: conversations endpoint API tests
         }
         """
 
+  Scenario: Check if conversations endpoint fails when the bearer token is missing
+    Given The system is in default state
+    And I set the Authorization header to Bearer
+     When I access REST API endpoint "conversations" using HTTP GET method
+     Then The status code of the response is 401
+      And The body of the response contains No token found in Authorization header
+
   Scenario: Check if conversations/{conversation_id} endpoint finds the correct conversation when it exists
     Given The system is in default state
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
@@ -110,9 +117,16 @@ Feature: conversations endpoint API tests
           "detail": {
               "response": "Missing or invalid credentials provided by client",
               "cause": "No Authorization header found"
-            }           
+            }
       }
       """
+
+  Scenario: Check if conversations/{conversation_id} endpoint fails when the bearer token is missing
+    Given The system is in default state
+    And I set the Authorization header to Bearer
+     When I use REST API conversation endpoint with conversation_id "12345678-abcd-0000-0123-456789abcdef" using HTTP GET method
+     Then The status code of the response is 401
+      And The body of the response contains No token found in Authorization header
 
   Scenario: Check if conversations/{conversation_id} GET endpoint fails when conversation_id is malformed
     Given The system is in default state


### PR DESCRIPTION
## Description

Add e2e tests for /conversation endpoint error status codes

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.5
- Generated by: Claude Opus 4.5

## Related Tickets & Documents

- Related Issue https://issues.redhat.com/browse/LCORE-704
- Closes https://issues.redhat.com/browse/LCORE-704

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test scenarios for missing authorization tokens on conversation endpoints, ensuring proper 401 error responses and error messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->