### PR TITLE
RSPEED-2523: fix missing type discriminator on MCP and file_search tool constructors

### DIFF
--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -323,6 +323,7 @@ def get_rag_tools(vector_store_ids: list[str]) -> Optional[list[InputToolFileSea
 
     return [
         InputToolFileSearch(
+            type="file_search",
             vector_store_ids=vector_store_ids,
             max_num_results=10,
         )
@@ -425,6 +426,7 @@ async def get_mcp_tools(  # pylint: disable=too-many-return-statements,too-many-
         authorization = headers.pop("Authorization", None)
         tools.append(
             InputToolMCP(
+                type="mcp",
                 server_label=mcp_server.name,
                 server_url=mcp_server.url,
                 require_approval="never",


### PR DESCRIPTION
## Description

`InputToolMCP()` and `InputToolFileSearch()` constructors in `src/utils/responses.py` rely on Pydantic model defaults for the `type` field without explicitly setting it. `llama_stack_client` serializes with `model_dump(exclude_unset=True)`, which drops fields that were never explicitly set, even if they have defaults. This removes the `type` discriminator and causes a `ValueError` downstream when deserializing the `OpenAIResponseInputTool` union.

This PR explicitly passes `type="mcp"` and `type="file_search"` to the constructors so the field is always considered "set" and survives serialization.

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2523](https://issues.redhat.com/browse/RSPEED-2523)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

Existing unit tests in `tests/unit/utils/test_responses.py` (`TestGetRAGTools`, `TestGetMCPTools`) already assert `type` on both constructors. All 18 tests pass:

```
tests/unit/utils/test_responses.py::TestGetRAGTools::test_get_rag_tools_empty_list PASSED
tests/unit/utils/test_responses.py::TestGetRAGTools::test_get_rag_tools_with_vector_stores PASSED
tests/unit/utils/test_responses.py::TestGetMCPTools::test_get_mcp_tools_without_auth PASSED
... (18/18 passed)
```

Pyright type checking: 0 errors, 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tool configuration with explicit type parameters for file search and MCP tools to ensure proper system initialization and configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->