### PR TITLE
Tag container images with a short commit hash

### DIFF
--- a/.github/workflows/build_and_push_dev.yaml
+++ b/.github/workflows/build_and_push_dev.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Create dev image tag
         run: |
           echo "DEV_TAG=dev-$(date +%Y%m%d)-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SHORT_COMMIT=$(git rev-parse --short=7 HEAD)" >> $GITHUB_ENV
           echo "dev image tag: ${{ env.DEV_TAG }}"
       - name: Build image with Buildah
         id: build_image
@@ -37,6 +38,7 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
           tags: |
             ${{ env.DEV_TAG }}
+            ${{ env.SHORT_COMMIT }}
             ${{ env.LATEST_TAG }}
           containerfiles: |
             ${{ env.CONTAINER_FILE }}

--- a/.tekton/lightspeed-stack-push.yaml
+++ b/.tekton/lightspeed-stack-push.yaml
@@ -557,6 +557,9 @@ spec:
         value: $(tasks.build-image-index.results.IMAGE_URL)
       - name: IMAGE_DIGEST
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: ADDITIONAL_TAGS
+        value:
+          - $(tasks.clone-repository.results.short-commit)
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
## Description

Images deployed by app-interface default to a seven character commit hash. Add this tag to build jobs so that images can be used in app-interface deployments.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

None

## Related Tickets & Documents

None

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Let Konflux and GitHub Actions run the build job
- Verify the seven character commit hash is added as a container image tag in `quay.io/lightspeed-core/lightspeed-stack` and `quay.io/repository/redhat-user-workloads/lightspeed-core-tenant/lightspeed-stack`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced image tagging in build pipelines to include short commit identifiers for improved build traceability and identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->