### PR TITLE
fix: add missing script for make target konflux-rpm-lock

### DIFF
--- a/scripts/generate-rpm-lock.sh
+++ b/scripts/generate-rpm-lock.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Default values for command-line arguments
+BASE_IMAGE="registry.redhat.io/rhai/base-image-cpu-rhel9:3.2"
+INPUT_FILE="rpms.in.yaml"
+OUTPUT_FILE="rpms.lock.yaml"
+
+usage() {
+    echo "Usage: $0 [-i BASE_IMAGE] [-f INPUT_FILE] [-o OUTPUT_FILE]"
+    echo ""
+    echo "Options:"
+    echo "  -i BASE_IMAGE   Base container image (default: $BASE_IMAGE)"
+    echo "  -f INPUT_FILE   Input RPM specification file (default: $INPUT_FILE)"
+    echo "  -o OUTPUT_FILE  Output lock file (default: $OUTPUT_FILE)"
+    echo "  -h              Show this help message"
+    exit 1
+}
+
+
+while getopts "i:f:o:h" opt; do
+    case $opt in
+        i) BASE_IMAGE="$OPTARG" ;;
+        f) INPUT_FILE="$OPTARG" ;;
+        o) OUTPUT_FILE="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+echo "Using BASE_IMAGE: $BASE_IMAGE"
+echo "Using INPUT_FILE: $INPUT_FILE"
+echo "Using OUTPUT_FILE: $OUTPUT_FILE"
+
+# check subscription status
+if ! sudo subscription-manager status; then
+    echo "Failed to check subscription status, please register the system to Red Hat by using the following command:"
+    echo "subscription-manager register --org=ORG ID  --activationkey="AK1,AK2,AK3""
+    echo "and then run the script again"
+    exit 1
+fi
+echo "Subscription status is OK"
+
+# find the entitlement certificate and key
+DNF_VAR_SSL_CLIENT_KEY=$(find /etc/pki/entitlement -type f -name "*key.pem" | head -1)
+export DNF_VAR_SSL_CLIENT_KEY
+DNF_VAR_SSL_CLIENT_CERT="${DNF_VAR_SSL_CLIENT_KEY//-key/}"
+export DNF_VAR_SSL_CLIENT_CERT
+
+rpm-lockfile-prototype --image "$BASE_IMAGE" --outfile "$OUTPUT_FILE" "$INPUT_FILE"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add the missing script for make target `konflux-rpm-lock`.
This is the missing bit from https://github.com/lightspeed-core/lightspeed-stack/pull/1074

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated RPM lockfile generation script with configurable base image, input and output locations, and help options. It verifies Red Hat subscription status before running, derives required entitlement certificate/key paths automatically, and invokes the lockfile generator to produce a reproducible RPM lockfile for builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->