### PR TITLE
RSPEED-2417: Add root_path support for reverse proxy deployments

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -16,6 +16,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_validator,
     model_validator,
     FilePath,
     AnyHttpUrl,
@@ -405,6 +406,36 @@ class ServiceConfiguration(ConfigurationBase):
         title="TLS configuration",
         description="Transport Layer Security configuration for HTTPS support",
     )
+
+    root_path: str = Field(
+        "",
+        title="Root path",
+        description="ASGI root path for serving behind a reverse proxy on a subpath",
+    )
+
+    @field_validator("root_path")
+    @classmethod
+    def validate_root_path(cls, value: str) -> str:
+        """Validate root_path format.
+
+        Ensures the root path is either empty or starts with a leading
+        slash and does not end with a trailing slash.
+
+        Parameters:
+            value: The root path value to validate.
+
+        Returns:
+            The validated root path value.
+
+        Raises:
+            ValueError: If root_path is missing a leading slash or has
+                a trailing slash.
+        """
+        if value and not value.startswith("/"):
+            raise ValueError("root_path must start with '/'")
+        if value.endswith("/"):
+            raise ValueError("root_path must not end with '/'")
+        return value
 
     cors: CORSConfiguration = Field(
         default_factory=lambda: CORSConfiguration(

--- a/src/runners/uvicorn.py
+++ b/src/runners/uvicorn.py
@@ -15,7 +15,7 @@ def start_uvicorn(configuration: ServiceConfiguration) -> None:
 
     Parameters:
         configuration (ServiceConfiguration): Configuration providing host,
-        port, workers, and `tls_config` (including `tls_key_path`,
+        port, workers, `root_path`, and `tls_config` (including `tls_key_path`,
         `tls_certificate_path`, and `tls_key_password`). TLS fields may be None
         and will be forwarded to uvicorn.run as provided.
     """
@@ -30,6 +30,7 @@ def start_uvicorn(configuration: ServiceConfiguration) -> None:
         host=configuration.host,
         port=configuration.port,
         workers=configuration.workers,
+        root_path=configuration.root_path,
         log_level=log_level,
         ssl_keyfile=configuration.tls_config.tls_key_path,
         ssl_certfile=configuration.tls_config.tls_certificate_path,

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -119,6 +119,7 @@ def test_dump_configuration(tmp_path: Path) -> None:
                     "tls_key_password": "tests/configuration/password",
                     "tls_key_path": "tests/configuration/server.key",
                 },
+                "root_path": "",
                 "cors": {
                     "allow_credentials": False,
                     "allow_headers": [
@@ -442,6 +443,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                     "tls_key_password": "tests/configuration/password",
                     "tls_key_path": "tests/configuration/server.key",
                 },
+                "root_path": "",
                 "cors": {
                     "allow_credentials": False,
                     "allow_headers": [
@@ -662,6 +664,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                     "tls_key_password": "tests/configuration/password",
                     "tls_key_path": "tests/configuration/server.key",
                 },
+                "root_path": "",
                 "cors": {
                     "allow_credentials": False,
                     "allow_headers": [
@@ -862,6 +865,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                     "tls_key_password": "tests/configuration/password",
                     "tls_key_path": "tests/configuration/server.key",
                 },
+                "root_path": "",
                 "cors": {
                     "allow_credentials": False,
                     "allow_headers": [
@@ -1051,6 +1055,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                     "tls_key_password": "tests/configuration/password",
                     "tls_key_path": "tests/configuration/server.key",
                 },
+                "root_path": "",
                 "cors": {
                     "allow_credentials": False,
                     "allow_headers": [

--- a/tests/unit/models/config/test_service_configuration.py
+++ b/tests/unit/models/config/test_service_configuration.py
@@ -19,6 +19,7 @@ def test_service_configuration_constructor() -> None:
     assert s.port == 8080
     assert s.auth_enabled is False
     assert s.workers == 1
+    assert s.root_path == ""
     assert s.color_log is True
     assert s.access_log is True
     assert s.tls_config == TLSConfiguration()  # pyright: ignore[reportCallIssue]
@@ -31,6 +32,27 @@ def test_service_configuration_port_value() -> None:
 
     with pytest.raises(ValueError, match="Port value should be less than 65536"):
         ServiceConfiguration(port=100000)  # pyright: ignore[reportCallIssue]
+
+
+def test_service_configuration_root_path() -> None:
+    """Test the ServiceConfiguration root_path field."""
+    s = ServiceConfiguration(
+        root_path="/api/lightspeed"
+    )  # pyright: ignore[reportCallIssue]
+    assert s.root_path == "/api/lightspeed"
+
+
+def test_service_configuration_root_path_validation() -> None:
+    """Test root_path validation rejects invalid formats."""
+    with pytest.raises(ValidationError, match="root_path must start with '/'"):
+        ServiceConfiguration(
+            root_path="api/lightspeed"
+        )  # pyright: ignore[reportCallIssue]
+
+    with pytest.raises(ValidationError, match="root_path must not end with '/'"):
+        ServiceConfiguration(
+            root_path="/api/lightspeed/"
+        )  # pyright: ignore[reportCallIssue]
 
 
 def test_service_configuration_workers_value() -> None:

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -22,6 +22,7 @@ def test_start_uvicorn(mocker: MockerFixture) -> None:
         host="localhost",
         port=8080,
         workers=1,
+        root_path="",
         log_level=20,
         ssl_certfile=None,
         ssl_keyfile=None,
@@ -45,6 +46,7 @@ def test_start_uvicorn_different_host_port(mocker: MockerFixture) -> None:
         host="x.y.com",
         port=1234,
         workers=10,
+        root_path="",
         log_level=20,
         ssl_certfile=None,
         ssl_keyfile=None,
@@ -69,6 +71,7 @@ def test_start_uvicorn_empty_tls_configuration(mocker: MockerFixture) -> None:
         host="x.y.com",
         port=1234,
         workers=10,
+        root_path="",
         log_level=20,
         ssl_certfile=None,
         ssl_keyfile=None,
@@ -97,10 +100,35 @@ def test_start_uvicorn_tls_configuration(mocker: MockerFixture) -> None:
         host="x.y.com",
         port=1234,
         workers=10,
+        root_path="",
         log_level=20,
         ssl_certfile=Path("tests/configuration/server.crt"),
         ssl_keyfile=Path("tests/configuration/server.key"),
         ssl_keyfile_password="tests/configuration/password",
+        use_colors=True,
+        access_log=True,
+    )
+
+
+def test_start_uvicorn_with_root_path(mocker: MockerFixture) -> None:
+    """Test the function to start Uvicorn server with a custom root path."""
+    configuration = ServiceConfiguration(
+        host="localhost", port=8080, workers=1, root_path="/api/lightspeed"
+    )  # pyright: ignore[reportCallIssue]
+
+    # don't start real Uvicorn server
+    mocked_run = mocker.patch("uvicorn.run")
+    start_uvicorn(configuration)
+    mocked_run.assert_called_once_with(
+        "app.main:app",
+        host="localhost",
+        port=8080,
+        workers=1,
+        root_path="/api/lightspeed",
+        log_level=20,
+        ssl_certfile=None,
+        ssl_keyfile=None,
+        ssl_keyfile_password="",
         use_colors=True,
         access_log=True,
     )


### PR DESCRIPTION
## Description

Add a configurable `root_path` setting to `ServiceConfiguration` so Lightspeed Stack can be deployed behind load balancers and reverse proxies that route traffic on a non-root path prefix (e.g. `/api/lightspeed`).

The `root_path` value is passed to `uvicorn.run()` at the ASGI server level, following [FastAPI's recommended approach](https://fastapi.tiangolo.com/advanced/behind-a-proxy/) for proxy path prefix handling. This ensures OpenAPI docs, redirects, and all routing work correctly when the service sits behind a path-rewriting proxy.

Default is an empty string (no change in behavior for existing deployments).

## Type of change

- [x] New feature

## Tools used to create PR

- Assisted-by: Claude (claude-opus-4-6)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2417](https://issues.redhat.com/browse/RSPEED-2417)
- Epic: [RSPEED-2229](https://issues.redhat.com/browse/RSPEED-2229)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. **Unit tests**: `pytest tests/unit/models/config/test_service_configuration.py tests/unit/runners/test_uvicorn_runner.py` — 9/9 passing
2. **Linters**: `make verify` passes clean (pylint 10/10, pyright 0 errors, ruff/docstyle/mypy clean)
3. **Manual verification**: Set `root_path: /api/lightspeed` in `service` config and confirm Swagger UI at `/api/lightspeed/docs` shows correct server URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable ASGI root path option (default empty) with validation: if set it must start with "/" and must not end with "/". The setting is forwarded to server startup and included in serialized configuration.

* **Tests**
  * Added coverage for default and custom root path scenarios, validation rules, server startup propagation, and serialization output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->