### PR TITLE
LCORE-1877: Added Prompts API

### DIFF
--- a/docs/auth/authorization.md
+++ b/docs/auth/authorization.md
@@ -109,6 +109,8 @@ authorization:
 | `get_metrics` | Access metrics | `/metrics` |
 | `feedback` | Submit feedback | `/feedback` |
 | `model_override` | Override model in queries | N/A (permission flag) |
+| `read_prompts` | List and get prompts | `/v1/prompts`, `/v1/prompts/{prompt_id}` |
+| `manage_prompts` | Manage prompts | `/v1/prompts`, `/v1/prompts/{prompt_id}` |
 
 ### Conversation Actions
 

--- a/src/app/endpoints/prompts.py
+++ b/src/app/endpoints/prompts.py
@@ -1,0 +1,350 @@
+"""Handler for REST API calls to manage Llama Stack stored prompt templates."""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from llama_stack_client import APIConnectionError, BadRequestError
+from llama_stack_client import APIStatusError as LLSApiStatusError
+from openai._exceptions import APIStatusError as OpenAIAPIStatusError
+
+from authentication import get_auth_dependency
+from authentication.interface import AuthTuple
+from authorization.middleware import authorize
+from client import AsyncLlamaStackClientHolder
+from configuration import configuration
+from log import get_logger
+from models.config import Action
+from models.requests import PromptCreateRequest, PromptUpdateRequest
+from models.responses import (
+    ForbiddenResponse,
+    InternalServerErrorResponse,
+    NotFoundResponse,
+    PromptDeleteResponse,
+    PromptResourceResponse,
+    PromptsListResponse,
+    ServiceUnavailableResponse,
+    UnauthorizedResponse,
+)
+from utils.endpoints import check_configuration_loaded
+from utils.query import handle_known_apistatus_errors
+
+logger = get_logger(__name__)
+router = APIRouter(tags=["prompts"])
+
+
+# Response schemas for OpenAPI documentation
+prompt_create_responses: dict[int | str, dict[str, Any]] = {
+    200: PromptResourceResponse.openapi_response(),
+    401: UnauthorizedResponse.openapi_response(
+        examples=["missing header", "missing token"]
+    ),
+    403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt manage"]),
+    500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
+    503: ServiceUnavailableResponse.openapi_response(examples=["llama stack"]),
+}
+
+prompt_list_responses: dict[int | str, dict[str, Any]] = {
+    200: PromptsListResponse.openapi_response(),
+    401: UnauthorizedResponse.openapi_response(
+        examples=["missing header", "missing token"]
+    ),
+    403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt read"]),
+    500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
+    503: ServiceUnavailableResponse.openapi_response(examples=["llama stack"]),
+}
+
+prompt_get_responses: dict[int | str, dict[str, Any]] = {
+    200: PromptResourceResponse.openapi_response(),
+    401: UnauthorizedResponse.openapi_response(
+        examples=["missing header", "missing token"]
+    ),
+    403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt read"]),
+    404: NotFoundResponse.openapi_response(examples=["prompt"]),
+    500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
+    503: ServiceUnavailableResponse.openapi_response(examples=["llama stack"]),
+}
+
+prompt_update_responses: dict[int | str, dict[str, Any]] = {
+    200: PromptResourceResponse.openapi_response(),
+    401: UnauthorizedResponse.openapi_response(
+        examples=["missing header", "missing token"]
+    ),
+    403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt manage"]),
+    404: NotFoundResponse.openapi_response(examples=["prompt"]),
+    500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
+    503: ServiceUnavailableResponse.openapi_response(examples=["llama stack"]),
+}
+
+prompt_delete_responses: dict[int | str, dict[str, Any]] = {
+    200: PromptDeleteResponse.openapi_response(),
+    401: UnauthorizedResponse.openapi_response(
+        examples=["missing header", "missing token"]
+    ),
+    403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt manage"]),
+    500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
+    503: ServiceUnavailableResponse.openapi_response(examples=["llama stack"]),
+}
+
+
+@router.post("/prompts", responses=prompt_create_responses)
+@authorize(Action.MANAGE_PROMPTS)
+async def create_prompt_handler(
+    request: Request,
+    auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
+    body: PromptCreateRequest,
+) -> PromptResourceResponse:
+    r"""
+    Handle requests to the POST /prompts endpoint.
+
+    Process requests to create a stored prompt template in Llama Stack. The
+    body must include the prompt text and may include template variable names.
+    For example:
+
+        curl -X POST http://localhost:8080/v1/prompts \\
+          -H 'Content-Type: application/json' \\
+          -d '{"prompt": "Hello {{name}}", "variables": ["name"]}'
+
+    ### Parameters:
+    - request: The incoming HTTP request (used by middleware).
+    - auth: Authentication tuple from the auth dependency (used by middleware).
+    - body: Prompt creation parameters.
+
+    ### Raises:
+    - HTTPException: If configuration is not loaded, if unable to connect to
+      Llama Stack, or if the prompts API returns an error response.
+
+    ### Returns:
+    - PromptResourceResponse: The created prompt as returned by Llama Stack.
+    """
+    _ = auth
+    _ = request
+
+    check_configuration_loaded(configuration)
+
+    try:
+        client = AsyncLlamaStackClientHolder().get_client()
+        payload = body.model_dump(exclude_none=True)
+        created = await client.prompts.create(**payload)
+        return PromptResourceResponse.model_validate(created.model_dump())
+    except APIConnectionError as e:
+        logger.error("Unable to connect to Llama Stack: %s", e)
+        response = ServiceUnavailableResponse(backend_name="Llama Stack", cause=str(e))
+        raise HTTPException(**response.model_dump()) from e
+    except (LLSApiStatusError, OpenAIAPIStatusError) as e:
+        logger.error("API status error while creating prompt: %s", e)
+        error_response = handle_known_apistatus_errors(e, "llama-stack")
+        raise HTTPException(**error_response.model_dump()) from e
+
+
+@router.get("/prompts", responses=prompt_list_responses)
+@authorize(Action.READ_PROMPTS)
+async def list_prompts_handler(
+    request: Request,
+    auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
+) -> PromptsListResponse:
+    """
+    Handle requests to the GET /prompts endpoint.
+
+    Process GET requests that list all stored prompt templates from the Llama
+    Stack service. For example:
+
+        curl http://localhost:8080/v1/prompts
+
+    ### Parameters:
+    - request: The incoming HTTP request (used by middleware).
+    - auth: Authentication tuple from the auth dependency (used by middleware).
+
+    ### Raises:
+    - HTTPException: If configuration is not loaded, if unable to connect to
+      Llama Stack, or if the prompts API returns an error response.
+
+    ### Returns:
+    - PromptsListResponse: An object containing the list of prompts.
+    """
+    _ = auth
+    _ = request
+
+    check_configuration_loaded(configuration)
+
+    try:
+        client = AsyncLlamaStackClientHolder().get_client()
+        items = await client.prompts.list()
+        data = [PromptResourceResponse.model_validate(p.model_dump()) for p in items]
+        return PromptsListResponse(data=data)
+    except APIConnectionError as e:
+        logger.error("Unable to connect to Llama Stack: %s", e)
+        response = ServiceUnavailableResponse(backend_name="Llama Stack", cause=str(e))
+        raise HTTPException(**response.model_dump()) from e
+    except (LLSApiStatusError, OpenAIAPIStatusError) as e:
+        logger.error("API status error while listing prompts: %s", e)
+        error_response = handle_known_apistatus_errors(e, "llama-stack")
+        raise HTTPException(**error_response.model_dump()) from e
+
+
+@router.get("/prompts/{prompt_id}", responses=prompt_get_responses)
+@authorize(Action.READ_PROMPTS)
+async def get_prompt_handler(
+    request: Request,
+    prompt_id: str,
+    auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
+    version: int | None = None,
+) -> PromptResourceResponse:
+    """
+    Handle requests to the GET /prompts/{prompt_id} endpoint.
+
+    Process GET requests to retrieve a single prompt by identifier. The
+    ``version`` query parameter is optional; when omitted, the latest version is
+    returned. For example:
+
+        curl http://localhost:8080/v1/prompts/pmpt_abc123?version=1
+
+    ### Parameters:
+    - request: The incoming HTTP request (used by middleware).
+    - prompt_id: The Llama Stack prompt identifier.
+    - auth: Authentication tuple from the auth dependency (used by middleware).
+    - version: Optional version number (latest when omitted).
+
+    ### Raises:
+    - HTTPException: If configuration is not loaded, if the prompt is not
+      found, if unable to connect to Llama Stack, or if the prompts API returns
+      an error response.
+
+    ### Returns:
+    - PromptResourceResponse: The requested prompt object.
+    """
+    _ = auth
+    _ = request
+
+    check_configuration_loaded(configuration)
+
+    try:
+        client = AsyncLlamaStackClientHolder().get_client()
+        if version is not None:
+            retrieved = await client.prompts.retrieve(prompt_id, version=version)
+        else:
+            retrieved = await client.prompts.retrieve(prompt_id)
+        return PromptResourceResponse.model_validate(retrieved.model_dump())
+    except APIConnectionError as e:
+        logger.error("Unable to connect to Llama Stack: %s", e)
+        response = ServiceUnavailableResponse(backend_name="Llama Stack", cause=str(e))
+        raise HTTPException(**response.model_dump()) from e
+    except (BadRequestError, ValueError) as e:
+        logger.error("Prompt not found: %s", e)
+        response = NotFoundResponse(resource="prompt", resource_id=prompt_id)
+        raise HTTPException(**response.model_dump()) from e
+    except (LLSApiStatusError, OpenAIAPIStatusError) as e:
+        logger.error("API status error while retrieving prompt: %s", e)
+        error_response = handle_known_apistatus_errors(e, "llama-stack")
+        raise HTTPException(**error_response.model_dump()) from e
+
+
+@router.put("/prompts/{prompt_id}", responses=prompt_update_responses)
+@authorize(Action.MANAGE_PROMPTS)
+async def update_prompt_handler(
+    request: Request,
+    prompt_id: str,
+    auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
+    body: PromptUpdateRequest,
+) -> PromptResourceResponse:
+    r"""
+    Handle requests to the PUT /prompts/{prompt_id} endpoint.
+
+    Process requests to update a stored prompt; Llama Stack increments the
+    version. The body includes the new text, the current version being
+    replaced, and optional fields such as ``set_as_default`` and ``variables``.
+    For example:
+
+        curl -X PUT http://localhost:8080/v1/prompts/pmpt_abc123 \\
+          -H 'Content-Type: application/json' \\
+          -d '{"prompt": "Hi", "version": 1, "set_as_default": true}'
+
+    ### Parameters:
+    - request: The incoming HTTP request (used by middleware).
+    - prompt_id: The Llama Stack prompt identifier.
+    - auth: Authentication tuple from the auth dependency (used by middleware).
+    - body: Prompt update parameters.
+
+    ### Raises:
+    - HTTPException: If configuration is not loaded, if the prompt is not
+      found, if unable to connect to Llama Stack, or if the prompts API returns
+      an error response.
+
+    ### Returns:
+    - PromptResourceResponse: The updated prompt object returned by Llama Stack.
+    """
+    _ = auth
+    _ = request
+
+    check_configuration_loaded(configuration)
+
+    try:
+        client = AsyncLlamaStackClientHolder().get_client()
+        payload = body.model_dump(exclude_none=True, exclude_unset=True)
+        updated = await client.prompts.update(prompt_id, **payload)
+        return PromptResourceResponse.model_validate(updated.model_dump())
+    except APIConnectionError as e:
+        logger.error("Unable to connect to Llama Stack: %s", e)
+        response = ServiceUnavailableResponse(backend_name="Llama Stack", cause=str(e))
+        raise HTTPException(**response.model_dump()) from e
+    except (BadRequestError, ValueError) as e:
+        logger.error("Prompt update failed: %s", e)
+        response = NotFoundResponse(resource="prompt", resource_id=prompt_id)
+        raise HTTPException(**response.model_dump()) from e
+    except (LLSApiStatusError, OpenAIAPIStatusError) as e:
+        logger.error("API status error while updating prompt: %s", e)
+        error_response = handle_known_apistatus_errors(e, "llama-stack")
+        raise HTTPException(**error_response.model_dump()) from e
+
+
+@router.delete("/prompts/{prompt_id}", responses=prompt_delete_responses)
+@authorize(Action.MANAGE_PROMPTS)
+async def delete_prompt_handler(
+    request: Request,
+    prompt_id: str,
+    auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
+) -> PromptDeleteResponse:
+    """
+    Handle requests to the DELETE /prompts/{prompt_id} endpoint.
+
+    Process requests to delete a stored prompt in Llama Stack. The response
+    always uses HTTP 200 with a JSON body indicating whether the deletion
+    succeeded (same pattern as deleting a conversation in ``/v2``). For example:
+
+        curl -X DELETE http://localhost:8080/v1/prompts/pmpt_abc123
+
+    When the prompt does not exist, the response still returns 200 with
+    ``deleted`` set to false in the body.
+
+    ### Parameters:
+    - request: The incoming HTTP request (used by middleware).
+    - prompt_id: The Llama Stack prompt identifier.
+    - auth: Authentication tuple from the auth dependency (used by middleware).
+
+    ### Raises:
+    - HTTPException: If configuration is not loaded, if unable to connect to
+      Llama Stack, or if the prompts API returns an error response.
+
+    ### Returns:
+    - PromptDeleteResponse: An object describing whether the prompt was
+      deleted and a human-readable message.
+    """
+    _ = auth
+    _ = request
+
+    check_configuration_loaded(configuration)
+
+    try:
+        client = AsyncLlamaStackClientHolder().get_client()
+        await client.prompts.delete(prompt_id)
+        return PromptDeleteResponse(deleted=True, prompt_id=prompt_id)
+    except APIConnectionError as e:
+        logger.error("Unable to connect to Llama Stack: %s", e)
+        response = ServiceUnavailableResponse(backend_name="Llama Stack", cause=str(e))
+        raise HTTPException(**response.model_dump()) from e
+    except (BadRequestError, ValueError) as e:
+        logger.error("Prompt delete failed: %s", e)
+        return PromptDeleteResponse(deleted=False, prompt_id=prompt_id)
+    except (LLSApiStatusError, OpenAIAPIStatusError) as e:
+        logger.error("API status error while deleting prompt: %s", e)
+        error_response = handle_known_apistatus_errors(e, "llama-stack")
+        raise HTTPException(**error_response.model_dump()) from e

