### PR TITLE
Fix Solr OKP default URL missing /solr path

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -190,7 +190,7 @@ SOLR_VECTOR_SEARCH_DEFAULT_MODE = "hybrid"
 SOLR_CHUNK_FILTER_QUERY = "is_chunk:true"
 
 # SOLR OKP RAG - default base URL when okp.rhokp_url is unset in configuration
-RH_SERVER_OKP_DEFAULT_URL = "http://localhost:8081"
+RH_SERVER_OKP_DEFAULT_URL = "http://localhost:8081/solr"
 
 SOLR_PROVIDER_ID = "okp_solr"
 


### PR DESCRIPTION
## Description

The default Solr base URL (`RH_SERVER_OKP_DEFAULT_URL`) was missing the `/solr` path prefix, causing `404 Not Found` errors when the OKP provider connected to Solr collections (e.g. `http://localhost:8081/portal-rag/select` instead of `http://localhost:8081/solr/portal-rag/select`).

## Type of change

- [x] Bug fix

## Tools used to create PR

- Assisted-by: Claude Code (Claude Opus 4.6)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested using solr as knowledge base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Solr endpoint configuration to append the `/solr` path segment to the base URL. This ensures the correct endpoint is used when no custom configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->