### PR TITLE
RSPEED-2875: bump /v1/infer question limit to 32KB and add /v1/responses body size validator

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -14676,7 +14676,7 @@
                 "properties": {
                     "question": {
                         "type": "string",
-                        "maxLength": 10240,
+                        "maxLength": 32768,
                         "minLength": 1,
                         "title": "Question",
                         "description": "User question",

--- a/src/constants.py
+++ b/src/constants.py
@@ -228,3 +228,9 @@ DEFAULT_LOG_FORMAT = "%(asctime)s %(levelname)-8s %(name)s:%(lineno)d %(message)
 LIGHTSPEED_STACK_DISABLE_RICH_HANDLER_ENV_VAR = "LIGHTSPEED_STACK_DISABLE_RICH_HANDLER"
 
 DEFAULT_VIOLATION_MESSAGE = "I cannot process this request due to policy restrictions."
+
+# Input size limits for API request validation
+# Maximum character length for the question field in /v1/infer requests (32 KiB)
+RLSAPI_V1_QUESTION_MAX_LENGTH = 32_768
+# Maximum character length for the serialized /v1/responses request body (64 KiB)
+RESPONSES_REQUEST_MAX_SIZE = 65_536

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=too-many-lines
 
+import json
 from enum import Enum
 from typing import Any, Optional, Self
 
@@ -32,6 +33,7 @@ from constants import (
     MCP_AUTH_OAUTH,
     MEDIA_TYPE_JSON,
     MEDIA_TYPE_TEXT,
+    RESPONSES_REQUEST_MAX_SIZE,
 )
 from log import get_logger
 from utils import suid
@@ -737,6 +739,40 @@ class ResponsesRequest(BaseModel):
             ]
         },
     }
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_body_size(cls, values: Any) -> Any:
+        """Validate that the request body does not exceed the maximum allowed size.
+
+        Serializes the raw request payload to JSON and checks the total character
+        count against the 65,536-character limit.  This guard runs before field
+        coercion so that the limit reflects only what the client actually sent,
+        not the expanded representation produced by Pydantic's defaults.
+
+        Parameters:
+            values: The raw input dict (or other object) passed to the model.
+
+        Returns:
+            Any: ``values`` unchanged when the size check passes.
+
+        Raises:
+            ValueError: If the JSON-serialized size of ``values`` exceeds
+                65,536 characters.
+        """
+        try:
+            serialized = json.dumps(values)
+        except (TypeError, ValueError):
+            # Non-JSON-serializable payload (e.g. programmatic use with Pydantic
+            # model instances).  The size guard only applies to wire-format HTTP
+            # requests which FastAPI always parses into JSON-compatible dicts.
+            return values
+        if len(serialized) > RESPONSES_REQUEST_MAX_SIZE:
+            raise ValueError(
+                f"Request body size ({len(serialized)} characters) exceeds maximum "
+                f"allowed size of {RESPONSES_REQUEST_MAX_SIZE} characters"
+            )
+        return values
 
     @model_validator(mode="after")
     def validate_conversation_and_previous_response_id_mutually_exclusive(self) -> Self:

--- a/src/models/rlsapi/requests.py
+++ b/src/models/rlsapi/requests.py
@@ -2,6 +2,7 @@
 
 from pydantic import Field, field_validator
 
+from constants import RLSAPI_V1_QUESTION_MAX_LENGTH
 from models.config import ConfigurationBase
 
 # Character validation patterns for fields flowing into Splunk telemetry.
@@ -177,7 +178,7 @@ class RlsapiV1InferRequest(ConfigurationBase):
     question: str = Field(
         ...,
         min_length=1,
-        max_length=10_240,
+        max_length=RLSAPI_V1_QUESTION_MAX_LENGTH,
         description="User question",
         examples=["How do I list files?", "How do I configure SELinux?"],
     )

