### PR TITLE
Fix 'Converastion' typo in log messages

### DIFF
--- a/src/app/endpoints/conversations_v2.py
+++ b/src/app/endpoints/conversations_v2.py
@@ -97,7 +97,7 @@ async def get_conversations_list_endpoint_handler(
     skip_userid_check = auth[2]
 
     if configuration.conversation_cache_configuration.type is None:
-        logger.warning("Converastion cache is not configured")
+        logger.warning("Conversation cache is not configured")
         response = InternalServerErrorResponse.cache_unavailable()
         raise HTTPException(**response.model_dump())
 
@@ -124,7 +124,7 @@ async def get_conversation_endpoint_handler(
     skip_userid_check = auth[2]
 
     if configuration.conversation_cache_configuration.type is None:
-        logger.warning("Converastion cache is not configured")
+        logger.warning("Conversation cache is not configured")
         response = InternalServerErrorResponse.cache_unavailable()
         raise HTTPException(**response.model_dump())
 
@@ -162,7 +162,7 @@ async def delete_conversation_endpoint_handler(
     skip_userid_check = auth[2]
 
     if configuration.conversation_cache_configuration.type is None:
-        logger.warning("Converastion cache is not configured")
+        logger.warning("Conversation cache is not configured")
         response = InternalServerErrorResponse.cache_unavailable()
         raise HTTPException(**response.model_dump())
 


### PR DESCRIPTION
## Description

Fixes a typo in three log messages in `conversations_v2.py`: "Converastion" → "Conversation".

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude (opencode)
- Generated by: N/A

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed spelling error in warning log messages related to conversation cache configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->