### PR TITLE
LCORE-688 Validate that user_id is not empty in noop authentication modules

### DIFF
--- a/src/authentication/noop.py
+++ b/src/authentication/noop.py
@@ -1,6 +1,6 @@
 """Manage authentication flow for FastAPI endpoints with no-op auth."""
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from constants import (
     DEFAULT_USER_NAME,
@@ -50,5 +50,7 @@ class NoopAuthDependency(AuthInterface):  # pylint: disable=too-few-public-metho
         )
         # try to extract user ID from request
         user_id = request.query_params.get("user_id", DEFAULT_USER_UID)
+        if not user_id:
+            raise HTTPException(status_code=400, detail="user_id cannot be empty")
         logger.debug("Retrieved user ID: %s", user_id)
         return user_id, DEFAULT_USER_NAME, self.skip_userid_check, NO_USER_TOKEN

--- a/src/authentication/noop_with_token.py
+++ b/src/authentication/noop_with_token.py
@@ -9,7 +9,7 @@ Behavior:
 - Returns a tuple: (user_id, DEFAULT_USER_NAME, user_token).
 """
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 from constants import (
     DEFAULT_USER_NAME,
@@ -63,5 +63,7 @@ class NoopWithTokenAuthDependency(
         user_token = extract_user_token(request.headers)
         # try to extract user ID from request
         user_id = request.query_params.get("user_id", DEFAULT_USER_UID)
+        if not user_id:
+            raise HTTPException(status_code=400, detail="user_id cannot be empty")
         logger.debug("Retrieved user ID: %s", user_id)
         return user_id, DEFAULT_USER_NAME, self.skip_userid_check, user_token

--- a/tests/e2e/features/authorized_noop.feature
+++ b/tests/e2e/features/authorized_noop.feature
@@ -35,14 +35,14 @@ Feature: Authorized endpoint API tests for the noop authentication module
             {"user_id": "00000000-0000-0000-0000-000","username": "lightspeed-user","skip_userid_check": true}
           """
 
-  Scenario: Check if the authorized endpoint works when providing empty user_id
+  Scenario: Check if the authorized endpoint rejects empty user_id
     Given The system is in default state
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
      When I access endpoint "authorized" using HTTP POST method with user_id ""
-     Then The status code of the response is 200
+     Then The status code of the response is 400
       And The body of the response is the following
           """
-            {"user_id": "","username": "lightspeed-user","skip_userid_check": true}
+            {"detail": "user_id cannot be empty"}
           """
 
   Scenario: Check if the authorized endpoint works when providing proper user_id

--- a/tests/e2e/features/authorized_noop_token.feature
+++ b/tests/e2e/features/authorized_noop_token.feature
@@ -32,14 +32,14 @@ Feature: Authorized endpoint API tests for the noop-with-token authentication mo
             {"user_id": "00000000-0000-0000-0000-000","username": "lightspeed-user","skip_userid_check": true}
           """
 
-  Scenario: Check if the authorized endpoint works when providing empty user_id
+  Scenario: Check if the authorized endpoint rejects empty user_id
     Given The system is in default state
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
      When I access endpoint "authorized" using HTTP POST method with user_id ""
-     Then The status code of the response is 200
+     Then The status code of the response is 400
       And The body of the response is the following
           """
-            {"user_id": "","username": "lightspeed-user","skip_userid_check": true}
+            {"detail": "user_id cannot be empty"}
           """
 
   Scenario: Check if the authorized endpoint works when providing proper user_id

--- a/tests/unit/authentication/test_noop.py
+++ b/tests/unit/authentication/test_noop.py
@@ -1,6 +1,8 @@
 """Unit tests for functions defined in authentication/noop.py"""
 
-from fastapi import Request
+from fastapi import Request, HTTPException
+import pytest
+
 from authentication.noop import NoopAuthDependency
 from constants import DEFAULT_USER_NAME, DEFAULT_USER_UID, NO_USER_TOKEN
 
@@ -37,3 +39,18 @@ async def test_noop_auth_dependency_custom_user_id() -> None:
     assert username == DEFAULT_USER_NAME
     assert skip_userid_check is True
     assert user_token == NO_USER_TOKEN
+
+
+async def test_noop_auth_dependency_empty_user_id() -> None:
+    """Test that NoopAuthDependency rejects empty user_id with HTTP 400."""
+    dependency = NoopAuthDependency()
+
+    # Create a mock request with empty user_id
+    request = Request(scope={"type": "http", "query_string": b"user_id="})
+
+    # Assert that an HTTPException is raised for empty user_id
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "user_id cannot be empty"


### PR DESCRIPTION
## Description

It was possible to provide an empty user_id (?user_id=""), now this throws a 400 error.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.5
- Generated by: Claude Opus 4.5

## Related Tickets & Documents

- Related Issue # LCORE-688
- Closes # LCORE-688

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Start the service with noop or noop-with-token authentication
2. Send a POST request to /v1/authorized with empty user_id:
$ curl -X POST "http://localhost:8080/v1/authorized?user_id=" -H "Content-Type: application/json" -d '{}'
3. Verify response is HTTP 400 with body: {"detail": "user_id cannot be empty"}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User ID validation: Authentication endpoints now properly validate and reject empty user IDs with a 400 error response and clear error message. This applies to both standard and token-based authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->