--- a/tests/integration/endpoints/test_rlsapi_v1_integration.py
+++ b/tests/integration/endpoints/test_rlsapi_v1_integration.py
@@ -539,7 +539,7 @@ async def test_rlsapi_v1_infer_skip_rag(
 @pytest.mark.parametrize(
     "json",
     (
-        ({"question": "?" * 10_241}),
+        ({"question": "?" * (constants.RLSAPI_V1_QUESTION_MAX_LENGTH + 1)}),
         ({"question": "Q", "context": {"stdin": "a" * 65_537}}),
         ({"question": "Q", "context": {"attachments": {"contents": "A" * 65_537}}}),
         ({"question": "Q", "context": {"terminal": {"output": "T" * 65_537}}}),

--- a/tests/unit/models/requests/test_responses_request.py
+++ b/tests/unit/models/requests/test_responses_request.py
@@ -1,0 +1,57 @@
+"""Unit tests for ResponsesRequest body-size validation."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from constants import RESPONSES_REQUEST_MAX_SIZE
+from models.requests import ResponsesRequest
+
+_LIMIT = RESPONSES_REQUEST_MAX_SIZE
+_OVERHEAD = len(json.dumps({"input": ""}))  # 13
+_AT_LIMIT_PADDING = _LIMIT - _OVERHEAD  # 65,523
+
+
+class TestResponsesRequestBodySize:
+    """Tests for the 65,536-character body-size guard on ResponsesRequest."""
+
+    def test_normal_request_accepted(self) -> None:
+        """A small, normal request must be accepted without raising."""
+        req = ResponsesRequest(input="hello")  # pyright: ignore[reportCallIssue]
+        assert req.input == "hello"
+
+    def test_at_limit_request_accepted(self) -> None:
+        """A request whose JSON serialization is exactly 65,536 chars is accepted."""
+        payload = "x" * _AT_LIMIT_PADDING
+        assert len(json.dumps({"input": payload})) == _LIMIT
+
+        req = ResponsesRequest(input=payload)  # pyright: ignore[reportCallIssue]
+        assert req.input == payload
+
+    def test_one_over_limit_rejected(self) -> None:
+        """A request whose JSON serialization is 65,537 chars raises ValidationError."""
+        payload = "x" * (_AT_LIMIT_PADDING + 1)
+        serialized = json.dumps({"input": payload})
+        assert len(serialized) == _LIMIT + 1
+
+        with pytest.raises(ValidationError) as exc_info:
+            ResponsesRequest(input=payload)  # pyright: ignore[reportCallIssue]
+
+        error_text = str(exc_info.value)
+        assert "65536" in error_text
+        assert str(_LIMIT + 1) in error_text
+
+    def test_large_list_input_rejected(self) -> None:
+        """A request with a list input that exceeds 64 KB is rejected."""
+        long_item_text = "a" * 1000
+        large_list = [{"role": "user", "content": long_item_text}] * 100
+
+        raw = {"input": large_list}
+        assert len(json.dumps(raw)) > _LIMIT
+
+        with pytest.raises(ValidationError) as exc_info:
+            ResponsesRequest(input=large_list)  # pyright: ignore[reportCallIssue]
+
+        error_text = str(exc_info.value)
+        assert "65536" in error_text

--- a/tests/unit/models/rlsapi/test_requests.py
+++ b/tests/unit/models/rlsapi/test_requests.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from constants import RLSAPI_V1_QUESTION_MAX_LENGTH
 from models.rlsapi.requests import (
     RlsapiV1Attachment,
     RlsapiV1CLA,
@@ -642,7 +643,7 @@ class TestGetInputSourceEdgeCases:
         (RlsapiV1Attachment, "contents", 65_536),
         (RlsapiV1Terminal, "output", 65_536),
         (RlsapiV1Context, "stdin", 65_536),
-        (RlsapiV1InferRequest, "question", 10_240),
+        (RlsapiV1InferRequest, "question", RLSAPI_V1_QUESTION_MAX_LENGTH),
     ],
     ids=[
         "attachment-contents",


### PR DESCRIPTION
## Description

Two targeted input-size guardrails:

1. **`/v1/infer` — raise `question` limit from 10 KB → 32 KB**
   The CLA client enforces a 32,000-character input limit (`MAX_QUESTION_SIZE` in [`command_line_assistant/commands/chat.py`](https://github.com/rhel-lightspeed/command-line-assistant/blob/main/command_line_assistant/commands/chat.py#L62)). The previous 10,240-character cap on the `question` field caused legitimate CLA requests to be rejected with a spurious 422. Raised `max_length` in `RlsapiV1InferRequest` to 32,768 to comfortably accommodate the CLA limit with headroom.

2. **`/v1/responses` — add 64 KB whole-body size guard**
   The `/responses` endpoint previously accepted arbitrarily-sized payloads. A new `@model_validator(mode='before')` on `ResponsesRequest` serialises the raw request with `json.dumps` and rejects anything whose total character count exceeds 65,536. Using `mode='before'` ensures the limit applies to the actual client payload, not the expanded form Pydantic produces after applying defaults. Returns 422 (not 413, which is reserved for LLM context-window exceeded).

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [x] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude (Anthropic)
- Generated by: opencode / Atlas orchestrator

## Related Tickets & Documents

- Related Issue: [RSPEED-2875](https://issues.redhat.com/browse/RSPEED-2875)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

**Unit tests** — run with `uv run make test-unit`:
- `tests/unit/models/requests/test_responses_request.py` — 4 new boundary tests:
  - Normal request (`{"input": "hello"}`) accepted
  - At-limit request (exactly 65,536 chars serialised) accepted
  - One-over-limit request (65,537 chars) rejected with clear error message containing actual and max size
  - Large list input (>64 KB) rejected

**Integration tests** — run with `uv run make test-integration`:
- `tests/integration/endpoints/test_rlsapi_v1_integration.py::test_infer_size_limit[question]` — confirms HTTP 422 for a 32,769-char question (one over the new limit); the other three parametrised cases (stdin, attachment, terminal) remain at 65,536.

**Linters** — `uv run make verify` passes clean: black, ruff, pylint 10/10, pyright 0 errors, pydocstyle, mypy.

### Files changed
| File | Change |
|---|---|
| `src/models/rlsapi/requests.py` | `max_length=10_240` → `max_length=32_768` on `question` field |
| `src/models/requests.py` | `import json` + new `validate_body_size` model validator on `ResponsesRequest` |
| `tests/unit/models/rlsapi/test_requests.py` | Parametrised value updated to 32,768 |
| `tests/integration/endpoints/test_rlsapi_v1_integration.py` | Payload changed to `"?" * 32_769` |
| `tests/unit/models/requests/test_responses_request.py` | **New** — 4 boundary tests for the body-size validator |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request body size validation for /v1/responses endpoint with a maximum limit of 65,536 characters.

* **Improvements**
  * Increased maximum question field length for /v1/infer endpoint to 32,768 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->