### PR TITLE
LCORE-1402: OKP Index name missing in chunk metadata (tool RAG)#69

### DIFF
--- a/src/configuration.py
+++ b/src/configuration.py
@@ -2,39 +2,38 @@
 
 from typing import Any, Optional
 
+import yaml
+
 # We want to support environment variable replacement in the configuration
 # similarly to how it is done in llama-stack, so we use their function directly
 from llama_stack.core.stack import replace_env_vars
 
-import yaml
 import constants
+from cache.cache import Cache
+from cache.cache_factory import CacheFactory
+from log import get_logger
 from models.config import (
     A2AStateConfiguration,
+    AuthenticationConfiguration,
     AuthorizationConfiguration,
     AzureEntraIdConfiguration,
     Configuration,
-    Customization,
-    LlamaStackConfiguration,
-    OkpConfiguration,
-    RagConfiguration,
-    UserDataCollection,
-    ServiceConfiguration,
-    ModelContextProtocolServer,
-    AuthenticationConfiguration,
-    InferenceConfiguration,
-    DatabaseConfiguration,
     ConversationHistoryConfiguration,
+    Customization,
+    DatabaseConfiguration,
+    InferenceConfiguration,
+    LlamaStackConfiguration,
+    ModelContextProtocolServer,
+    OkpConfiguration,
     QuotaHandlersConfiguration,
+    RagConfiguration,
+    ServiceConfiguration,
     SplunkConfiguration,
+    UserDataCollection,
 )
-
-from cache.cache import Cache
-from cache.cache_factory import CacheFactory
-
 from quota.quota_limiter import QuotaLimiter
-from quota.token_usage_history import TokenUsageHistory
 from quota.quota_limiter_factory import QuotaLimiterFactory
-from log import get_logger
+from quota.token_usage_history import TokenUsageHistory
 
 logger = get_logger(__name__)
 
@@ -382,18 +381,28 @@ class AppConfig:  # pylint: disable=too-many-public-methods
 
     @property
     def rag_id_mapping(self) -> dict[str, str]:
-        """Return mapping from vector_db_id to rag_id from BYOK RAG config.
+        """Return mapping from vector_db_id to rag_id from BYOK and OKP RAG config.
 
         Returns:
