### PR TITLE
LCORE-1179: Update metadata extraction from chunks

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3664,7 +3664,7 @@
                     "rlsapi-v1"
                 ],
                 "summary": "Infer Endpoint",
-                "description": "Handle rlsapi v1 /infer requests for stateless inference.\n\nThis endpoint serves requests from the RHEL Lightspeed Command Line Assistant (CLA).\n\nAccepts a question with optional context (stdin, attachments, terminal output,\nsystem info) and returns an LLM-generated response.\n\nArgs:\n    infer_request: The inference request containing question and context.\n    auth: Authentication tuple from the configured auth provider.\n\nReturns:\n    RlsapiV1InferResponse containing the generated response text and request ID.\n\nRaises:\n    HTTPException: 503 if the LLM service is unavailable.",
+                "description": "Handle rlsapi v1 /infer requests for stateless inference.\n\nThis endpoint serves requests from the RHEL Lightspeed Command Line Assistant (CLA).\n\nAccepts a question with optional context (stdin, attachments, terminal output,\nsystem info) and returns an LLM-generated response.\n\nArgs:\n    infer_request: The inference request containing question and context.\n    request: The FastAPI request object for accessing headers and state.\n    background_tasks: FastAPI background tasks for async Splunk event sending.\n    auth: Authentication tuple from the configured auth provider.\n\nReturns:\n    RlsapiV1InferResponse containing the generated response text and request ID.\n\nRaises:\n    HTTPException: 503 if the LLM service is unavailable.",
                 "operationId": "infer_endpoint_v1_infer_post",
                 "requestBody": {
                     "content": {
@@ -4290,7 +4290,7 @@
                 ],
                 "summary": "Handle A2A Jsonrpc",
                 "description": "Handle A2A JSON-RPC requests following the A2A protocol specification.\n\nThis endpoint uses the DefaultRequestHandler from the A2A SDK to handle\nall JSON-RPC requests including message/send, message/stream, etc.\n\nThe A2A SDK application is created per-request to include authentication\ncontext while still leveraging FastAPI's authorization middleware.\n\nAutomatically detects streaming requests (message/stream JSON-RPC method)\nand returns a StreamingResponse to enable real-time chunk delivery.\n\nArgs:\n    request: FastAPI request object\n    auth: Authentication tuple\n    mcp_headers: MCP headers for context propagation\n\nReturns:\n    JSON-RPC response or streaming response",
-                "operationId": "handle_a2a_jsonrpc_a2a_get",
+                "operationId": "handle_a2a_jsonrpc_a2a_post",
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -4308,7 +4308,7 @@
                 ],
                 "summary": "Handle A2A Jsonrpc",
                 "description": "Handle A2A JSON-RPC requests following the A2A protocol specification.\n\nThis endpoint uses the DefaultRequestHandler from the A2A SDK to handle\nall JSON-RPC requests including message/send, message/stream, etc.\n\nThe A2A SDK application is created per-request to include authentication\ncontext while still leveraging FastAPI's authorization middleware.\n\nAutomatically detects streaming requests (message/stream JSON-RPC method)\nand returns a StreamingResponse to enable real-time chunk delivery.\n\nArgs:\n    request: FastAPI request object\n    auth: Authentication tuple\n    mcp_headers: MCP headers for context propagation\n\nReturns:\n    JSON-RPC response or streaming response",
-                "operationId": "handle_a2a_jsonrpc_a2a_get",
+                "operationId": "handle_a2a_jsonrpc_a2a_post",
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -5339,7 +5339,7 @@
                         "type": "string",
                         "minLength": 1,
                         "title": "Vector DB ID",
-                        "description": "Vector DB identification."
+                        "description": "Vector database identification."
                     },
                     "db_path": {
                         "type": "string",

--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -3200,6 +3200,8 @@ system info) and returns an LLM-generated response.
 
 Args:
     infer_request: The inference request containing question and context.
+    request: The FastAPI request object for accessing headers and state.
+    background_tasks: FastAPI background tasks for async Splunk event sending.
     auth: Authentication tuple from the configured auth provider.
 
 Returns:
