### PR TITLE
LCORE-1328 Send x-llamastack-provider-data header with MCP auth to llama-stack

### DIFF
--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -123,6 +123,10 @@ class ResponsesApiParams(BaseModel):
     conversation: str = Field(description="The conversation ID in llama-stack format")
     stream: bool = Field(description="Whether to stream the response")
     store: bool = Field(description="Whether to store the response")
+    extra_headers: Optional[dict[str, str]] = Field(
+        default=None,
+        description="Extra HTTP headers to send with the request (e.g. x-llamastack-provider-data)",
+    )
 
 
 class ToolCallSummary(BaseModel):


### PR DESCRIPTION
## Description

Restore the x-llamastack-provider-data HTTP header that regressed (stopped being sent). Now llama-stack can forward auth credentials per-MCP server again.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.6
- Generated by: Claude Opus 4.6

## Related Tickets & Documents

- Related Issue # LCORE-1328
- Closes # LCORE-1328

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

Unit tests:

`uv run pytest tests/unit/utils/test_responses.py -v`

On live stack:

Send a POST /v1/streaming_query with MCP-HEADERS: {"mock-mcp": {"X-Authorization": "my-secret-client-token"}}, confirm MCP receives them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send provider-specific headers with API requests to support downstream provider authentication.
  * API request parameters now accept per-request extra headers for provider data.

* **Tests**
  * Added unit tests confirming provider header construction when provider tools include headers.
  * Added unit tests confirming no extra headers are included when provider tools do not supply headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->