### PR TITLE
fix: pass root_path to FastAPI constructor instead of uvicorn

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -84,6 +84,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(
+    root_path=configuration.service_configuration.root_path,
     title=f"{service_name} service - OpenAPI",
     summary=f"{service_name} service API specification.",
     description=f"{service_name} service API specification.",

--- a/src/runners/uvicorn.py
+++ b/src/runners/uvicorn.py
@@ -16,7 +16,7 @@ def start_uvicorn(configuration: ServiceConfiguration) -> None:
 
     Parameters:
         configuration (ServiceConfiguration): Configuration providing host,
-        port, workers, `root_path`, and `tls_config` (including `tls_key_path`,
+        port, workers, and `tls_config` (including `tls_key_path`,
         `tls_certificate_path`, and `tls_key_password`). TLS fields may be None
         and will be forwarded to uvicorn.run as provided.
     """
@@ -31,7 +31,6 @@ def start_uvicorn(configuration: ServiceConfiguration) -> None:
         host=configuration.host,
         port=configuration.port,
         workers=configuration.workers,
-        root_path=configuration.root_path,
         log_level=log_level,
         ssl_keyfile=configuration.tls_config.tls_key_path,
         ssl_certfile=configuration.tls_config.tls_certificate_path,

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -22,7 +22,6 @@ def test_start_uvicorn(mocker: MockerFixture) -> None:
         host="localhost",
         port=8080,
         workers=1,
-        root_path="",
         log_level=20,
         ssl_certfile=None,
         ssl_keyfile=None,
@@ -46,7 +45,6 @@ def test_start_uvicorn_different_host_port(mocker: MockerFixture) -> None:
         host="x.y.com",
         port=1234,
         workers=10,
-        root_path="",
         log_level=20,
         ssl_certfile=None,
         ssl_keyfile=None,
@@ -71,7 +69,6 @@ def test_start_uvicorn_empty_tls_configuration(mocker: MockerFixture) -> None:
         host="x.y.com",
         port=1234,
         workers=10,
-        root_path="",
         log_level=20,
         ssl_certfile=None,
         ssl_keyfile=None,
@@ -100,7 +97,6 @@ def test_start_uvicorn_tls_configuration(mocker: MockerFixture) -> None:
         host="x.y.com",
         port=1234,
         workers=10,
-        root_path="",
         log_level=20,
         ssl_certfile=Path("tests/configuration/server.crt"),
         ssl_keyfile=Path("tests/configuration/server.key"),
@@ -111,7 +107,7 @@ def test_start_uvicorn_tls_configuration(mocker: MockerFixture) -> None:
 
 
 def test_start_uvicorn_with_root_path(mocker: MockerFixture) -> None:
-    """Test the function to start Uvicorn server with a custom root path."""
+    """Test that root_path is not passed to uvicorn (it belongs on the FastAPI constructor)."""
     configuration = ServiceConfiguration(
         host="localhost", port=8080, workers=1, root_path="/api/lightspeed"
     )  # pyright: ignore[reportCallIssue]
@@ -124,7 +120,6 @@ def test_start_uvicorn_with_root_path(mocker: MockerFixture) -> None:
         host="localhost",
         port=8080,
         workers=1,
-        root_path="/api/lightspeed",
         log_level=20,
         ssl_certfile=None,
         ssl_keyfile=None,


### PR DESCRIPTION
## Description

When lightspeed-stack runs behind 3scale with `ROOT_PATH=/api/lightspeed`, requests arrive with a doubled path prefix (`/api/lightspeed/api/lightspeed/v1/infer`) because `uvicorn.run(root_path=...)` injects the value into `scope['root_path']`, and Starlette concatenates it with the already-prefixed `scope['path']` from 3scale.

Move `root_path` from `uvicorn.run()` to the `FastAPI()` constructor, matching how rlsapi handles it. This way Starlette knows the mount prefix without uvicorn double-prepending it.

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude
- Generated by: N/A

## Related Tickets & Documents

- Closes [RSPEED-2467](https://issues.redhat.com/browse/RSPEED-2467)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- Existing uvicorn runner unit tests updated to verify `root_path` is no longer passed to `uvicorn.run()`.
- All 5 tests in `tests/unit/runners/test_uvicorn_runner.py` pass.
- Full verification requires deploying behind 3scale with `ROOT_PATH=/api/lightspeed` and confirming requests to `/v1/infer` route correctly without path doubling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed root path configuration to be applied during FastAPI initialization, ensuring correct base URL resolution.

* **Tests**
  * Updated tests to reflect changes in root path configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->