### PR TITLE
LCORE-1461: Fix `/tools` not handling "kubernetes" and static token auth

### DIFF
--- a/docker-compose-library.yaml
+++ b/docker-compose-library.yaml
@@ -38,6 +38,8 @@ services:
       - ./run.yaml:/app-root/run.yaml:Z
       - ${GCP_KEYS_PATH:-./tmp/.gcp-keys-dummy}:/opt/app-root/.gcp-keys:ro
       - ./tests/e2e/rag:/opt/app-root/src/.llama/storage/rag:Z
+      - ./tests/e2e/secrets/mcp-token:/tmp/mcp-token:ro
+      - ./tests/e2e/secrets/invalid-mcp-token:/tmp/invalid-mcp-token:ro
     environment:
       # LLM Provider API Keys
       - BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY:-}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,8 +81,8 @@ services:
       - "8080:8080"
     volumes:
       - ./lightspeed-stack.yaml:/app-root/lightspeed-stack.yaml:z
-      - ./tests/e2e/secrets/mcp-token:/tmp/mcp-secret-token:ro
-      - ./tests/e2e/secrets/invalid-mcp-token:/tmp/invalid-mcp-secret-token:ro
+      - ./tests/e2e/secrets/mcp-token:/tmp/mcp-token:ro
+      - ./tests/e2e/secrets/invalid-mcp-token:/tmp/invalid-mcp-token:ro
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       # Azure Entra ID credentials (AZURE_API_KEY is obtained dynamically)

--- a/src/app/endpoints/tools.py
+++ b/src/app/endpoints/tools.py
@@ -20,7 +20,7 @@ from models.responses import (
     UnauthorizedResponse,
 )
 from utils.endpoints import check_configuration_loaded
-from utils.mcp_headers import McpHeaders, mcp_headers_dependency
+from utils.mcp_headers import McpHeaders, build_mcp_headers, mcp_headers_dependency
 from utils.mcp_oauth_probe import check_mcp_auth
 from utils.tool_formatter import format_tools_list
 