@@ -4184,7 +4186,7 @@ BYOK (Bring Your Own Knowledge) RAG configuration.
 | rag_type | string | Type of RAG database. |
 | embedding_model | string | Embedding model identification |
 | embedding_dimension | integer | Dimensionality of embedding vectors. |
-| vector_db_id | string | Vector DB identification. |
+| vector_db_id | string | Vector database identification. |
 | db_path | string | Path to RAG database. |
 
 

--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -20,18 +20,9 @@ apis:
 - vector_io
       
 benchmarks: []
-conversations_store:
-  db_path: ~/.llama/storage/conversations.db
-  type: sqlite
 datasets: []
 image_name: starter
 # external_providers_dir: /opt/app-root/src/.llama/providers.d
-inference_store:
-  db_path: ~/.llama/storage/inference-store.db
-  type: sqlite
-metadata_store:
-  db_path: ~/.llama/storage/registry.db
-  type: sqlite
 
 providers:
   inference:
@@ -55,7 +46,8 @@ providers:
   - config:
       excluded_categories: []
     provider_id: llama-guard
-    provider_type: inline::llama-guard  scoring:
+    provider_type: inline::llama-guard
+  scoring:
   - provider_id: basic
     provider_type: inline::basic
     config: {}
@@ -155,6 +147,11 @@ registered_resources:
     provider_model_id: sentence-transformers/all-mpnet-base-v2
     metadata:
       embedding_dimension: 768
+  vector_stores: 
+  - embedding_dimension: 768
+    embedding_model: sentence-transformers/nomic-ai/nomic-embed-text-v1.5
+    provider_id: faiss
+    vector_store_id: vs_503a2261-c256-45ff-90aa-580a80de64b8
   shields:
   - shield_id: llama-guard
     provider_id: llama-guard

--- a/run.yaml
+++ b/run.yaml
@@ -13,18 +13,9 @@ apis:
 - vector_io
       
 benchmarks: []
-conversations_store:
-  db_path: ~/.llama/storage/conversations.db
-  type: sqlite
 datasets: []
 image_name: starter
 # external_providers_dir: /opt/app-root/src/.llama/providers.d
-inference_store:
-  db_path: ~/.llama/storage/inference-store.db
-  type: sqlite
-metadata_store:
-  db_path: ~/.llama/storage/registry.db
-  type: sqlite
 
 providers:
   inference:
@@ -141,7 +132,7 @@ registered_resources:
   - shield_id: llama-guard
     provider_id: llama-guard
     provider_shield_id: openai/gpt-4o-mini
-  vector_dbs: []
+  vector_stores: []
   datasets: []
   scoring_fns: []
   benchmarks: []

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1484,7 +1484,7 @@ class ByokRag(ConfigurationBase):
         ...,
         min_length=1,
         title="Vector DB ID",
