### PR TITLE
RSPEED-2445: Standardize exception logging to use logger.exception() for unexpected errors

### DIFF
--- a/src/authentication/k8s.py
+++ b/src/authentication/k8s.py
@@ -181,7 +181,7 @@ class K8sClientSingleton:
             logger.error("API exception during ClusterInfo: %s", e)
             raise ClusterIDUnavailableError("Failed to get cluster ID") from e
         except Exception as e:
-            logger.error("Unexpected error during getting cluster ID: %s", e)
+            logger.exception("Unexpected error during getting cluster ID")
             raise ClusterIDUnavailableError("Failed to get cluster ID") from e
 
     @classmethod
@@ -227,7 +227,7 @@ def get_user_info(token: str) -> Optional[kubernetes.client.V1TokenReview]:
     try:
         auth_api = K8sClientSingleton.get_authn_api()
     except Exception as e:
-        logger.error("Failed to get Kubernetes authentication API: %s", e)
+        logger.exception("Failed to get Kubernetes authentication API")
         response = ServiceUnavailableResponse(
             backend_name="Kubernetes API",
             cause="Unable to initialize Kubernetes client",
@@ -242,8 +242,8 @@ def get_user_info(token: str) -> Optional[kubernetes.client.V1TokenReview]:
         if response.status.authenticated:
             return response.status
         return None
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.error("API exception during TokenReview: %s", e)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("API exception during TokenReview")
         return None
 
 
@@ -332,7 +332,7 @@ class K8SAuthDependency(AuthInterface):  # pylint: disable=too-few-public-method
             response = authorization_api.create_subject_access_review(sar)
 
         except Exception as e:
-            logger.error("API exception during SubjectAccessReview: %s", e)
+            logger.exception("API exception during SubjectAccessReview")
             response = ServiceUnavailableResponse(
                 backend_name="Kubernetes API",
                 cause="Unable to perform authorization check",

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -134,7 +134,7 @@ def main() -> None:
             configuration.configuration.dump()
             logger.info("Configuration dumped to configuration.json")
         except Exception as e:
-            logger.error("Failed to dump configuration: %s", e)
+            logger.exception("Failed to dump configuration")
             raise SystemExit(1) from e
         return
 
@@ -145,7 +145,7 @@ def main() -> None:
             schema_dumper.dump_schema("schema.json")
             logger.info("Configuration schema dumped to schema.json")
         except Exception as e:
-            logger.error("Failed to dump configuration schema: %s", e)
+            logger.exception("Failed to dump configuration schema")
             raise SystemExit(1) from e
         return
 

--- a/src/runners/quota_scheduler.py
+++ b/src/runners/quota_scheduler.py
@@ -108,8 +108,8 @@ def quota_scheduler(config: QuotaHandlersConfiguration) -> bool:
                 quota_revocation(
                     connection, limiter, increase_quota_statement, reset_quota_statement
                 )
-            except Exception as e:  # pylint: disable=broad-exception-caught
-                logger.error("Quota revoke error: %s", e)
+            except Exception:  # pylint: disable=broad-exception-caught
+                logger.exception("Quota revoke error")
         logger.info("Quota scheduler sync finished")
         sleep(period)
     # unreachable code
@@ -136,8 +136,8 @@ def connected(connection: Any) -> bool:
         cursor.close()
         logger.info("Connection to storage is ok")
         return True
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.error("Disconnected from storage: %s", e)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Disconnected from storage")
         return False
 
 


### PR DESCRIPTION
## Description

Catch-all `except Exception` blocks inconsistently used `logger.error()` (losing tracebacks)
instead of `logger.exception()`. Converts 13 calls across 4 files and removes one redundant
`exc_info=True` from a specific exception handler.

## Type of change

- [x] Refactor

## Tools used to create PR

- Assisted-by: Claude (opencode)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2445](https://issues.redhat.com/browse/RSPEED-2445)
- Epic: [RSPEED-2229](https://issues.redhat.com/browse/RSPEED-2229)
- Follow-up to #1148, #1165

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

All unit tests pass. No behavioral changes beyond improved traceback inclusion for unexpected errors.