### PR TITLE
LCORE-1583: Allowed passthrough attributes in responses

### DIFF
--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -238,13 +238,9 @@ async def responses_endpoint_handler(
     if responses_request.reasoning is not None:
         logger.warning("reasoning is not yet supported in LCORE and will be ignored")
         responses_request.reasoning = None
-    if responses_request.max_output_tokens is not None:
-        logger.warning(
-            "max_output_tokens is not yet supported in LCORE and will be ignored"
-        )
-        responses_request.max_output_tokens = None
 
     responses_request = responses_request.model_copy(deep=True)
+
     check_configuration_loaded(configuration)
     client_instructions = responses_request.instructions
     responses_request.instructions = get_system_prompt(

--- a/tests/e2e/features/responses.feature
+++ b/tests/e2e/features/responses.feature
@@ -20,8 +20,6 @@ Feature: Responses endpoint API tests
     Then The status code of the response is 200
       And The body of the response contains hello
 
-  # https://redhat.atlassian.net/browse/LCORE-1583
-  @skip
   Scenario: Responses accepts passthrough parameters with valid types
     Given The system is in default state
     When I use "responses" to ask question with authorization header
@@ -31,8 +29,6 @@ Feature: Responses endpoint API tests
       "model": "{PROVIDER}/{MODEL}",
       "stream": false,
       "instructions": "You are a helpful assistant.",
-      "prompt": {"id": "e2e_responses_passthrough_prompt"},
-      "reasoning": {"effort": "low"},
       "safety_identifier": "e2e-responses-passthrough",
       "text": {"format": {"type": "text"}},
       "tool_choice": "auto",
@@ -54,8 +50,6 @@ Feature: Responses endpoint API tests
           "status": "completed",
           "model": "{PROVIDER}/{MODEL}",
           "instructions": "You are a helpful assistant.",
-          "prompt": {"id": "e2e_responses_passthrough_prompt"},
-          "reasoning": {"effort": "low"},
           "safety_identifier": "e2e-responses-passthrough",
           "text": {"format": {"type": "text"}},
           "tool_choice": "auto",

--- a/tests/e2e/features/responses_streaming.feature
+++ b/tests/e2e/features/responses_streaming.feature
@@ -20,8 +20,6 @@ Feature: Responses endpoint streaming API tests
     Then The status code of the response is 200
       And The body of the response contains hello
 
-  # https://redhat.atlassian.net/browse/LCORE-1583
-  @skip
   Scenario: Streaming responses accepts passthrough parameters with valid types
     When I use "responses" to ask question with authorization header
     """
@@ -30,8 +28,6 @@ Feature: Responses endpoint streaming API tests
       "model": "{PROVIDER}/{MODEL}",
       "stream": true,
       "instructions": "You are a helpful assistant.",
-      "prompt": {"id": "e2e_responses_passthrough_prompt"},
-      "reasoning": {"effort": "low"},
       "safety_identifier": "e2e-responses-passthrough",
       "text": {"format": {"type": "text"}},
       "tool_choice": "auto",
@@ -53,8 +49,6 @@ Feature: Responses endpoint streaming API tests
           "status": "completed",
           "model": "{PROVIDER}/{MODEL}",
           "instructions": "You are a helpful assistant.",
-          "prompt": {"id": "e2e_responses_passthrough_prompt"},
-          "reasoning": {"effort": "low"},
           "safety_identifier": "e2e-responses-passthrough",
           "text": {"format": {"type": "text"}},
           "tool_choice": "auto",


### PR DESCRIPTION
## Description

Allows passthrough attribute `max_output_tokens` which validation was recently fixed on upstream.
Removes `@skip` tag from e2e test that is testing passthrough attributes.
Prompt attribute is removed as it relies on Prompts API (will be tested separately)
Reasoning attribute has bug on upstream and will be tracked by separate ticket.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A
## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-1583](https://redhat.atlassian.net/browse/LCORE-1583)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Responses now preserve provided request parameters (e.g., output token limits) instead of clearing them.

* **Tests**
  * Updated end-to-end response tests and streaming scenarios; removed outdated/disabled scenarios and cleaned up passthrough parameter checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->