### PR TITLE
RSPEED-2521: include today's date in rlsapi v1 system prompt

### DIFF
--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -5,6 +5,7 @@ from the RHEL Lightspeed Command Line Assistant (CLA).
 """
 
 import time
+from datetime import datetime
 from typing import Annotated, Any, Optional, cast
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
@@ -101,18 +102,20 @@ infer_responses: dict[int | str, dict[str, Any]] = {
 
 
 def _build_instructions(systeminfo: RlsapiV1SystemInfo) -> str:
-    """Build LLM instructions incorporating system context when available.
+    """Build LLM instructions incorporating date and system context.
 
-    Enhances the default system prompt with RHEL system information to provide
-    the LLM with relevant context about the user's environment.
+    Enhances the default system prompt with today's date and RHEL system
+    information to provide the LLM with relevant context about the user's
+    environment and current time.
 
     Args:
         systeminfo: System information from the client (OS, version, arch).
 
     Returns:
-        Instructions string for the LLM, with system context if available.
+        Instructions string for the LLM, with date and system context.
     """
     base_prompt = _get_base_prompt()
+    date_today = datetime.now().strftime("%B %d, %Y")
 
     context_parts = []
     if systeminfo.os:
@@ -123,10 +126,10 @@ def _build_instructions(systeminfo: RlsapiV1SystemInfo) -> str:
         context_parts.append(f"Architecture: {systeminfo.arch}")
 
     if not context_parts:
-        return base_prompt
+        return f"{base_prompt}\n\nToday's date: {date_today}"
 
     system_context = ", ".join(context_parts)
-    return f"{base_prompt}\n\nUser's system: {system_context}"
+    return f"{base_prompt}\n\nToday's date: {date_today}\n\nUser's system: {system_context}"
 
 
 def _get_base_prompt() -> str:

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access
 # pylint: disable=unused-argument
 
+import re
 from typing import Any, Optional
 
 import pytest
@@ -167,10 +168,11 @@ def test_build_instructions(
     expected_contains: list[str],
     expected_not_contains: list[str],
 ) -> None:
-    """Test _build_instructions with various system info combinations."""
+    """Test _build_instructions includes date and system info."""
     systeminfo = RlsapiV1SystemInfo(**systeminfo_kwargs)
     result = _build_instructions(systeminfo)
 
+    assert re.search(r"Today's date: \w+ \d{2}, \d{4}", result)
     for expected in expected_contains:
         assert expected in result
     for not_expected in expected_not_contains:
@@ -223,7 +225,8 @@ def test_build_instructions_no_customization(mocker: MockerFixture) -> None:
     systeminfo = RlsapiV1SystemInfo()
     result = _build_instructions(systeminfo)
 
-    assert result == constants.DEFAULT_SYSTEM_PROMPT
+    assert result.startswith(constants.DEFAULT_SYSTEM_PROMPT)
+    assert re.search(r"Today's date: \w+ \d{2}, \d{4}", result)
 
 
 # --- Test _get_default_model_id ---


### PR DESCRIPTION
## Description

Include today's date in the rlsapi v1 system prompt so the LLM has temporal awareness for date-sensitive questions (e.g., "when does RHEL 9 reach end of life?"). This matches the existing pattern in [rlsapi](https://gitlab.cee.redhat.com/lightspeed/rlsapi), where the date is formatted as `"%B %d, %Y"` and injected into the system prompt context.

`_build_instructions()` now always appends `Today's date: March 03, 2026` as a separate line between the base prompt and the `User's system:` context block.

## Type of change

- [x] New feature

## Tools used to create PR

- Assisted-by: Claude (opencode)
- Generated by: N/A

## Related Tickets & Documents

- [RSPEED-2521](https://issues.redhat.com/browse/RSPEED-2521)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. `uv run pytest tests/unit/app/endpoints/test_rlsapi_v1.py -x -q` (33 tests pass)
2. `uv run make format` (clean)
3. `uv run make verify` (all linters pass, mypy clean)
4. Verified the date regex pattern `Today's date: \w+ \d{2}, \d{4}` matches in all `_build_instructions` test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM prompts now automatically include today's date to provide better temporal context for AI-generated responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->