### PR TITLE
LCORE-1206: add tests for too long question

### DIFF
--- a/tests/e2e/features/query.feature
+++ b/tests/e2e/features/query.feature
@@ -216,3 +216,20 @@ Scenario: Check if LLM responds for query request with error for missing query
     }
     """
     Then The status code of the response is 200
+
+  Scenario: Check if query with shields returns 413 when question is too long for model context 
+    Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+    When I use "query" to ask question with too-long query and authorization header
+    Then The status code of the response is 413
+    And The body of the response contains Prompt is too long
+
+  #https://issues.redhat.com/browse/LCORE-1387
+  @skip
+  @disable-shields
+  Scenario: Check if query without shields returns 413 when question is too long for model context
+    Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+    When I use "query" to ask question with too-long query and authorization header
+    Then The status code of the response is 413
+    And The body of the response contains Prompt is too long

--- a/tests/e2e/features/streaming_query.feature
+++ b/tests/e2e/features/streaming_query.feature
@@ -178,3 +178,18 @@ Feature: streaming_query endpoint API tests
             }
           }
           """
+
+  Scenario: Check if streaming_query with shields returns 413 when question is too long for model context
+    Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+    When I use "streaming_query" to ask question with too-long query and authorization header
+    Then The status code of the response is 413
+    And The body of the response contains Prompt is too long
+
+  @disable-shields
+  Scenario: Check if streaming_query without shields returns 200 and error in stream when question is too long for model context
+    Given The system is in default state
+    And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+    When I use "streaming_query" to ask question with too-long query and authorization header
+    Then The status code of the response is 200
+    And The streamed response contains error message Prompt is too long

--- a/tests/e2e/utils/llama_stack_shields.py
+++ b/tests/e2e/utils/llama_stack_shields.py
@@ -1,0 +1,104 @@
+"""E2E helpers to unregister and re-register Llama Stack shields via the client API.
+
+Used by the @disable-shields tag: before the scenario we call client.shields.delete()
+to unregister the shield; after the scenario we call client.shields.register()
+to restore it. Only applies in server mode (Llama Stack as a separate service).
+Requires E2E_LLAMA_STACK_URL or E2E_LLAMA_HOSTNAME/E2E_LLAMA_PORT.
+"""
+
+import asyncio
+import os
+from typing import Optional
+
+from llama_stack_client import (
+    APIConnectionError,
+    AsyncLlamaStackClient,
+    APIStatusError,
+)
+
+
+def _get_llama_stack_client() -> AsyncLlamaStackClient:
+    """Build an AsyncLlamaStackClient from env (for e2e test use)."""
+    base_url = os.getenv("E2E_LLAMA_STACK_URL")
+    if not base_url:
+        host = os.getenv("E2E_LLAMA_HOSTNAME", "localhost")
+        port = os.getenv("E2E_LLAMA_PORT", "8321")
+        base_url = f"http://{host}:{port}"
+    api_key = os.getenv("E2E_LLAMA_STACK_API_KEY", "xyzzy")
+    timeout = int(os.getenv("E2E_LLAMA_STACK_TIMEOUT", "60"))
+    return AsyncLlamaStackClient(base_url=base_url, api_key=api_key, timeout=timeout)
+
+
+async def _unregister_shield_async(identifier: str) -> Optional[tuple[str, str]]:
+    """Unregister a shield by identifier; return (provider_id, provider_shield_id) for restore."""
+    client = _get_llama_stack_client()
+    try:
+        shields = await client.shields.list()
+        provider_id = None
+        provider_shield_id = None
+        found = False
+        for shield in shields:
+            if getattr(shield, "identifier", None) == identifier:
+                provider_id = getattr(shield, "provider_id", None)
+                provider_shield_id = getattr(
+                    shield, "provider_resource_id", None
+                ) or getattr(shield, "provider_shield_id", None)
+                found = True
+                break
+        if not found:
+            # Shield not registered; nothing to delete, scenario can proceed
+            return None
+        try:
+            await client.shields.delete(identifier)
+        except APIConnectionError:
+            raise
+        except APIStatusError as e:
+            # 400 "not found": shield already absent, scenario can proceed
+            if e.status_code == 400 and "not found" in str(e).lower():
+                return None
+            raise
+        if provider_id is not None and provider_shield_id is not None:
+            return (provider_id, provider_shield_id)
+        return None
+    finally:
+        await client.close()
+
+
+async def _register_shield_async(
+    shield_id: str,
+    provider_id: str,
+    provider_shield_id: str,
+) -> None:
+    """Register a shield (restore after unregister)."""
+    client = _get_llama_stack_client()
+    try:
+        await client.shields.register(
+            shield_id=shield_id,
+            provider_id=provider_id,
+            provider_shield_id=provider_shield_id,
+        )
+    finally:
+        await client.close()
+
+
+def unregister_shield(
+    identifier: str = "llama-guard",
+) -> Optional[tuple[str, str]]:
+    """Unregister the shield via client.shields.delete(); return (provider_id, provider_shield_id)."""
+    return asyncio.run(_unregister_shield_async(identifier))
+
+
+def register_shield(
+    shield_id: str = "llama-guard",
+    provider_id: Optional[str] = None,
+    provider_shield_id: Optional[str] = None,
+) -> None:
+    """Re-register the shield via client.shields.register()."""
+    if not provider_id:
+        provider_id = os.getenv("E2E_LLAMA_GUARD_PROVIDER_ID", "llama-guard")
+    if not provider_shield_id:
+        provider_shield_id = os.getenv(
+            "E2E_LLAMA_GUARD_PROVIDER_SHIELD_ID",
+            "openai/gpt-4o-mini",
+        )
+    asyncio.run(_register_shield_async(shield_id, provider_id, provider_shield_id))


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [X] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used) Cursor
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #1103 
- Closes #1103

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for long-input queries (with and without shields), including scenarios asserting HTTP 413 and streamed error responses.
  * Added streaming-response handling and new steps to validate streamed SSE error messages and too-long query behavior.
* **Chores**
  * Automated shield management for test scenarios tagged to disable shields (unregister/re-register around tests).
  * Improved diagnostics emitting container status, health checks, and recent logs for restoration and failure debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->