### PR TITLE
Environment variable to force StreamHandler instead of RichHandler

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -52,7 +52,8 @@ For Output Constraints:
 - Do **NOT** use all uppercase - capitalize only the first letter of significant words
 - Exclude articles and prepositions (e.g., "a," "the," "of," "on," "in")
 - Exclude all punctuation and interpunction marks (e.g., . , : ; ! ? | "")
-- Retain original abbreviations. Do not expand an abbreviation if its specific meaning in the context is unknown or ambiguous.
+- Retain original abbreviations. Do not expand an abbreviation if its specific meaning in the
+  context is unknown or ambiguous.
 - Neutral objective language
 - Do **NOT** provide explanations, reasoning, or "processing steps".
 - Do **NOT** provide multiple options (e.g., do not use "or").
@@ -188,3 +189,6 @@ LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR = "LIGHTSPEED_STACK_LOG_LEVEL"
 DEFAULT_LOG_LEVEL = "INFO"
 # Default log format for plain-text logging in non-TTY environments
 DEFAULT_LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s:%(lineno)d %(message)s"
+# Environment variable to force StreamHandler instead of RichHandler
+# Set to any non-empty value to disable RichHandler
+LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR = "LIGHTSPEED_STACK_DISABLE_RICH_HANDLER"

--- a/src/log.py
+++ b/src/log.py
@@ -7,9 +7,10 @@ import sys
 from rich.logging import RichHandler
 
 from constants import (
-    LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR,
-    DEFAULT_LOG_LEVEL,
     DEFAULT_LOG_FORMAT,
+    DEFAULT_LOG_LEVEL,
+    LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR,
+    LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR,
 )
 
 
@@ -49,18 +50,23 @@ def resolve_log_level() -> int:
 
 def create_log_handler() -> logging.Handler:
     """
-    Create and return a configured log handler based on TTY availability.
+    Create and return a configured log handler based on TTY availability and environment settings.
 
-    If stderr is connected to a terminal (TTY), returns a RichHandler for
-    rich-formatted console output. Otherwise, returns a StreamHandler with
+    If LIGHTSPEED_STACK_DISABLE_RICH_HANDLER is set to any non-empty value,
+    returns a StreamHandler with plain-text formatting. Otherwise, if stderr
+    is connected to a terminal (TTY), returns a RichHandler for rich-formatted
+    console output. If neither condition is met, returns a StreamHandler with
     plain-text formatting suitable for non-TTY environments (e.g., containers).
-
-    Parameters:
-        None
 
     Returns:
         logging.Handler: A configured handler instance (RichHandler or StreamHandler).
     """
+    # Check if RichHandler is explicitly disabled via environment variable
+    if os.environ.get(LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR):
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(DEFAULT_LOG_FORMAT))
+        return handler
+
     if sys.stderr.isatty():
         # RichHandler's columnar layout assumes a real terminal.
         # RichHandler handles its own formatting, so no formatter is set.

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -6,8 +6,12 @@ import pytest
 from pytest_mock import MockerFixture
 from rich.logging import RichHandler
 
-from log import get_logger, resolve_log_level, create_log_handler
-from constants import LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR, DEFAULT_LOG_FORMAT
+from constants import (
+    DEFAULT_LOG_FORMAT,
+    LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR,
+    LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR,
+)
+from log import create_log_handler, get_logger, resolve_log_level
 
 
 def test_get_logger() -> None:
@@ -116,3 +120,36 @@ def test_create_log_handler_non_tty_format(mocker: MockerFixture) -> None:
     assert handler.formatter is not None
     # pylint: disable=protected-access
     assert handler.formatter._fmt == DEFAULT_LOG_FORMAT
