### PR TITLE
RSPEED-2658: Remove dead GraniteToolParser and legacy Agents API imports

### DIFF
--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -19,11 +19,6 @@ from llama_stack_api.openai_responses import (
     OpenAIResponseText as Text,
     OpenAIResponseReasoning as Reasoning,
 )
-from llama_stack_client.lib.agents.tool_parser import ToolParser
-from llama_stack_client.lib.agents.types import (
-    CompletionMessage as AgentCompletionMessage,
-    ToolCall as AgentToolCall,
-)
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field
 
 from models.database.conversations import UserConversation
@@ -68,49 +63,6 @@ class Singleton(type):
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
-
-
-# See https://github.com/meta-llama/llama-stack-client-python/issues/206
-class GraniteToolParser(ToolParser):
-    """Workaround for 'tool_calls' with granite models."""
-
-    def get_tool_calls(
-        self, output_message: AgentCompletionMessage
-    ) -> list[AgentToolCall]:
-        """
-        Return the `tool_calls` list from a CompletionMessage, or an empty list if none are present.
-
-        Parameters:
-            output_message (Optional[AgentCompletionMessage]): Completion
-            message potentially containing `tool_calls`.
-
-        Returns:
-            list[AgentToolCall]: The list of tool call entries
-            extracted from `output_message`, or an empty list.
-        """
-        if output_message and output_message.tool_calls:
-            return output_message.tool_calls
-        return []
-
-    @staticmethod
-    def get_parser(model_id: str) -> Optional[ToolParser]:
-        """
-        Return a GraniteToolParser when the model identifier denotes a Granite model.
-
-        Returns None otherwise.
-
-        Parameters:
-            model_id (str): Model identifier string checked case-insensitively.
-            If it starts with "granite", a GraniteToolParser instance is
-            returned.
-
-        Returns:
-            Optional[ToolParser]: GraniteToolParser for Granite models, or None
-            if `model_id` is falsy or does not start with "granite".
-        """
-        if model_id and model_id.lower().startswith("granite"):
-            return GraniteToolParser()
-        return None
 
 
 class ShieldModerationPassed(BaseModel):

--- a/tests/unit/utils/test_types.py
+++ b/tests/unit/utils/test_types.py
@@ -8,69 +8,14 @@ from llama_stack_api.openai_responses import (
 )
 
 from pydantic import AnyUrl, ValidationError
-from pytest_mock import MockerFixture
 
 from utils.types import (
-    GraniteToolParser,
     ReferencedDocument,
     ResponsesApiParams,
     ToolCallSummary,
     ToolResultSummary,
     content_to_str,
 )
-
-
-class TestGraniteToolParser:
-    """Unit tests for functions defined in utils/types.py."""
-
-    def test_get_tool_parser_when_model_is_is_not_granite(self) -> None:
-        """Test that the tool_parser is None when model_id is not a granite model."""
-        assert (
-            GraniteToolParser.get_parser("ollama3.3") is None
-        ), "tool_parser should be None"
-
-    def test_get_tool_parser_when_model_id_does_not_start_with_granite(self) -> None:
-        """Test that the tool_parser is None when model_id does not start with granite."""
-        assert (
-            GraniteToolParser.get_parser("a-fine-trained-granite-model") is None
-        ), "tool_parser should be None"
-
-    def test_get_tool_parser_when_model_id_starts_with_granite(self) -> None:
-        """Test that the tool_parser is not None when model_id starts with granite."""
-        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
-        assert tool_parser is not None, "tool_parser should not be None"
-
-    def test_get_tool_calls_from_completion_message_when_none(self) -> None:
-        """Test that get_tool_calls returns an empty array when CompletionMessage is None."""
-        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
-        assert tool_parser is not None, "tool parser was not returned"
-        result = tool_parser.get_tool_calls(None)  # pyright: ignore[reportArgumentType]
-        assert result == [], "get_tool_calls should return []"
-
-    def test_get_tool_calls_from_completion_message_when_not_none(
-        self, mocker: MockerFixture
-    ) -> None:
-        """Test that get_tool_calls returns an empty array when CompletionMessage has no tool_calls."""  # pylint: disable=line-too-long
-        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
-        assert tool_parser is not None, "tool parser was not returned"
-        completion_message = mocker.Mock()
-        completion_message.tool_calls = []
-        assert not tool_parser.get_tool_calls(
-            completion_message
-        ), "get_tool_calls should return []"
-
-    def test_get_tool_calls_from_completion_message_when_message_has_tool_calls(
-        self, mocker: MockerFixture
-    ) -> None:
-        """Test that get_tool_calls returns the tool_calls when CompletionMessage has tool_calls."""
-        tool_parser = GraniteToolParser.get_parser("granite-3.3-8b-instruct")
-        assert tool_parser is not None, "tool parser was not returned"
-        completion_message = mocker.Mock()
-        tool_calls = [mocker.Mock(tool_name="tool-1"), mocker.Mock(tool_name="tool-2")]
-        completion_message.tool_calls = tool_calls
-        assert (
-            tool_parser.get_tool_calls(completion_message) == tool_calls
-        ), f"get_tool_calls should return {tool_calls}"
 
 
 class TestContentToStr:


### PR DESCRIPTION
## Description

The `GraniteToolParser` class was a workaround for [llama-stack-client-python#206](https://github.com/meta-llama/llama-stack-client-python/issues/206), built for the old Agents API. The codebase has migrated to the Responses API and this class has zero production callers. This removes it, its legacy imports from `llama_stack_client.lib.agents` (`AgentCompletionMessage`, `AgentToolCall`), and the corresponding unit tests.

## Type of change

- [x] Refactor

## Tools used to create PR

- Assisted-by: Claude (OpenCode)
- Generated by: N/A

## Related Tickets & Documents

- [RSPEED-2658](https://redhat.atlassian.net/browse/RSPEED-2658)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Pure deletion of dead code (103 lines removed, 0 added). Verified via grep that `GraniteToolParser`, `AgentCompletionMessage`, and `AgentToolCall` have zero remaining references in the codebase. No new tests needed since this only removes unused code and its tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Removed GraniteToolParser class and associated tool-related imports from the public API. Existing implementations using these components will require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->