-            dict[str, str]: Mapping where keys are llama-stack vector_db_ids
-            and values are user-facing rag_ids from configuration.
+            dict[str, str]: Mapping where keys are llama-stack vector_store_ids
+            (old vector_db_id) and values are user-facing rag_ids from configuration.
 
         Raises:
             LogicError: If the configuration has not been loaded.
         """
         if self._configuration is None:
             raise LogicError("logic error: configuration is not loaded")
-        return {brag.vector_db_id: brag.rag_id for brag in self._configuration.byok_rag}
+        byok_mapping = {
+            brag.vector_db_id: brag.rag_id for brag in self._configuration.byok_rag
+        }
+
+        rag = self._configuration.rag
+        okp_id = constants.OKP_RAG_ID
+        okp_enabled = okp_id in (rag.inline or []) or okp_id in (rag.tool or [])
+        okp_mapping = (
+            {constants.SOLR_DEFAULT_VECTOR_STORE_ID: okp_id} if okp_enabled else {}
+        )
+        return {**byok_mapping, **okp_mapping}
 
     @property
     def score_multiplier_mapping(self) -> dict[str, float]:

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -2,16 +2,18 @@
 
 # pylint: disable=too-many-lines
 
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
-from collections.abc import Generator
-from pydantic import ValidationError
 
 import pytest
+from pydantic import ValidationError
+
+import constants
+from cache.in_memory_cache import InMemoryCache
+from cache.sqlite_cache import SQLiteCache
 from configuration import AppConfig, LogicError
 from models.config import CustomProfile, ModelContextProtocolServer
-from cache.sqlite_cache import SQLiteCache
-from cache.in_memory_cache import InMemoryCache
 
 
 # pylint: disable=broad-exception-caught,protected-access
@@ -947,9 +949,59 @@ azure_entra_id:
         cfg.load_configuration(str(cfg_filename))
 
 
-def test_rag_id_mapping_empty_when_no_byok(minimal_config: AppConfig) -> None:
-    """Test that rag_id_mapping returns empty dict when no BYOK RAG configured."""
+def test_rag_id_mapping_excludes_solr_when_okp_not_configured(
+    minimal_config: AppConfig,
+) -> None:
+    """Test that rag_id_mapping does not include OKP/Solr when OKP is not in rag config."""
     assert minimal_config.rag_id_mapping == {}
+
+
+def test_rag_id_mapping_includes_solr_when_okp_in_inline() -> None:
+    """Test that rag_id_mapping includes OKP/Solr mapping when OKP is in rag.inline."""
+    cfg = AppConfig()
+    cfg.init_from_dict(
+        {
+            "name": "test",
+            "service": {"host": "localhost", "port": 8080},
+            "llama_stack": {
+                "api_key": "k",
+                "url": "http://test.com:1234",
+                "use_as_library_client": False,
+            },
+            "user_data_collection": {},
+            "authentication": {"module": "noop"},
+            "rag": {"inline": [constants.OKP_RAG_ID]},
+        }
+    )
+    assert constants.SOLR_DEFAULT_VECTOR_STORE_ID in cfg.rag_id_mapping
+    assert (
+        cfg.rag_id_mapping[constants.SOLR_DEFAULT_VECTOR_STORE_ID]
+        == constants.OKP_RAG_ID
+    )
+
+
+def test_rag_id_mapping_includes_solr_when_okp_in_tool() -> None:
+    """Test that rag_id_mapping includes OKP/Solr mapping when OKP is in rag.tool."""
+    cfg = AppConfig()
+    cfg.init_from_dict(
+        {
+            "name": "test",
+            "service": {"host": "localhost", "port": 8080},
+            "llama_stack": {
+                "api_key": "k",
+                "url": "http://test.com:1234",
+                "use_as_library_client": False,
+            },
+            "user_data_collection": {},
+            "authentication": {"module": "noop"},
+            "rag": {"tool": [constants.OKP_RAG_ID]},
+        }
+    )
+    assert constants.SOLR_DEFAULT_VECTOR_STORE_ID in cfg.rag_id_mapping
+    assert (
+        cfg.rag_id_mapping[constants.SOLR_DEFAULT_VECTOR_STORE_ID]
+        == constants.OKP_RAG_ID
+    )
 
 
 def test_rag_id_mapping_with_byok(tmp_path: Path) -> None:
@@ -978,6 +1030,41 @@ def test_rag_id_mapping_with_byok(tmp_path: Path) -> None:
         }
     )
     assert cfg.rag_id_mapping == {"vs-001": "my-kb"}
+
+
+def test_rag_id_mapping_with_byok_and_okp(tmp_path: Path) -> None:
+    """Test that rag_id_mapping includes both BYOK and OKP entries when OKP is configured."""
+    db_file = tmp_path / "test.db"
+    db_file.touch()
+    cfg = AppConfig()
+    cfg.init_from_dict(
+        {
+            "name": "test",
+            "service": {"host": "localhost", "port": 8080},
+            "llama_stack": {
+                "api_key": "k",
+                "url": "http://test.com:1234",
+                "use_as_library_client": False,
+            },
+            "user_data_collection": {},
+            "authentication": {"module": "noop"},
+            "rag": {"inline": [constants.OKP_RAG_ID]},
+            "byok_rag": [
+                {
+                    "rag_id": "my-kb",
+                    "vector_db_id": "vs-001",
+                    "db_path": str(db_file),
+                },
+            ],
+        }
+    )
+    assert "vs-001" in cfg.rag_id_mapping
+    assert cfg.rag_id_mapping["vs-001"] == "my-kb"
+    assert constants.SOLR_DEFAULT_VECTOR_STORE_ID in cfg.rag_id_mapping
+    assert (
+        cfg.rag_id_mapping[constants.SOLR_DEFAULT_VECTOR_STORE_ID]
+        == constants.OKP_RAG_ID
+    )
 
 
 def test_resolve_index_name_with_mapping(minimal_config: AppConfig) -> None:


### PR DESCRIPTION
## Description

This is a workaround to the llama-stack issue of unknown source in chunks returned from the RAG tool.

Changes:
- Added okp mapping to `rag_id_mapping`

Changes in `lightspeed-providers` [here](https://github.com/lightspeed-core/lightspeed-providers/pull/69)

(Continuation of https://github.com/lightspeed-core/lightspeed-stack/pull/1135, https://github.com/lightspeed-core/lightspeed-stack/pull/1208, https://github.com/lightspeed-core/lightspeed-stack/pull/1248, https://github.com/lightspeed-core/lightspeed-stack/pull/1300)

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

NA

## Related Tickets & Documents

- Related Issue # LCORE-1402
- Closes # LCORE-1402

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Set up OKP in inline and tool, check that the source attribute is "okp".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RAG configuration now properly merges vector store ID mappings from multiple sources when additional backends are configured, improving system flexibility across different search infrastructure setups.

* **Tests**
  * Added comprehensive test coverage for RAG configuration mapping behavior across all supported backend combinations and configuration states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->