### PR TITLE
LCORE-1209: Custom shields not compatible with LCORE

### DIFF
--- a/tests/unit/utils/test_shields.py
+++ b/tests/unit/utils/test_shields.py
@@ -229,15 +229,47 @@ class TestRunShieldModeration:
         assert result.shield_model == "moderation-model"
 
     @pytest.mark.asyncio
+    async def test_skips_model_check_for_non_llama_guard_shields(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that non-llama-guard shields skip model validation and proceed to moderation."""
+        mock_client = mocker.Mock()
+
+        # Setup custom shield (not llama-guard) with provider_resource_id not in models
+        shield = mocker.Mock()
+        shield.identifier = "custom-shield"
+        shield.provider_id = "lightspeed_question_validity"
+        shield.provider_resource_id = "not-a-model-id"
+        mock_client.shields.list = mocker.AsyncMock(return_value=[shield])
+
+        # No matching models - should NOT raise for non-llama-guard
+        mock_client.models.list = mocker.AsyncMock(return_value=[])
+
+        # Setup moderation result (not flagged)
+        moderation_result = mocker.Mock()
+        moderation_result.results = [mocker.Mock(flagged=False)]
+        mock_client.moderations.create = mocker.AsyncMock(
+            return_value=moderation_result
+        )
+
+        result = await run_shield_moderation(mock_client, "test input")
+
+        assert result.blocked is False
+        mock_client.moderations.create.assert_called_once_with(
+            input="test input", model="not-a-model-id"
+        )
+
+    @pytest.mark.asyncio
     async def test_raises_http_exception_when_shield_model_not_found(
         self, mocker: MockerFixture
     ) -> None:
         """Test that run_shield_moderation raises HTTPException when shield model not in models."""
         mock_client = mocker.Mock()
 
-        # Setup shield with provider_resource_id
+        # Setup llama-guard shield with provider_resource_id not in models
         shield = mocker.Mock()
         shield.identifier = "test-shield"
+        shield.provider_id = "llama-guard"
         shield.provider_resource_id = "missing-model"
         mock_client.shields.list = mocker.AsyncMock(return_value=[shield])
 
@@ -259,9 +291,10 @@ class TestRunShieldModeration:
         """Test that run_shield_moderation raises HTTPException when no provider_resource_id."""
         mock_client = mocker.Mock()
 
-        # Setup shield without provider_resource_id
+        # Setup llama-guard shield without provider_resource_id
         shield = mocker.Mock()
         shield.identifier = "test-shield"
+        shield.provider_id = "llama-guard"
         shield.provider_resource_id = None
         mock_client.shields.list = mocker.AsyncMock(return_value=[shield])
 


### PR DESCRIPTION
## Description

We were assuming that all shields would have a provider_resource_id, however custom shields (e.g. the ones defined in `lightspeed-providers`) do not have this field, resulting in failure.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

NA

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested manually, with llama-guard shield with invalid shield name, and a custom shield


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation for shield moderation to properly detect and report missing or invalid model configurations, with improved error responses for misconfigured shields.

* **Tests**
  * Expanded test coverage to verify correct behavior across different shield provider types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->