### PR TITLE
RSPEED-2466: Replace verbose rh-identity error messages with opaque responses

### DIFF
--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -54,45 +54,53 @@ class RHIdentityData:
             "identity" not in self.identity_data
             or self.identity_data["identity"] is None
         ):
-            raise HTTPException(status_code=400, detail="Missing 'identity' field")
+            logger.warning("Identity validation failed: missing 'identity' field")
+            raise HTTPException(status_code=400, detail="Invalid identity data")
 
         identity = self.identity_data["identity"]
         if "type" not in identity:
-            raise HTTPException(status_code=400, detail="Missing identity 'type' field")
+            logger.warning("Identity validation failed: missing 'type' field")
+            raise HTTPException(status_code=400, detail="Invalid identity data")
 
         identity_type = identity["type"]
         if identity_type == "User":
             if "user" not in identity:
-                raise HTTPException(
-                    status_code=400, detail="Missing 'user' field for User type"
+                logger.warning(
+                    "Identity validation failed: missing 'user' field for User type"
                 )
+                raise HTTPException(status_code=400, detail="Invalid identity data")
             user = identity["user"]
             if "user_id" not in user:
-                raise HTTPException(
-                    status_code=400, detail="Missing 'user_id' in user data"
+                logger.warning(
+                    "Identity validation failed: missing 'user_id' in user data"
                 )
+                raise HTTPException(status_code=400, detail="Invalid identity data")
             if "username" not in user:
-                raise HTTPException(
-                    status_code=400, detail="Missing 'username' in user data"
+                logger.warning(
+                    "Identity validation failed: missing 'username' in user data"
                 )
+                raise HTTPException(status_code=400, detail="Invalid identity data")
         elif identity_type == "System":
             if "system" not in identity:
-                raise HTTPException(
-                    status_code=400, detail="Missing 'system' field for System type"
+                logger.warning(
+                    "Identity validation failed: missing 'system' field for System type"
                 )
+                raise HTTPException(status_code=400, detail="Invalid identity data")
             system = identity["system"]
             if "cn" not in system:
-                raise HTTPException(
-                    status_code=400, detail="Missing 'cn' in system data"
+                logger.warning(
+                    "Identity validation failed: missing 'cn' in system data"
                 )
+                raise HTTPException(status_code=400, detail="Invalid identity data")
             if "account_number" not in identity:
-                raise HTTPException(
-                    status_code=400, detail="Missing 'account_number' for System type"
+                logger.warning(
+                    "Identity validation failed: "
+                    "missing 'account_number' for System type"
                 )
+                raise HTTPException(status_code=400, detail="Invalid identity data")
         else:
-            raise HTTPException(
-                status_code=400, detail=f"Unsupported identity type: {identity_type}"
-            )
+            logger.warning("Identity validation failed: unsupported identity type")
+            raise HTTPException(status_code=400, detail="Invalid identity data")
 
     def _get_identity_type(self) -> str:
         """Get the identity type (User or System).
@@ -169,10 +177,13 @@ class RHIdentityData:
 
         missing = [s for s in self.required_entitlements if not self.has_entitlement(s)]
         if missing:
-            entitlement_word = "entitlement" if len(missing) == 1 else "entitlements"
+            logger.warning(
+                "Entitlement validation failed: missing required entitlements: %s",
+                ", ".join(missing),
+            )
             raise HTTPException(
                 status_code=403,
-                detail=f"Missing required {entitlement_word}: {', '.join(missing)}",
+                detail="Insufficient entitlements",
             )
 
 

--- a/tests/e2e/features/authorized_rh_identity.feature
+++ b/tests/e2e/features/authorized_rh_identity.feature
@@ -28,7 +28,7 @@ Feature: Authorized endpoint API tests for the rh-identity authentication module
      {"placeholder":"abc"}
      """
      Then The status code of the response is 400
-      And The body of the response contains Missing 'identity' field
+      And The body of the response contains Invalid identity data
 
   Scenario: Request succeeds with valid User identity and required entitlements
     Given The system is in default state
@@ -79,7 +79,7 @@ Feature: Authorized endpoint API tests for the rh-identity authentication module
      {"placeholder":"abc"}
      """
      Then The status code of the response is 403
-      And The body of the response contains Missing required entitlement
+      And The body of the response contains Insufficient entitlements
 
   Scenario: Request fails when entitlement exists but is_entitled is false
     Given The system is in default state
@@ -99,7 +99,7 @@ Feature: Authorized endpoint API tests for the rh-identity authentication module
      {"placeholder":"abc"}
      """
      Then The status code of the response is 403
-      And The body of the response contains Missing required entitlement
+      And The body of the response contains Insufficient entitlements
 
   Scenario: Request fails when User identity is missing user_id
     Given The system is in default state
@@ -119,7 +119,7 @@ Feature: Authorized endpoint API tests for the rh-identity authentication module
      {"placeholder":"abc"}
      """
      Then The status code of the response is 400
-      And The body of the response contains Missing 'user_id' in user data
+      And The body of the response contains Invalid identity data
 
   Scenario: Request fails when User identity is missing username
     Given The system is in default state
@@ -139,7 +139,7 @@ Feature: Authorized endpoint API tests for the rh-identity authentication module
      {"placeholder":"abc"}
      """
      Then The status code of the response is 400
-      And The body of the response contains Missing 'username' in user data
+      And The body of the response contains Invalid identity data
 
   Scenario: Request fails when System identity is missing cn
     Given The system is in default state
@@ -160,4 +160,4 @@ Feature: Authorized endpoint API tests for the rh-identity authentication module
      {"placeholder":"abc"}
      """
      Then The status code of the response is 400
-      And The body of the response contains Missing 'cn' in system data
+      And The body of the response contains Invalid identity data


### PR DESCRIPTION
## Description

The rh-identity auth module returned error messages that revealed the full expected JSON structure of the `x-rh-identity` header (field names, nesting, valid identity types, required entitlements). An attacker could reconstruct the schema in ~9 requests by iterating on malformed headers.

All 11 verbose error messages now return generic responses (`"Invalid identity data"` / `"Insufficient entitlements"`), with detailed diagnostics moved to `logger.warning()` for ops troubleshooting.

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude
- Generated by: N/A

## Related Tickets & Documents

- Closes RSPEED-2466

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `uv run pytest tests/unit/authentication/test_rh_identity.py` — 50/50 pass
- `uv run make verify` — pylint 10/10, pyright 0 errors, mypy clean, all linters pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authentication error messages: field-specific messages replaced with generic "Invalid identity data" and entitlements errors now return "Insufficient entitlements" while preserving HTTP status codes; added warning logs for validation issues.

* **Tests**
  * Updated unit and end-to-end tests to expect the new, standardized error messages and to assert warning logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->