### PR TITLE
[feat] Add configurable timeout for Llama Stack requests

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -66,8 +66,13 @@ class AsyncLlamaStackClientHolder(metaclass=Singleton):
     def _load_service_client(self, config: LlamaStackConfiguration) -> None:
         """Initialize client in service mode (remote HTTP)."""
         logger.info("Using Llama stack running as a service")
+        logger.info(
+            "Using timeout of %d seconds for Llama Stack requests", config.timeout
+        )
         api_key = config.api_key.get_secret_value() if config.api_key else None
-        self._lsc = AsyncLlamaStackClient(base_url=config.url, api_key=api_key)
+        self._lsc = AsyncLlamaStackClient(
+            base_url=config.url, api_key=api_key, timeout=config.timeout
+        )
 
     def _enrich_library_config(
         self, input_config_path: str, byok_rag: list[dict]

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -558,6 +558,13 @@ class LlamaStackConfiguration(ConfigurationBase):
         description="Path to configuration file used when Llama Stack is run in library mode",
     )
 
+    timeout: PositiveInt = Field(
+        180,
+        title="Request timeout",
+        description="Timeout in seconds for requests to Llama Stack service. "
+        "Default is 180 seconds (3 minutes) to accommodate long-running RAG queries.",
+    )
+
     @model_validator(mode="after")
     def check_llama_stack_model(self) -> Self:
         """

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -143,6 +143,7 @@ def test_dump_configuration(tmp_path: Path) -> None:
                 "use_as_library_client": True,
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
+                "timeout": 180,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -465,6 +466,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "use_as_library_client": True,
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
+                "timeout": 180,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -684,6 +686,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "use_as_library_client": True,
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
+                "timeout": 180,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -883,6 +886,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "use_as_library_client": True,
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
+                "timeout": 180,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -1071,6 +1075,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "use_as_library_client": True,
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
+                "timeout": 180,
             },
             "user_data_collection": {
                 "feedback_enabled": False,


### PR DESCRIPTION
## Description

Introduces a timeout configuration parameter (default 180s) to accommodate long-running RAG queries and prevent premature request failures.

I did some work on POCing Lightspeed for a project in Red Hat OpenShift AI (the POC can be found [in my repo](https://github.com/amito/rosa-lightspeed-poc-deployment)).
Ran into some issues with slightly larger models where I timed out on RAG inference calls and had to increase Llama Stack timeouts. The change here implements this timeout extension. I thought it can be useful to others, hence the PR.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement

## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Code
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
- Fixed unit tests and made sure they work
- I have built the `lightspeed-core` image and deployed it on my OpenShift cluster to test this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable request timeout setting for Llama Stack service requests, with a default of 180 seconds.

* **Tests**
  * Updated test expectations to verify the new timeout configuration is properly serialized.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->