--- a/src/app/routers.py
+++ b/src/app/routers.py
@@ -16,6 +16,7 @@ from app.endpoints import (
     mcp_servers,
     metrics,
     models,
+    prompts,
     providers,
     # Query endpoints for Response API support
     query,
@@ -54,6 +55,7 @@ def include_routers(app: FastAPI) -> None:
     app.include_router(mcp_servers.router, prefix="/v1")
     app.include_router(shields.router, prefix="/v1")
     app.include_router(providers.router, prefix="/v1")
+    app.include_router(prompts.router, prefix="/v1")
     app.include_router(rags.router, prefix="/v1")
     app.include_router(vector_stores.router, prefix="/v1")
     # Query endpoints

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1038,6 +1038,10 @@ class Action(str, Enum):
     READ_VECTOR_STORES = "read_vector_stores"
     MANAGE_FILES = "manage_files"
 
+    # Llama Stack stored prompt templates (/v1/prompts)
+    MANAGE_PROMPTS = "manage_prompts"
+    READ_PROMPTS = "read_prompts"
+
 
 class AccessRule(ConfigurationBase):
     """Rule defining what actions a role can perform."""

--- a/src/models/requests.py
+++ b/src/models/requests.py
@@ -1167,3 +1167,72 @@ class VectorStoreFileCreateRequest(BaseModel):
                 raise ValueError(f"attribute value for '{key}' exceeds 512 characters")
 
         return value
+
+
+class PromptCreateRequest(BaseModel):
+    """Request body to create a stored prompt template in Llama Stack."""
+
+    prompt: str = Field(
+        ...,
+        description="Prompt text with variable placeholders",
+        examples=["Summarize: {{text}}"],
+        min_length=1,
+    )
+    variables: Optional[list[str]] = Field(
+        None,
+        description="Variable names allowed in the template",
+        examples=[["text"]],
+    )
+
+    model_config = {
+        "extra": "forbid",
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "prompt": "Summarize: {{text}}",
+                    "variables": ["text"],
+                }
+            ]
+        },
+    }
+
+
+class PromptUpdateRequest(BaseModel):
+    """Request body to update a stored prompt (creates a new version)."""
+
+    prompt: str = Field(
+        ...,
+        description="Updated prompt text",
+        examples=["Summarize in bullet points: {{text}}"],
+        min_length=1,
+    )
+    version: int = Field(
+        ...,
+        description="Current version being updated",
+        examples=[1],
+        gt=0,
+    )
+    set_as_default: Optional[bool] = Field(
+        None,
+        description="Whether the new version becomes the default",
+        examples=[True],
+    )
+    variables: Optional[list[str]] = Field(
+        None,
+        description="Updated allowed variable names",
+        examples=[["text"]],
+    )
+
+    model_config = {
+        "extra": "forbid",
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "prompt": "Summarize in bullet points: {{text}}",
+                    "version": 1,
+                    "set_as_default": True,
+                    "variables": ["text"],
+                }
+            ]
+        },
+    }

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -1961,6 +1961,26 @@ class ForbiddenResponse(AbstractErrorResponse):
                     },
                 },
                 {
+                    "label": "prompt read",
+                    "detail": {
+                        "response": "User does not have permission to perform this action",
+                        "cause": (
+                            "User 6789 does not have permission to list or read stored prompts "
+                            "(missing permission: read_prompts)."
+                        ),
+                    },
+                },
+                {
+                    "label": "prompt manage",
+                    "detail": {
+                        "response": "User does not have permission to perform this action",
+                        "cause": (
+                            "User 6789 does not have permission to create, update, or delete "
+                            "stored prompts (missing permission: manage_prompts)."
+                        ),
+                    },
+                },
+                {
                     "label": "feedback",
                     "detail": {
                         "response": "Storing feedback is disabled",
@@ -2150,6 +2170,16 @@ class NotFoundResponse(AbstractErrorResponse):
                     "detail": {
                         "response": "File not found",
                         "cause": "File with ID file_abc123 does not exist",
+                    },
+                },
+                {
+                    "label": "prompt",
+                    "detail": {
+                        "response": "Prompt not found",
+                        "cause": (
+                            "Prompt with ID "
+                            "pmpt_0123456789abcdef0123456789abcdef01234567 does not exist"
+                        ),
                     },
                 },
             ]