-        description="Vector DB identification.",
+        description="Vector database identification.",
     )
 
     db_path: FilePath = Field(

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -8,8 +8,8 @@ from fastapi import status
 from pydantic import AnyUrl, BaseModel, Field
 from pydantic_core import SchemaError
 
-from quota.quota_exceed_error import QuotaExceedError
 from models.config import Action, Configuration
+from quota.quota_exceed_error import QuotaExceedError
 from utils.types import RAGChunk, ToolCallSummary, ToolResultSummary
 
 SUCCESSFUL_RESPONSE_DESCRIPTION = "Successful response"

--- a/tests/configuration/run.yaml
+++ b/tests/configuration/run.yaml
@@ -9,61 +9,54 @@ apis:
   - post_training
   - safety
   - scoring
-  - telemetry
   - tool_runtime
   - vector_io
 benchmarks: []
 container_image: null
 datasets: []
 external_providers_dir: null
-inference_store:
-  db_path: .llama/distributions/ollama/inference_store.db
-  type: sqlite
 logging: null
-metadata_store:
-  db_path: .llama/distributions/ollama/registry.db
-  namespace: null
-  type: sqlite
 providers:
   agents:
-  - config:
-      persistence_store:
-        db_path: .llama/distributions/ollama/agents_store.db
-        namespace: null
-        type: sqlite
-      responses_store:
-        db_path: .llama/distributions/ollama/responses_store.db
-        type: sqlite
-    provider_id: meta-reference
+  - provider_id: meta-reference
     provider_type: inline::meta-reference
+    config:
+      persistence:
+        agent_state:
+          namespace: agents_state
+          backend: kv_default
+        responses:
+          table_name: agents_responses
+          backend: sql_default
   datasetio:
-  - config:
-      kvstore:
-        db_path: .llama/distributions/ollama/huggingface_datasetio.db
-        namespace: null
-        type: sqlite
-    provider_id: huggingface
+  - provider_id: huggingface
     provider_type: remote::huggingface
-  - config:
+    config:
       kvstore:
-        db_path: .llama/distributions/ollama/localfs_datasetio.db
-        namespace: null
-        type: sqlite
-    provider_id: localfs
+        namespace: huggingface_datasetio
+        backend: kv_default
+  - provider_id: localfs
     provider_type: inline::localfs
-  eval:
-  - config:
+    config:
       kvstore:
-        db_path: .llama/distributions/ollama/meta_reference_eval.db
-        namespace: null
-        type: sqlite
-    provider_id: meta-reference
+        namespace: localfs_datasetio
+        backend: kv_default
+  eval:
+  - provider_id: meta-reference
     provider_type: inline::meta-reference
+    config:
+      kvstore:
+        namespace: eval_store
+        backend: kv_default
   inference:
-    - provider_id: openai
-      provider_type: remote::openai
-      config:
-        api_key: ${env.OPENAI_API_KEY}
+  - provider_id: openai
+    provider_type: remote::openai
+    config:
+      api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["gpt-4-turbo"]
+  - provider_id: sentence-transformers
+    provider_type: inline::sentence-transformers
+    config: {}
   post_training:
   - config:
       checkpoint_format: huggingface
@@ -95,15 +88,17 @@ providers:
     provider_id: meta-reference
     provider_type: inline::meta-reference
   tool_runtime:
-    - provider_id: model-context-protocol
-      provider_type: remote::model-context-protocol
-      config: {}
+  - provider_id: rag-runtime
+    provider_type: inline::rag-runtime
+    config: {}
+  - provider_id: model-context-protocol
+    provider_type: remote::model-context-protocol
+    config: {}
   vector_io:
   - config:
-      kvstore:
-        db_path: .llama/distributions/ollama/faiss_store.db
-        namespace: null
-        type: sqlite
+      persistence:
+        namespace: vector_io::faiss
+        backend: kv_default
     provider_id: faiss
     provider_type: inline::faiss
 scoring_fns: []
@@ -115,11 +110,41 @@ server:
   tls_cafile: null
   tls_certfile: null
   tls_keyfile: null
-shields: []
-vector_dbs: []
-
-models:
-  - model_id: gpt-4-turbo
-    provider_id: openai
-    model_type: llm
-    provider_model_id: gpt-4-turbo
+storage:
+  backends:
+    kv_default:
+      type: kv_sqlite
+      db_path: ${env.KV_STORE_PATH:=~/.llama/storage/kv_store.db}
+    sql_default:
+      type: sql_sqlite
+      db_path: ${env.SQL_STORE_PATH:=~/.llama/storage/sql_store.db}
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+    inference:
+      table_name: inference_store
+      backend: sql_default
+    conversations:
+      table_name: openai_conversations
+      backend: sql_default
+    prompts:
+      namespace: prompts
+      backend: kv_default
+registered_resources:
+  models: []
+  shields: []
+  vector_stores: []
+  datasets: []
+  scoring_fns: []
+  benchmarks: []
+  tool_groups:
+  - toolgroup_id: builtin::rag
+    provider_id: rag-runtime
+telemetry:
+  enabled: true
+vector_stores:
+  default_provider_id: faiss
+  default_embedding_model:
+    provider_id: sentence-transformers
+    model_id: nomic-ai/nomic-embed-text-v1.5

--- a/tests/e2e/configs/run-ci.yaml
+++ b/tests/e2e/configs/run-ci.yaml
@@ -14,17 +14,8 @@ apis:
 - vector_io
       
 benchmarks: []
-conversations_store:
-  db_path: ~/.llama/storage/conversations.db
-  type: sqlite
 datasets: []
 # external_providers_dir: /opt/app-root/src/.llama/providers.d
-inference_store:
-  db_path: ~/.llama/storage/inference-store.db
-  type: sqlite
-metadata_store:
-  db_path: ~/.llama/storage/registry.db
-  type: sqlite
 
 providers:
   inference:
@@ -146,6 +137,12 @@ registered_resources:
     provider_model_id: sentence-transformers/all-mpnet-base-v2
     metadata:
       embedding_dimension: 768
+  # Commented out because the vector_store is already registered in the kv_store
+  # vector_stores: 
+  # - embedding_dimension: 768
+  #   embedding_model: sentence-transformers/nomic-ai/nomic-embed-text-v1.5
+  #   provider_id: faiss
+  #   vector_store_id: vs_503a2261-c256-45ff-90aa-580a80de64b8
   shields:
   - shield_id: llama-guard
     provider_id: llama-guard

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -1,22 +1,20 @@
 """Unit tests for PostgreSQL cache implementation."""
 
 import json
-
 from typing import Any
 
-import pytest
-from pytest_mock import MockerFixture
-from pydantic import SecretStr, AnyUrl
-
 import psycopg2
+import pytest
+from pydantic import AnyUrl, SecretStr
+from pytest_mock import MockerFixture
 
-from models.config import PostgreSQLDatabaseConfiguration
+from cache.cache_error import CacheError
+from cache.postgres_cache import PostgresCache
 from models.cache_entry import CacheEntry
+from models.config import PostgreSQLDatabaseConfiguration
 from models.responses import ConversationData, ReferencedDocument
 from utils import suid
 from utils.types import ToolCallSummary, ToolResultSummary
-from cache.cache_error import CacheError
-from cache.postgres_cache import PostgresCache
 
 USER_ID_1 = suid.get_suid()
 USER_ID_2 = suid.get_suid()

--- a/tests/unit/test_llama_stack_configuration.py
+++ b/tests/unit/test_llama_stack_configuration.py
@@ -8,8 +8,10 @@ import yaml
 
 from llama_stack_configuration import (
     generate_configuration,
-    construct_vector_dbs_section,
+    construct_vector_stores_section,
     construct_vector_io_providers_section,
+    construct_storage_backends_section,
+    construct_models_section,
 )
 from models.config import (
     Configuration,
@@ -20,55 +22,59 @@ from models.config import (
 )
 
 # =============================================================================
-# Test construct_vector_dbs_section
+# Test construct_vector_stores_section
 # =============================================================================
 
 
-def test_construct_vector_dbs_section_empty() -> None:
+def test_construct_vector_stores_section_empty() -> None:
     """Test with no BYOK RAG config."""
     ls_config: dict[str, Any] = {}
     byok_rag: list[dict[str, Any]] = []
-    output = construct_vector_dbs_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ls_config, byok_rag)
     assert len(output) == 0
 
 
-def test_construct_vector_dbs_section_preserves_existing() -> None:
-    """Test preserves existing vector_dbs entries."""
+def test_construct_vector_stores_section_preserves_existing() -> None:
+    """Test preserves existing vector_stores entries."""
     ls_config = {
-        "vector_dbs": [
-            {"vector_db_id": "existing", "provider_id": "existing_provider"},
-        ]
+        "registered_resources": {
+            "vector_stores": [
+                {"vector_store_id": "existing", "provider_id": "existing_provider"},
+            ]
+        }
     }
     byok_rag: list[dict[str, Any]] = []
-    output = construct_vector_dbs_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ls_config, byok_rag)
     assert len(output) == 1
