### PR TITLE
LCORE-1616 /v1/responses support for MCP tool merging (goose agent support)

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -23,6 +23,7 @@ This document describes the LCORE implementation of the OpenResponses API, expos
   * [Conversation Handling](#conversation-handling)
   * [Output Representation](#output-representation)
   * [Tool Configuration Differences](#tool-configuration-differences)
+  * [Server-Tool Merging](#server-tool-merging)
   * [LCORE-Specific Extensions](#lcore-specific-extensions-2)
   * [System Prompt Resolution](#system-prompt-resolution)
   * [Streaming Differences](#streaming-differences)
@@ -532,6 +533,65 @@ Vector store IDs are configured within the `tools` as `file_search` tools rather
 The response includes `tools` and `tool_choice` fields that reflect the internally resolved configuration. More specifically, the final set of tools and selection constraints after internal resolution and filtering.
 
 `tool_choice` only constrains how the model may use tools (including RAG via the `file_search` tool). It does **not** change inline RAG: vector store IDs you list under `tools` for file search are still used to build inline RAG context even if you set `tool_choice` to `none` or use an allowlist that omits `file_search`.
+
+### Server-Tool Merging
+
+By default, the `tools` field acts as a per-request override: when provided, only the specified tools are available for that request, and server-configured tools (RAG, MCP) are not included. The **server-tool merging** feature allows clients to provide their own tools while also retaining all server-configured tools.
+
+This is useful for hybrid MCP architectures where a client (e.g. Goose) runs its own local MCP servers or function tools but also needs access to server-configured RAG and MCP tools.
+
+#### Enabling Server-Tool Merging
+
+Set the `X-LCS-Merge-Server-Tools: true` request header to enable merging:
+
+```bash
+curl -X POST http://localhost:8090/v1/responses \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-LCS-Merge-Server-Tools: true" \
+  -d '{
+    "input": "Find relevant docs and run my analysis tool",
+    "tools": [
+      { "type": "mcp", "server_label": "my-local-tool", "server_url": "http://localhost:3000/sse" }
+    ]
+  }'
+```
+
+When this header is set:
+
+1. **Client-provided tools** are resolved first (BYOK translation, MCP header injection).
+2. **Server-configured tools** (RAG file_search, server MCP tools) are loaded from the LCORE configuration.
+3. The two sets are **merged** into a single tool list, with client tools appearing first.
+
+When the header is absent or `false`, the `tools` field behaves as a standard per-request override: only the explicitly listed tools are used.
+
+#### Conflict Detection
+
+Merging rejects conflicting tools with an HTTP **409 Conflict** error:
+
+- **MCP conflict**: A client-provided MCP tool has the same `server_label` as a server-configured MCP tool.
+- **file_search conflict**: The client provides a `file_search` tool when the server also configures one.
+
+Example 409 response:
+
+```json
+{
+  "status_code": 409,
+  "detail": {
+    "response": "Tool conflict detected",
+    "cause": "Client MCP tool 'my-server' conflicts with a server-configured MCP tool with the same server_label."
+  }
+}
+```
+
+#### Stream Filtering
+
+When server-tool merging is active, the response stream and output include items from both client and server tools. To keep streams clean for clients that manage their own tool execution, LCORE automatically distinguishes between server-deployed and client-provided tool output:
+
+- **Server-deployed tool events** (`mcp_call`, `mcp_list_tools`, `mcp_approval_request` from server-configured MCP servers, plus `file_search_call` and `web_search_call`) are included in turn summaries, metrics, and conversation storage.
+- **Client-provided tool events** (`function_call` items and MCP events from non-server-configured labels) are passed through in the response but excluded from server-side processing (turn summary, metrics, storage).
+
+In streaming mode, server-deployed MCP events (e.g. `mcp_call`, `mcp_list_tools`) are filtered from the SSE stream so clients only see standard output types (`message`, `function_call`, etc.) for their own tools.
 
 ### LCORE-Specific Extensions
 

--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -562,6 +562,47 @@ def _should_filter_mcp_chunk(
     return False
 
 
+def _populate_turn_summary(
+    response_object: OpenAIResponseObject,
+    turn_summary: TurnSummary,
+    api_params: ResponsesApiParams,
+    inline_rag_context: RAGContext,
+    filter_server_tools: bool,
+) -> None:
+    """Populate turn summary with metadata extracted from the final response object.
+
+    Args:
+        response_object: The completed response object from Llama Stack
+        turn_summary: TurnSummary to populate
+        api_params: ResponsesApiParams
+        inline_rag_context: Inline RAG context used for the response
+        filter_server_tools: Whether to filter server-deployed MCP tool events
+    """
+    turn_summary.id = response_object.id
+    vector_store_ids = extract_vector_store_ids_from_tools(api_params.tools)
+    tool_rag_docs = parse_referenced_documents(
+        response_object, vector_store_ids, configuration.rag_id_mapping
+    )
+    turn_summary.referenced_documents = deduplicate_referenced_documents(
+        inline_rag_context.referenced_documents + tool_rag_docs
+    )
+    for item in response_object.output:
+        if filter_server_tools and not is_server_deployed_output(item):
+            continue
+        tool_call, tool_result = build_tool_call_summary(item)
+        if tool_call:
+            turn_summary.tool_calls.append(tool_call)
+        if tool_result:
+            turn_summary.tool_results.append(tool_result)
+
+    tool_rag_chunks = parse_rag_chunks(
+        response_object,
+        vector_store_ids,
+        configuration.rag_id_mapping,
+    )
+    turn_summary.rag_chunks = inline_rag_context.rag_chunks + tool_rag_chunks
+
+
 async def response_generator(
     stream: AsyncIterator[OpenAIResponseObjectStream],
     user_input: ResponseInput,
@@ -674,29 +715,13 @@ async def response_generator(
 
     # Extract response metadata from final response object
     if latest_response_object:
-        turn_summary.id = latest_response_object.id
-        vector_store_ids = extract_vector_store_ids_from_tools(api_params.tools)
-        tool_rag_docs = parse_referenced_documents(
-            latest_response_object, vector_store_ids, configuration.rag_id_mapping
-        )
-        turn_summary.referenced_documents = deduplicate_referenced_documents(
-            inline_rag_context.referenced_documents + tool_rag_docs
-        )
-        for item in latest_response_object.output:
-            if filter_server_tools and not is_server_deployed_output(item):
-                continue
-            tool_call, tool_result = build_tool_call_summary(item)
-            if tool_call:
-                turn_summary.tool_calls.append(tool_call)
-            if tool_result:
-                turn_summary.tool_results.append(tool_result)
-
-        tool_rag_chunks = parse_rag_chunks(
+        _populate_turn_summary(
             latest_response_object,
-            vector_store_ids,
-            configuration.rag_id_mapping,
+            turn_summary,
+            api_params,
+            inline_rag_context,
+            filter_server_tools,
         )
-        turn_summary.rag_chunks = inline_rag_context.rag_chunks + tool_rag_chunks
 
     client = AsyncLlamaStackClientHolder().get_client()
     # Explicitly append the turn to conversation if context passed by previous response

--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -40,6 +40,7 @@ from log import get_logger
 from models.config import Action
 from models.requests import ResponsesRequest
 from models.responses import (
+    ConflictResponse,
     ForbiddenResponse,
     InternalServerErrorResponse,
     NotFoundResponse,
@@ -79,8 +80,10 @@ from utils.responses import (
     extract_vector_store_ids_from_tools,
     get_topic_summary,
     get_zero_usage,
+    is_server_deployed_output,
     parse_rag_chunks,
     parse_referenced_documents,
+    resolve_client_tool_choice,
     resolve_tool_choice,
     select_model_for_responses,
 )
@@ -115,6 +118,9 @@ responses_response: dict[int | str, dict[str, Any]] = {
     ),
     404: NotFoundResponse.openapi_response(
         examples=["model", "conversation", "provider"]
+    ),
+    409: ConflictResponse.openapi_response(
+        examples=["mcp tool conflict", "file search conflict"]
     ),
     413: PromptTooLongResponse.openapi_response(),
     422: UnprocessableEntityResponse.openapi_response(),
@@ -244,13 +250,30 @@ async def responses_endpoint_handler(
         else None
     )
 
-    responses_request.tools, responses_request.tool_choice = await resolve_tool_choice(
-        responses_request.tools,
-        responses_request.tool_choice,
-        auth[1],
-        mcp_headers,
-        request.headers,
+    filter_server_tools = (
+        request.headers.get("X-LCS-Merge-Server-Tools", "").lower() == "true"
     )
+
+    if filter_server_tools:
+        responses_request.tools, responses_request.tool_choice = (
+            await resolve_client_tool_choice(
+                responses_request.tools,
+                responses_request.tool_choice,
+                auth[1],
+                mcp_headers,
+                request.headers,
+            )
+        )
+    else:
+        responses_request.tools, responses_request.tool_choice = (
+            await resolve_tool_choice(
+                responses_request.tools,
+                responses_request.tool_choice,
+                auth[1],
+                mcp_headers,
+                request.headers,
+            )
+        )
 
     # Build RAG context from Inline RAG sources
     inline_rag_context = await build_rag_context(
@@ -278,6 +301,7 @@ async def responses_endpoint_handler(
         started_at=started_at,
         moderation_result=moderation_result,
         inline_rag_context=inline_rag_context,
+        filter_server_tools=filter_server_tools,
     )
 
 
@@ -289,6 +313,7 @@ async def handle_streaming_response(
     started_at: datetime,
     moderation_result: ShieldModerationResult,
     inline_rag_context: RAGContext,
+    filter_server_tools: bool = False,
 ) -> StreamingResponse:
     """Handle streaming response from Responses API.
 
@@ -300,6 +325,7 @@ async def handle_streaming_response(
         started_at: Timestamp when the conversation started
         moderation_result: Result of shield moderation check
         inline_rag_context: Inline RAG context to be used for the response
+        filter_server_tools: Whether to filter server-deployed MCP tool events from the stream
     Returns:
         StreamingResponse with SSE-formatted events
     """
@@ -338,6 +364,7 @@ async def handle_streaming_response(
                 user_id=auth[0],
                 turn_summary=turn_summary,
                 inline_rag_context=inline_rag_context,
+                filter_server_tools=filter_server_tools,
             )
         except RuntimeError as e:  # library mode wraps 413 into runtime error
             if is_context_length_error(str(e)):
@@ -409,7 +436,9 @@ async def shield_violation_generator(
         output_text="",
         **echoed_params,
     )
-    created_response_dict = created_response_object.model_dump(exclude_none=True)
+    created_response_dict = created_response_object.model_dump(
+        exclude_none=True, by_alias=True
+    )
     created_event = {
         "type": "response.created",
         "sequence_number": 0,
@@ -425,7 +454,9 @@ async def shield_violation_generator(
         output_index=0,
         sequence_number=1,
     )
-    data_json = json.dumps(item_added_event.model_dump(exclude_none=True))
+    data_json = json.dumps(
+        item_added_event.model_dump(exclude_none=True, by_alias=True)
+    )
     yield f"event: response.output_item.added\ndata: {data_json}\n\n"
 
     # 3. Send response.output_item.done event
@@ -435,7 +466,7 @@ async def shield_violation_generator(
         output_index=0,
         sequence_number=2,
     )
-    data_json = json.dumps(item_done_event.model_dump(exclude_none=True))
+    data_json = json.dumps(item_done_event.model_dump(exclude_none=True, by_alias=True))
     yield f"event: response.output_item.done\ndata: {data_json}\n\n"
 
     # 4. Send response.completed event with status "completed" and output populated
@@ -451,7 +482,9 @@ async def shield_violation_generator(
         output_text=moderation_result.message,
         **echoed_params,
     )
-    completed_response_dict = completed_response_object.model_dump(exclude_none=True)
+    completed_response_dict = completed_response_object.model_dump(
+        exclude_none=True, by_alias=True
+    )
     completed_event = {
         "type": "response.completed",
         "sequence_number": 3,
@@ -463,6 +496,72 @@ async def shield_violation_generator(
     yield "data: [DONE]\n\n"
 
 
+def _is_server_mcp_output_item(
+    item: dict[str, Any], configured_mcp_labels: set[str]
+) -> bool:
+    """Check if a serialized output item is a server-deployed MCP tool call.
+
+    Args:
+        item: A dict from the serialized response output array.
+        configured_mcp_labels: Set of server_label names configured in LCS.
+
+    Returns:
+        True if the item is an MCP call/list/approval from a server-deployed MCP server.
+    """
+    item_type = item.get("type")
+    if item_type in ("mcp_call", "mcp_list_tools", "mcp_approval_request"):
+        return item.get("server_label") in configured_mcp_labels
+    return False
+
+
+def _should_filter_mcp_chunk(
+    chunk: OpenAIResponseObjectStream,
+    event_type: Optional[str],
+    configured_mcp_labels: set[str],
+    server_mcp_output_indices: set[int],
+) -> bool:
+    """Check if a streaming chunk is a server-deployed MCP event that should be filtered.
+
+    Args:
+        chunk: The streaming chunk to check.
+        event_type: The event type of the chunk.
+        configured_mcp_labels: Set of server_label names configured in LCS.
+        server_mcp_output_indices: Tracked output indices of server-deployed MCP calls.
+
+    Returns:
+        True if the chunk should be filtered out from the client stream.
+    """
+    if event_type == "response.output_item.added":
+        item_added_chunk = cast(OutputItemAddedChunk, chunk)
+        item = item_added_chunk.item
+        item_type = getattr(item, "type", None)
+        if item_type in ("mcp_call", "mcp_list_tools", "mcp_approval_request"):
+            server_label = getattr(item, "server_label", None)
+            if server_label in configured_mcp_labels:
+                server_mcp_output_indices.add(item_added_chunk.output_index)
+                return True
+
+    if event_type and (
+        event_type.startswith("response.mcp_call.")
+        or event_type.startswith("response.mcp_list_tools.")
+        or event_type.startswith("response.mcp_approval_request.")
+    ):
+        output_index = getattr(chunk, "output_index", None)
+        if output_index in server_mcp_output_indices:
+            return True
+
+    if event_type == "response.output_item.done":
+        item_done_chunk = cast(OutputItemDoneChunk, chunk)
+        item = item_done_chunk.item
+        item_type = getattr(item, "type", None)
+        if item_type in ("mcp_call", "mcp_list_tools", "mcp_approval_request"):
+            if item_done_chunk.output_index in server_mcp_output_indices:
+                server_mcp_output_indices.discard(item_done_chunk.output_index)
+                return True
+
+    return False
+
+
 async def response_generator(
     stream: AsyncIterator[OpenAIResponseObjectStream],
     user_input: ResponseInput,
@@ -470,6 +569,7 @@ async def response_generator(
     user_id: str,
     turn_summary: TurnSummary,
     inline_rag_context: RAGContext,
+    filter_server_tools: bool = False,
 ) -> AsyncIterator[str]:
     """Generate SSE-formatted streaming response with LCORE-enriched events.
 
@@ -480,6 +580,7 @@ async def response_generator(
         user_id: User ID for quota retrieval
         turn_summary: TurnSummary to populate during streaming
         inline_rag_context: Inline RAG context to be used for the response
+        filter_server_tools: Whether to filter server-deployed MCP tool events from the stream
     Yields:
         SSE-formatted strings for streaming events, ending with [DONE]
     """
@@ -489,12 +590,25 @@ async def response_generator(
 
     latest_response_object: Optional[OpenAIResponseObject] = None
     sequence_number = 0
+    configured_mcp_labels = (
+        {s.name for s in configuration.mcp_servers} if filter_server_tools else set()
+    )
+    # Track output indices of server-deployed MCP calls to filter their events
+    server_mcp_output_indices: set[int] = set()
 
     async for chunk in stream:
         event_type = getattr(chunk, "type", None)
         logger.debug("Processing streaming chunk, type: %s", event_type)
 
-        chunk_dict = chunk.model_dump(exclude_none=True)
+        # Filter out streaming events for server-deployed MCP tools.
+        # These are handled internally by LCS and should not be forwarded
+        # to clients that don't understand the mcp_call item type.
+        if _should_filter_mcp_chunk(
+            chunk, event_type, configured_mcp_labels, server_mcp_output_indices
+        ):
+            continue
+
+        chunk_dict = chunk.model_dump(exclude_none=True, by_alias=True)
 
         # Create own sequence number for chunks to maintain order
         chunk_dict["sequence_number"] = sequence_number
@@ -510,6 +624,15 @@ async def response_generator(
                         configuration.rag_id_mapping,
                     )
                 )
+            # Remove server-deployed MCP items from the output array so
+            # clients only see item types they understand (message, function_call, etc.)
+            output = chunk_dict["response"].get("output")
+            if output is not None:
+                chunk_dict["response"]["output"] = [
+                    item
+                    for item in output
+                    if not _is_server_mcp_output_item(item, configured_mcp_labels)
+                ]
 
         # Intermediate response - no quota consumption and text yet
         if event_type == "response.in_progress":
@@ -560,6 +683,8 @@ async def response_generator(
             inline_rag_context.referenced_documents + tool_rag_docs
         )
         for item in latest_response_object.output:
+            if filter_server_tools and not is_server_deployed_output(item):
+                continue
             tool_call, tool_result = build_tool_call_summary(item)
             if tool_call:
                 turn_summary.tool_calls.append(tool_call)
@@ -643,6 +768,7 @@ async def handle_non_streaming_response(
     started_at: datetime,
     moderation_result: ShieldModerationResult,
     inline_rag_context: RAGContext,
+    filter_server_tools: bool = False,
 ) -> ResponsesResponse:
     """Handle non-streaming response from Responses API.
 
@@ -654,6 +780,7 @@ async def handle_non_streaming_response(
         started_at: Timestamp when the conversation started
         moderation_result: Result of shield moderation check
         inline_rag_context: Inline RAG context to be used for the response
+        filter_server_tools: Whether to filter server-deployed MCP tool output
     Returns:
         ResponsesResponse with the completed response
     """
@@ -732,6 +859,7 @@ async def handle_non_streaming_response(
         api_params.model,
         vector_store_ids,
         configuration.rag_id_mapping,
+        filter_server_tools=filter_server_tools,
     )
     turn_summary.referenced_documents = deduplicate_referenced_documents(
         inline_rag_context.referenced_documents + turn_summary.referenced_documents

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -2195,6 +2195,28 @@ class ConflictResponse(AbstractErrorResponse):
                         ),
                     },
                 },
+                {
+                    "label": "mcp tool conflict",
+                    "detail": {
+                        "response": "Tool conflict",
+                        "cause": (
+                            "Client MCP tool with server_label 'my-server' "
+                            "conflicts with a server-configured MCP tool. "
+                            "Rename the client tool to avoid the conflict."
+                        ),
+                    },
+                },
+                {
+                    "label": "file search conflict",
+                    "detail": {
+                        "response": "Tool conflict",
+                        "cause": (
+                            "Client file_search tool conflicts with a "
+                            "server-configured file_search tool. "
+                            "Remove the client file_search to use the server's configuration."
+                        ),
+                    },
+                },
             ]
         }
     }
@@ -2212,6 +2234,66 @@ class ConflictResponse(AbstractErrorResponse):
         super().__init__(
             response=response, cause=cause, status_code=status.HTTP_409_CONFLICT
         )
+
+    @classmethod
+    def mcp_tool(cls, server_label: str) -> "ConflictResponse":
+        """Create a ConflictResponse for a client MCP tool conflicting with a server-configured one.
+
+        Parameters:
+        ----------
+            server_label: The server_label that conflicts.
+
+        Returns:
+        -------
+            ConflictResponse with a cause describing the MCP tool conflict.
+        """
+        return cls._from_cause(
+            response="Tool conflict",
+            cause=(
+                f"Client MCP tool with server_label '{server_label}' "
+                f"conflicts with a server-configured MCP tool. "
+                f"Rename the client tool to avoid the conflict."
+            ),
+        )
+
+    @classmethod
+    def file_search(cls) -> "ConflictResponse":
+        """Create a ConflictResponse for a client file_search tool conflicting with a server one.
+
+        Returns:
+        -------
+            ConflictResponse with a cause describing the file_search tool conflict.
+        """
+        return cls._from_cause(
+            response="Tool conflict",
+            cause=(
+                "Client file_search tool conflicts with a "
+                "server-configured file_search tool. "
+                "Remove the client file_search to use the server's configuration."
+            ),
+        )
+
+    @classmethod
+    def _from_cause(cls, *, response: str, cause: str) -> "ConflictResponse":
+        """Create a ConflictResponse with explicit response and cause strings.
+
+        Parameters:
+        ----------
+            response: Short summary of the conflict.
+            cause: Detailed explanation of the conflict.
+
+        Returns:
+        -------
+            ConflictResponse instance.
+        """
+        instance = cls.__new__(cls)
+        AbstractErrorResponse.__init__(
+            instance,
+            response=response,
+            cause=cause,
+            status_code=status.HTTP_409_CONFLICT,
+        )
+        return instance
 
 
 class PromptTooLongResponse(AbstractErrorResponse):

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -95,6 +95,7 @@ from models.config import ByokRag
 from models.database.conversations import UserConversation
 from models.requests import QueryRequest
 from models.responses import (
+    ConflictResponse,
     InternalServerErrorResponse,
     NotFoundResponse,
     ServiceUnavailableResponse,
@@ -1401,11 +1402,47 @@ async def select_model_for_responses(
     return model.id
 
 
+def is_server_deployed_output(output_item: ResponseOutput) -> bool:
+    """Check if a response output item belongs to a tool deployed by LCS.
+
+    In the hybrid architecture clients may provide their own tools (function
+    tools or MCP servers running locally) alongside server-configured tools.
+    This function identifies items that belong to LCS-deployed tools so that
+    only those are included in server-side processing (turn summary, metrics,
+    storage).  Client tool output items are still returned in the response
+    to the caller but are not processed internally.
+
+    Args:
+        output_item: A ResponseOutput item from the response.
+
+    Returns:
+        True if the item should be processed by LCS, False for client tools.
+    """
+    item_type = getattr(output_item, "type", None)
+
+    # function_call items are always from client-provided tools;
+    # LCS only configures file_search and mcp tools.
+    if item_type == "function_call":
+        return False
+
+    # MCP items: check server_label against configured servers
+    if item_type in ("mcp_call", "mcp_list_tools", "mcp_approval_request"):
+        server_label = getattr(output_item, "server_label", None)
+        if server_label is not None:
+            configured_labels = {s.name for s in configuration.mcp_servers}
+            return server_label in configured_labels
+
+    # file_search_call, web_search_call, message, and unknown types
+    # are treated as server-side.
+    return True
+
+
 def build_turn_summary(
     response: Optional[OpenAIResponseObject],
     model: str,
     vector_store_ids: Optional[list[str]] = None,
     rag_id_mapping: Optional[dict[str, str]] = None,
+    filter_server_tools: bool = False,
 ) -> TurnSummary:
     """Build a TurnSummary from a ResponseObject.
 
@@ -1414,6 +1451,8 @@ def build_turn_summary(
         model: The model identifier in "provider/model" format
         vector_store_ids: Vector store IDs used in the query for source resolution.
         rag_id_mapping: Mapping from vector_db_id to user-facing rag_id.
+        filter_server_tools: When True, skip client-provided tool output items
+            so only server-deployed tool calls are included in the summary.
 
     Returns:
         TurnSummary with extracted response text, referenced_documents, rag_chunks,
@@ -1435,6 +1474,8 @@ def build_turn_summary(
     )
 
     for item in response.output:
+        if filter_server_tools and not is_server_deployed_output(item):
+            continue
         tool_call, tool_result = build_tool_call_summary(item)
         if tool_call:
             summary.tool_calls.append(tool_call)
@@ -1602,6 +1643,120 @@ def extract_attachments_text(response_input: ResponseInput) -> str:
     return "\n\n".join(file_data_parts)
 
 
+def _merge_tools(
+    client_tools: list[InputTool],
+    server_tools: list[InputTool],
+) -> list[InputTool]:
+    """Merge server-configured tools into client-provided tools, rejecting conflicts.
+
+    Raises an HTTP 409 error when a client tool conflicts with a
+    server-configured tool.  Conflicts are detected by:
+    - MCP tools: matching ``server_label``
+    - file_search tools: client provides file_search when server also configures one
+
+    Args:
+        client_tools: Tools explicitly provided by the client.
+        server_tools: Tools loaded from server configuration.
+
+    Returns:
+        Merged list with client tools first, followed by non-conflicting server tools.
+
+    Raises:
+        HTTPException: 409 if a client tool conflicts with a server-configured tool.
+    """
+    server_mcp_labels: set[str] = {
+        t.server_label for t in server_tools if t.type == "mcp"
+    }
+    has_server_file_search = any(t.type == "file_search" for t in server_tools)
+
+    for tool in client_tools:
+        if tool.type == "mcp" and tool.server_label in server_mcp_labels:
+            error_response = ConflictResponse.mcp_tool(tool.server_label)
+            raise HTTPException(**error_response.model_dump())
+        if tool.type == "file_search" and has_server_file_search:
+            error_response = ConflictResponse.file_search()
+            raise HTTPException(**error_response.model_dump())
+
+    return list(client_tools) + list(server_tools)
+
+
+async def _resolve_client_tools(
+    tools: list[InputTool],
+    token: str,
+    mcp_headers: Optional[McpHeaders],
+    request_headers: Optional[Mapping[str, str]],
+    merge_server_tools: bool,
+) -> list[InputTool]:
+    """Resolve client-provided tools, optionally merging with server tools.
+
+    Translates vector store IDs using BYOK configuration, applies MCP headers,
+    and optionally merges server-configured tools when merge is requested.
+    Conflicts (e.g. a client MCP tool with the same server_label as a
+    server-configured one, or duplicate file_search tools) are rejected with
+    a 409 error.
+
+    Args:
+        tools: Tools explicitly provided by the client.
+        token: User token for MCP and auth.
+        mcp_headers: Optional MCP headers.
+        request_headers: Optional headers for tool resolution.
+        merge_server_tools: Whether to merge server-configured tools.
+
+    Returns:
+        Resolved list of tools.
+    """
+    # Per-request override of vector stores (user-facing rag_ids)
+    vector_store_ids = extract_vector_store_ids_from_tools(tools) or None
+    # Translate user-facing rag_ids to llama-stack vector_store_ids in each file_search tool
+    byok_rags = configuration.configuration.byok_rag
+    prepared_tools = translate_tools_vector_store_ids(tools, byok_rags)
+    prepared_tools = apply_mcp_headers_to_explicit_tools(
+        prepared_tools, token, mcp_headers, request_headers
+    )
+
+    # Optionally merge server-configured tools (RAG, MCP) with client tools
+    if merge_server_tools:
+        client = AsyncLlamaStackClientHolder().get_client()
+        server_tools = await prepare_tools(
+            client=client,
+            vector_store_ids=vector_store_ids,
+            no_tools=False,
+            token=token,
+            mcp_headers=mcp_headers,
+            request_headers=request_headers,
+        )
+        if server_tools:
+            prepared_tools = _merge_tools(prepared_tools, server_tools)
+
+    return prepared_tools
+
+
+async def _resolve_server_tools(
+    token: str,
+    mcp_headers: Optional[McpHeaders],
+    request_headers: Optional[Mapping[str, str]],
+) -> Optional[list[InputTool]]:
+    """Load all server-configured tools from LCORE configuration.
+
+    Args:
+        token: User token for MCP and auth.
+        mcp_headers: Optional MCP headers.
+        request_headers: Optional headers for tool resolution.
+
+    Returns:
+        List of server-configured tools, or None if none are configured.
+    """
+    client = AsyncLlamaStackClientHolder().get_client()
+    return await prepare_tools(
+        client=client,
+        vector_store_ids=None,  # allow all vector stores configured
+        no_tools=False,
+        token=token,
+        mcp_headers=mcp_headers,
+        request_headers=request_headers,
+    )
+
+
 async def resolve_tool_choice(
     tools: Optional[list[InputTool]],
     tool_choice: Optional[ToolChoice],
@@ -1652,6 +1807,71 @@ async def resolve_tool_choice(
         prepared_tools = translate_tools_vector_store_ids(tools, byok_rags)
         prepared_tools = apply_mcp_headers_to_explicit_tools(
             prepared_tools, token, mcp_headers, request_headers
+        )
+
+    if isinstance(tool_choice, AllowedTools):
+        # Apply filters to tools if specified and overwrite tool choice mode
+        prepared_tool_choice = ToolChoiceMode(tool_choice.mode)
+        prepared_tools = filter_tools_by_allowed_entries(
+            prepared_tools, tool_choice.tools
+        )
+    else:
+        # Use request tool choice mode or default to auto
+        prepared_tool_choice = tool_choice or ToolChoiceMode.auto
+
+    # Clear tools and tool choice if no tools remain for consistency with Responses API
+    if not prepared_tools:
+        prepared_tools = None
+        prepared_tool_choice = None
+
+    return prepared_tools, prepared_tool_choice
+
+
+async def resolve_client_tool_choice(
+    tools: Optional[list[InputTool]],
+    tool_choice: Optional[ToolChoice],
+    token: str,
+    mcp_headers: Optional[McpHeaders] = None,
+    request_headers: Optional[Mapping[str, str]] = None,
+) -> tuple[Optional[list[InputTool]], Optional[ToolChoice]]:
+    """Resolve tools and tool choice when client tools are merged with server tools.
+
+    This function isolates the tool resolution logic used when the
+    ``X-LCS-Merge-Server-Tools`` header is present.  Client-provided tools are
+    resolved via BYOK translation and MCP header application, then merged with
+    server-configured tools.  Conflicts (duplicate MCP server_label or
+    file_search) are rejected with a 409 error.
+
+    When tool choice is mode none, returns (None, None) so Llama Stack sees no
+    tools, even if the request listed tools.
+
+    When filters are present, apply them to prepared tools and overwrite tool
+    choice mode.
+
+    If no tools remain after filtering, both prepared tools and tool choice are
+    cleared.
+
+    Args:
+        tools: Request tools, or None for LCORE-configured tools.
+        tool_choice: Requested strategy, or None.
+        token: User token for MCP and auth.
+        mcp_headers: Optional MCP headers.
+        request_headers: Optional headers for tool resolution.
+
+    Returns:
+        Prepared tools and resolved tool choice, each possibly None.
+    """
+    # If tool_choice mode is "none", tools are explicitly disallowed
+    if isinstance(tool_choice, ToolChoiceMode) and tool_choice == ToolChoiceMode.none:
+        return None, None
+
+    if tools:
+        prepared_tools: Optional[list[InputTool]] = await _resolve_client_tools(
+            tools, token, mcp_headers, request_headers, merge_server_tools=True
+        )
+    else:
+        prepared_tools = await _resolve_server_tools(
+            token, mcp_headers, request_headers
         )
 
     if isinstance(tool_choice, AllowedTools):

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -8,11 +8,16 @@ import pytest
 from fastapi import HTTPException, Request
 from fastapi.responses import StreamingResponse
 from llama_stack_api import OpenAIResponseObject
+from llama_stack_api.openai_responses import (
+    OpenAIResponseInputToolChoiceMode as ToolChoiceMode,
+)
 from llama_stack_api.openai_responses import OpenAIResponseMessage
 from llama_stack_client import APIConnectionError, APIStatusError, AsyncLlamaStackClient
 from pytest_mock import MockerFixture
 
 from app.endpoints.responses import (
+    _is_server_mcp_output_item,
+    _should_filter_mcp_chunk,
     handle_non_streaming_response,
     handle_streaming_response,
     responses_endpoint_handler,
@@ -569,6 +574,65 @@ class TestResponsesEndpointHandler:
         payload = response.model_dump()
         assert "model" in payload, "Handler must set model on the response payload"
         ResponsesResponse.model_validate(payload)
+
+    @pytest.mark.asyncio
+    async def test_tool_choice_none_without_tools_does_not_load_server_tools(
+        self,
+        dummy_request: Request,
+        minimal_config: AppConfig,
+        mocker: MockerFixture,
+    ) -> None:
+        """Regression: tool_choice='none' with no client tools must not load server tools."""
+        responses_request = ResponsesRequest(
+            input="Hello",
+            tool_choice=ToolChoiceMode.none,
+            # tools intentionally omitted
+        )
+        _patch_base(mocker, minimal_config)
+        _patch_client(mocker)
+        _patch_resolve_response_context(mocker, conversation="conv_new_123")
+        mocker.patch(
+            f"{MODULE}.select_model_for_responses",
+            new=mocker.AsyncMock(return_value="provider/model1"),
+        )
+        mocker.patch(
+            f"{MODULE}.check_model_configured",
+            new=mocker.AsyncMock(return_value=True),
+        )
+        _patch_rag(mocker)
+        _patch_moderation(mocker, decision="passed")
+
+        mock_handle = mocker.patch(
+            f"{MODULE}.handle_non_streaming_response",
+            new=mocker.AsyncMock(
+                return_value=_make_responses_response(
+                    output_text="answer",
+                    conversation="conv_new_123",
+                )
+            ),
+        )
+
+        # Spy on prepare_tools to verify it is never called
+        mock_prepare = mocker.patch(
+            f"{UTILS_RESPONSES_MODULE}.prepare_tools",
+            new=mocker.AsyncMock(return_value=None),
+        )
+
+        await responses_endpoint_handler(
+            request=dummy_request,
+            responses_request=responses_request,
+            auth=MOCK_AUTH,
+            mcp_headers={},
+        )
+
+        # prepare_tools must NOT be called when tool_choice is "none"
+        mock_prepare.assert_not_awaited()
+
+        # The handler passes tools=None and tool_choice=None to the response handler
+        # (the endpoint deep-copies the request, so we inspect the handler call args)
+        call_kwargs = mock_handle.call_args[1]
+        assert call_kwargs["request"].tools is None
+        assert call_kwargs["request"].tool_choice is None
 
 
 class TestHandleNonStreamingResponse:
@@ -1614,3 +1678,193 @@ class TestResponsesInstructionResolution:
 
         call_kwargs = mock_handler.call_args[1]
         assert call_kwargs["request"].instructions == DEFAULT_SYSTEM_PROMPT
+
+
+class TestIsServerMcpOutputItem:
+    """Tests for _is_server_mcp_output_item helper."""
+
+    def test_mcp_call_with_matching_label(self) -> None:
+        """Test mcp_call item with a configured server_label returns True."""
+        item: dict[str, Any] = {"type": "mcp_call", "server_label": "my-server"}
+        assert _is_server_mcp_output_item(item, {"my-server"}) is True
+
+    def test_mcp_call_with_non_matching_label(self) -> None:
+        """Test mcp_call item with unconfigured server_label returns False."""
+        item: dict[str, Any] = {"type": "mcp_call", "server_label": "client-server"}
+        assert _is_server_mcp_output_item(item, {"my-server"}) is False
+
+    def test_mcp_list_tools_with_matching_label(self) -> None:
+        """Test mcp_list_tools item with configured label returns True."""
+        item: dict[str, Any] = {"type": "mcp_list_tools", "server_label": "fs"}
+        assert _is_server_mcp_output_item(item, {"fs", "other"}) is True
+
+    def test_mcp_approval_request_with_matching_label(self) -> None:
+        """Test mcp_approval_request item with configured label returns True."""
+        item: dict[str, Any] = {
+            "type": "mcp_approval_request",
+            "server_label": "tool-a",
+        }
+        assert _is_server_mcp_output_item(item, {"tool-a"}) is True
+
+    def test_mcp_call_missing_server_label(self) -> None:
+        """Test mcp_call without server_label returns False."""
+        item: dict[str, Any] = {"type": "mcp_call"}
+        assert _is_server_mcp_output_item(item, {"my-server"}) is False
+
+    def test_message_type_returns_false(self) -> None:
+        """Test non-MCP type returns False."""
+        item: dict[str, Any] = {"type": "message", "role": "assistant"}
+        assert _is_server_mcp_output_item(item, {"my-server"}) is False
+
+    def test_function_call_type_returns_false(self) -> None:
+        """Test function_call type returns False."""
+        item: dict[str, Any] = {"type": "function_call", "name": "get_weather"}
+        assert _is_server_mcp_output_item(item, {"my-server"}) is False
+
+    def test_empty_configured_labels(self) -> None:
+        """Test mcp_call with empty configured labels returns False."""
+        item: dict[str, Any] = {"type": "mcp_call", "server_label": "any-server"}
+        assert _is_server_mcp_output_item(item, set()) is False
+
+    def test_file_search_call_returns_false(self) -> None:
+        """Test file_search_call type returns False."""
+        item: dict[str, Any] = {"type": "file_search_call"}
+        assert _is_server_mcp_output_item(item, {"my-server"}) is False
+
+
+class TestShouldFilterMcpChunk:
+    """Tests for _should_filter_mcp_chunk helper."""
+
+    def test_filters_mcp_call_substream_events(self, mocker: MockerFixture) -> None:
+        """Test that response.mcp_call.* events are filtered for tracked indices."""
+        chunk = mocker.Mock()
+        chunk.output_index = 5
+        server_mcp_output_indices: set[int] = {5}
+        assert (
+            _should_filter_mcp_chunk(
+                chunk,
+                "response.mcp_call.in_progress",
+                {"server-a"},
+                server_mcp_output_indices,
+            )
+            is True
+        )
+
+    def test_filters_mcp_list_tools_substream_events(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that response.mcp_list_tools.* events are filtered for tracked indices."""
+        chunk = mocker.Mock()
+        chunk.output_index = 3
+        server_mcp_output_indices: set[int] = {3}
+        assert (
+            _should_filter_mcp_chunk(
+                chunk,
+                "response.mcp_list_tools.in_progress",
+                {"server-a"},
+                server_mcp_output_indices,
+            )
+            is True
+        )
+
+    def test_filters_mcp_approval_request_substream_events(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that response.mcp_approval_request.* events are filtered for tracked indices."""
+        chunk = mocker.Mock()
+        chunk.output_index = 7
+        server_mcp_output_indices: set[int] = {7}
+        assert (
+            _should_filter_mcp_chunk(
+                chunk,
+                "response.mcp_approval_request.in_progress",
+                {"server-a"},
+                server_mcp_output_indices,
+            )
+            is True
+        )
+
+    def test_does_not_filter_untracked_mcp_approval_request(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that mcp_approval_request events for untracked indices pass through."""
+        chunk = mocker.Mock()
+        chunk.output_index = 7
+        server_mcp_output_indices: set[int] = {99}
+        assert (
+            _should_filter_mcp_chunk(
+                chunk,
+                "response.mcp_approval_request.in_progress",
+                {"server-a"},
+                server_mcp_output_indices,
+            )
+            is False
+        )
+
+    def test_does_not_filter_untracked_mcp_call(self, mocker: MockerFixture) -> None:
+        """Test that mcp_call events for untracked indices pass through."""
+        chunk = mocker.Mock()
+        chunk.output_index = 10
+        server_mcp_output_indices: set[int] = {5}
+        assert (
+            _should_filter_mcp_chunk(
+                chunk,
+                "response.mcp_call.completed",
+                {"server-a"},
+                server_mcp_output_indices,
+            )
+            is False
+        )
+
+    def test_filters_output_item_added_for_server_mcp(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that output_item.added for server MCP items is filtered and tracked."""
+        item = mocker.Mock()
+        item.type = "mcp_approval_request"
+        item.server_label = "server-a"
+        chunk = mocker.Mock()
+        chunk.item = item
+        chunk.output_index = 2
+        server_mcp_output_indices: set[int] = set()
+        assert (
+            _should_filter_mcp_chunk(
+                chunk,
+                "response.output_item.added",
+                {"server-a"},
+                server_mcp_output_indices,
+            )
+            is True
+        )
+        assert 2 in server_mcp_output_indices
+
+    def test_filters_output_item_done_for_server_mcp(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that output_item.done for server MCP items is filtered and cleaned up."""
+        item = mocker.Mock()
+        item.type = "mcp_approval_request"
+        chunk = mocker.Mock()
+        chunk.item = item
+        chunk.output_index = 2
+        server_mcp_output_indices: set[int] = {2}
+        assert (
+            _should_filter_mcp_chunk(
+                chunk,
+                "response.output_item.done",
+                {"server-a"},
+                server_mcp_output_indices,
+            )
+            is True
+        )
+        assert 2 not in server_mcp_output_indices
+
+    def test_does_not_filter_non_mcp_event(self, mocker: MockerFixture) -> None:
+        """Test that non-MCP events pass through."""
+        chunk = mocker.Mock()
+        assert (
+            _should_filter_mcp_chunk(
+                chunk, "response.output_text.delta", {"server-a"}, set()
+            )
+            is False
+        )

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -64,6 +64,7 @@ from models.requests import QueryRequest
 from utils.responses import (
     _build_chunk_attributes,
     _increment_llm_call_metric,
+    _merge_tools,
     _resolve_source_for_result,
     build_mcp_tool_call_from_arguments_done,
     build_tool_call_summary,
@@ -78,10 +79,12 @@ from utils.responses import (
     get_rag_tools,
     get_topic_summary,
     get_vector_store_ids,
+    is_server_deployed_output,
     parse_arguments_string,
     parse_referenced_documents,
     prepare_responses_params,
     prepare_tools,
+    resolve_client_tool_choice,
     resolve_tool_choice,
     resolve_vector_store_ids,
 )
@@ -3168,3 +3171,326 @@ class TestGetRAGToolsWithConfig:
         assert tools is not None
         assert tools[0].type == constants.DEFAULT_RAG_TOOL
         assert tools[0].vector_store_ids == ["vs1"]
+
+
+class TestIsServerDeployedOutput:
+    """Tests for is_server_deployed_output function."""
+
+    def test_function_call_returns_false(self, mocker: MockerFixture) -> None:
+        """Test that function_call items are always client-side."""
+        item = mocker.Mock()
+        item.type = "function_call"
+        assert is_server_deployed_output(item) is False
+
+    def test_mcp_call_server_label_matches(self, mocker: MockerFixture) -> None:
+        """Test mcp_call with matching server_label is server-deployed."""
+        mock_config = mocker.Mock()
+        mock_server = mocker.Mock()
+        mock_server.name = "my-server"
+        mock_config.mcp_servers = [mock_server]
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        item = mocker.Mock()
+        item.type = "mcp_call"
+        item.server_label = "my-server"
+        assert is_server_deployed_output(item) is True
+
+    def test_mcp_call_server_label_not_configured(self, mocker: MockerFixture) -> None:
+        """Test mcp_call with non-matching server_label is client-side."""
+        mock_config = mocker.Mock()
+        mock_server = mocker.Mock()
+        mock_server.name = "server-a"
+        mock_config.mcp_servers = [mock_server]
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        item = mocker.Mock()
+        item.type = "mcp_call"
+        item.server_label = "client-server"
+        assert is_server_deployed_output(item) is False
+
+    def test_mcp_list_tools_server_deployed(self, mocker: MockerFixture) -> None:
+        """Test mcp_list_tools with matching server_label is server-deployed."""
+        mock_config = mocker.Mock()
+        mock_server = mocker.Mock()
+        mock_server.name = "fs"
+        mock_config.mcp_servers = [mock_server]
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        item = mocker.Mock()
+        item.type = "mcp_list_tools"
+        item.server_label = "fs"
+        assert is_server_deployed_output(item) is True
+
+    def test_mcp_approval_request_client_side(self, mocker: MockerFixture) -> None:
+        """Test mcp_approval_request with unmatched label is client-side."""
+        mock_config = mocker.Mock()
+        mock_config.mcp_servers = []
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        item = mocker.Mock()
+        item.type = "mcp_approval_request"
+        item.server_label = "client-mcp"
+        assert is_server_deployed_output(item) is False
+
+    def test_mcp_call_no_server_label(self, mocker: MockerFixture) -> None:
+        """Test mcp_call without server_label returns True (default server-side)."""
+        item = mocker.Mock()
+        item.type = "mcp_call"
+        item.server_label = None
+        assert is_server_deployed_output(item) is True
+
+    def test_message_returns_true(self) -> None:
+        """Test message items are treated as server-side."""
+        item = make_output_item(item_type="message", role="assistant", content="hi")
+        assert is_server_deployed_output(item) is True
+
+    def test_file_search_call_returns_true(self, mocker: MockerFixture) -> None:
+        """Test file_search_call items are treated as server-side."""
+        item = mocker.Mock()
+        item.type = "file_search_call"
+        assert is_server_deployed_output(item) is True
+
+    def test_web_search_call_returns_true(self, mocker: MockerFixture) -> None:
+        """Test web_search_call items are treated as server-side."""
+        item = mocker.Mock()
+        item.type = "web_search_call"
+        assert is_server_deployed_output(item) is True
+
+
+class TestMergeTools:
+    """Tests for _merge_tools function."""
+
+    def test_merge_no_conflicts(self) -> None:
+        """Test merging client and server tools without conflicts."""
+        client_tools: list = [
+            InputToolMCP(server_label="client-mcp", server_url="http://client"),
+        ]
+        server_tools: list = [
+            InputToolMCP(server_label="server-mcp", server_url="http://server"),
+            InputToolFileSearch(type="file_search", vector_store_ids=["vs1"]),
+        ]
+        result = _merge_tools(client_tools, server_tools)
+        assert len(result) == 3
+        # Client tools come first
+        assert result[0] == client_tools[0]
+        assert result[1] == server_tools[0]
+        assert result[2] == server_tools[1]
+
+    def test_merge_mcp_label_conflict_raises_409(self) -> None:
+        """Test that conflicting MCP server_labels raise a 409 error."""
+        client_tools: list = [
+            InputToolMCP(server_label="shared-label", server_url="http://client"),
+        ]
+        server_tools: list = [
+            InputToolMCP(server_label="shared-label", server_url="http://server"),
+        ]
+        with pytest.raises(HTTPException) as exc_info:
+            _merge_tools(client_tools, server_tools)
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        assert isinstance(detail, dict)
+        assert "shared-label" in detail["cause"]
+
+    def test_merge_file_search_conflict_raises_409(self) -> None:
+        """Test that duplicate file_search tools raise a 409 error."""
+        client_tools: list = [
+            InputToolFileSearch(type="file_search", vector_store_ids=["client-vs"]),
+        ]
+        server_tools: list = [
+            InputToolFileSearch(type="file_search", vector_store_ids=["server-vs"]),
+        ]
+        with pytest.raises(HTTPException) as exc_info:
+            _merge_tools(client_tools, server_tools)
+        assert exc_info.value.status_code == 409
+        detail = exc_info.value.detail
+        assert isinstance(detail, dict)
+        assert "file_search" in detail["cause"]
+
+    def test_merge_empty_server_tools(self) -> None:
+        """Test merging when server has no tools."""
+        client_tools: list = [
+            InputToolMCP(server_label="client-mcp", server_url="http://client"),
+        ]
+        result = _merge_tools(client_tools, [])
+        assert len(result) == 1
+        assert result[0] == client_tools[0]
+
+    def test_merge_empty_client_tools(self) -> None:
+        """Test merging when client has no tools."""
+        server_tools: list = [
+            InputToolMCP(server_label="server-mcp", server_url="http://server"),
+        ]
+        result = _merge_tools([], server_tools)
+        assert len(result) == 1
+        assert result[0] == server_tools[0]
+
+    def test_merge_client_mcp_does_not_conflict_with_different_server_mcp(
+        self,
+    ) -> None:
+        """Test client MCP with different label does not conflict with server MCP."""
+        client_tools: list = [
+            InputToolMCP(server_label="client-a", server_url="http://a"),
+            InputToolMCP(server_label="client-b", server_url="http://b"),
+        ]
+        server_tools: list = [
+            InputToolMCP(server_label="server-c", server_url="http://c"),
+        ]
+        result = _merge_tools(client_tools, server_tools)
+        assert len(result) == 3
+
+
+class TestResolveToolChoiceMerge:
+    """Tests for resolve_client_tool_choice with server-tool merging."""
+
+    @pytest.mark.asyncio
+    async def test_client_tools_without_merge_header(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test client tools used as-is without merge header."""
+        mock_client = mocker.AsyncMock()
+        mock_holder = mocker.Mock()
+        mock_holder.get_client.return_value = mock_client
+        mocker.patch(
+            "utils.responses.AsyncLlamaStackClientHolder",
+            return_value=mock_holder,
+        )
+        mock_config = mocker.Mock()
+        mock_config.configuration.byok_rag = []
+        mock_config.mcp_servers = []
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        client_tool = InputToolMCP(server_label="my-tool", server_url="http://tool")
+        tools, tool_choice = await resolve_tool_choice(
+            tools=[client_tool],
+            tool_choice=None,
+            token="tok",
+        )
+        assert tools is not None
+        assert len(tools) == 1
+        assert tool_choice == "auto"
+
+    @pytest.mark.asyncio
+    async def test_client_tools_with_merge_header(self, mocker: MockerFixture) -> None:
+        """Test client tools merged with server tools when header is set."""
+        mock_client = mocker.AsyncMock()
+        mock_holder = mocker.Mock()
+        mock_holder.get_client.return_value = mock_client
+        mocker.patch(
+            "utils.responses.AsyncLlamaStackClientHolder",
+            return_value=mock_holder,
+        )
+        mock_config = mocker.Mock()
+        mock_config.configuration.byok_rag = []
+        mock_config.mcp_servers = []
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        server_mcp = InputToolMCP(
+            server_label="server-tool", server_url="http://server"
+        )
+        mocker.patch(
+            "utils.responses.prepare_tools",
+            new=mocker.AsyncMock(return_value=[server_mcp]),
+        )
+
+        client_tool = InputToolMCP(
+            server_label="client-tool", server_url="http://client"
+        )
+        tools, tool_choice = await resolve_client_tool_choice(
+            tools=[client_tool],
+            tool_choice=None,
+            token="tok",
+        )
+        assert tools is not None
+        assert len(tools) == 2
+        assert tool_choice == "auto"
+
+    @pytest.mark.asyncio
+    async def test_merge_header_conflict_raises_409(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test 409 when merge header is set and tools conflict."""
+        mock_client = mocker.AsyncMock()
+        mock_holder = mocker.Mock()
+        mock_holder.get_client.return_value = mock_client
+        mocker.patch(
+            "utils.responses.AsyncLlamaStackClientHolder",
+            return_value=mock_holder,
+        )
+        mock_config = mocker.Mock()
+        mock_config.configuration.byok_rag = []
+        mock_config.mcp_servers = []
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        conflicting_server = InputToolMCP(
+            server_label="same-label", server_url="http://server"
+        )
+        mocker.patch(
+            "utils.responses.prepare_tools",
+            new=mocker.AsyncMock(return_value=[conflicting_server]),
+        )
+
+        client_tool = InputToolMCP(
+            server_label="same-label", server_url="http://client"
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_client_tool_choice(
+                tools=[client_tool],
+                tool_choice=None,
+                token="tok",
+            )
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_no_tools_uses_prepare_tools(self, mocker: MockerFixture) -> None:
+        """Test that no client tools falls through to prepare_tools."""
+        mock_client = mocker.AsyncMock()
+        mock_holder = mocker.Mock()
+        mock_holder.get_client.return_value = mock_client
+        mocker.patch(
+            "utils.responses.AsyncLlamaStackClientHolder",
+            return_value=mock_holder,
+        )
+        server_tool = InputToolFileSearch(type="file_search", vector_store_ids=["vs1"])
+        mock_prepare = mocker.AsyncMock(return_value=[server_tool])
+        mocker.patch("utils.responses.prepare_tools", new=mock_prepare)
+
+        tools, _ = await resolve_tool_choice(
+            tools=None,
+            tool_choice=None,
+            token="tok",
+        )
+        assert tools is not None
+        assert len(tools) == 1
+        mock_prepare.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_merge_header_no_server_tools_returns_client_only(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test merge header with no server tools returns client tools unchanged."""
+        mock_client = mocker.AsyncMock()
+        mock_holder = mocker.Mock()
+        mock_holder.get_client.return_value = mock_client
+        mocker.patch(
+            "utils.responses.AsyncLlamaStackClientHolder",
+            return_value=mock_holder,
+        )
+        mock_config = mocker.Mock()
+        mock_config.configuration.byok_rag = []
+        mock_config.mcp_servers = []
+        mocker.patch("utils.responses.configuration", mock_config)
+        mocker.patch(
+            "utils.responses.prepare_tools",
+            new=mocker.AsyncMock(return_value=None),
+        )
+
+        client_tool = InputToolMCP(
+            server_label="client-tool", server_url="http://client"
+        )
+        tools, _ = await resolve_client_tool_choice(
+            tools=[client_tool],
+            tool_choice=None,
+            token="tok",
+        )
+        assert tools is not None
+        assert len(tools) == 1


### PR DESCRIPTION
## Description
Add server-tool merging and filtering for Responses API

Introduce X-LCS-Merge-Server-Tools header that allows client-provided
tools to be merged with server-configured tools (RAG, MCP) instead of
replacing them. Tool conflicts (duplicate MCP server_label or duplicate
file_search) are rejected with a 409 error.

Add is_server_deployed_output() to distinguish LCS-deployed tools from
client tools so only server tools are included in turn summaries,
metrics, and storage. Client tool output items are still returned in
the response.

Filter server-deployed MCP streaming events (mcp_call, mcp_list_tools,
mcp_approval_request) from the SSE stream so OpenAI-compatible clients
like Goose don't fail on unknown item types. Strip these items from the
 response.completed output array as well.

## Type of change

- [ ] Refactor
- [x ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: Claude

## Checklist before requesting a review

- [x ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Added unit tests
- Testing locally with working lightspeed-stack installation using /v1/responses API with Goose. Was able to verify working MCP tools at both the local agent (goose) level, and via the lightspeed-stack (server) level. If no extra header was configured in goose only the client tools were active (previous behavior)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header-controlled server-tool merging (client + server tools) with optional filtering of server-deployed tool events from responses.
  * New 409 Conflict response variants and examples for MCP-tool and file-search configuration overlaps.

* **Bug Fixes / Behavior**
  * Streaming SSE now omits filtered server-deployed tool events while still tracking them server-side; non-streaming summaries match filtering.
  * Improved SSE serialization for filtered events.

* **Documentation**
  * Added docs for merge mode, ordering, conflict rules, and streaming/filtering semantics.

* **Tests**
  * Added unit tests for merging, conflict cases, and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->