### PR TITLE
RSPEED-2472: Fix uvicorn ignoring LIGHTSPEED_STACK_LOG_LEVEL env var

### DIFF
--- a/src/runners/uvicorn.py
+++ b/src/runners/uvicorn.py
@@ -1,18 +1,41 @@
 """Uvicorn runner."""
 
-from logging import INFO
+import logging
+import os
 
 import uvicorn
 
+from constants import DEFAULT_LOG_LEVEL, LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR
 from log import get_logger
 from models.config import ServiceConfiguration
 
 logger = get_logger(__name__)
 
 
-def start_uvicorn(configuration: ServiceConfiguration) -> None:
+def _resolve_log_level() -> int:
+    """Resolve the uvicorn log level from the environment.
+
+    Reads the LIGHTSPEED_STACK_LOG_LEVEL environment variable and converts it
+    to a Python logging level constant. Falls back to the default log level
+    when the variable is unset or contains an invalid value.
+
+    Returns:
+        The resolved logging level as an integer constant.
     """
-    Start the Uvicorn server using the provided service configuration.
+    level_str = os.environ.get(LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR, DEFAULT_LOG_LEVEL)
+    level = getattr(logging, level_str.upper(), None)
+    if not isinstance(level, int):
+        logger.warning(
+            "Invalid log level '%s', falling back to %s",
+            level_str,
+            DEFAULT_LOG_LEVEL,
+        )
+        level = getattr(logging, DEFAULT_LOG_LEVEL)
+    return level
+
+
+def start_uvicorn(configuration: ServiceConfiguration) -> None:
+    """Start the Uvicorn server using the provided service configuration.
 
     Parameters:
         configuration (ServiceConfiguration): Configuration providing host,
@@ -20,9 +43,8 @@ def start_uvicorn(configuration: ServiceConfiguration) -> None:
         `tls_certificate_path`, and `tls_key_password`). TLS fields may be None
         and will be forwarded to uvicorn.run as provided.
     """
-    logger.info("Starting Uvicorn")
-
-    log_level = INFO
+    log_level = _resolve_log_level()
+    logger.info("Starting Uvicorn with log level %s", logging.getLevelName(log_level))
 
     # please note:
     # TLS fields can be None, which means we will pass those values as None to uvicorn.run

--- a/tests/unit/runners/test_uvicorn_runner.py
+++ b/tests/unit/runners/test_uvicorn_runner.py
@@ -1,11 +1,14 @@
 """Unit tests for the Uvicorn runner implementation."""
 
+import logging
 from pathlib import Path
+
+import pytest
 from pytest_mock import MockerFixture
 
-
+from constants import LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR
 from models.config import ServiceConfiguration, TLSConfiguration
-from runners.uvicorn import start_uvicorn
+from runners.uvicorn import _resolve_log_level, start_uvicorn
 
 
 def test_start_uvicorn(mocker: MockerFixture) -> None:
@@ -121,6 +124,58 @@ def test_start_uvicorn_with_root_path(mocker: MockerFixture) -> None:
         port=8080,
         workers=1,
         log_level=20,
+        ssl_certfile=None,
+        ssl_keyfile=None,
+        ssl_keyfile_password="",
+        use_colors=True,
+        access_log=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_level"),
+    [
+        ("DEBUG", logging.DEBUG),
+        ("debug", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("BOGUS", logging.INFO),
+    ],
+)
+def test_resolve_log_level_from_env(
+    monkeypatch: pytest.MonkeyPatch, env_value: str, expected_level: int
+) -> None:
+    """Test that _resolve_log_level resolves env var values to logging constants."""
+    monkeypatch.setenv(LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR, env_value)
+    assert _resolve_log_level() == expected_level
+
+
+def test_resolve_log_level_defaults_to_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that _resolve_log_level falls back to INFO when the env var is unset."""
+    monkeypatch.delenv(LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR, raising=False)
+    assert _resolve_log_level() == logging.INFO
+
+
+def test_start_uvicorn_respects_debug_log_level(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that start_uvicorn passes the DEBUG log level to uvicorn.run."""
+    monkeypatch.setenv(LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR, "DEBUG")
+    configuration = ServiceConfiguration(
+        host="localhost", port=8080, workers=1
+    )  # pyright: ignore[reportCallIssue]
+
+    mocked_run = mocker.patch("uvicorn.run")
+    start_uvicorn(configuration)
+    mocked_run.assert_called_once_with(
+        "app.main:app",
+        host="localhost",
+        port=8080,
+        workers=1,
+        log_level=logging.DEBUG,
         ssl_certfile=None,
         ssl_keyfile=None,
         ssl_keyfile_password="",


### PR DESCRIPTION
## Description

`start_uvicorn()` hardcoded `log_level = INFO` and passed it directly to `uvicorn.run()`. Setting `LIGHTSPEED_STACK_LOG_LEVEL=DEBUG` or using `--verbose` had no effect on uvicorn's log output.

The fix adds `_resolve_log_level()` which reads the env var the same way `log.py` and `lightspeed_stack.py` already do, falling back to INFO when unset or invalid.

## Type of change

- [x] Bug fix
- [x] Unit tests improvement

## Tools used to create PR

- Assisted-by: Claude
- Generated by: N/A

## Related Tickets & Documents

- https://issues.redhat.com/browse/RSPEED-2472

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. `LIGHTSPEED_STACK_LOG_LEVEL=DEBUG uv run src/lightspeed_stack.py` — uvicorn now outputs DEBUG-level messages (previously stayed at INFO)
2. `uv run pytest tests/unit/runners/test_uvicorn_runner.py -v` — 12/12 tests pass, covering DEBUG/WARNING/ERROR, case-insensitivity, invalid values, and unset env var
3. `uv run make verify` — all linters pass (pylint 10/10, pyright 0 errors, mypy clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application log level can now be configured via an environment variable; startup logs show the resolved level and the system falls back to a safe default with a warning if the value is unset or invalid.

* **Tests**
  * Added tests confirming environment-driven log level resolution and that startup uses the resolved verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->