-    assert output[0]["vector_db_id"] == "existing"
+    assert output[0]["vector_store_id"] == "existing"
 
 
-def test_construct_vector_dbs_section_adds_new() -> None:
+def test_construct_vector_stores_section_adds_new() -> None:
     """Test adds new BYOK RAG entries."""
     ls_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "rag1",
-            "vector_db_id": "db1",
+            "vector_db_id": "store1",
             "embedding_model": "test-model",
             "embedding_dimension": 512,
         },
     ]
-    output = construct_vector_dbs_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ls_config, byok_rag)
     assert len(output) == 1
-    assert output[0]["vector_db_id"] == "db1"
-    assert output[0]["provider_id"] == "byok_db1"
+    assert output[0]["vector_store_id"] == "store1"
+    assert output[0]["provider_id"] == "byok_store1"
     assert output[0]["embedding_model"] == "test-model"
     assert output[0]["embedding_dimension"] == 512
 
 
-def test_construct_vector_dbs_section_merge() -> None:
+def test_construct_vector_stores_section_merge() -> None:
     """Test merges existing and new entries."""
-    ls_config = {"vector_dbs": [{"vector_db_id": "existing"}]}
-    byok_rag = [{"vector_db_id": "new_db"}]
-    output = construct_vector_dbs_section(ls_config, byok_rag)
+    ls_config = {
+        "registered_resources": {"vector_stores": [{"vector_store_id": "existing"}]}
+    }
+    byok_rag = [{"vector_db_id": "new_store"}]
+    output = construct_vector_stores_section(ls_config, byok_rag)
     assert len(output) == 2
 
 
