### PR TITLE
LCORE-1508: added missing OpenAI Responses API documentation

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -3655,7 +3655,9 @@ Returns:
 | Status Code | Description | Component |
 |-------------|-------------|-----------|
 | 200 | Successful response | [ReadinessResponse](#readinessresponse) |
-| 401 | Unauthorized | [UnauthorizedResponse](#unauthorizedresponse)
+| 401 | Unauthorized | [UnauthorizedResponse](#unauthorizedresponse) |
+| 403 | Permission denied | [ForbiddenResponse](#forbiddenresponse) |
+| 503 | Service unavailable | [ServiceUnavailableResponse](#serviceunavailableresponse) |
 
 Examples
 
@@ -3683,10 +3685,6 @@ Examples
   }
 }
 ```
- |
-| 403 | Permission denied | [ForbiddenResponse](#forbiddenresponse)
-
-Examples
 
 
 
@@ -3700,10 +3698,6 @@ Examples
   }
 }
 ```
- |
-| 503 | Service unavailable | [ServiceUnavailableResponse](#serviceunavailableresponse)
-
-Examples
 
 
 
@@ -3717,7 +3711,7 @@ Examples
   }
 }
 ```
- |
+
 ## GET `/liveness`
 
 > **Liveness Probe Get Method**
@@ -3805,9 +3799,8 @@ Returns:
 | Status Code | Description | Component |
 |-------------|-------------|-----------|
 | 200 | Successful response | [AuthorizedResponse](#authorizedresponse) |
-| 401 | Unauthorized | [UnauthorizedResponse](#unauthorizedresponse)
-
-Examples
+| 401 | Unauthorized | [UnauthorizedResponse](#unauthorizedresponse) |
+| 403 | Permission denied | [ForbiddenResponse](#forbiddenresponse) |
 
 
 
@@ -3833,11 +3826,6 @@ Examples
   }
 }
 ```
- |
-| 403 | Permission denied | [ForbiddenResponse](#forbiddenresponse)
-
-Examples
-
 
 
 
@@ -3850,7 +3838,7 @@ Examples
   }
 }
 ```
- |
+
 ## GET `/metrics`
 
 > **Metrics Endpoint Handler**


### PR DESCRIPTION
## Description

LCORE-1508: added missing OpenAI Responses API documentation

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1508


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the previous Infer API docs with a new Responses API section (supports non-stream and streaming/SSE event behavior), expanded error guidance across many HTTP statuses, and clarified readiness/liveness and authorized probe sections.
  * Added documentation for server/tool management and detailed response/annotation formats.

* **New Features**
  * Added an allow_verbose_infer configuration option to enable richer infer metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->