### PR TITLE
RSPEED-2444: Replace remaining raw logging imports with get_logger()

### DIFF
--- a/src/app/database.py
+++ b/src/app/database.py
@@ -1,6 +1,6 @@
 """Database engine management."""
 
-import logging
+from logging import DEBUG
 from pathlib import Path
 from typing import Any, Optional
 
@@ -175,7 +175,7 @@ def initialize_database() -> None:
     global engine, session_local  # pylint: disable=global-statement
 
     # Debug print all SQL statements if our logger is at-least DEBUG level
-    echo = bool(logger.isEnabledFor(logging.DEBUG))
+    echo = bool(logger.isEnabledFor(DEBUG))
 
     create_engine_kwargs = {
         "echo": echo,

--- a/src/runners/uvicorn.py
+++ b/src/runners/uvicorn.py
@@ -1,6 +1,7 @@
 """Uvicorn runner."""
 
-import logging
+from logging import INFO
+
 import uvicorn
 
 from log import get_logger
@@ -21,7 +22,7 @@ def start_uvicorn(configuration: ServiceConfiguration) -> None:
     """
     logger.info("Starting Uvicorn")
 
-    log_level = logging.INFO
+    log_level = INFO
 
     # please note:
     # TLS fields can be None, which means we will pass those values as None to uvicorn.run

--- a/src/telemetry/configuration_snapshot.py
+++ b/src/telemetry/configuration_snapshot.py
@@ -10,7 +10,6 @@ No integration with ingress is provided here — only methods to build the JSON.
 """
 
 import asyncio
-import logging
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
@@ -19,9 +18,10 @@ from typing import Any, Literal, Optional
 import yaml
 from pydantic import SecretStr
 
+from log import get_logger
 from models.config import Configuration
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Masking output constants
 CONFIGURED: Literal["configured"] = "configured"

--- a/src/utils/vector_search.py
+++ b/src/utils/vector_search.py
@@ -4,7 +4,6 @@ This module contains common functionality for performing vector searches
 and processing RAG chunks that is shared between query_v2.py and streaming_query_v2.py.
 """
 
-import logging
 import traceback
 from typing import Any, Optional
 from urllib.parse import urljoin
@@ -15,11 +14,12 @@ from llama_stack_client import AsyncLlamaStackClient
 
 import constants
 from configuration import AppConfig
+from log import get_logger
 from models.requests import QueryRequest
 from models.responses import ReferencedDocument
 from utils.types import RAGChunk
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _is_solr_enabled(configuration: AppConfig) -> bool:


### PR DESCRIPTION
## Description

Four modules were missed during the initial `get_logger()` migration (PR #1148 / RSPEED-2437).
Two still used `logging.getLogger()` directly, two imported the `logging` module only for level constants.

**Changes:**
- `src/utils/vector_search.py` — `logging.getLogger()` → `get_logger()`
- `src/telemetry/configuration_snapshot.py` — `logging.getLogger()` → `get_logger()`
- `src/runners/uvicorn.py` — `import logging` → `from logging import INFO`
- `src/app/database.py` — `import logging` → `from logging import DEBUG`

## Type of change

- [x] Refactor

## Tools used to create PR

- Assisted-by: Claude (opencode)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2444](https://issues.redhat.com/browse/RSPEED-2444)
- Epic: [RSPEED-2229](https://issues.redhat.com/browse/RSPEED-2229)
- Follow-up to #1148

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

All existing unit tests pass (1476 passed, 0 failed). No behavioral changes — only import
paths were updated. Verified with `uv run make format`, `uv run make verify`, and
`uv run make test-unit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal logging infrastructure across multiple application modules for improved code organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->