### PR TITLE
RSPEED-2465: Add character pattern validation to rlsapi v1 fields

### DIFF
--- a/src/models/rlsapi/requests.py
+++ b/src/models/rlsapi/requests.py
@@ -4,6 +4,22 @@ from pydantic import Field, field_validator
 
 from models.config import ConfigurationBase
 
+# Character validation patterns for fields flowing into Splunk telemetry.
+# Restrict the character set to prevent injection of control characters,
+# HTML/script tags, or other malicious content into the telemetry pipeline.
+
+# Alphanumeric, dots, underscores, spaces, and hyphens.
+_SAFE_TEXT_PATTERN = r"^[a-zA-Z0-9._ \-]*$"
+
+# Machine IDs: alphanumeric, dots, underscores, and hyphens (no spaces).
+_MACHINE_ID_PATTERN = r"^[a-zA-Z0-9._\-]*$"
+
+# NEVRA (Name-Epoch:Version-Release.Arch): also needs colons, plus, and tilde.
+_NEVRA_PATTERN = r"^[a-zA-Z0-9._:+~\-]*$"
+
+# Version strings share the same allowed set as machine IDs.
+_VERSION_PATTERN = _MACHINE_ID_PATTERN
+
 
 class RlsapiV1Attachment(ConfigurationBase):
     """Attachment data from rlsapi v1 context.
@@ -49,16 +65,28 @@ class RlsapiV1SystemInfo(ConfigurationBase):
         system_id: The id of the client machine.
     """
 
-    os: str = Field(default="", description="Operating system name", examples=["RHEL"])
+    os: str = Field(
+        default="",
+        pattern=_SAFE_TEXT_PATTERN,
+        description="Operating system name",
+        examples=["RHEL"],
+    )
     version: str = Field(
-        default="", description="Operating system version", examples=["9.3", "8.10"]
+        default="",
+        pattern=_SAFE_TEXT_PATTERN,
+        description="Operating system version",
+        examples=["9.3", "8.10"],
     )
     arch: str = Field(
-        default="", description="System architecture", examples=["x86_64", "aarch64"]
+        default="",
+        pattern=_SAFE_TEXT_PATTERN,
+        description="System architecture",
+        examples=["x86_64", "aarch64"],
     )
     system_id: str = Field(
         default="",
         alias="id",
+        pattern=_MACHINE_ID_PATTERN,
         description="Client machine ID",
         examples=["01JDKR8N7QW9ZMXVGK3PB5TQWZ"],
     )
@@ -76,11 +104,13 @@ class RlsapiV1CLA(ConfigurationBase):
 
     nevra: str = Field(
         default="",
+        pattern=_NEVRA_PATTERN,
         description="CLA NEVRA identifier",
         examples=["command-line-assistant-0:0.2.0-1.el9.noarch"],
     )
     version: str = Field(
         default="",
+        pattern=_VERSION_PATTERN,
         description="Command line assistant version",
         examples=["0.2.0"],
     )


### PR DESCRIPTION
## Description

The `os`, `version`, `arch`, and `system_id` fields in `RlsapiV1SystemInfo` (and `nevra`, `version` in `RlsapiV1CLA`) accept arbitrary strings with no character restrictions. These values flow directly into Splunk telemetry via `_queue_splunk_event()`, so a client could inject control characters, newlines, or HTML/script tags into the pipeline.

This adds Pydantic `pattern` validators to all six fields, restricting each to the safe character set appropriate for its known value space. Empty strings are still accepted since the fields default to `""`. Invalid characters now result in a 422 rejection.

## Type of change

- [x] New feature
- [x] Unit tests improvement

## Tools used to create PR

- Assisted-by: Claude
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2465](https://issues.redhat.com/browse/RSPEED-2465)
- Closes: [RSPEED-2465](https://issues.redhat.com/browse/RSPEED-2465)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

41 new parameterized test cases across `TestSystemInfoCharacterValidation` and `TestCLACharacterValidation`:

```
uv run pytest tests/unit/models/rlsapi/test_requests.py -v
```

Valid values (RHEL, 9.3, x86_64, ULIDs, UUIDs, NEVRA strings) pass. Invalid values (XSS payloads, control chars, newlines, null bytes, semicolons) are rejected with `ValidationError` matching "String should match pattern".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for system information and package data fields to enforce stricter character constraints and prevent invalid data submission.

* **Tests**
  * Added comprehensive validation tests to verify correct handling of system information and package field constraints.
  * Added edge-case tests for input source composition and formatting preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->