### PR TITLE
RSPEED-2651: enforce max header size on x-rh-identity before base64 decode

### DIFF
--- a/src/authentication/__init__.py
+++ b/src/authentication/__init__.py
@@ -72,6 +72,7 @@ def get_auth_dependency(
             return rh_identity.RHIdentityAuthDependency(
                 required_entitlements=rh_identity_config.required_entitlements,
                 virtual_path=virtual_path,
+                max_header_size=rh_identity_config.max_header_size,
             )
         case constants.AUTH_MOD_APIKEY_TOKEN:
             return api_key_token.APIKeyTokenAuthDependency(

--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -12,7 +12,11 @@ from fastapi import HTTPException, Request
 
 from authentication.interface import NO_AUTH_TUPLE, AuthInterface, AuthTuple
 from configuration import configuration
-from constants import DEFAULT_VIRTUAL_PATH, NO_USER_TOKEN
+from constants import (
+    DEFAULT_RH_IDENTITY_MAX_HEADER_SIZE,
+    DEFAULT_VIRTUAL_PATH,
+    NO_USER_TOKEN,
+)
 from log import get_logger
 
 logger = get_logger(__name__)
@@ -198,15 +202,20 @@ class RHIdentityAuthDependency(AuthInterface):  # pylint: disable=too-few-public
         self,
         required_entitlements: Optional[list[str]] = None,
         virtual_path: str = DEFAULT_VIRTUAL_PATH,
+        max_header_size: int = DEFAULT_RH_IDENTITY_MAX_HEADER_SIZE,
     ) -> None:
         """Initialize RH Identity authentication dependency.
 
         Args:
             required_entitlements: Services to require (ALL must be present)
             virtual_path: Virtual path for authorization checks
+            max_header_size: Maximum allowed size in bytes for the base64-encoded
+                x-rh-identity header. Headers exceeding this size are rejected
+                before decoding.
         """
         self.required_entitlements = required_entitlements
         self.virtual_path = virtual_path
+        self.max_header_size = max_header_size
         self.skip_userid_check = False
 
     async def __call__(self, request: Request) -> AuthTuple:
@@ -233,6 +242,18 @@ class RHIdentityAuthDependency(AuthInterface):  # pylint: disable=too-few-public
                     return NO_AUTH_TUPLE
             logger.warning("Missing x-rh-identity header")
             raise HTTPException(status_code=401, detail="Missing x-rh-identity header")
+
+        # Enforce header size limit before decoding
+        if len(identity_header) > self.max_header_size:
+            logger.warning(
+                "x-rh-identity header size %d exceeds maximum allowed size %d",
+                len(identity_header),
+                self.max_header_size,
+            )
+            raise HTTPException(
+                status_code=400,
+                detail="x-rh-identity header exceeds maximum allowed size",
+            )
 
         # Decode base64
         try:

--- a/src/constants.py
+++ b/src/constants.py
@@ -123,6 +123,8 @@ SUPPORTED_AUTHENTICATION_MODULES = frozenset(
     }
 )
 DEFAULT_AUTHENTICATION_MODULE = AUTH_MOD_NOOP
+# Maximum allowed size for base64-encoded x-rh-identity header (bytes)
+DEFAULT_RH_IDENTITY_MAX_HEADER_SIZE = 8192
 DEFAULT_JWT_UID_CLAIM = "user_id"
 DEFAULT_JWT_USER_NAME_CLAIM = "username"
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1131,6 +1131,13 @@ class RHIdentityConfiguration(ConfigurationBase):
         description="List of all required entitlements.",
     )
 
+    max_header_size: PositiveInt = Field(
+        default=constants.DEFAULT_RH_IDENTITY_MAX_HEADER_SIZE,
+        title="Maximum header size",
+        description="Maximum allowed size in bytes for the base64-encoded x-rh-identity header. "
+        "Headers exceeding this size are rejected before decoding.",
+    )
+
 
 class APIKeyTokenConfiguration(ConfigurationBase):
     """API Key Token configuration."""

--- a/tests/unit/authentication/test_rh_identity.py
+++ b/tests/unit/authentication/test_rh_identity.py
@@ -547,3 +547,50 @@ class TestRHIdentityHealthProbeSkip:
         with pytest.raises(HTTPException) as exc_info:
             await auth_dep(request)
         assert exc_info.value.status_code == 401