@@ -115,15 +115,18 @@ async def tools_endpoint_handler(  # pylint: disable=too-many-locals,too-many-st
         ToolsResponse: An object containing the consolidated list of available tools
         with metadata including tool name, description, parameters, and server source.
     """
-    # Used only by the middleware
-    _ = auth
+    _, _, _, token = auth
 
     # Nothing interesting in the request
     _ = request
 
     check_configuration_loaded(configuration)
 
-    await check_mcp_auth(configuration, mcp_headers)
+    complete_mcp_headers = build_mcp_headers(
+        configuration, mcp_headers, request.headers, token
+    )
+
+    await check_mcp_auth(configuration, complete_mcp_headers)
 
     toolgroups_response = []
     try:
@@ -145,7 +148,7 @@ async def tools_endpoint_handler(  # pylint: disable=too-many-locals,too-many-st
     for toolgroup in toolgroups_response:
         try:
             # Get tools for each toolgroup
-            headers = mcp_headers.get(toolgroup.identifier, {})
+            headers = complete_mcp_headers.get(toolgroup.identifier, {})
             authorization = headers.pop("Authorization", None)
 
             tools_response = await client.tools.list(

--- a/src/utils/mcp_headers.py
+++ b/src/utils/mcp_headers.py
@@ -2,10 +2,12 @@
 
 import json
 from collections.abc import Mapping
+from typing import Optional
 from urllib.parse import urlparse
 
 from fastapi import Request
 
+import constants
 from configuration import AppConfig
 from log import get_logger
 from models.config import ModelContextProtocolServer
@@ -121,3 +123,132 @@ def extract_propagated_headers(
         if value is not None:
             propagated[header_name] = value
     return propagated
+
+
+def find_unresolved_auth_headers(
+    configured: Mapping[str, str],
+    resolved: Mapping[str, str],
+) -> list[str]:
+    """Return configured auth header names that are absent from the resolved headers.
+
+    Comparison is case-insensitive so that ``Authorization`` and ``authorization``
+    are treated as the same header name.
+
+    Args:
+        configured: The server's ``authorization_headers`` configuration mapping
+            (header name → secret path or keyword).
+        resolved: The fully resolved headers that will be sent to the MCP server.
+
+    Returns:
+        List of header names from ``configured`` that could not be resolved, i.e.
+        are not present as a key in ``resolved``. An empty list means all headers
+        were resolved successfully.
+    """
+    resolved_lower = {k.lower() for k in resolved}
+    return [h for h in configured if h.lower() not in resolved_lower]
+
+
+def build_server_headers(
+    mcp_server: ModelContextProtocolServer,
+    client_headers: dict[str, str],
+    request_headers: Optional[Mapping[str, str]],
+    token: Optional[str],
+) -> dict[str, str]:
+    """Build the complete set of headers for a single MCP server.
+
+    Merges client-supplied headers, resolved authorization headers, and propagated
+    request headers in priority order (highest first):
+
+    1. Client-supplied headers (already present in ``client_headers``).
+    2. Statically resolved authorization headers from configuration.
+    3. Kubernetes Bearer token for headers configured with the ``kubernetes`` keyword.
+       ``client`` and ``oauth`` keywords are skipped — those values are already
+       provided by the client in source 1.
+    4. Headers propagated from the incoming request via the server's allowlist.
+
+    Args:
+        mcp_server: MCP server configuration.
+        client_headers: Headers already supplied by the client for this server.
+        request_headers: Headers from the incoming HTTP request, or ``None``.
+        token: Optional Kubernetes service-account token.
+
+    Returns:
+        Merged headers dictionary for the server. May be empty if no headers apply.
+    """
+    server_headers: dict[str, str] = dict(client_headers)
+    existing_lower = {k.lower() for k in server_headers}
+
+    for (
+        header_name,
+        resolved_value,
+    ) in mcp_server.resolved_authorization_headers.items():
+        if header_name.lower() in existing_lower:
+            continue
+        match resolved_value:
+            case constants.MCP_AUTH_KUBERNETES:
+                if token:
+                    server_headers[header_name] = f"Bearer {token}"
+                    existing_lower.add(header_name.lower())
+            case constants.MCP_AUTH_CLIENT | constants.MCP_AUTH_OAUTH:
+                pass  # client-provided; already included via the initial client_headers copy
+            case _:
+                server_headers[header_name] = resolved_value
+                existing_lower.add(header_name.lower())
+
+    if mcp_server.headers and request_headers is not None:
+        propagated = extract_propagated_headers(mcp_server, request_headers)
+        for h_name, h_value in propagated.items():
+            if h_name.lower() not in existing_lower:
+                server_headers[h_name] = h_value
+                existing_lower.add(h_name.lower())
+
+    return server_headers
+
+
+def build_mcp_headers(
+    config: AppConfig,
+    mcp_headers: McpHeaders,
+    request_headers: Optional[Mapping[str, str]],
+    token: Optional[str] = None,
+) -> McpHeaders:
+    """Build complete MCP headers by merging all header sources for each MCP server.
+
+    For each configured MCP server, combines four header sources (in priority order,
+    highest first):
+
+    1. Client-supplied headers from the ``MCP-HEADERS`` request header (keyed by server name).
+    2. Statically resolved authorization headers from configuration (e.g. file-based secrets).
+    3. Kubernetes Bearer token: when a header is configured with the ``kubernetes`` keyword,
+       the supplied ``token`` is formatted as ``Bearer <token>`` and used as its value.
+       ``client`` and ``oauth`` keywords are not resolved here — those values are already
+       provided by the client in source 1.
+    4. Headers propagated from the incoming request via the server's configured allowlist.
+
+    Args:
+        config: Application configuration containing mcp_servers.
+        mcp_headers: Per-request headers from the client, keyed by MCP server name.
+        request_headers: Headers from the incoming HTTP request used for allowlist
+            propagation, or ``None`` when not available.
+        token: Optional Kubernetes service-account token used to resolve headers
+            configured with the ``kubernetes`` keyword.
+
+    Returns:
+        McpHeaders keyed by MCP server name with the complete merged set of headers.
+        Servers that end up with no headers are omitted from the result.
+    """
+    if not config.mcp_servers:
+        return {}
+
+    complete: McpHeaders = {}
+
+    for mcp_server in config.mcp_servers:
+        server_headers = build_server_headers(
+            mcp_server,
+            dict(mcp_headers.get(mcp_server.name, {})),
+            request_headers,
+            token,
+        )
+        if server_headers:
+            complete[mcp_server.name] = server_headers
+
+    return complete

--- a/src/utils/mcp_oauth_probe.py
+++ b/src/utils/mcp_oauth_probe.py
@@ -40,7 +40,16 @@ async def check_mcp_auth(configuration: AppConfig, mcp_headers: McpHeaders) -> N
     probes = []
     for mcp_server in configuration.mcp_servers:
         headers = mcp_headers.get(mcp_server.name, {})
-        authorization = headers.get("Authorization", None)
+        auth_header = headers.get("Authorization")
+        if auth_header is not None:
+            authorization = (
+                auth_header
+                if auth_header.startswith("Bearer ")
+                else f"Bearer {auth_header}"
+            )
+        else:
+            authorization = None
+
         if (
             authorization
             or constants.MCP_AUTH_OAUTH

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -96,7 +96,11 @@ from models.responses import (
     NotFoundResponse,
     ServiceUnavailableResponse,
 )
-from utils.mcp_headers import McpHeaders, extract_propagated_headers
+from utils.mcp_headers import (
+    McpHeaders,
+    build_mcp_headers,
+    find_unresolved_auth_headers,
+)
 from utils.prompts import get_system_prompt, get_topic_summary_system_prompt
 from utils.query import (
     extract_provider_and_model_from_model_id,
@@ -483,17 +487,21 @@ def get_rag_tools(vector_store_ids: list[str]) -> Optional[list[InputToolFileSea
     ]
 
 
-async def get_mcp_tools(  # pylint: disable=too-many-return-statements,too-many-locals
+async def get_mcp_tools(
     token: Optional[str] = None,
     mcp_headers: Optional[McpHeaders] = None,
     request_headers: Optional[Mapping[str, str]] = None,
 ) -> list[InputToolMCP]:
     """Convert MCP servers to tools format for Responses API.
 
+    Fully delegates header assembly to ``build_mcp_headers``, which handles static
+    config tokens, the kubernetes Bearer token, client/oauth client-provided headers,
+    and propagated request headers.
+
     Args:
-        token: Optional authentication token for MCP server authorization
-        mcp_headers: Optional per-request headers for MCP servers, keyed by server URL
-        request_headers: Optional incoming HTTP request headers for allowlist propagation
+        token: Optional Kubernetes service-account token for ``kubernetes`` auth headers.
+        mcp_headers: Optional per-request headers for MCP servers, keyed by server name.
+        request_headers: Optional incoming HTTP request headers for allowlist propagation.
 
     Returns:
         List of MCP tool definitions with server details and optional auth. When
@@ -504,68 +512,27 @@ async def get_mcp_tools(  # pylint: disable=too-many-return-statements,too-many-
         HTTPException: 401 with WWW-Authenticate header when an MCP server uses OAuth,
             no headers are passed, and the server responds with 401 and WWW-Authenticate.
     """
-
-    def _get_token_value(original: str, header: str) -> Optional[str]:
-        """Convert to header value."""
-        match original:
-            case constants.MCP_AUTH_KUBERNETES:
-                # use k8s token
-                if token is None or token == "":
-                    return None
-                return f"Bearer {token}"
-            case constants.MCP_AUTH_CLIENT:
-                # use client provided token
-                if mcp_headers is None:
-                    return None
-                c_headers = mcp_headers.get(mcp_server.name, None)
-                if c_headers is None:
-                    return None
-                return c_headers.get(header, None)
-            case constants.MCP_AUTH_OAUTH:
-                # use oauth token
-                if mcp_headers is None:
-                    return None
-                c_headers = mcp_headers.get(mcp_server.name, None)
-                if c_headers is None:
-                    return None
-                return c_headers.get(header, None)
-            case _:
-                # use provided
-                return original
+    complete_headers = build_mcp_headers(
+        configuration, mcp_headers or {}, request_headers, token
+    )
 
     tools: list[InputToolMCP] = []
     for mcp_server in configuration.mcp_servers:
-        # Build headers
-        headers: dict[str, str] = {}
-        for name, value in mcp_server.resolved_authorization_headers.items():
-            # for each defined header
-            h_value = _get_token_value(value, name)
-            # only add the header if we got value
-            if h_value is not None:
-                headers[name] = h_value
+        headers: dict[str, str] = dict(complete_headers.get(mcp_server.name, {}))
 
-        # Skip server if auth headers were configured but not all could be resolved
-        if mcp_server.authorization_headers and len(headers) != len(
-            mcp_server.authorization_headers
-        ):
+        # Skip server if any configured auth header could not be resolved.
+        unresolved = find_unresolved_auth_headers(
+            mcp_server.authorization_headers, headers
+        )
+        if unresolved:
             logger.warning(
                 "Skipping MCP server %s: required %d auth headers but only resolved %d",
                 mcp_server.name,
                 len(mcp_server.authorization_headers),
-                len(headers),
+                len(mcp_server.authorization_headers) - len(unresolved),
             )
             continue
 
-        # Propagate allowlisted headers from the incoming request
-        if mcp_server.headers and request_headers is not None:
-            propagated = extract_propagated_headers(mcp_server, request_headers)
-            existing_lower = {name.lower() for name in headers}
-            for h_name, h_value in propagated.items():
-                if h_name.lower() not in existing_lower:
-                    headers[h_name] = h_value
-                    existing_lower.add(h_name.lower())
-
-        # Build Authorization header
         authorization = headers.pop("Authorization", None)
         tools.append(
             InputToolMCP(

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-invalid-mcp-file-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-invalid-mcp-file-auth.yaml
@@ -21,4 +21,4 @@ mcp_servers:
   - name: "mcp-file"
     url: "http://mock-mcp:3001"
     authorization_headers:
-      Authorization: "/tmp/invalid-mcp-secret-token"
+      Authorization: "/tmp/invalid-mcp-token"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-file-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-file-auth.yaml
@@ -21,4 +21,4 @@ mcp_servers:
   - name: "mcp-file"
     url: "http://mock-mcp:3001"
     authorization_headers:
-      Authorization: "/tmp/mcp-secret-token"
+      Authorization: "/tmp/mcp-token"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
@@ -16,7 +16,7 @@ user_data_collection:
   transcripts_enabled: true
   transcripts_storage: "/tmp/data/transcripts"
 authentication:
-  module: "noop"
+  module: "noop-with-token"
 mcp_servers:
   - name: "mcp-kubernetes"
     url: "http://mock-mcp:3001"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp.yaml
@@ -29,7 +29,7 @@ mcp_servers:
   - name: "mcp-file"
     url: "http://mock-mcp:3001"
     authorization_headers:
-      Authorization: "/tmp/mcp-secret-token"
+      Authorization: "/tmp/mcp-token"
   - name: "mcp-client"
     url: "http://mock-mcp:3001"
     authorization_headers:

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-invalid-mcp-file-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-invalid-mcp-file-auth.yaml
@@ -22,4 +22,4 @@ mcp_servers:
   - name: "mcp-file"
     url: "http://mock-mcp:3001"
     authorization_headers:
-      Authorization: "/tmp/invalid-mcp-secret-token"
+      Authorization: "/tmp/invalid-mcp-token"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-file-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-file-auth.yaml
@@ -22,4 +22,4 @@ mcp_servers:
   - name: "mcp-file"
     url: "http://mock-mcp:3001"
     authorization_headers:
-      Authorization: "/tmp/mcp-secret-token"
+      Authorization: "/tmp/mcp-token"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
@@ -17,7 +17,7 @@ user_data_collection:
   transcripts_enabled: true
   transcripts_storage: "/tmp/data/transcripts"
 authentication:
-  module: "noop"
+  module: "noop-with-token"
 mcp_servers:
   - name: "mcp-kubernetes"
     url: "http://mock-mcp:3001"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp.yaml
@@ -30,7 +30,7 @@ mcp_servers:
   - name: "mcp-file"
     url: "http://mock-mcp:3001"
     authorization_headers:
-      Authorization: "/tmp/mcp-secret-token"
+      Authorization: "/tmp/mcp-token"
   - name: "mcp-client"
     url: "http://mock-mcp:3001"
     authorization_headers:

--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -435,12 +435,6 @@ def before_feature(context: Context, feature: Feature) -> None:
         switch_config(context.feature_config)
         restart_container("lightspeed-stack")
 
-    if "MCPFileAuth" in feature.tags:
-        context.feature_config = _get_config_path("mcp-file-auth", mode_dir)
-        context.default_config_backup = create_config_backup("lightspeed-stack.yaml")
-        switch_config(context.feature_config)
-        restart_container("lightspeed-stack")
-
 
 def after_feature(context: Context, feature: Feature) -> None:
     """Run after each feature file is exercised.
@@ -470,11 +464,6 @@ def after_feature(context: Context, feature: Feature) -> None:
             assert response.status_code == 200, f"{url} returned {response.status_code}"
 
     if "MCP" in feature.tags:
-        switch_config(context.default_config_backup)
-        restart_container("lightspeed-stack")
-        remove_config_backup(context.default_config_backup)
-
-    if "MCPFileAuth" in feature.tags:
         switch_config(context.default_config_backup)
         restart_container("lightspeed-stack")
         remove_config_backup(context.default_config_backup)

--- a/tests/e2e/features/mcp.feature
+++ b/tests/e2e/features/mcp.feature
@@ -7,11 +7,10 @@ Feature: MCP tests
 
 
 # File-based
-  @skip #TODO: LCORE-1461
   @MCPFileAuthConfig
   Scenario: Check if tools endpoint succeeds when MCP file-based auth token is passed 
     Given The system is in default state
-    And The mcp-file mcp server Authorization header is set to "/tmp/mcp-secret-token"
+    And The mcp-file mcp server Authorization header is set to "/tmp/mcp-token"
     When I access REST API endpoint "tools" using HTTP GET method
     Then The status code of the response is 200
     And The body of the response contains mcp-file
@@ -20,7 +19,7 @@ Feature: MCP tests
   @MCPFileAuthConfig
   Scenario: Check if query endpoint succeeds when MCP file-based auth token is passed
     Given The system is in default state
-    And The mcp-file mcp server Authorization header is set to "/tmp/mcp-secret-token"
+    And The mcp-file mcp server Authorization header is set to "/tmp/mcp-token"
     And I capture the current token metrics
     When I use "query" to ask question
     """
@@ -36,7 +35,7 @@ Feature: MCP tests
   @MCPFileAuthConfig
   Scenario: Check if streaming_query endpoint succeeds when MCP file-based auth token is passed
     Given The system is in default state
-    And The mcp-file mcp server Authorization header is set to "/tmp/mcp-secret-token"
+    And The mcp-file mcp server Authorization header is set to "/tmp/mcp-token"
     And I capture the current token metrics
     When I use "streaming_query" to ask question
     """
@@ -49,11 +48,10 @@ Feature: MCP tests
         | Hello                     |
     And The token metrics should have increased
 
-  @skip #TODO: LCORE-1461
   @InvalidMCPFileAuthConfig
   Scenario: Check if tools endpoint reports error when MCP file-based invalid auth token is passed 
     Given The system is in default state
-    And The mcp-file mcp server Authorization header is set to "/tmp/invalid-mcp-secret-token"
+    And The mcp-file mcp server Authorization header is set to "/tmp/invalid-mcp-token"
     When I access REST API endpoint "tools" using HTTP GET method
     Then The status code of the response is 401
     And The body of the response is the following
@@ -70,7 +68,7 @@ Feature: MCP tests
   @InvalidMCPFileAuthConfig
   Scenario: Check if query endpoint reports error when MCP file-based invalid auth token is passed 
     Given The system is in default state
-    And The mcp-file mcp server Authorization header is set to "/tmp/invalid-mcp-secret-token"
+    And The mcp-file mcp server Authorization header is set to "/tmp/invalid-mcp-token"
     When I use "query" to ask question
     """
     {"query": "Say hello", "model": "{MODEL}", "provider": "{PROVIDER}"}
@@ -90,7 +88,7 @@ Feature: MCP tests
   @InvalidMCPFileAuthConfig
   Scenario: Check if streaming_query endpoint reports error when MCP file-based invalid auth token is passed 
     Given The system is in default state
-    And The mcp-file mcp server Authorization header is set to "/tmp/invalid-mcp-secret-token"
+    And The mcp-file mcp server Authorization header is set to "/tmp/invalid-mcp-token"
     When I use "streaming_query" to ask question
     """
     {"query": "Say hello", "model": "{MODEL}", "provider": "{PROVIDER}"}
@@ -107,7 +105,6 @@ Feature: MCP tests
     """
 
 # Kubernetes
-  @skip #TODO: LCORE-1461
   @MCPKubernetesAuthConfig
   Scenario: Check if tools endpoint succeeds when MCP kubernetes auth token is passed 
     Given The system is in default state
@@ -149,7 +146,6 @@ Feature: MCP tests
         | Hello                     |
     And The token metrics should have increased
 
-  @skip #TODO: LCORE-1461
   @MCPKubernetesAuthConfig
   Scenario: Check if tools endpoint reports error when MCP kubernetes invalid auth token is passed 
     Given The system is in default state

--- a/tests/unit/utils/test_mcp_headers.py
+++ b/tests/unit/utils/test_mcp_headers.py
@@ -5,9 +5,14 @@ import pytest
 
 from fastapi import Request
 
+import constants
 from models.config import ModelContextProtocolServer
 from utils import mcp_headers
-from utils.mcp_headers import extract_propagated_headers
+from utils.mcp_headers import (
+    build_server_headers,
+    extract_propagated_headers,
+    find_unresolved_auth_headers,
+)
 
 
 def test_extract_mcp_headers_empty_headers(mocker: MockerFixture) -> None:
@@ -289,3 +294,163 @@ class TestExtractPropagatedHeaders:
         request_headers = {"x-rh-identity": "identity-value"}
         result = extract_propagated_headers(server, request_headers)
         assert not result
+
+
+class TestFindUnresolvedAuthHeaders:
+    """Test cases for find_unresolved_auth_headers function."""
+
+    def test_all_configured_headers_present(self) -> None:
+        """Test that an empty list is returned when all configured headers are resolved."""
+        configured = {"Authorization": "kubernetes", "X-Api-Key": "/var/secrets/key"}
+        resolved = {"Authorization": "Bearer tok", "X-Api-Key": "secret"}
+        assert not find_unresolved_auth_headers(configured, resolved)
+
+    def test_missing_header_is_returned(self) -> None:
+        """Test that a configured header absent from resolved is returned."""
+        configured = {"Authorization": "kubernetes"}
+        resolved: dict[str, str] = {}
+        assert find_unresolved_auth_headers(configured, resolved) == ["Authorization"]
+
+    def test_partially_resolved_returns_missing(self) -> None:
+        """Test that only unresolved headers are returned when some are resolved."""
+        configured = {"Authorization": "kubernetes", "X-Api-Key": "/var/secrets/key"}
+        resolved = {"Authorization": "Bearer tok"}
+        assert find_unresolved_auth_headers(configured, resolved) == ["X-Api-Key"]
+
+    def test_comparison_is_case_insensitive(self) -> None:
+        """Test that header name matching is case-insensitive."""
+        configured = {"Authorization": "kubernetes"}
+        resolved = {"authorization": "Bearer tok"}
+        assert not find_unresolved_auth_headers(configured, resolved)
+
+    def test_empty_configured_returns_empty(self) -> None:
+        """Test that an empty configured dict returns an empty list."""
+        assert not find_unresolved_auth_headers({}, {"Authorization": "Bearer tok"})
+
+    def test_empty_resolved_returns_all_configured(self) -> None:
+        """Test that all configured headers are returned when resolved is empty."""
+        configured = {"Authorization": "kubernetes", "X-Api-Key": "/path"}
+        result = find_unresolved_auth_headers(configured, {})
+        assert sorted(result) == ["Authorization", "X-Api-Key"]
+
+
+class TestBuildServerHeaders:
+    """Test cases for build_server_headers function."""
+
+    def _make_server(
+        self,
+        resolved_auth: dict[str, str] | None = None,
+        headers: list[str] | None = None,
+    ) -> ModelContextProtocolServer:
+        """Create a ModelContextProtocolServer with given auth and allowlist headers."""
+        server = ModelContextProtocolServer(
+            name="test-server",
+            url="http://test:8080",
+            provider_id="xyzzy",
+            headers=headers or [],
+        )
+        object.__setattr__(
+            server, "_resolved_authorization_headers", resolved_auth or {}
+        )
+        return server
+
+    def test_static_resolved_header_is_added(self) -> None:
+        """Test that a statically resolved header value is included in the result."""
+        server = self._make_server(resolved_auth={"Authorization": "static-token"})
+        result = build_server_headers(server, {}, None, None)
+        assert result == {"Authorization": "static-token"}
+
+    def test_kubernetes_token_resolves_to_bearer(self) -> None:
+        """Test that a kubernetes keyword resolves to a Bearer token."""
+        server = self._make_server(
+            resolved_auth={"Authorization": constants.MCP_AUTH_KUBERNETES}
+        )
+        result = build_server_headers(server, {}, None, token="my-k8s-token")
+        assert result == {"Authorization": "Bearer my-k8s-token"}
+
+    def test_kubernetes_without_token_is_skipped(self) -> None:
+        """Test that a kubernetes keyword with no token produces no header."""
+        server = self._make_server(
+            resolved_auth={"Authorization": constants.MCP_AUTH_KUBERNETES}
+        )
+        result = build_server_headers(server, {}, None, token=None)
+        assert not result
+
+    def test_client_keyword_is_skipped(self) -> None:
+        """Test that a client keyword is skipped (value comes from client_headers)."""
+        server = self._make_server(
+            resolved_auth={"Authorization": constants.MCP_AUTH_CLIENT}
+        )
+        result = build_server_headers(server, {}, None, None)
+        assert not result
+
+    def test_oauth_keyword_is_skipped(self) -> None:
+        """Test that an oauth keyword is skipped (value comes from client_headers)."""
+        server = self._make_server(
+            resolved_auth={"Authorization": constants.MCP_AUTH_OAUTH}
+        )
+        result = build_server_headers(server, {}, None, None)
+        assert not result
+
+    def test_client_headers_take_priority_over_resolved(self) -> None:
+        """Test that a client-supplied header is not overwritten by a resolved value."""
+        server = self._make_server(resolved_auth={"Authorization": "static-token"})
+        result = build_server_headers(
+            server, {"Authorization": "client-token"}, None, None
+        )
+        assert result == {"Authorization": "client-token"}
+
+    def test_client_headers_priority_is_case_insensitive(self) -> None:
+        """Test that case-insensitive comparison prevents overwriting client headers."""
+        server = self._make_server(resolved_auth={"authorization": "static-token"})
+        result = build_server_headers(
+            server, {"Authorization": "client-token"}, None, None
+        )
+        assert result == {"Authorization": "client-token"}
+
+    def test_propagated_request_headers_are_added(self) -> None:
+        """Test that allowlisted request headers are propagated."""
+        server = self._make_server(headers=["x-rh-identity"])
+        result = build_server_headers(
+            server, {}, {"x-rh-identity": "my-identity"}, None
+        )
+        assert result == {"x-rh-identity": "my-identity"}
+
+    def test_existing_header_blocks_propagation(self) -> None:
+        """Test that a propagated header does not overwrite an already-set header."""
+        server = self._make_server(headers=["x-rh-identity"])
+        result = build_server_headers(
+            server,
+            {"x-rh-identity": "client-identity"},
+            {"x-rh-identity": "request-identity"},
+            None,
+        )
+        assert result == {"x-rh-identity": "client-identity"}
+
+    def test_no_headers_no_config_returns_empty(self) -> None:
+        """Test that a server with no applicable headers returns an empty dict."""
+        server = self._make_server()
+        result = build_server_headers(server, {}, None, None)
+        assert not result
+
+    def test_multiple_sources_are_merged(self) -> None:
+        """Test that all header sources are combined into one dictionary."""
+        server = self._make_server(
+            resolved_auth={
+                "Authorization": constants.MCP_AUTH_KUBERNETES,
+                "X-Api-Key": "static-key",
+            },
+            headers=["x-request-id"],
+        )
+        result = build_server_headers(
+            server,
+            {"X-Client-Header": "client-value"},
+            {"x-request-id": "req-123"},
+            token="k8s-token",
+        )
+        assert result == {
+            "X-Client-Header": "client-value",
+            "Authorization": "Bearer k8s-token",
+            "X-Api-Key": "static-key",
+            "x-request-id": "req-123",
+        }


### PR DESCRIPTION
## Description
Fixed LCORE-1461 which was caused by the `/tools` endpoint not handling "kubernetes" and static token auth. 

The fix involved creating a function that builds the complete MCP server headers and checking authorization on the complete MCP headers not just the passed MCP-HEADERS.

## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: Cursor

## Related Tickets & Documents

- Related Issue LCORE-1461
- Closes LCORE-1461

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized MCP header assembly that merges client, server and request sources and accepts an optional token.

* **Bug Fixes**
  * Normalize Authorization values to a consistent Bearer format.
  * Improved per-server header resolution and detection of unresolved auth headers.
  * Endpoints now extract and forward provided tokens for MCP requests.

* **Tests**
  * Re-enabled e2e MCP auth scenarios, updated test configs/token paths, and added unit coverage for header utilities.

* **Chores**
  * Added test token fixtures to development compose for e2e runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->