### PR TITLE
LCORE-1282: unify version usage in LCore

### DIFF
--- a/tests/integration/endpoints/test_rlsapi_v1_integration.py
+++ b/tests/integration/endpoints/test_rlsapi_v1_integration.py
@@ -31,6 +31,7 @@ from models.rlsapi.requests import (
 from models.rlsapi.responses import RlsapiV1InferResponse
 from tests.unit.utils.auth_helpers import mock_authorization_resolvers
 from utils.suid import check_suid
+from version import __version__
 
 # ==========================================
 # Shared Fixtures
@@ -170,7 +171,7 @@ async def test_rlsapi_v1_infer_minimal_request(
                 attachments=RlsapiV1Attachment(contents="log content"),
                 terminal=RlsapiV1Terminal(output="command not found"),
                 systeminfo=RlsapiV1SystemInfo(os="RHEL", version="9.3", arch="x86_64"),
-                cla=RlsapiV1CLA(nevra="cla-0.4.1", version="0.4.1"),
+                cla=RlsapiV1CLA(nevra=f"cla-{__version__}", version=__version__),
             ),
             "full_context",
             id="full_context",


### PR DESCRIPTION
## Description

LCORE-1282: unify version usage in LCore

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1282


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Integration tests updated to derive CLA and version values from the package version instead of fixed literals.
  * Makes versioning in full-context test cases dynamic, improving test maintainability and alignment with releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->