@@ -99,14 +105,120 @@ def test_construct_vector_io_providers_section_adds_new() -> None:
     ls_config: dict[str, Any] = {"providers": {}}
     byok_rag = [
         {
-            "vector_db_id": "db1",
+            "vector_db_id": "store1",
             "rag_type": "inline::faiss",
         },
     ]
     output = construct_vector_io_providers_section(ls_config, byok_rag)
     assert len(output) == 1
-    assert output[0]["provider_id"] == "byok_db1"
+    assert output[0]["provider_id"] == "byok_store1"
     assert output[0]["provider_type"] == "inline::faiss"
+    assert output[0]["config"]["persistence"]["backend"] == "byok_store1_storage"
+    assert output[0]["config"]["persistence"]["namespace"] == "vector_io::faiss"
+
+
+# =============================================================================
+# Test construct_storage_backends_section
+# =============================================================================
+
+
+def test_construct_storage_backends_section_empty() -> None:
+    """Test with no BYOK RAG config."""
+    ls_config: dict[str, Any] = {}
+    byok_rag: list[dict[str, Any]] = []
+    output = construct_storage_backends_section(ls_config, byok_rag)
+    assert len(output) == 0
+
+
+def test_construct_storage_backends_section_preserves_existing() -> None:
+    """Test preserves existing backends."""
+    ls_config = {
+        "storage": {
+            "backends": {
+                "kv_default": {"type": "kv_sqlite", "db_path": "~/.llama/kv.db"}
+            }
+        }
+    }
+    byok_rag: list[dict[str, Any]] = []
+    output = construct_storage_backends_section(ls_config, byok_rag)
+    assert len(output) == 1
+    assert "kv_default" in output
+
+
+def test_construct_storage_backends_section_adds_new() -> None:
+    """Test adds new BYOK RAG backend entries."""
+    ls_config: dict[str, Any] = {}
+    byok_rag = [
+        {
+            "vector_db_id": "store1",
+            "db_path": "/path/to/store1.db",
+        },
+    ]
+    output = construct_storage_backends_section(ls_config, byok_rag)
+    assert len(output) == 1
+    assert "byok_store1_storage" in output
+    assert output["byok_store1_storage"]["type"] == "kv_sqlite"
+    assert output["byok_store1_storage"]["db_path"] == "/path/to/store1.db"
+
+
+# =============================================================================
+# Test construct_models_section
+# =============================================================================
+
+
+def test_construct_models_section_empty() -> None:
+    """Test with no BYOK RAG config."""
+    ls_config: dict[str, Any] = {}
+    byok_rag: list[dict[str, Any]] = []
+    output = construct_models_section(ls_config, byok_rag)
+    assert len(output) == 0
+
+
+def test_construct_models_section_preserves_existing() -> None:
+    """Test preserves existing models."""
+    ls_config = {
+        "registered_resources": {
+            "models": [{"model_id": "existing", "model_type": "llm"}]
+        }
+    }
+    byok_rag: list[dict[str, Any]] = []
+    output = construct_models_section(ls_config, byok_rag)
+    assert len(output) == 1
+    assert output[0]["model_id"] == "existing"
+
+
+def test_construct_models_section_adds_embedding_model() -> None:
+    """Test adds embedding model from BYOK RAG."""
+    ls_config: dict[str, Any] = {}
+    byok_rag = [
+        {
+            "vector_db_id": "store1",
+            "embedding_model": "sentence-transformers/all-mpnet-base-v2",
+            "embedding_dimension": 768,
+        },
+    ]
+    output = construct_models_section(ls_config, byok_rag)
+    assert len(output) == 1
+    assert output[0]["model_id"] == "byok_store1_embedding"
+    assert output[0]["model_type"] == "embedding"
+    assert output[0]["provider_id"] == "sentence-transformers"
+    assert output[0]["provider_model_id"] == "all-mpnet-base-v2"
+    assert output[0]["metadata"]["embedding_dimension"] == 768
+
+
+def test_construct_models_section_strips_prefix() -> None:
+    """Test strips sentence-transformers/ prefix from embedding model."""
+    ls_config: dict[str, Any] = {}
+    byok_rag = [
+        {
+            "vector_db_id": "store1",
+            "embedding_model": "sentence-transformers//usr/path/model",
+            "embedding_dimension": 768,
+        },
+    ]
+    output = construct_models_section(ls_config, byok_rag)
+    assert len(output) == 1
+    assert output[0]["provider_model_id"] == "/usr/path/model"
 
 
 # =============================================================================
