### PR TITLE
RSPEED-2408: fix(rlsapi): use customization.system_prompt in /v1/infer

### DIFF
--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -92,7 +92,13 @@ def _build_instructions(systeminfo: RlsapiV1SystemInfo) -> str:
     Returns:
         Instructions string for the LLM, with system context if available.
     """
-    base_prompt = constants.DEFAULT_SYSTEM_PROMPT
+    if (
+        configuration.customization is not None
+        and configuration.customization.system_prompt is not None
+    ):
+        base_prompt = configuration.customization.system_prompt
+    else:
+        base_prompt = constants.DEFAULT_SYSTEM_PROMPT
 
     context_parts = []
     if systeminfo.os:


### PR DESCRIPTION
## Description

The `/v1/infer` endpoint hardcodes `constants.DEFAULT_SYSTEM_PROMPT` ("You are a helpful assistant") in `_build_instructions()`. The `/v1/query` and `/v1/streaming_query` endpoints already support configurable system prompts via `customization.system_prompt` in `lightspeed-stack.yaml`, but `/v1/infer` ignores this config entirely.

This change makes `_build_instructions()` check `configuration.customization.system_prompt` first, falling back to `DEFAULT_SYSTEM_PROMPT` when unset. Follows the same precedence pattern as `get_system_prompt()` in `src/utils/prompts.py`, simplified for rlsapi (no per-request prompt, no custom profiles).

## Type of change

- [x] Bug fix
- [x] Unit tests improvement

## Tools used to create PR

- Assisted-by: Claude (claude-opus-4-6)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2408](https://issues.redhat.com/browse/RSPEED-2408)
- Epic: [RSPEED-2229](https://issues.redhat.com/browse/RSPEED-2229)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `uv run pytest tests/unit/app/endpoints/test_rlsapi_v1.py -v -k "build_instructions"` — all 6 tests pass (3 existing + 3 new)
- `uv run make verify` — all linters clean
- New test cases:
  - `test_build_instructions_customization_system_prompt_set` — custom prompt used when configured
  - `test_build_instructions_customization_system_prompt_none` — falls back to DEFAULT_SYSTEM_PROMPT when system_prompt is None
  - `test_build_instructions_no_customization` — falls back when customization itself is None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System prompts can now be customized via configuration; the app uses a provided custom prompt or falls back to the default when none is set.

* **Tests**
  * Added tests verifying custom prompt usage and correct fallback to the default prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->