### PR TITLE
recommend `uv run` instead of `python` in `rag_guide.md`

### DIFF
--- a/docs/rag_guide.md
+++ b/docs/rag_guide.md
@@ -67,7 +67,7 @@ For users with BYOK or OKP/Solr configurations, you can automatically enrich you
 
 ```bash
 # Enrich run.yaml with BYOK and/or Solr configurations from lightspeed-stack.yaml
-python src/llama_stack_configuration.py -c lightspeed-stack.yaml -i run.yaml -o run_enriched.yaml
+uv run src/llama_stack_configuration.py -c lightspeed-stack.yaml -i run.yaml -o run_enriched.yaml
 ```
 
 This script automatically adds the necessary:


### PR DESCRIPTION
## Description

Update rag_guide.md to recommend `uv run` instead of `python` for running  `llama_stack_configuration.py`, otherwise the dependency on `azure` will not be loaded.

```
$ python src/llama_stack_configuration.py -c lightspeed-stack.yaml -i run.yaml -o run_enriched.yaml
Traceback (most recent call last):
  File "/home/user/projects/lightspeed-stack/src/llama_stack_configuration.py", line 14, in <module>
    from azure.core.exceptions import ClientAuthenticationError
ModuleNotFoundError: No module named 'azure'
```

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: none
- Generated by: none

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the RAG guide to reflect the correct command syntax for executing configuration scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->