### PR TITLE
RSPEED-2326: feat(auth): store RH Identity data in request.state

### DIFF
--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -247,6 +247,9 @@ class RHIdentityAuthDependency(AuthInterface):  # pylint: disable=too-few-public
         # Validate entitlements if configured
         rh_identity.validate_entitlements()
 
+        # Store identity data in request.state for downstream access
+        request.state.rh_identity_data = rh_identity
+
         # Extract user data
         user_id = rh_identity.get_user_id()
         username = rh_identity.get_username()


### PR DESCRIPTION
## Description

Add `get_org_id()` method to `RHIdentityData` class and store the identity data in `request.state` for downstream access by other middleware and endpoints.

- `get_org_id()` extracts the organization ID from the decoded identity header, returning an empty string if not present
- `RHIdentityData` is now stored in `request.state.rh_identity_data` after successful authentication

## Type of change

- [x] New feature

## Tools used to create PR

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue: [RSPEED-2326](https://issues.redhat.com/browse/RSPEED-2326)
- Related PR: #1032 (Splunk HEC integration) - independent, can merge in any order

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Unit tests added for `get_org_id()` method covering:
   - User identity type with org_id present
   - System identity type with org_id present  
   - Missing org_id returns empty string

2. Unit tests added for `request.state.rh_identity_data` storage:
   - Verifies identity data is accessible via request state after authentication