+
+
+class TestRHIdentityHeaderSizeLimit:
+    """Test suite for x-rh-identity header size limit enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_header_at_exact_limit_accepted(
+        self, mocker: MockerFixture, user_identity_data: dict
+    ) -> None:
+        """Test that a header at exactly the size limit is accepted."""
+        header_value = create_auth_header(user_identity_data)
+        auth_dep = RHIdentityAuthDependency(max_header_size=len(header_value))
+        request = create_request_with_header(mocker, header_value)
+
+        user_id, username, _, _ = await auth_dep(request)
+
+        assert user_id == "abc123"
+        assert username == "user@redhat.com"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "header_size,max_size",
+        [
+            (9000, 8192),  # Well over default limit
+            (101, 100),  # One byte over custom limit
+            (200, 100),  # Well over custom limit
+        ],
+    )
+    async def test_header_exceeding_limit_rejected(
+        self,
+        mocker: MockerFixture,
+        header_size: int,
+        max_size: int,
+    ) -> None:
+        """Test oversized headers rejected with HTTP 400 and a warning logged."""
+        mock_warning = mocker.patch("authentication.rh_identity.logger.warning")
+        auth_dep = RHIdentityAuthDependency(max_header_size=max_size)
+        request = create_request_with_header(mocker, "x" * header_size)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_dep(request)
+
+        assert exc_info.value.status_code == 400
+        assert "exceeds maximum" in str(exc_info.value.detail)
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.args[1] == header_size
+        assert mock_warning.call_args.args[2] == max_size

--- a/tests/unit/models/config/test_authentication_configuration.py
+++ b/tests/unit/models/config/test_authentication_configuration.py
@@ -1,5 +1,6 @@
 """Unit tests for AuthenticationConfiguration model."""
 
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,7 @@ from constants import (
     AUTH_MOD_JWK_TOKEN,
     AUTH_MOD_RH_IDENTITY,
     AUTH_MOD_APIKEY_TOKEN,
+    DEFAULT_RH_IDENTITY_MAX_HEADER_SIZE,
 )
 
 
@@ -572,3 +574,31 @@ def test_authentication_configuration_api_key_but_insufficient_config() -> None:
             k8s_cluster_api=None,
             skip_for_health_probes=True,
         )
+
+
+def test_rh_identity_max_header_size_default() -> None:
+    """Test that RHIdentityConfiguration default max_header_size matches the constant."""
+    config = RHIdentityConfiguration()
+    assert config.max_header_size == DEFAULT_RH_IDENTITY_MAX_HEADER_SIZE
+
+
+@pytest.mark.parametrize(
+    "max_header_size,expectation",
+    [
+        (4096, nullcontext()),
+        (0, pytest.raises(ValidationError)),
+        (-1, pytest.raises(ValidationError)),
+    ],
+)
+def test_rh_identity_max_header_size_validation(
+    max_header_size: int,
+    expectation: AbstractContextManager,
+) -> None:
+    """Test that RHIdentityConfiguration validates max_header_size correctly.
+
+    Verify that PositiveInt accepts valid custom values and rejects zero and
+    negative values.
+    """
+    with expectation:
+        config = RHIdentityConfiguration(max_header_size=max_header_size)
+        assert config.max_header_size == max_header_size


### PR DESCRIPTION
## Description

The rh-identity auth module passes the `x-rh-identity` header value directly to `base64.b64decode()` with no size check. An attacker can send a multi-megabyte header and force memory allocation for decoding, JSON parsing, and dict traversal (DoS vector).

This PR adds a configurable `max_header_size` field to `RHIdentityConfiguration` (default 8KB) and enforces a size check on the raw base64-encoded header **before** any decoding occurs. Oversized headers are rejected with HTTP 400 and a warning is logged with size details.

### Changes

- `src/constants.py`: add `DEFAULT_RH_IDENTITY_MAX_HEADER_SIZE = 8192`
- `src/models/config.py`: add `max_header_size: PositiveInt` field to `RHIdentityConfiguration`
- `src/authentication/rh_identity.py`: add `max_header_size` constructor param and size check before `base64.b64decode()`
- `src/authentication/__init__.py`: wire `max_header_size` from config into the auth dependency
- Unit tests for config validation and auth header size enforcement

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude (OpenCode)
- Generated by: N/A

## Related Tickets & Documents

- Closes [RSPEED-2651](https://redhat.atlassian.net/browse/RSPEED-2651)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. `uv run make verify` passes all linters (pylint 10/10, pyright 0 errors, ruff clean)
2. `uv run make test-unit` passes all 1765 tests with 60%+ coverage
3. `rh_identity.py` has 100% test coverage
4. New tests verify:
   - Oversized headers (9000 bytes, 101 bytes, 200 bytes) rejected with HTTP 400
   - Header at exact limit is accepted and auth succeeds
   - Custom `max_header_size` is respected
   - Warning logged with actual header size and configured limit
   - Config field defaults to 8192, rejects 0 and negative values via `PositiveInt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added header size validation for authentication headers. The x-rh-identity header now enforces a configurable maximum size limit (default: 8192 bytes), rejecting requests exceeding this threshold with a 400 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->