### PR TITLE
[RHIDP-11647] Add interrupted user query to conversation

### DIFF
--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -31,6 +31,7 @@ from authorization.middleware import authorize
 from client import AsyncLlamaStackClientHolder
 from configuration import configuration
 from constants import (
+    INTERRUPTED_RESPONSE_MESSAGE,
     LLM_TOKEN_EVENT,
     LLM_TOOL_CALL_EVENT,
     LLM_TOOL_RESULT_EVENT,
@@ -320,6 +321,110 @@ async def retrieve_response_generator(
         raise HTTPException(**error_response.model_dump()) from e
 
 
+async def _persist_interrupted_turn(
+    context: ResponseGeneratorContext,
+    responses_params: ResponsesApiParams,
+    turn_summary: TurnSummary,
+) -> None:
+    """Persist the user query and an interrupted response into the conversation.
+
+    Called when a streaming request is cancelled so the exchange is not lost.
+    All errors are caught and logged to avoid masking the original
+    cancellation.
+
+    Parameters:
+        context: The response generator context.
+        responses_params: The Responses API parameters.
+        turn_summary: TurnSummary with llm_response already set to the
+            interrupted message.
+    """
+    try:
+        await append_turn_to_conversation(
+            context.client,
+            responses_params.conversation,
+            responses_params.input,
+            INTERRUPTED_RESPONSE_MESSAGE,
+        )
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to append interrupted turn to conversation for request %s",
+            context.request_id,
+        )
+
+    try:
+        completed_at = datetime.datetime.now(datetime.UTC).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        store_query_results(
+            user_id=context.user_id,
+            conversation_id=context.conversation_id,
+            model=responses_params.model,
+            completed_at=completed_at,
+            started_at=context.started_at,
+            summary=turn_summary,
+            query_request=context.query_request,
+            skip_userid_check=context.skip_userid_check,
+            topic_summary=None,
+        )
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to store interrupted query results for request %s",
+            context.request_id,
+        )
+
+
+def _register_interrupt_callback(
+    context: ResponseGeneratorContext,
+    responses_params: ResponsesApiParams,
+    turn_summary: TurnSummary,
+) -> list[bool]:
+    """Build an interrupt callback and register the stream for cancellation.
+
+    The callback is scheduled as a **separate** asyncio task by
+    ``cancel_stream`` so it executes regardless of where the
+    ``CancelledError`` is raised in the ASGI stack.
+
+    A mutable one-element list is used as a shared guard so the
+    callback and the in-generator ``CancelledError`` handler never
+    both persist the same turn.
+
+    Parameters:
+        context: The response generator context.
+        responses_params: The Responses API parameters.
+        turn_summary: TurnSummary populated during streaming.
+
+    Returns:
+        A mutable list ``[False]`` used as a persist-done guard; the
+        caller should check ``guard[0]`` before persisting and set
+        it to ``True`` afterwards.
+    """
+    guard: list[bool] = [False]
+
+    async def _on_interrupt() -> None:
+        if guard[0]:
+            return
+        guard[0] = True
+        turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
+        await _persist_interrupted_turn(context, responses_params, turn_summary)
+
+    current_task = asyncio.current_task()
+    if current_task is not None:
+        get_stream_interrupt_registry().register_stream(
+            request_id=context.request_id,
+            user_id=context.user_id,
+            task=current_task,
+            on_interrupt=_on_interrupt,
+        )
+    else:
+        logger.warning(
+            "No current asyncio task for request %s; "
+            "stream interruption will not be available",
+            context.request_id,
+        )
+
+    return guard
+
+
 async def generate_response(
     generator: AsyncIterator[str],
     context: ResponseGeneratorContext,
@@ -330,9 +435,9 @@ async def generate_response(
 
     Re-yields events from the generator, handles errors, and ensures
     persistence and token consumption after completion.  When the
-    stream is interrupted via ``CancelledError``, all post-stream side
-    effects (token consumption, result storage) are skipped and the
-    request is deregistered from the interrupt registry.
+    stream is interrupted via ``CancelledError``, the user query and
+    an interrupted response are persisted to the conversation, but
+    token consumption is skipped (no usage data is available).
 
     Args:
         generator: The base generator to wrap
@@ -343,20 +448,9 @@ async def generate_response(
     Yields:
         SSE-formatted strings from the wrapped generator
     """
-    user_id = context.user_id
-
-    current_task = asyncio.current_task()
-    if current_task is not None:
-        get_stream_interrupt_registry().register_stream(
-            request_id=context.request_id,
-            user_id=user_id,
-            task=current_task,
-        )
-    else:
-        logger.warning(
-            "No current asyncio task for request %s; stream interruption will not be available",
-            context.request_id,
-        )
+    persist_guard = _register_interrupt_callback(
+        context, responses_params, turn_summary
+    )
 
     stream_completed = False
     try:
@@ -390,6 +484,13 @@ async def generate_response(
         yield stream_http_error_event(error_response, context.query_request.media_type)
     except asyncio.CancelledError:
         logger.info("Streaming request %s interrupted by user", context.request_id)
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            current_task.uncancel()
+        if not persist_guard[0]:
+            persist_guard[0] = True
+            turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
+            await _persist_interrupted_turn(context, responses_params, turn_summary)
         yield stream_interrupted_event(context.request_id)
     finally:
         get_stream_interrupt_registry().deregister_stream(context.request_id)

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,6 +6,9 @@ MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION = "0.4.3"
 
 UNABLE_TO_PROCESS_RESPONSE = "Unable to process this request"
 
+# Response stored in the conversation when the user interrupts a streaming request
+INTERRUPTED_RESPONSE_MESSAGE = "You interrupted this request."
+
 # Supported attachment types
 ATTACHMENT_TYPES = frozenset(
     {

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -1358,12 +1358,12 @@ class TestGenerateResponse:
         assert any("error" in item for item in result)
 
     @pytest.mark.asyncio
-    async def test_generate_response_cancelled_skips_side_effects(
+    async def test_generate_response_cancelled_persists_interrupted_turn(
         self,
         mocker: MockerFixture,
         isolate_stream_interrupt_registry: Any,
     ) -> None:
-        """Test cancelled stream exits without quota consumption and persistence."""
+        """Test cancelled stream persists user query with interrupted response."""
 
         async def mock_generator() -> AsyncIterator[str]:
             yield "data: token\n\n"
@@ -1377,9 +1377,12 @@ class TestGenerateResponse:
         )  # pyright: ignore[reportCallIssue]
         mock_context.started_at = "2024-01-01T00:00:00Z"
         mock_context.skip_userid_check = False
+        mock_context.client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
 
         mock_responses_params = mocker.Mock(spec=ResponsesApiParams)
         mock_responses_params.model = "provider1/model1"
+        mock_responses_params.conversation = "conv_123"
+        mock_responses_params.input = "test"
 
         mock_turn_summary = TurnSummary()
         mock_turn_summary.token_usage = TokenCounter(input_tokens=10, output_tokens=5)
@@ -1389,6 +1392,10 @@ class TestGenerateResponse:
         )
         store_query_results_mock = mocker.patch(
             "app.endpoints.streaming_query.store_query_results"
+        )
+        append_turn_mock = mocker.patch(
+            "app.endpoints.streaming_query.append_turn_to_conversation",
+            new_callable=mocker.AsyncMock,
         )
 
         test_request_id = "123e4567-e89b-12d3-a456-426614174000"
@@ -1407,10 +1414,182 @@ class TestGenerateResponse:
         assert any('"event": "interrupted"' in item for item in result)
         assert not any('"event": "end"' in item for item in result)
         consume_query_tokens_mock.assert_not_called()
-        store_query_results_mock.assert_not_called()
+
+        append_turn_mock.assert_called_once_with(
+            mock_context.client,
+            "conv_123",
+            "test",
+            "You interrupted this request.",
+        )
+        store_query_results_mock.assert_called_once()
+        call_kwargs = store_query_results_mock.call_args[1]
+        assert call_kwargs["user_id"] == "user_123"
+        assert call_kwargs["conversation_id"] == "conv_123"
+        assert call_kwargs["summary"].llm_response == "You interrupted this request."
+        assert call_kwargs["topic_summary"] is None
+
         isolate_stream_interrupt_registry.deregister_stream.assert_called_once_with(
             test_request_id
         )
+
+    @pytest.mark.asyncio
+    async def test_generate_response_cancelled_stores_results_when_append_fails(
+        self,
+        mocker: MockerFixture,
+        isolate_stream_interrupt_registry: Any,
+    ) -> None:
+        """Test store_query_results still runs when append_turn_to_conversation fails."""
+
+        async def mock_generator() -> AsyncIterator[str]:
+            yield "data: token\n\n"
+            raise asyncio.CancelledError()
+
+        mock_context = mocker.Mock(spec=ResponseGeneratorContext)
+        mock_context.conversation_id = "conv_123"
+        mock_context.user_id = "user_123"
+        mock_context.query_request = QueryRequest(
+            query="test", media_type=MEDIA_TYPE_JSON
+        )  # pyright: ignore[reportCallIssue]
+        mock_context.started_at = "2024-01-01T00:00:00Z"
+        mock_context.skip_userid_check = False
+        mock_context.client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+
+        mock_responses_params = mocker.Mock(spec=ResponsesApiParams)
+        mock_responses_params.model = "provider1/model1"
+        mock_responses_params.conversation = "conv_123"
+        mock_responses_params.input = "test"
+
+        mock_turn_summary = TurnSummary()
+
+        mocker.patch("app.endpoints.streaming_query.consume_query_tokens")
+        store_query_results_mock = mocker.patch(
+            "app.endpoints.streaming_query.store_query_results"
+        )
+        mocker.patch(
+            "app.endpoints.streaming_query.append_turn_to_conversation",
+            new_callable=mocker.AsyncMock,
+            side_effect=RuntimeError("Llama Stack unavailable"),
+        )
+
+        test_request_id = "123e4567-e89b-12d3-a456-426614174000"
+        mock_context.request_id = test_request_id
+
+        result = []
+        async for item in generate_response(
+            mock_generator(),
+            mock_context,
+            mock_responses_params,
+            mock_turn_summary,
+        ):
+            result.append(item)
+
+        assert any('"event": "interrupted"' in item for item in result)
+        store_query_results_mock.assert_called_once()
+        isolate_stream_interrupt_registry.deregister_stream.assert_called_once_with(
+            test_request_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_response_task_cancel_persists_results(
+        self,
+        mocker: MockerFixture,
+        isolate_stream_interrupt_registry: Any,
+    ) -> None:
+        """Test that real task.cancel() persists via CancelledError handler."""
+        cancel_event = asyncio.Event()
+
+        async def slow_generator() -> AsyncIterator[str]:
+            yield "data: token\n\n"
+            await cancel_event.wait()
+            yield "data: should not reach\n\n"
+
+        mock_context = mocker.Mock(spec=ResponseGeneratorContext)
+        mock_context.conversation_id = "conv_123"
+        mock_context.user_id = "user_123"
+        mock_context.query_request = QueryRequest(
+            query="test", media_type=MEDIA_TYPE_JSON
+        )  # pyright: ignore[reportCallIssue]
+        mock_context.started_at = "2024-01-01T00:00:00Z"
+        mock_context.skip_userid_check = False
+        mock_context.client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+
+        mock_responses_params = mocker.Mock(spec=ResponsesApiParams)
+        mock_responses_params.model = "provider1/model1"
+        mock_responses_params.conversation = "conv_123"
+        mock_responses_params.input = "test"
+
+        mock_turn_summary = TurnSummary()
+
+        mocker.patch("app.endpoints.streaming_query.consume_query_tokens")
+        store_query_results_mock = mocker.patch(
+            "app.endpoints.streaming_query.store_query_results"
+        )
+        append_turn_mock = mocker.patch(
+            "app.endpoints.streaming_query.append_turn_to_conversation",
+            new_callable=mocker.AsyncMock,
+        )
+
+        test_request_id = "123e4567-e89b-12d3-a456-426614174000"
+        mock_context.request_id = test_request_id
+
+        result: list[str] = []
+
+        async def consume_generator() -> None:
+            async for item in generate_response(
+                slow_generator(),
+                mock_context,
+                mock_responses_params,
+                mock_turn_summary,
+            ):
+                result.append(item)
+
+        task = asyncio.create_task(consume_generator())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        await asyncio.sleep(0.05)
+
+        assert any('"event": "interrupted"' in item for item in result)
+        append_turn_mock.assert_called_once()
+        store_query_results_mock.assert_called_once()
+        isolate_stream_interrupt_registry.deregister_stream.assert_called_once_with(
+            test_request_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancel_stream_callback_persists_when_error_hits_outside_generator(
+        self,
+    ) -> None:
+        """Test on_interrupt callback runs via cancel_stream as a separate task."""
+        registry = StreamInterruptRegistry()
+        test_request_id = "123e4567-e89b-12d3-a456-426614174099"
+        registry.deregister_stream(test_request_id)
+
+        callback_ran = False
+
+        async def mock_callback() -> None:
+            nonlocal callback_ran
+            callback_ran = True
+
+        async def pending_stream() -> None:
+            await asyncio.sleep(10)
+
+        task = asyncio.create_task(pending_stream())
+        registry.register_stream(
+            test_request_id, "user_123", task, on_interrupt=mock_callback
+        )
+
+        result = registry.cancel_stream(test_request_id, "user_123")
+        assert result.value == "cancelled"
+
+        # Let the scheduled callback task execute
+        await asyncio.sleep(0.01)
+
+        assert callback_ran is True
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        registry.deregister_stream(test_request_id)
 
 
 class TestResponseGenerator:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
In https://github.com/lightspeed-core/lightspeed-stack/pull/1176 a new endpoint was added for interrupting in-flight queries (streaming). If a query was interrupted however it was not adding what the user said to the conversation. This change adds the user query to the conversation and adds a generic "you interrupted this" response from the LLM side. This makes sure that users displaying the conversation in a chatbot window don't have missing data.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.6
- Generated by:

## Related Tickets & Documents

- Related Issue https://issues.redhat.com/browse/RHIDP-11647
- Closes https://issues.redhat.com/browse/RHIDP-11647

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interrupted streaming requests now automatically persist user queries and partial responses, allowing you to review them later
  * Interrupted responses are clearly marked to indicate cancellation

* **Improvements**
  * Enhanced error handling and recovery during request cancellation
  * Optimized token consumption tracking to exclude interruption scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->