@@ -2900,6 +2930,152 @@ class VectorStoresListResponse(AbstractSuccessfulResponse):
             ]
         },
     }
+
+
+class PromptResourceResponse(AbstractSuccessfulResponse):
+    """A stored prompt template as returned by Llama Stack."""
+
+    prompt_id: str = Field(..., description="Prompt identifier from Llama Stack")
+    version: int = Field(..., description="Version number for this prompt")
+    is_default: Optional[bool] = Field(
+        None, description="Whether this version is the default"
+    )
+    prompt: Optional[str] = Field(None, description="Prompt text with placeholders")
+    variables: Optional[list[str]] = Field(
+        None, description="Variable names used in the template"
+    )
+
+    model_config = {
+        "extra": "forbid",
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
+                    "version": 1,
+                    "is_default": True,
+                    "prompt": "Summarize: {{text}}",
+                    "variables": ["text"],
+                }
+            ]
+        },
+    }
+
+
+class PromptsListResponse(AbstractSuccessfulResponse):
+    """List of stored prompt templates returned by Llama Stack."""
+
+    data: list[PromptResourceResponse] = Field(
+        default_factory=list,
+        description="Prompt entries (as returned by Llama Stack list)",
+    )
+
+    model_config = {
+        "extra": "forbid",
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "data": [
+                        {
+                            "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
+                            "version": 1,
+                            "is_default": True,
+                            "prompt": "Summarize: {{text}}",
+                            "variables": ["text"],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+
+class PromptDeleteResponse(AbstractSuccessfulResponse):
+    """Result of deleting a stored prompt (always HTTP 200, like conversations v2)."""
+
+    prompt_id: str = Field(
+        ...,
+        description="Prompt identifier that was passed to delete.",
+        examples=["pmpt_0123456789abcdef0123456789abcdef01234567"],
+    )
+    success: bool = Field(
+        ...,
+        description="Whether Llama Stack deleted the prompt.",
+        examples=[True, False],
+    )
+    response: str = Field(
+        ...,
+        description="Human-readable outcome.",
+        examples=[
+            "Prompt deleted successfully",
+            "Prompt cannot be deleted",
+        ],
+    )
+
+    def __init__(self, *, deleted: bool, prompt_id: str) -> None:
+        """Build delete outcome from Llama Stack result.
+
+        Parameters:
+            deleted: True if the backend removed the prompt.
+            prompt_id: Prompt id from the request path.
+        """
+        response_msg = (
+            "Prompt deleted successfully" if deleted else "Prompt cannot be deleted"
+        )
+        super().__init__(
+            prompt_id=prompt_id,  # type: ignore[call-arg]
+            success=deleted,  # type: ignore[call-arg]
+            response=response_msg,  # type: ignore[call-arg]
+        )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "label": "deleted",
+                    "value": {
+                        "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
+                        "success": True,
+                        "response": "Prompt deleted successfully",
+                    },
+                },
+                {
+                    "label": "not_deleted",
+                    "value": {
+                        "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
+                        "success": False,
+                        "response": "Prompt cannot be deleted",
+                    },
+                },
+            ]
+        }
+    }
+
+    @classmethod
+    def openapi_response(cls) -> dict[str, Any]:
+        """Build the response spec for HTTP 200 with labeled JSON examples."""
+        schema = cls.model_json_schema()
+        model_examples = schema.get("examples", [])
+
+        named_examples: dict[str, Any] = {}
+
+        for ex in model_examples:
+            label = ex.get("label")
+            if label is None:
+                raise SchemaError(f"Example {ex} in {cls.__name__} has no label")
+
+            value = ex.get("value")
+            if value is None:
+                raise SchemaError(f"Example '{label}' in {cls.__name__} has no value")
+
+            named_examples[label] = {"value": value}
+
+        content = {"application/json": {"examples": named_examples or None}}
+
+        return {
+            "description": SUCCESSFUL_RESPONSE_DESCRIPTION,
+            "model": cls,
+            "content": content,
+        }
 
 
 class FileResponse(AbstractSuccessfulResponse):

