### PR TITLE
LCORE-1260 Deduplicate vector_store entries when modifying BYOK RAG config

### DIFF
--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -179,9 +179,15 @@ def construct_vector_stores_section(
         if "vector_stores" in ls_config["registered_resources"]:
             output = ls_config["registered_resources"]["vector_stores"].copy()
 
-    # append new vector_stores entries
+    # append new vector_stores entries, skipping duplicates
+    existing_store_ids = {vs.get("vector_store_id") for vs in output}
+    added = 0
     for brag in byok_rag:
         vector_db_id = brag.get("vector_db_id", "")
+        if vector_db_id in existing_store_ids:
+            continue
+        existing_store_ids.add(vector_db_id)
+        added += 1
         output.append(
             {
                 "vector_store_id": vector_db_id,
@@ -192,7 +198,7 @@ def construct_vector_stores_section(
         )
     logger.info(
         "Added %s items into registered_resources.vector_stores, total items %s",
-        len(byok_rag),
+        added,
         len(output),
     )
     return output

--- a/tests/unit/test_llama_stack_configuration.py
+++ b/tests/unit/test_llama_stack_configuration.py
@@ -78,6 +78,47 @@ def test_construct_vector_stores_section_merge() -> None:
     assert len(output) == 2
 
 
+def test_construct_vector_stores_section_skips_duplicate_from_existing() -> None:
+    """Test skips BYOK entry when vector_store_id already exists in config."""
+    ls_config = {
+        "registered_resources": {
+            "vector_stores": [
+                {"vector_store_id": "store1", "provider_id": "original_provider"},
+            ]
+        }
+    }
+    byok_rag = [
+        {
+            "vector_db_id": "store1",
+            "embedding_model": "test-model",
+            "embedding_dimension": 512,
+        },
+    ]
+    output = construct_vector_stores_section(ls_config, byok_rag)
+    assert len(output) == 1
+    assert output[0]["provider_id"] == "original_provider"
+
+
+def test_construct_vector_stores_section_skips_duplicate_within_byok() -> None:
+    """Test skips duplicate vector_db_id entries within the BYOK RAG list."""
+    ls_config: dict[str, Any] = {}
+    byok_rag = [
+        {
+            "vector_db_id": "store1",
+            "embedding_model": "model-a",
+            "embedding_dimension": 512,
+        },
+        {
+            "vector_db_id": "store1",
+            "embedding_model": "model-b",
+            "embedding_dimension": 768,
+        },
+    ]
+    output = construct_vector_stores_section(ls_config, byok_rag)
+    assert len(output) == 1
+    assert output[0]["embedding_model"] == "model-a"
+
+
 # =============================================================================
 # Test construct_vector_io_providers_section
 # =============================================================================


### PR DESCRIPTION
## Description

Add dedup to appending of BYOK RAG entries in construct_vector_stores_section() so that duplicate vector_store-id are not created in the config.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.6
- Generated by: Claude Opus 4.6

## Related Tickets & Documents

- Related Issue # LCORE-1260
- Closes # LCORE-1260

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

`uv run pytest tests/unit/test_llama_stack_configuration.py -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate vector store entries in configuration by implementing deduplication logic. The system now prevents duplicate entries from being added based on existing identifiers and removes duplicates within import batches.

* **Tests**
  * Added unit tests to verify proper handling and prevention of duplicate vector store entries during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->