### PR TITLE
RSPEED-2435: fix rh-identity health probe path matching with root_path

### DIFF
--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -217,7 +217,7 @@ class RHIdentityAuthDependency(AuthInterface):  # pylint: disable=too-few-public
         identity_header = request.headers.get("x-rh-identity")
         if not identity_header:
             # Skip auth for health probes when configured
-            if request.url.path in ("/readiness", "/liveness"):
+            if request.url.path.endswith(("/readiness", "/liveness")):
                 if configuration.authentication_configuration.skip_for_health_probes:
                     return NO_AUTH_TUPLE
             logger.warning("Missing x-rh-identity header")

--- a/tests/unit/authentication/test_rh_identity.py
+++ b/tests/unit/authentication/test_rh_identity.py
@@ -111,6 +111,7 @@ def create_request_with_header(header_value: Optional[str]) -> Mock:
     """
     request = Mock(spec=Request)
     request.headers = {"x-rh-identity": header_value} if header_value else {}
+    request.url = Mock(path="/test")
     request.state = Mock()
     return request
 
@@ -467,7 +468,15 @@ class TestRHIdentityHealthProbeSkip:
         mocker.patch("authentication.rh_identity.configuration", mock_config)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("path", ["/readiness", "/liveness"])
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/readiness",
+            "/liveness",
+            "/api/lightspeed/readiness",
+            "/api/lightspeed/liveness",
+        ],
+    )
     async def test_probe_paths_skip_auth_when_enabled(
         self, mocker: MockerFixture, path: str
     ) -> None:
@@ -481,7 +490,15 @@ class TestRHIdentityHealthProbeSkip:
         assert result == NO_AUTH_TUPLE
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("path", ["/readiness", "/liveness"])
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/readiness",
+            "/liveness",
+            "/api/lightspeed/readiness",
+            "/api/lightspeed/liveness",
+        ],
+    )
     async def test_probe_paths_require_auth_when_disabled(
         self, mocker: MockerFixture, path: str
     ) -> None:


### PR DESCRIPTION
## Summary

- Fix health probe auth bypass in `rh-identity` auth plugin when `root_path` is configured

## Problem

When `root_path` is set (e.g. `/api/lightspeed`), request paths become `/api/lightspeed/liveness` instead of `/liveness`. The `skip_for_health_probes` check in `rh_identity.py` uses an exact match (`in ("/readiness", "/liveness")`) which fails on the prefixed paths, causing health probes to get 401 and pods to crash-loop.

## Fix

```python
# Before
if request.url.path in ("/readiness", "/liveness"):

# After
if request.url.path.rsplit("/", 1)[-1] in ("readiness", "liveness"):
```

Matches only the final path segment — avoids false positives on paths like `/api/v1/conversations/liveness`.

Only the `rh-identity` auth plugin is affected — this is the only auth module used in our deployment.

## Jira

https://issues.redhat.com/browse/RSPEED-2435