### PR TITLE
LCORE-1210: Missing JWK auth header correctly returns 401 error

### DIFF
--- a/src/authentication/jwk_token.py
+++ b/src/authentication/jwk_token.py
@@ -16,7 +16,7 @@ from authlib.jose.errors import (
 from cachetools import TTLCache
 from fastapi import HTTPException, Request
 
-from authentication.interface import NO_AUTH_TUPLE, AuthInterface, AuthTuple
+from authentication.interface import AuthInterface, AuthTuple
 from authentication.utils import extract_user_token
 from constants import (
     DEFAULT_VIRTUAL_PATH,
@@ -163,24 +163,27 @@ class JwkTokenAuthDependency(AuthInterface):  # pylint: disable=too-few-public-m
     async def __call__(self, request: Request) -> AuthTuple:
         """Authenticate the JWT in the headers against the keys from the JWK url.
 
-        If the Authorization header is missing, returns NO_AUTH_TUPLE. On token
-        verification or validation failures this function raises HTTPException
-        with appropriate HTTP status codes:
-        - 401 for unknown signing key/algorithm, bad signature, expired token,
-              or missing required claims;
+        When the Authorization header is missing, this method raises
+        HTTPException with status 401 (Unauthorized). On token verification or
+        validation failures it also raises HTTPException with appropriate
+        status codes:
         - 400 for token decode or other JOSE-related decode/validation errors;
+        - 401 for missing Authorization header, unknown signing key/algorithm,
+              bad signature, expired token, or missing required claims;
         - 500 for unexpected internal errors.
 
         Parameters:
-            request (Request): The incoming FastAPI request containing the Authorization header.
+            request (Request): The incoming FastAPI request; must include the
+                Authorization header (Bearer token) or 401 is raised.
 
         Returns:
             AuthTuple: A tuple (user_id, username, skip_userid_check, token)
-            extracted from the validated token, or NO_AUTH_TUPLE when no
-            Authorization header is present.
+            extracted from the validated JWT. Only returned on successful
+            authentication; all error paths raise HTTPException.
         """
         if not request.headers.get("Authorization"):
-            return NO_AUTH_TUPLE
+            response = UnauthorizedResponse(cause="No Authorization header found")
+            raise HTTPException(**response.model_dump())
 
         user_token = extract_user_token(request.headers)
 

--- a/tests/e2e/features/rbac.feature
+++ b/tests/e2e/features/rbac.feature
@@ -12,14 +12,20 @@ Feature: Role-Based Access Control (RBAC)
   # Authentication - Token Validation
   # ============================================
 
-  #https://issues.redhat.com/browse/LCORE-1210
-  @skip
   Scenario: Request without token returns 401
     Given The system is in default state
       And I remove the auth header
      When I access REST API endpoint "models" using HTTP GET method
      Then The status code of the response is 401
-      And The body of the response contains Missing or invalid credentials
+     And The body of the response is the following
+        """
+        {
+              "detail": {
+                  "response": "Missing or invalid credentials provided by client",
+                  "cause": "No Authorization header found"
+                }     
+        }
+        """
 
   Scenario: Request with malformed Authorization header returns 401
     Given The system is in default state

--- a/tests/unit/authentication/test_jwk_token.py
+++ b/tests/unit/authentication/test_jwk_token.py
@@ -13,7 +13,6 @@ from pytest_mock import MockerFixture
 from authlib.jose import JsonWebKey, JsonWebToken
 
 from authentication.jwk_token import JwkTokenAuthDependency, _jwk_cache
-from constants import DEFAULT_USER_NAME, DEFAULT_USER_UID, NO_USER_TOKEN
 from models.config import JwkConfiguration, JwtConfiguration
 
 TEST_USER_ID = "test-user-123"
@@ -435,19 +434,18 @@ async def test_no_auth_header(
     mocked_signing_keys_server: Any,
     no_token_request: Request,
 ) -> None:
-    """Test with no Authorization header."""
+    """Test with no Authorization header returns 401 Unauthorized."""
     _ = mocked_signing_keys_server
 
     dependency = JwkTokenAuthDependency(default_jwk_configuration)
 
-    user_id, username, skip_userid_check, token_claims = await dependency(
-        no_token_request
-    )
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(no_token_request)
 
-    assert user_id == DEFAULT_USER_UID
-    assert username == DEFAULT_USER_NAME
-    assert skip_userid_check is True
-    assert token_claims == NO_USER_TOKEN
+    assert exc_info.value.status_code == 401
+    detail = cast(dict, exc_info.value.detail)
+    assert detail["cause"] == "No Authorization header found"
+    assert detail["response"] == "Missing or invalid credentials provided by client"
 
 
 async def test_no_bearer(


### PR DESCRIPTION
## Description

This PR fixes bug in JWK auth that previously returned 403 Forbidden error instead of 401 Unauthorized.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-1210](https://redhat.atlassian.net/browse/LCORE-1210)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the Authorization header is missing: clients now receive a clear 401 Unauthorized response with an explicit JSON error payload ("No Authorization header found").
* **Tests**
  * End-to-end tests updated to assert the explicit JSON error response for missing authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->