@@ -164,10 +276,11 @@ def test_generate_configuration_with_byok(tmp_path: Path) -> None:
         "byok_rag": [
             {
                 "rag_id": "rag1",
-                "vector_db_id": "db1",
+                "vector_db_id": "store1",
                 "embedding_model": "test-model",
                 "embedding_dimension": 256,
                 "rag_type": "inline::faiss",
+                "db_path": "/tmp/store1.db",
             },
         ],
     }
@@ -178,5 +291,19 @@ def test_generate_configuration_with_byok(tmp_path: Path) -> None:
     with open(outfile, encoding="utf-8") as f:
         result = yaml.safe_load(f)
 
-    db_ids = [db["vector_db_id"] for db in result["vector_dbs"]]
-    assert "db1" in db_ids
+    # Check registered_resources.vector_stores
+    store_ids = [
+        s["vector_store_id"] for s in result["registered_resources"]["vector_stores"]
+    ]
+    assert "store1" in store_ids
+
+    # Check storage.backends
+    assert "byok_store1_storage" in result["storage"]["backends"]
+
+    # Check providers.vector_io
+    provider_ids = [p["provider_id"] for p in result["providers"]["vector_io"]]
+    assert "byok_store1" in provider_ids
+
+    # Check registered_resources.models for embedding model
+    model_ids = [m["model_id"] for m in result["registered_resources"]["models"]]
+    assert "byok_store1_embedding" in model_ids


### PR DESCRIPTION
## Description

- now extracting doc_title, doc_url from the "attributes" in response
- removed chunk metadata extraction from results which are not "type": "file_search_call"
- deleted deprecated method in old query endpoint
- updated the BYOK config generation
- updated documentation for BYOK and RAG

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude

## Related Tickets & Documents

- Related Issue # LCORE-1179
- Closes # LCORE-1179

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
I have registered a vector store, called `/v1/query` and `/v1/streaming_query` endpoints, making sure that the `referenced_docs` field is well structured.

E.g.
```
"referenced_documents":` [
    {
      "doc_url": "https://www.redhat.com/openshift_docs/virt/about_virt/about-virt.txt",
      "doc_title": "About OpenShift Virtualization",
    },
 ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Referenced-document extraction now prefers document titles and improved URL resolution (doc_url, docs_url, url, link); deduplication uses title+URL instead of filenames.
  * Centralized configuration: added storage.backends and registered_resources (vector_stores, models); BYOK RAG wiring now populates storage, providers, vector stores, and model registrations.
  * Inference endpoint accepts additional request context inputs for richer integrations.

* **Bug Fixes**
  * A2A endpoint mapping corrected to use POST.

* **Documentation**
  * Docs/OpenAPI updated: vector_db_id renamed to vector_store_id and new storage/registered_resources schema documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->