--- a/tests/unit/app/endpoints/test_prompts.py
+++ b/tests/unit/app/endpoints/test_prompts.py
@@ -1,0 +1,329 @@
+"""Unit tests for the /prompts REST API endpoints."""
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException, Request, status
+from llama_stack_client import APIConnectionError, BadRequestError
+from llama_stack_client.types.prompt import Prompt
+from pytest_mock import MockerFixture
+
+from app.endpoints.prompts import (
+    create_prompt_handler,
+    delete_prompt_handler,
+    get_prompt_handler,
+    list_prompts_handler,
+    update_prompt_handler,
+)
+from authentication.interface import AuthTuple
+from configuration import AppConfig
+from models.requests import PromptCreateRequest, PromptUpdateRequest
+from models.responses import PromptDeleteResponse
+from tests.unit.utils.auth_helpers import mock_authorization_resolvers
+
+MOCK_AUTH: AuthTuple = ("mock_user_id", "mock_username", False, "mock_token")
+
+
+def _sample_prompt(
+    prompt_id: str,
+    version: int,
+    *,
+    is_default: bool | None = True,
+    prompt: str | None = "hello",
+    variables: list[str] | None = None,
+) -> Prompt:
+    """Build a Llama Stack SDK Prompt for test return values."""
+    return Prompt(
+        prompt_id=prompt_id,
+        version=version,
+        is_default=is_default,
+        prompt=prompt,
+        variables=variables,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_prompts_authorization(mocker: MockerFixture) -> None:
+    """Stub authorization resolvers for prompts endpoint tests."""
+    mock_authorization_resolvers(mocker)
+
+
+@pytest.fixture(name="prompts_http_request")
+def prompts_http_request_fixture() -> Request:
+    """Minimal ASGI Request; Authorization matches MOCK_AUTH token."""
+    return Request(
+        scope={
+            "type": "http",
+            "headers": [(b"authorization", b"Bearer mock_token")],
+        }
+    )
+
+
+@pytest.fixture(name="prompts_client_mocks")
+def prompts_client_mocks_fixture(
+    mocker: MockerFixture,
+    minimal_config: AppConfig,
+) -> tuple[Any, Any]:
+    """Patch loaded configuration and mocked Llama Stack client with ``.prompts`` API."""
+    mocker.patch("app.endpoints.prompts.configuration", minimal_config)
+    mock_prompts = mocker.AsyncMock()
+    mock_client = mocker.AsyncMock()
+    mock_client.prompts = mock_prompts
+    mocker.patch(
+        "app.endpoints.prompts.AsyncLlamaStackClientHolder.get_client",
+        return_value=mock_client,
+    )
+    return mock_client, mock_prompts
+
+
+@pytest.mark.asyncio
+async def test_create_prompt_configuration_not_loaded(
+    mocker: MockerFixture,
+    prompts_http_request: Request,
+) -> None:
+    """create_prompt returns 500 when configuration is not loaded."""
+    mock_config = AppConfig()
+    mocker.patch("app.endpoints.prompts.configuration", mock_config)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await create_prompt_handler(
+            request=prompts_http_request,
+            auth=MOCK_AUTH,
+            body=PromptCreateRequest(prompt="x", variables=None),
+        )
+
+    assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    detail = exc_info.value.detail
+    assert detail["response"] == "Configuration is not loaded"  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_create_prompt_success(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+) -> None:
+    """create_prompt delegates to client.prompts.create."""
+    _, mock_prompts = prompts_client_mocks
+    mock_prompts.create.return_value = _sample_prompt(
+        "pmpt_abc", 1, prompt="Hi {{n}}", variables=["n"]
+    )
+
+    result = await create_prompt_handler(
+        request=prompts_http_request,
+        auth=MOCK_AUTH,
+        body=PromptCreateRequest(prompt="Hi {{n}}", variables=["n"]),
+    )
+
+    assert result.prompt_id == "pmpt_abc"
+    assert result.version == 1
+    mock_prompts.create.assert_awaited_once_with(prompt="Hi {{n}}", variables=["n"])
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_with_version(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+) -> None:
+    """get_prompt passes version when provided."""
+    _, mock_prompts = prompts_client_mocks
+    mock_prompts.retrieve.return_value = _sample_prompt("pmpt_abc", 2)
+
+    result = await get_prompt_handler(
+        request=prompts_http_request,
+        prompt_id="pmpt_abc",
+        auth=MOCK_AUTH,
+        version=2,
+    )
+
+    assert result.version == 2
+    mock_prompts.retrieve.assert_awaited_once_with("pmpt_abc", version=2)
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_without_version_omits_kwarg(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+) -> None:
+    """get_prompt calls retrieve with prompt_id only when version is omitted."""
+    _, mock_prompts = prompts_client_mocks
+    mock_prompts.retrieve.return_value = _sample_prompt("pmpt_abc", 1)
+
+    await get_prompt_handler(
+        request=prompts_http_request,
+        prompt_id="pmpt_abc",
+        auth=MOCK_AUTH,
+    )
+
+    mock_prompts.retrieve.assert_awaited_once_with("pmpt_abc")
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_success(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+) -> None:
+    """update_prompt forwards body fields to the client."""
+    _, mock_prompts = prompts_client_mocks
+    mock_prompts.update.return_value = _sample_prompt("pmpt_abc", 2)
+
+    body = PromptUpdateRequest(
+        prompt="new", version=1, set_as_default=True, variables=None
+    )
+    result = await update_prompt_handler(
+        request=prompts_http_request,
+        prompt_id="pmpt_abc",
+        auth=MOCK_AUTH,
+        body=body,
+    )
+
+    assert result.version == 2
+    mock_prompts.update.assert_awaited_once_with(
+        "pmpt_abc", prompt="new", version=1, set_as_default=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_prompt_success(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+) -> None:
+    """delete_prompt calls client.prompts.delete and returns 200 body."""
+    _, mock_prompts = prompts_client_mocks
+
+    result = await delete_prompt_handler(
+        request=prompts_http_request,
+        prompt_id="pmpt_abc",
+        auth=MOCK_AUTH,
+    )
+
+    assert isinstance(result, PromptDeleteResponse)
+    assert result.success is True
+    assert result.prompt_id == "pmpt_abc"
+    mock_prompts.delete.assert_awaited_once_with("pmpt_abc")
+
+
+@pytest.mark.asyncio
+async def test_delete_prompt_not_found_returns_body(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+    mocker: MockerFixture,
+) -> None:
+    """delete_prompt returns success=False on Llama Stack BadRequestError (v2 style)."""
+    _, mock_prompts = prompts_client_mocks
+    mock_response = mocker.Mock()
+    mock_response.request = mocker.Mock()
+    mock_prompts.delete.side_effect = BadRequestError(
+        message="not found", response=mock_response, body=None
+    )
+
+    result = await delete_prompt_handler(
+        request=prompts_http_request,
+        prompt_id="pmpt_missing",
+        auth=MOCK_AUTH,
+    )
+
+    assert result.success is False
+    assert result.prompt_id == "pmpt_missing"
+
+
+@pytest.mark.asyncio
+async def test_list_prompts_success(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+) -> None:
+    """list_prompts maps client.prompts.list to PromptsListResponse."""
+    _, mock_prompts = prompts_client_mocks
+    mock_prompts.list.return_value = [
+        _sample_prompt("pmpt_a", 1),
+        _sample_prompt("pmpt_b", 2, is_default=False),
+    ]
+
+    out = await list_prompts_handler(request=prompts_http_request, auth=MOCK_AUTH)
+
+    assert len(out.data) == 2
+    assert out.data[0].prompt_id == "pmpt_a"
+    mock_prompts.list.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_api_connection_error(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+) -> None:
+    """get_prompt maps APIConnectionError to 503."""
+    _, mock_prompts = prompts_client_mocks
+    mock_prompts.retrieve.side_effect = APIConnectionError(request=None)  # type: ignore
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_prompt_handler(
+            request=prompts_http_request,
+            prompt_id="pmpt_abc",
+            auth=MOCK_AUTH,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_bad_request_maps_to_404(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+    mocker: MockerFixture,
+) -> None:
+    """get_prompt maps Llama Stack BadRequestError to 404 NotFoundResponse."""
+    _, mock_prompts = prompts_client_mocks
+    mock_response = mocker.Mock()
+    mock_response.request = mocker.Mock()
+    mock_prompts.retrieve.side_effect = BadRequestError(
+        message="not found", response=mock_response, body=None
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_prompt_handler(
+            request=prompts_http_request,
+            prompt_id="pmpt_missing",
+            auth=MOCK_AUTH,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    detail = exc_info.value.detail
+    assert detail["response"] == "Prompt not found"  # type: ignore[index]
+    assert (
+        detail["cause"]  # type: ignore[index]
+        == "Prompt with ID pmpt_missing does not exist"
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_bad_request_maps_to_404(
+    prompts_client_mocks: tuple[Any, Any],
+    prompts_http_request: Request,
+    mocker: MockerFixture,
+) -> None:
+    """update_prompt maps Llama Stack BadRequestError to 404 NotFoundResponse."""
+    _, mock_prompts = prompts_client_mocks
+    mock_response = mocker.Mock()
+    mock_response.request = mocker.Mock()
+    mock_prompts.update.side_effect = BadRequestError(
+        message="invalid version", response=mock_response, body=None
+    )
+
+    body = PromptUpdateRequest(
+        prompt="x", version=99, set_as_default=False, variables=None
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await update_prompt_handler(
+            request=prompts_http_request,
+            prompt_id="pmpt_missing",
+            auth=MOCK_AUTH,
+            body=body,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
+    detail = exc_info.value.detail
+    assert detail["response"] == "Prompt not found"  # type: ignore[index]
+    assert (
+        detail["cause"]  # type: ignore[index]
+        == "Prompt with ID pmpt_missing does not exist"
+    )
+    mock_prompts.update.assert_awaited_once()

--- a/tests/unit/app/test_routers.py
+++ b/tests/unit/app/test_routers.py
@@ -18,6 +18,7 @@ from app.endpoints import (
     mcp_servers,
     metrics,
     models,
+    prompts,
     providers,
     query,
     rags,
@@ -115,7 +116,7 @@ def test_include_routers() -> None:
     include_routers(app)
 
     # are all routers added?
-    assert len(app.routers) == 23
+    assert len(app.routers) == 24
     assert root.router in app.get_routers()
     assert info.router in app.get_routers()
     assert models.router in app.get_routers()
@@ -124,6 +125,7 @@ def test_include_routers() -> None:
     assert mcp_servers.router in app.get_routers()
     assert shields.router in app.get_routers()
     assert providers.router in app.get_routers()
+    assert prompts.router in app.get_routers()
     assert query.router in app.get_routers()
     assert streaming_query.router in app.get_routers()
     assert config.router in app.get_routers()
@@ -146,7 +148,7 @@ def test_check_prefixes() -> None:
 
     Verify that include_routers registers the expected routers with their configured URL prefixes.
 
-    Asserts that 23 routers are registered on a MockFastAPI instance and that
+    Asserts that 24 routers are registered on a MockFastAPI instance and that
     each router's prefix matches the expected value (e.g., root, health,
     authorized, metrics use an empty prefix; most API routers use "/v1";
     conversations_v2 uses "/v2").
@@ -155,7 +157,7 @@ def test_check_prefixes() -> None:
     include_routers(app)
 
     # are all routers added?
-    assert len(app.routers) == 23
+    assert len(app.routers) == 24
     assert app.get_router_prefix(root.router) == ""
     assert app.get_router_prefix(info.router) == "/v1"
     assert app.get_router_prefix(models.router) == "/v1"
@@ -164,6 +166,7 @@ def test_check_prefixes() -> None:
     assert app.get_router_prefix(mcp_servers.router) == "/v1"
     assert app.get_router_prefix(shields.router) == "/v1"
     assert app.get_router_prefix(providers.router) == "/v1"
+    assert app.get_router_prefix(prompts.router) == "/v1"
     assert app.get_router_prefix(rags.router) == "/v1"
     assert app.get_router_prefix(query.router) == "/v1"
     assert app.get_router_prefix(streaming_query.router) == "/v1"

--- a/tests/unit/models/responses/test_error_responses.py
+++ b/tests/unit/models/responses/test_error_responses.py
@@ -85,6 +85,7 @@ class TestBadRequestResponse:
 
         # Verify example structure
         assert "conversation_id" in examples
+        assert "file_upload" in examples
         conversation_example = examples["conversation_id"]
         assert "value" in conversation_example
         assert "detail" in conversation_example["value"]
@@ -269,13 +270,16 @@ class TestForbiddenResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 5
+        assert expected_count == 7
 
         # Verify all labeled examples are present
         assert "conversation read" in examples
         assert "conversation delete" in examples
         assert "endpoint" in examples
+        assert "prompt read" in examples
+        assert "prompt manage" in examples
         assert "feedback" in examples
+        assert "model override" in examples
 
         # Verify example structure for one example
         feedback_example = examples["feedback"]
@@ -506,7 +510,7 @@ class TestNotFoundResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 8
+        assert expected_count == 9
 
         # Verify all labeled examples are present
         assert "conversation" in examples
@@ -517,6 +521,7 @@ class TestNotFoundResponse:
         assert "mcp server" in examples
         assert "vector store" in examples
         assert "file" in examples
+        assert "prompt" in examples
 
         # Verify example structure for one example
         conversation_example = examples["conversation"]


### PR DESCRIPTION
## Description

Created lightweight wrapper around LLS Prompts API to allow creating prompt templates that can be then referenced by responses request.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-1877](https://redhat.atlassian.net/browse/LCORE-1877)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added prompt management REST API with full CRUD operations (create, read, update, delete, list).
  * Introduced fine-grained authorization controls for prompt operations (read and manage actions).

* **Documentation**
  * Updated authorization documentation with new prompt-related actions and endpoints.

* **Tests**
  * Added comprehensive unit tests for prompt endpoint handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->