### PR TITLE
LCORE-1240: Bump up llama-stack to 0.4.3, fixing the vector registration issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
     # Used by authentication/k8s integration
     "kubernetes>=30.1.0",
     # Used to call Llama Stack APIs
-    "llama-stack==0.4.2",
-    "llama-stack-client==0.4.2",
+    "llama-stack==0.4.3",
+    "llama-stack-client==0.4.3",
     # Used by Logger
     "rich>=14.0.0",
     # Used by JWK token auth handler

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,7 +2,7 @@
 
 # Minimal and maximal supported Llama Stack version
 MINIMAL_SUPPORTED_LLAMA_STACK_VERSION = "0.2.17"
-MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION = "0.4.2"
+MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION = "0.4.3"
 
 UNABLE_TO_PROCESS_RESPONSE = "Unable to process this request"
 

--- a/tests/e2e/features/info.feature
+++ b/tests/e2e/features/info.feature
@@ -16,7 +16,7 @@ Feature: Info tests
      When I access REST API endpoint "info" using HTTP GET method
      Then The status code of the response is 200
       And The body of the response has proper name Lightspeed Core Service (LCS) and version 0.4.0
-      And The body of the response has llama-stack version 0.4.2
+      And The body of the response has llama-stack version 0.4.3
 
   @skip-in-library-mode
   Scenario: Check if info endpoint reports error when llama-stack connection is not working

--- a/uv.lock
+++ b/uv.lock
@@ -1392,8 +1392,8 @@ requires-dist = [
     { name = "jsonpath-ng", specifier = ">=1.6.1" },
     { name = "kubernetes", specifier = ">=30.1.0" },
     { name = "litellm", specifier = ">=1.75.5.post1" },
-    { name = "llama-stack", specifier = "==0.4.2" },
-    { name = "llama-stack-client", specifier = "==0.4.2" },
+    { name = "llama-stack", specifier = "==0.4.3" },
+    { name = "llama-stack-client", specifier = "==0.4.3" },
     { name = "openai", specifier = ">=1.99.9" },
     { name = "prometheus-client", specifier = ">=0.22.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
-version = "0.4.2"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1521,9 +1521,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/8c/c47416e024ed0791583e7ab499289d7326afe5a50c26c181b77424610105/llama_stack-0.4.2.tar.gz", hash = "sha256:38caaed133139c1de8c4ef2d352f562c98d7a2797f97f2e4558015762787b20e", size = 3353750, upload-time = "2026-01-16T14:18:10.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/f8/b46c825c7d4050524ca4da9ff7f2622b101044f65cf50f708cf5b6ac935d/llama_stack-0.4.3.tar.gz", hash = "sha256:70d379ae9dbb5b1d0693f14054d9817aba183ffcd805133f0a4442baee132c6d", size = 3357773, upload-time = "2026-01-26T21:46:01.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/fd/b4c51a12ac4d8db1985ba6870fc175797a46f25b910f621312d772a80d72/llama_stack-0.4.2-py3-none-any.whl", hash = "sha256:f4dbd043704d5e3b382a3fba690536b54baa58ae8ec27dae3ceba8ec7a377427", size = 3691482, upload-time = "2026-01-16T14:18:08.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/eb/a4c6c6e6391e13b7d71a116df847b13c334355e9ec18441635140b8fbe1f/llama_stack-0.4.3-py3-none-any.whl", hash = "sha256:423207eae2b640894992a9075ff9dd6300ff904ab06a49fe38cfe0bb809d4669", size = 3695786, upload-time = "2026-01-26T21:45:59.607Z" },
 ]
 
 [[package]]
@@ -1545,7 +1545,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.4.2"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1564,9 +1564,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/b5/fdfef39a1dedc319b98782a3b2e047b9aae394ca59010fb25146aef5edca/llama_stack_client-0.4.2.tar.gz", hash = "sha256:1277bf563531d9bc476e305f2d2bead9900986d426a2e32c9adf4b6a464804c3", size = 352951, upload-time = "2026-01-16T14:17:19.688Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/3d/2aaeeef910e821ef7d3e65f3d773ba183cc84b7852f877396f64619a250c/llama_stack_client-0.4.3.tar.gz", hash = "sha256:cb807be258206e8fedeb5e5ceba7be7108d3badb31d74199406808c3d1679c35", size = 352952, upload-time = "2026-01-26T21:45:09.725Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/af/e1c5065b06f98f832a9f74cb8e092e88fd0c10fdf670ab2aecd614548768/llama_stack_client-0.4.2-py3-none-any.whl", hash = "sha256:d6e1c73391bdc3494fe1fa9ce7575a4749d13d111718e458e874ece544988729", size = 375941, upload-time = "2026-01-16T14:17:18.458Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/39/193aad0d49d834539fdc04c5f774fda22283267aff2400b68ffeb307474c/llama_stack_client-0.4.3-py3-none-any.whl", hash = "sha256:97b8cc5032bad4f0cdd1b0ae992cf44f5554679d315b7c40f46deb358c041f50", size = 375940, upload-time = "2026-01-26T21:45:08.067Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The new version of llama-stack fixed the following issues:
- registration of multiple vector-stores
- missing metadata (attributes) in request

Thus the need to bump up. This PR is created in conjunction with the [bump up of the rag-content tool](https://github.com/lightspeed-core/rag-content/pull/70).
## Description

Just bump-up.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

NA

## Related Tickets & Documents

- Related Issue # LCORE-1240

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
e2e tests
