### PR TITLE
LCORE-1890: Bump-up sentence transformers

### DIFF
--- a/requirements.hashes.source.txt
+++ b/requirements.hashes.source.txt
@@ -1013,9 +1013,9 @@ rich==14.3.3 \
 semver==3.0.4 \
     --hash=sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746 \
     --hash=sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602
-sentence-transformers==5.3.0 \
-    --hash=sha256:414a0a881f53a4df0e6cbace75f823bfcb6b94d674c42a384b498959b7c065e2 \
-    --hash=sha256:dca6b98db790274a68185d27a65801b58b4caf653a4e556b5f62827509347c7d
+sentence-transformers==5.4.1 \
+    --hash=sha256:436bcb1182a0ff42a8fb2b1c43498a70d0a75b688d182f2cd0d1dd115af61ddc \
+    --hash=sha256:a6d640fc363849b63affb8e140e9d328feabab86f83d58ac3e16b1c28140b790
 sse-starlette==3.3.4 \
     --hash=sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1 \
     --hash=sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1


### PR DESCRIPTION
## Description

LCORE-1890: Bump-up sentence transformers

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1890


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `sentence-transformers` dependency to version 5.4.1 for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->