### PR TITLE
fix: handle all RuntimeError exceptions in inference endpoints

### DIFF
--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
-from fastapi import HTTPException, Request
+from fastapi import HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from llama_stack_api.openai_responses import (
     OpenAIResponseObject,
@@ -257,20 +257,14 @@ class TestOLSCompatibilityIntegration:
 
     def test_media_type_validation(self) -> None:
         """Test that media type validation works correctly."""
-        valid_request = QueryRequest(
-            query="test", media_type="application/json"
-        )  # pyright: ignore[reportCallIssue]
+        valid_request = QueryRequest(query="test", media_type="application/json")  # pyright: ignore[reportCallIssue]
         assert valid_request.media_type == "application/json"
 
-        valid_request = QueryRequest(
-            query="test", media_type="text/plain"
-        )  # pyright: ignore[reportCallIssue]
+        valid_request = QueryRequest(query="test", media_type="text/plain")  # pyright: ignore[reportCallIssue]
         assert valid_request.media_type == "text/plain"
 
         with pytest.raises(ValueError, match="media_type must be either"):
-            QueryRequest(
-                query="test", media_type="invalid/type"
-            )  # pyright: ignore[reportCallIssue]
+            QueryRequest(query="test", media_type="invalid/type")  # pyright: ignore[reportCallIssue]
 
     def test_ols_end_event_structure(self) -> None:
         """Test that end event follows OLS structure."""
@@ -322,9 +316,7 @@ class TestStreamingQueryEndpointHandler:
         mocker: MockerFixture,
     ) -> None:
         """Test successful streaming query."""
-        query_request = QueryRequest(
-            query="What is Kubernetes?"
-        )  # pyright: ignore[reportCallIssue]
+        query_request = QueryRequest(query="What is Kubernetes?")  # pyright: ignore[reportCallIssue]
 
         mocker.patch("app.endpoints.streaming_query.configuration", setup_configuration)
         mocker.patch("app.endpoints.streaming_query.check_configuration_loaded")
@@ -574,9 +566,7 @@ class TestStreamingQueryEndpointHandler:
         mocker: MockerFixture,
     ) -> None:
         """Test streaming query refreshes Azure token when needed."""
-        query_request = QueryRequest(
-            query="What is Kubernetes?"
-        )  # pyright: ignore[reportCallIssue]
+        query_request = QueryRequest(query="What is Kubernetes?")  # pyright: ignore[reportCallIssue]
 
         mocker.patch("app.endpoints.streaming_query.configuration", setup_configuration)
         mocker.patch("app.endpoints.streaming_query.check_configuration_loaded")
@@ -679,9 +669,7 @@ class TestCreateResponseGenerator:
 
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.client = mock_client
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
 
         async def mock_response_gen() -> AsyncIterator[str]:
             yield "test"
@@ -769,9 +757,7 @@ class TestCreateResponseGenerator:
 
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.client = mock_client
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
 
         mocker.patch(
             "app.endpoints.streaming_query.run_shield_moderation",
@@ -822,9 +808,7 @@ class TestCreateResponseGenerator:
 
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.client = mock_client
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
 
         mocker.patch(
             "app.endpoints.streaming_query.run_shield_moderation",
@@ -872,9 +856,7 @@ class TestCreateResponseGenerator:
 
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.client = mock_client
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
 
         mocker.patch(
             "app.endpoints.streaming_query.run_shield_moderation",
@@ -919,9 +901,7 @@ class TestCreateResponseGenerator:
 
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.client = mock_client
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
 
         mocker.patch(
             "app.endpoints.streaming_query.run_shield_moderation",
@@ -932,8 +912,9 @@ class TestCreateResponseGenerator:
             side_effect=RuntimeError("Some other error")
         )
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(HTTPException) as exc_info:
             await retrieve_response_generator(mock_responses_params, mock_context)
+        assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
 
 class TestGenerateResponse:
@@ -950,9 +931,7 @@ class TestGenerateResponse:
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.conversation_id = "conv_123"
         mock_context.user_id = "user_123"
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
         mock_context.started_at = "2024-01-01T00:00:00Z"
         mock_context.skip_userid_check = False
 
@@ -1047,9 +1026,7 @@ class TestGenerateResponse:
 
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.conversation_id = "conv_123"
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
         mock_context.started_at = "2024-01-01T00:00:00Z"
         mock_context.skip_userid_check = False
 
@@ -1082,9 +1059,7 @@ class TestGenerateResponse:
 
         mock_context = mocker.Mock(spec=ResponseGeneratorContext)
         mock_context.conversation_id = "conv_123"
-        mock_context.query_request = QueryRequest(
-            query="test"
-        )  # pyright: ignore[reportCallIssue]
+        mock_context.query_request = QueryRequest(query="test")  # pyright: ignore[reportCallIssue]
         mock_context.started_at = "2024-01-01T00:00:00Z"
         mock_context.skip_userid_check = False
 


### PR DESCRIPTION
## Description

Handle all `RuntimeError` exceptions in `/v1/infer`, `/v1/query`, and `/v1/streaming_query` endpoints instead of only catching context-length errors.

In library mode, llama-stack wraps various HTTP errors as `RuntimeError`. Previously, only the context-length case (HTTP 413) was handled — all other `RuntimeError` exceptions were bare re-raised, which crashed the Starlette ASGI middleware with `RuntimeError: No response returned` (HTTP 500 with no useful error info).

This is particularly visible when MCP tools are configured — the inference pipeline succeeds (LLM calls MCP tools, retrieves RAG knowledge, returns valid response), but the HTTP endpoint handler fails to serialize the `ResponseObject` back through the Starlette ASGI middleware chain.

The fix logs the error and returns a proper `HTTPException(500)` with `InternalServerErrorResponse.generic()`, matching the existing correct pattern already in `streaming_query.py`'s second `RuntimeError` handler.

### Files changed

| File | Change |
|------|--------|
| `src/app/endpoints/rlsapi_v1.py` | `raise` → `logger.error()` + `HTTPException(500)` |
| `src/app/endpoints/query.py` | `raise e` → `logger.error()` + `HTTPException(500)` |
| `src/app/endpoints/streaming_query.py` | `raise e` → `logger.error()` + `HTTPException(500)` |
| `tests/.../test_rlsapi_v1.py` | Assert `HTTPException(500)` instead of `RuntimeError` |
| `tests/.../test_query.py` | Assert `HTTPException(500)` instead of `RuntimeError` |
| `tests/.../test_streaming_query.py` | Assert `HTTPException(500)` instead of `RuntimeError` |

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude (opencode/claude-opus-4-6)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Deploy lightspeed-stack with `quay.io/lightspeed-core/lightspeed-stack:dev-latest` in library mode (`use_as_library_client: true`)
2. Configure an MCP server in `lightspeed-stack.yaml` under `mcp_servers`
3. Send a POST request to `/v1/infer` with a question payload
4. **Before fix:** HTTP 500 with `RuntimeError: No response returned` in logs
5. **After fix:** Proper HTTP 500 with `InternalServerErrorResponse.generic()` JSON body and error logged

Unit tests: 1337 passed, 0 failed, 87% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime errors during inference and retrieval now produce proper HTTP error responses (generic 500) instead of bubbling as raw runtime exceptions.
  * Prompts that exceed context limits still return a clear "prompt too long" response (413). Added logging and telemetry for these cases.

* **Tests**
  * Added and updated tests to verify 413 context-length responses and 500 handling for other runtime errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->