### PR TITLE
Fix: BYOK with llama-stack as a library

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1559,7 +1559,7 @@ class ByokRag(ConfigurationBase):
         description="Vector database identification.",
     )
 
-    db_path: FilePath = Field(
+    db_path: str = Field(
         ...,
         title="DB path",
         description="Path to RAG database.",

--- a/tests/unit/models/config/test_byok_rag.py
+++ b/tests/unit/models/config/test_byok_rag.py
@@ -29,7 +29,7 @@ def test_byok_rag_configuration_default_values() -> None:
     assert byok_rag.embedding_model == DEFAULT_EMBEDDING_MODEL
     assert byok_rag.embedding_dimension == DEFAULT_EMBEDDING_DIMENSION
     assert byok_rag.vector_db_id == "vector_db_id"
-    assert byok_rag.db_path == Path("tests/configuration/rag.txt")
+    assert byok_rag.db_path == "tests/configuration/rag.txt"
 
 
 def test_byok_rag_configuration_nondefault_values() -> None:
@@ -48,7 +48,7 @@ def test_byok_rag_configuration_nondefault_values() -> None:
         embedding_model="embedding_model",
         embedding_dimension=1024,
         vector_db_id="vector_db_id",
-        db_path=Path("tests/configuration/rag.txt"),
+        db_path="tests/configuration/rag.txt",
     )
     assert byok_rag is not None
     assert byok_rag.rag_id == "rag_id"
@@ -56,7 +56,7 @@ def test_byok_rag_configuration_nondefault_values() -> None:
     assert byok_rag.embedding_model == "embedding_model"
     assert byok_rag.embedding_dimension == 1024
     assert byok_rag.vector_db_id == "vector_db_id"
-    assert byok_rag.db_path == Path("tests/configuration/rag.txt")
+    assert byok_rag.db_path == "tests/configuration/rag.txt"
 
 
 def test_byok_rag_configuration_wrong_dimension() -> None:


### PR DESCRIPTION
## Description

When using a BYOK rag database and llama-stack as a library the service blows up on start with:

```
yaml.constructor.ConstructorError: could not determine a constructor for the tag
'tag:yaml.org,2002:python/object/apply:pathlib._local.PosixPath'
  in "<unicode string>", line 122, column 16:
          db_path: !!python/object/apply:pathlib._l ...
```

And we can see in `/tmp/llama_stack_enriched_config.yaml`:

```
storage:
  backends:
    byok_rag_1_storage:
      db_path: !!python/object/apply:pathlib._local.PosixPath
        - /home/geguileo/osls/rags/llamastack/rag/vector_db/os_product_docs/faiss_store.db
      type: kv_sqlite
```

This is caused by how we define the `db_path` in our model and how it is being used:

In `src/models/config.py` we define it as a FilePath:

```
   1563     db_path: FilePath = Field(
   1564         ...,
   1565         title="DB path",
   1566         description="Path to RAG database.",
   1567     )
```

And in `src/llama_stack_configuration.py` we use it as a `str`:
```
    138     # add new backends for each BYOK RAG
    139     for brag in byok_rag:
    140         vector_db_id = brag.get("vector_db_id", "")
    141         backend_name = f"byok_{vector_db_id}_storage"
    142         output[backend_name] = {
    143             "type": "kv_sqlite",
    144             "db_path": brag.get("db_path", f".llama/{vector_db_id}.db"),
    145         }
```

This patch fixes this in the simplest way, making the field in the BYOK model match the other existing `db_path` field, in other words, changing it to a `str`.

## Type of change

- [x] Bug fix

## Tools used to create PR

None

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.

## Testing
- I have manually verified that `/tmp/llama_stack_enriched_config.yaml` looks good and the service no longer blows up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration database path field updated to accept string input instead of Path objects. This modifies validation behavior for RAG database path specifications and adjusts how paths are processed and stored in system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->