### PR TITLE
[LCORE-1342] OKP Solr documentation

### DIFF
--- a/docs/rag_guide.md
+++ b/docs/rag_guide.md
@@ -261,6 +261,70 @@ Currently, tool calling is not supported out of the box. Some experimental patch
 
 The RAG tool calls where not working properly when experimenting with `mistralai/Mistral-7B-Instruct-v0.3` on vLLM.
 
+### Solr Vector IO
+
+The OKP (Offline Knowledge Portal) Solr Vector IO is a read-only vector search provider that integrates with Apache Solr for enhanced vector search capabilities. It enables retrieving contextual information from Solr-indexed Red Hat documents to enhance query responses with support for hybrid search and chunk window expansion.
+
+
+#### How to Enable Solr Vector IO
+
+**1. Configure Llama Stack (`run.yaml`):**
+
+```yaml
+providers:
+  vector_io:
+  - provider_id: solr-vector
+    provider_type: remote::solr_vector_io
+    config:
+      solr_url: http://localhost:8983/solr
+      collection_name: portal-rag
+      vector_field: chunk_vector
+      content_field: chunk
+      embedding_dimension: 384
+      embedding_model: ${env.EMBEDDING_MODEL_DIR}
+      persistence:
+        namespace: portal-rag
+        backend: kv_default
+
+registered_resources:
+  vector_stores:
+  - vector_store_id: portal-rag
+    provider_id: solr-vector
+    embedding_model: granite-embedding-30m
+    embedding_dimension: 384
+```
+
+**2. Configure Lightspeed Stack (`lightspeed-stack.yaml`):**
+
+```yaml
+solr:
+  enabled: true     # Enable Solr vector IO functionality
+  offline: true     # Use parent_id for document URLs (offline mode)
+                   # Set to false to use reference_url (online mode)
+```
+
+**Query Processing:**
+
+1. When Solr is enabled, queries use the `portal-rag` vector store
+2. Vector search is performed with configurable parameters:
+   - `k`: Number of results (default: 5)
+   - `score_threshold`: Minimum similarity score (default: 0.0)  
+   - `mode`: Search mode (default: "hybrid")
+3. Results include document metadata and source URLs
+4. Document URLs are built based on the `offline` setting:
+   - **Offline mode**: Uses `parent_id` with Mimir base URL
+   - **Online mode**: Uses `reference_url` from document metadata
+
+**Prerequisites:**
+
+- Solr must be running and accessible at the configured URL
+  for instructions on how to pull and run the OKP Solr image visit: https://github.com/lightspeed-core/lightspeed-providers/lightspeed_stack_providers/providers/remote/solr_vector_io/solr_vector_io/README.md
+
+
+**Limitations:**
+
+- This is a **read-only** provider - no insert/delete operations
+
 ---
 
 # Complete Configuration Reference

--- a/lightspeed-stack.yaml
+++ b/lightspeed-stack.yaml
@@ -32,6 +32,7 @@ authentication:
   module: "noop"
 
 
+# OKP Solr for supplementary RAG
 solr:
-  enabled: true
+  enabled: false
   offline: true


### PR DESCRIPTION
## Description

Initial documentation to help users onboard to using OKP Solr in lightspeed-core. Also, set Solr disabled by default.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue https://issues.redhat.com/browse/LCORE-1342
- Closes https://issues.redhat.com/browse/LCORE-1342

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Solr Vector IO, describing its functionality as a read-only vector search provider. Includes detailed configuration examples, query processing information, system prerequisites, and known limitations for various deployment scenarios.

* **Chores**
  * Modified default stack configuration to disable Solr integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->