+
+
+def test_create_log_handler_disable_rich_with_tty(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that RichHandler is disabled when env var is set, even with TTY."""
+    mocker.patch("sys.stderr.isatty", return_value=True)
+    monkeypatch.setenv(LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR, "1")
+    handler = create_log_handler()
+    assert isinstance(handler, logging.StreamHandler)
+    assert not isinstance(handler, RichHandler)
+
+
+def test_create_log_handler_disable_rich_format(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that disabled RichHandler uses DEFAULT_LOG_FORMAT."""
+    mocker.patch("sys.stderr.isatty", return_value=True)
+    monkeypatch.setenv(LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR, "true")
+    handler = create_log_handler()
+    assert handler.formatter is not None
+    # pylint: disable=protected-access
+    assert handler.formatter._fmt == DEFAULT_LOG_FORMAT
+
+
+def test_create_log_handler_enable_rich_when_env_var_empty(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that RichHandler is used when env var is empty string."""
+    mocker.patch("sys.stderr.isatty", return_value=True)
+    monkeypatch.setenv(LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR, "")
+    handler = create_log_handler()
+    assert isinstance(handler, RichHandler)


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Provide an environment variable `LIGHTSPEED_STACK_DISABLE_RICH_HANDLER` to force lightspeed-stack to use
`StreamHandler` instead of `RichHandler` even if a terminal is connectd to tty.

Background: `RichHandler` falls into an infinite recursive loop to handle certain exception. According to the analysis by Claude Code, it occurs  when processing exceptions that contain circular references. While we may want to remove such circular references, we also had better have an option to disable `RichHandler` explicitly for easier development.

(Infinite Recursive Loop Example)
```
  :
  :
│ /usr/lib/python3.12/site-packages/rich/traceback.py:466 in extract │
│ │
│ 463 │ │ │ │ │ stack.is_group = True │
│ 464 │ │ │ │ │ for exception in exc_value.exceptions: │
│ 465 │ │ │ │ │ │ stack.exceptions.append( │
│ ❱ 466 │ │ │ │ │ │ │ Traceback.extract( │
│ 467 │ │ │ │ │ │ │ │ type(exception), │
│ 468 │ │ │ │ │ │ │ │ exception, │
│ 469 │ │ │ │ │ │ │ │ exception.__traceback__, │
│ │
│ /usr/lib/python3.12/site-packages/rich/traceback.py:466 in extract │
│ │
│ 463 │ │ │ │ │ stack.is_group = True │
│ 464 │ │ │ │ │ for exception in exc_value.exceptions: │
│ 465 │ │ │ │ │ │ stack.exceptions.append( │
│ ❱ 466 │ │ │ │ │ │ │ Traceback.extract( │
│ 467 │ │ │ │ │ │ │ │ type(exception), │
│ 468 │ │ │ │ │ │ │ │ exception, │
│ 469 │ │ │ │ │ │ │ │ exception.__traceback__, │
│ │
│ /usr/lib/python3.12/site-packages/rich/traceback.py:466 in extract │
│ │
│ 463 │ │ │ │ │ stack.is_group = True │
│ 464 │ │ │ │ │ for exception in exc_value.exceptions: │
│ 465 │ │ │ │ │ │ stack.exceptions.append( │
│ ❱ 466 │ │ │ │ │ │ │ Traceback.extract( │
│ 467 │ │ │ │ │ │ │ │ type(exception), │
│ 468 │ │ │ │ │ │ │ │ exception, │
│ 469 │ │ │ │ │ │ │ │ exception.__traceback__, │
│ │
│ /usr/lib/python3.12/site-packages/rich/traceback.py:466 in extract │
│ │
│ 463 │ │ │ │ │ stack.is_group = True │
│ 464 │ │ │ │ │ for exception in exc_value.exceptions: │
│ 465 │ │ │ │ │ │ stack.exceptions.append( │
│ ❱ 466 │ │ │ │ │ │ │ Traceback.extract( │
│ 467 │ │ │ │ │ │ │ │ type(exception), │
│ 468 │ │ │ │ │ │ │ │ exception, │
│ 469 │ │ │ │ │ │ │ │ exception.__traceback__, │
│ │
│ /usr/lib/python3.12/site-packages/rich/traceback.py:491 in extract │
│ │
│ 488 │ │ │ append = stack.frames.append │
│ 489 │ │ │ │
│ 490 │ │ │ def get_locals( │
│ ❱ 491 │ │ │ │ iter_locals: Iterable[Tuple[str, object]], │
│ 492 │ │ │ ) -> Iterable[Tuple[str, object]]: │
│ 493 │ │ │ │ """Extract locals from an iterator of key pairs.""" │
│ 494 │ │ │ │ if not (locals_hide_dunder or locals_hide_sunder): │
│ │
│ /usr/lib64/python3.12/typing.py:395 in inner │
│ │
│ 392 │ │ @functools.wraps(func) │
│ 393 │ │ def inner(*args, **kwds): │
│ 394 │ │ │ try: │
│ ❱ 395 │ │ │ │ return _caches[func](*args, **kwds) │
│ 396 │ │ │ except TypeError: │
│ 397 │ │ │ │ pass # All real errors (not unhashable args) are raised below. │
│ 398 │ │ │ return func(*args, **kwds) │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
RecursionError: maximum recursion depth exceeded
```

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Code
- Generated by: Claude Code

## Related Tickets & Documents

- Related Issue # n/a
- Closes # n/a

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
  
  Simple unit tests are provided. This is a feature for development purpose only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable to disable rich-formatted console output, allowing users to switch to plain text logging when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->