### PR TITLE
add `chunk_family_fields` to okp enrichment config

### DIFF
--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -442,7 +442,7 @@ def enrich_solr(ls_config: dict[str, Any], solr_config: dict[str, Any]) -> None:
                         "parent_total_chunks_field": "total_chunks",
                         "parent_total_tokens_field": "total_tokens",
                         "chunk_filter_query": chunk_filter_query,
-                        "chunk_family_fields": ["headings"]
+                        "chunk_family_fields": ["headings"],
                     },
                     "persistence": {
                         "namespace": constants.SOLR_DEFAULT_VECTOR_STORE_ID,


### PR DESCRIPTION
## Description

In the OKP enrichment config, this sets `chunk_family_fields` to `["headings"]` which causes the Solr provider's chunk expansion algorithm to expand only within a shared heading, lowering the likelihood of irrelevant chunks being included.   I'm marking it as a bug fix too, because currently if chunk expansion is enabled, omitting `chunk_family_fields` causes an error even though the field is meant to be optional.  

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: none
- Generated by: none

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Solr-based search filtering by including heading metadata in chunk grouping, improving organization and relevance of search results and enabling more comprehensive content filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->