### PR TITLE
Restored rag_chunks attribute in query response

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -7648,6 +7648,14 @@
                             "Kubernetes is an open-source container orchestration system for automating ..."
                         ]
                     },
+                    "rag_chunks": {
+                        "items": {
+                            "$ref": "#/components/schemas/RAGChunk"
+                        },
+                        "type": "array",
+                        "title": "Rag Chunks",
+                        "description": "Deprecated: List of RAG chunks used to generate the response."
+                    },
                     "referenced_documents": {
                         "items": {
                             "$ref": "#/components/schemas/ReferencedDocument"
@@ -7711,32 +7719,18 @@
                         ]
                     },
                     "tool_calls": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "$ref": "#/components/schemas/ToolCallSummary"
-                                },
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "items": {
+                            "$ref": "#/components/schemas/ToolCallSummary"
+                        },
+                        "type": "array",
                         "title": "Tool Calls",
                         "description": "List of tool calls made during response generation"
                     },
                     "tool_results": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "$ref": "#/components/schemas/ToolResultSummary"
-                                },
-                                "type": "array"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
+                        "items": {
+                            "$ref": "#/components/schemas/ToolResultSummary"
+                        },
+                        "type": "array",
                         "title": "Tool Results",
                         "description": "List of tool results"
                     }
@@ -7746,7 +7740,7 @@
                     "response"
                 ],
                 "title": "QueryResponse",
-                "description": "Model representing LLM response to a query.\n\nAttributes:\n    conversation_id: The optional conversation ID (UUID).\n    response: The response.\n    rag_chunks: List of RAG chunks used to generate the response.\n    referenced_documents: The URLs and titles for the documents used to generate the response.\n    tool_calls: List of tool calls made during response generation.\n    truncated: Whether conversation history was truncated.\n    input_tokens: Number of tokens sent to LLM.\n    output_tokens: Number of tokens received from LLM.\n    available_quotas: Quota available as measured by all configured quota limiters.",
+                "description": "Model representing LLM response to a query.\n\nAttributes:\n    conversation_id: The optional conversation ID (UUID).\n    response: The response.\n    rag_chunks: Deprecated. List of RAG chunks used to generate the response.\n        This information is now available in tool_results under file_search_call type.\n    referenced_documents: The URLs and titles for the documents used to generate the response.\n    tool_calls: List of tool calls made during response generation.\n    tool_results: List of tool results.\n    truncated: Whether conversation history was truncated.\n    input_tokens: Number of tokens sent to LLM.\n    output_tokens: Number of tokens received from LLM.\n    available_quotas: Quota available as measured by all configured quota limiters.",
                 "examples": [
                     {
                         "available_quotas": {
@@ -7978,6 +7972,45 @@
                 "type": "object",
                 "title": "QuotaSchedulerConfiguration",
                 "description": "Quota scheduler configuration."
+            },
+            "RAGChunk": {
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "title": "Content",
+                        "description": "The content of the chunk"
+                    },
+                    "source": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Source",
+                        "description": "Source document or URL"
+                    },
+                    "score": {
+                        "anyOf": [
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Score",
+                        "description": "Relevance score"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "content"
+                ],
+                "title": "RAGChunk",
+                "description": "Model representing a RAG chunk used in the response."
             },
             "RAGInfoResponse": {
                 "properties": {

--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -441,6 +441,7 @@ async def query_endpoint_handler_base(  # pylint: disable=R0914
             response=summary.llm_response,
             tool_calls=summary.tool_calls,
             tool_results=summary.tool_results,
+            rag_chunks=summary.rag_chunks,
             referenced_documents=referenced_documents,
             truncated=False,  # TODO: implement truncation detection
             input_tokens=token_usage.input_tokens,

--- a/src/app/endpoints/query_v2.py
+++ b/src/app/endpoints/query_v2.py
@@ -492,7 +492,7 @@ def extract_rag_chunks_from_file_search_item(
     if item.results is not None:
         for result in item.results:
             rag_chunk = RAGChunk(
-                content=result.text, source="file_search", score=result.score
+                content=result.text, source=result.filename, score=result.score
             )
             rag_chunks.append(rag_chunk)
 

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -10,7 +10,7 @@ from pydantic_core import SchemaError
 
 from quota.quota_exceed_error import QuotaExceedError
 from models.config import Action, Configuration
-from utils.types import ToolCallSummary, ToolResultSummary
+from utils.types import RAGChunk, ToolCallSummary, ToolResultSummary
 
 SUCCESSFUL_RESPONSE_DESCRIPTION = "Successful response"
 BAD_REQUEST_DESCRIPTION = "Invalid request format"
@@ -348,9 +348,11 @@ class QueryResponse(AbstractSuccessfulResponse):
     Attributes:
         conversation_id: The optional conversation ID (UUID).
         response: The response.
-        rag_chunks: List of RAG chunks used to generate the response.
+        rag_chunks: Deprecated. List of RAG chunks used to generate the response.
+            This information is now available in tool_results under file_search_call type.
         referenced_documents: The URLs and titles for the documents used to generate the response.
         tool_calls: List of tool calls made during response generation.
+        tool_results: List of tool results.
         truncated: Whether conversation history was truncated.
         input_tokens: Number of tokens sent to LLM.
         output_tokens: Number of tokens received from LLM.
@@ -368,6 +370,11 @@ class QueryResponse(AbstractSuccessfulResponse):
         examples=[
             "Kubernetes is an open-source container orchestration system for automating ..."
         ],
+    )
+
+    rag_chunks: list[RAGChunk] = Field(
+        default_factory=list,
+        description="Deprecated: List of RAG chunks used to generate the response.",
     )
 
     referenced_documents: list[ReferencedDocument] = Field(

--- a/tests/unit/app/endpoints/test_query_v2.py
+++ b/tests/unit/app/endpoints/test_query_v2.py
@@ -998,8 +998,8 @@ async def test_retrieve_response_parses_referenced_documents(
     # Verify RAG chunks were extracted from file_search_call results
     assert len(_summary.rag_chunks) == 2
     assert _summary.rag_chunks[0].content == "Sample text from file2.pdf"
-    assert _summary.rag_chunks[0].source == "file_search"
+    assert _summary.rag_chunks[0].source == "file2.pdf"
     assert _summary.rag_chunks[0].score == 0.95
     assert _summary.rag_chunks[1].content == "Sample text from file3.docx"
-    assert _summary.rag_chunks[1].source == "file_search"
+    assert _summary.rag_chunks[1].source == "file3.docx"
     assert _summary.rag_chunks[1].score == 0.85


### PR DESCRIPTION
## Description

This PR restores the original  `rag_chunks` attribute in query response and marks it as deprecated. It also fixes source attribute parsing in rag chunk object.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rag_chunks` field to API responses (marked deprecated; use `tool_results` instead).
  * Added `tool_results` field to query responses for improved tool interaction transparency.
  * Enhanced RAG chunk source information to display actual file names instead of generic labels.
  * Refined API schema structure for tool calls and results fields for better consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->