### PR TITLE
RSPEED-2464: fix inconsistent error response format in rlsapi v1 /infer endpoint

### DIFF
--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -133,10 +133,11 @@ def _get_default_model_id() -> str:
     if configuration.inference is None:
         msg = "No inference configuration available"
         logger.error(msg)
-        raise HTTPException(
-            status_code=503,
-            detail={"response": "Service configuration error", "cause": msg},
+        error_response = ServiceUnavailableResponse(
+            backend_name="inference service (configuration)",
+            cause=msg,
         )
+        raise HTTPException(**error_response.model_dump())
 
     model_id = configuration.inference.default_model
     provider_id = configuration.inference.default_provider
@@ -146,10 +147,11 @@ def _get_default_model_id() -> str:
 
     msg = "No default model configured for rlsapi v1 inference"
     logger.error(msg)
-    raise HTTPException(
-        status_code=503,
-        detail={"response": "Service configuration error", "cause": msg},
+    error_response = ServiceUnavailableResponse(
+        backend_name="inference service (configuration)",
+        cause=msg,
     )
+    raise HTTPException(**error_response.model_dump())
 
 
 async def retrieve_simple_response(


### PR DESCRIPTION
## Description

The `/v1/infer` endpoint produced two different JSON response shapes for HTTP 503 errors. Configuration errors in `_get_default_model_id()` used raw dicts while LLM errors used `ServiceUnavailableResponse` models, giving clients inconsistent payloads depending on which failure path triggered.

Both `raise HTTPException` calls in `_get_default_model_id()` now use `ServiceUnavailableResponse` so all 503 responses share the same `{"response": ..., "cause": ...}` detail shape.

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude
- Generated by: N/A

## Related Tickets & Documents

- Related Issue # N/A
- Closes # N/A
- Jira: [RSPEED-2464](https://issues.redhat.com/browse/RSPEED-2464)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Run the rlsapi v1 unit tests: `uv run pytest tests/unit/app/endpoints/test_rlsapi_v1.py -v`
2. All 33 tests pass, including:
   - `test_get_default_model_id_errors` — verifies both config error paths raise 503 with `ServiceUnavailableResponse` shape (dict with exactly `{"response", "cause"}` keys)
   - `test_config_error_503_matches_llm_error_503_shape` — new test confirming configuration error 503s and LLM connection error 503s produce identical detail key sets
3. `uv run make verify` passes all linters (black, pylint, pyright, ruff, pydocstyle, mypy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized 503 error payloads for missing configuration so service-unavailable errors share the same structured response (includes backend name and cause).
* **Tests**
  * Updated and added tests to assert the new standardized 503 error shape and verify the cause and response detail keys are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->