### PR TITLE
endpoints: Surface failed event errors in logs

### DIFF
--- a/src/app/endpoints/streaming_query_v2.py
+++ b/src/app/endpoints/streaming_query_v2.py
@@ -266,6 +266,7 @@ def create_responses_response_generator(  # pylint: disable=too-many-locals,too-
                 )
                 error_response = InternalServerErrorResponse.query_failed(error_message)
                 logger.error("Error while obtaining answer for user question")
+                logger.debug("Full error response: %s", error_message)
                 yield format_stream_data(
                     {"event": "error", "data": {**error_response.detail.model_dump()}}
                 )


### PR DESCRIPTION


## Description

I wasn't able to make out what was wrong while running LCS, as the unexpected error message wasn't much to go on with. Upon surfacing the actual error, I noticed that the failed event fired since I had hit my token limit, which I believe is useful enough information to be surfaced.

I understand if this wasn't done earlier to prevent sensitive data leakage, in which case, I'll close this, or add a case to surface only when token limit is hit, although that may be tricky since different LLMs report that in different ways.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [X] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement

## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A
- Generated by: N/A

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging for streaming queries to include full failed-response details, improving diagnostics and making issues easier to investigate. This change only augments logged information for troubleshooting and does not alter runtime behavior or error handling observable by users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->