### PR TITLE
Doc stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ user_data_collection:
 
 **Important**: Only MCP servers defined in the `lightspeed-stack.yaml` configuration are available to the agents. Tools configured in the llama-stack `run.yaml` are not accessible to lightspeed-core agents.
 
+Besides configuring the MCP Servers in `lightspeed-stack.yaml` we also need to enable the appropriate tool in llama-stack's `run.yaml` file under the `tool_runtime` section. Here's an example using the default `provider_id` name used by lightspeed-stack for MCPs:
+
+```yaml
+  tool_runtime:
+    - provider_id: model-context-protocol
+      provider_type: remote::model-context-protocol
+      config: {}
+```
+
 #### Configuring MCP Servers
 
 MCP (Model Context Protocol) servers provide tools and capabilities to the AI agents. These are configured in the `mcp_servers` section of your `lightspeed-stack.yaml`.

--- a/examples/run.yaml
+++ b/examples/run.yaml
@@ -1,9 +1,9 @@
 # Example llama-stack configuration for OpenAI inference + FAISS (RAG)
-# 
+#
 # Notes:
 # - You will need an OpenAI API key
 # - You can generate the vector index with the rag-content tool (https://github.com/lightspeed-core/rag-content)
-# 
+#
 version: 2
 
 apis:
@@ -17,7 +17,7 @@ apis:
 - scoring
 - tool_runtime
 - vector_io
-      
+
 benchmarks: []
 datasets: []
 image_name: starter
@@ -61,6 +61,9 @@ providers:
   - config: {} # Enable the RAG tool
     provider_id: rag-runtime
     provider_type: inline::rag-runtime
+  - config: {} # Enable the MCP tool
+    provider_id: model-context-protocol
+    provider_type: remote::model-context-protocol
   vector_io:
   - config: # Define the storage backend for RAG
       persistence:
@@ -144,7 +147,7 @@ registered_resources:
     provider_model_id: sentence-transformers/all-mpnet-base-v2
     metadata:
       embedding_dimension: 768
-  vector_stores: 
+  vector_stores:
   - embedding_dimension: 768
     embedding_model: sentence-transformers/nomic-ai/nomic-embed-text-v1.5
     provider_id: faiss


### PR DESCRIPTION
## Description

Small doc improvements:

- One of the `Authorization` examples incorrectly indicates that the file should have the `Bearer` section when it shouldn't.
- There is no mention of how in `run.yaml` under thee `tool_runtime` there's a need for the mcp remote provider.

## Type of change

- [x] Documentation Update

## Tools used to create PR

Manually written.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded tool configuration documentation with detailed setup instructions
  * Added comprehensive MCP server configuration guide covering authentication methods (tokens, Kubernetes, OAuth) and header propagation
  * Enhanced example configurations demonstrating vector store and MCP tool integration
  * Improved authentication token sample output formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->