### PR TITLE
LCORE-1849: Fail test if expected model is not in the connectivity ch…

### DIFF
--- a/.github/workflows/e2e_tests_providers.yaml
+++ b/.github/workflows/e2e_tests_providers.yaml
@@ -20,6 +20,7 @@ jobs:
         # | azure       | gpt-4o-mini                         | azure         |
         # | vertexai    | google/gemini-2.5-flash             | google-vertex |
         # | watsonx     | meta-llama/llama-3-3-70b-instruct   | watsonx       |
+        # | bedrock     | deepseek.v3-v1:0                    | aws-bedrock   |
         include:
           - environment: azure
             e2e_default_model: gpt-4o-mini
@@ -31,8 +32,8 @@ jobs:
             e2e_default_model: meta-llama/llama-3-3-70b-instruct
             e2e_default_provider: watsonx
           - environment: bedrock
-            e2e_default_model: meta-llama/llama-3-3-70b-instruct
-            e2e_default_provider: bedrock
+            e2e_default_model: deepseek.v3-v1:0
+            e2e_default_provider: aws-bedrock
     
     name: "E2E: ${{ matrix.mode }} mode / ${{ matrix.environment }}"
     

--- a/.github/workflows/e2e_tests_providers.yaml
+++ b/.github/workflows/e2e_tests_providers.yaml
@@ -14,6 +14,25 @@ jobs:
       matrix:
         mode: ["server", "library"]
         environment: ["azure", "vertexai", "watsonx", "bedrock"]
+        # Expected default LLM for Behave (matches tests/e2e/configs/run-<env>.yaml).
+        # | environment | model_id                            | provider_id   |
+        # |-------------|-------------------------------------|---------------|
+        # | azure       | gpt-4o-mini                         | azure         |
+        # | vertexai    | google/gemini-2.5-flash             | google-vertex |
+        # | watsonx     | meta-llama/llama-3-3-70b-instruct   | watsonx       |
+        include:
+          - environment: azure
+            e2e_default_model: gpt-4o-mini
+            e2e_default_provider: azure
+          - environment: vertexai
+            e2e_default_model: google/gemini-2.5-flash
+            e2e_default_provider: google-vertex
+          - environment: watsonx
+            e2e_default_model: meta-llama/llama-3-3-70b-instruct
+            e2e_default_provider: watsonx
+          - environment: bedrock
+            e2e_default_model: meta-llama/llama-3-3-70b-instruct
+            e2e_default_provider: bedrock
     
     name: "E2E: ${{ matrix.mode }} mode / ${{ matrix.environment }}"
     
@@ -25,6 +44,8 @@ jobs:
       TENANT_ID: ${{ secrets.TENANT_ID }}
       E2E_DEPLOYMENT_MODE: ${{ matrix.mode }}
       FAISS_VECTOR_STORE_ID: ${{ vars.FAISS_VECTOR_STORE_ID }}
+      E2E_DEFAULT_MODEL_OVERRIDE: ${{ matrix.e2e_default_model }}
+      E2E_DEFAULT_PROVIDER_OVERRIDE: ${{ matrix.e2e_default_provider }}
 
     steps:
       - uses: actions/checkout@v4
@@ -161,7 +182,7 @@ jobs:
           echo "=== Configuration Summary ==="
           echo "Deployment mode: ${{ matrix.mode }}"
           echo "Environment: ${{ matrix.environment }}"
-          echo "Source config: tests/e2e/configs/run-ci.yaml"
+          echo "Source config: tests/e2e/configs/run-${{ matrix.environment }}.yaml"
           echo ""
           echo "=== Configuration Preview ==="
           echo "Providers: $(grep -c "provider_id:" run.yaml)"
@@ -249,30 +270,45 @@ jobs:
           sleep 20
 
       - name: Quick connectivity test
+        env:
+          EXPECTED_PROVIDER: ${{ matrix.e2e_default_provider }}
+          EXPECTED_MODEL: ${{ matrix.e2e_default_model }}
         run: |
-          echo "Testing basic connectivity before full test suite..."
-          curl -f http://localhost:8080/v1/models || {
-            echo "❌ Basic connectivity failed - showing logs"
+          set -euo pipefail
+          show_logs() {
             if [ "${{ matrix.mode }}" == "server" ]; then
-              docker compose logs --tail=30
+              docker compose logs --tail=80
             else
-              docker compose -f docker-compose-library.yaml logs --tail=30
+              docker compose -f docker-compose-library.yaml logs --tail=80
             fi
+          }
+
+          echo "Testing /v1/models and verifying expected LLM is registered..."
+          echo "Expected: provider_id=${EXPECTED_PROVIDER} provider_resource_id=${EXPECTED_MODEL}"
+
+          MODEL_JSON=$(curl -sfS "http://localhost:8080/v1/models?model_type=llm") || {
+            echo "❌ GET /v1/models?model_type=llm failed"
+            show_logs
             exit 1
           }
+
+          if ! echo "$MODEL_JSON" | jq -e --arg p "$EXPECTED_PROVIDER" --arg m "$EXPECTED_MODEL" \
+            '.models | any(.provider_id == $p and .provider_resource_id == $m)' >/dev/null
+          then
+            echo "❌ Expected LLM not listed by /v1/models (provider_id + provider_resource_id must match)"
+            echo "Registered LLM entries (provider_id, provider_resource_id, api_model_type):"
+            echo "$MODEL_JSON" | jq -r '.models[] | "\(.provider_id)\t\(.provider_resource_id)\t\(.api_model_type)"' || true
+            show_logs
+            exit 1
+          fi
+
+          echo "✅ Connectivity OK; expected model is registered (${EXPECTED_PROVIDER} / ${EXPECTED_MODEL})"
 
       # Wait for watsonx library mode to finish before running server mode
       # watsonx has a rate limit of 2 calls / second
       - name: Wait for watsonx library mode to finish
         if: matrix.environment == 'watsonx' && matrix.mode == 'server'
         run: sleep 7200  # 120 minutes
-
-      # watsonx has a different convention than "<provider>/<model>"
-      - name: Set watsonx test overrides
-        if: matrix.environment == 'watsonx'
-        run: |
-          echo "E2E_DEFAULT_MODEL_OVERRIDE=meta-llama/llama-3-3-70b-instruct" >> $GITHUB_ENV
-          echo "E2E_DEFAULT_PROVIDER_OVERRIDE=watsonx" >> $GITHUB_ENV
 
       - name: Run e2e tests
         env:

--- a/.github/workflows/e2e_tests_rhaiis.yaml
+++ b/.github/workflows/e2e_tests_rhaiis.yaml
@@ -14,7 +14,15 @@ jobs:
       fail-fast: false
       matrix:
         mode: ["server", "library"]
-        environment: [ "rhaiis" ]
+        environment: ["rhaiis"]
+        # Expected default LLM for Behave (matches tests/e2e/configs/run-rhaiis.yaml).
+        # | environment | model_id (repo var) | provider_id |
+        # |-------------|---------------------|-------------|
+        # | rhaiis      | RHAIIS_MODEL        | vllm        |
+        include:
+          - environment: rhaiis
+            e2e_default_provider: vllm
+            e2e_default_model: ${{ vars.RHAIIS_MODEL }}
 
     name: "RHAIIS E2E: ${{ matrix.mode }} mode / ${{ matrix.environment }}"
 
@@ -156,17 +164,39 @@ jobs:
           sleep 20  # adjust depending on boot time
 
       - name: Quick connectivity test
+        env:
+          EXPECTED_PROVIDER: ${{ matrix.e2e_default_provider }}
+          EXPECTED_MODEL: ${{ matrix.e2e_default_model }}
         run: |
-          echo "Testing basic connectivity before full test suite..."
-          curl -f http://localhost:8080/v1/models || {
-            echo "Basic connectivity failed - showing logs"
+          set -euo pipefail
+          show_logs() {
             if [ "${{ matrix.mode }}" == "server" ]; then
-              docker compose logs --tail=30
+              docker compose logs --tail=80
             else
-              docker compose -f docker-compose-library.yaml logs --tail=30
+              docker compose -f docker-compose-library.yaml logs --tail=80
             fi
+          }
+
+          echo "Testing /v1/models and verifying expected LLM is registered..."
+          echo "Expected: provider_id=${EXPECTED_PROVIDER} provider_resource_id=${EXPECTED_MODEL}"
+
+          MODEL_JSON=$(curl -sfS "http://localhost:8080/v1/models?model_type=llm") || {
+            echo "❌ GET /v1/models?model_type=llm failed"
+            show_logs
             exit 1
           }
+
+          if ! echo "$MODEL_JSON" | jq -e --arg p "$EXPECTED_PROVIDER" --arg m "$EXPECTED_MODEL" \
+            '.models | any(.provider_id == $p and .provider_resource_id == $m)' >/dev/null
+          then
+            echo "❌ Expected LLM not listed by /v1/models (provider_id + provider_resource_id must match)"
+            echo "Registered LLM entries (provider_id, provider_resource_id, api_model_type):"
+            echo "$MODEL_JSON" | jq -r '.models[] | "\(.provider_id)\t\(.provider_resource_id)\t\(.api_model_type)"' || true
+            show_logs
+            exit 1
+          fi
+
+          echo "✅ Connectivity OK; expected model is registered (${EXPECTED_PROVIDER} / ${EXPECTED_MODEL})"
 
       - name: Run e2e tests
         env:

--- a/.github/workflows/e2e_tests_rhelai.yaml
+++ b/.github/workflows/e2e_tests_rhelai.yaml
@@ -11,7 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [ "rhelai" ]
+        environment: ["rhelai"]
+        # Expected default LLM for Behave (matches tests/e2e/configs/run-rhelai.yaml).
+        # | environment | model_id (repo var) | provider_id |
+        # |-------------|---------------------|-------------|
+        # | rhelai      | RHEL_AI_MODEL       | vllm        |
+        include:
+          - environment: rhelai
+            e2e_default_provider: vllm
+            e2e_default_model: ${{ vars.RHEL_AI_MODEL }}
+
     env:
       RHEL_AI_URL: ${{ secrets.RHEL_AI_URL }}
       RHEL_AI_PORT: ${{ secrets.RHEL_AI_PORT }}
@@ -19,6 +28,8 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       RHEL_AI_MODEL: ${{ vars.RHEL_AI_MODEL }}
       FAISS_VECTOR_STORE_ID: ${{ vars.FAISS_VECTOR_STORE_ID }}
+      E2E_DEFAULT_MODEL_OVERRIDE: ${{ matrix.e2e_default_model }}
+      E2E_DEFAULT_PROVIDER_OVERRIDE: ${{ matrix.e2e_default_provider }}
 
     steps:
       - uses: actions/checkout@v4
@@ -151,13 +162,35 @@ jobs:
           sleep 20  # adjust depending on boot time
 
       - name: Quick connectivity test
+        env:
+          EXPECTED_PROVIDER: ${{ matrix.e2e_default_provider }}
+          EXPECTED_MODEL: ${{ matrix.e2e_default_model }}
         run: |
-          echo "Testing basic connectivity before full test suite..."
-          curl -f http://localhost:8080/v1/models || {
-            echo "❌ Basic connectivity failed - showing logs before running full tests"
-            docker compose logs --tail=30
+          set -euo pipefail
+          show_logs() {
+            docker compose logs --tail=80
+          }
+
+          echo "Testing /v1/models and verifying expected LLM is registered..."
+          echo "Expected: provider_id=${EXPECTED_PROVIDER} provider_resource_id=${EXPECTED_MODEL}"
+
+          MODEL_JSON=$(curl -sfS "http://localhost:8080/v1/models?model_type=llm") || {
+            echo "❌ GET /v1/models?model_type=llm failed"
+            show_logs
             exit 1
           }
+
+          if ! echo "$MODEL_JSON" | jq -e --arg p "$EXPECTED_PROVIDER" --arg m "$EXPECTED_MODEL" \
+            '.models | any(.provider_id == $p and .provider_resource_id == $m)' >/dev/null
+          then
+            echo "❌ Expected LLM not listed by /v1/models (provider_id + provider_resource_id must match)"
+            echo "Registered LLM entries (provider_id, provider_resource_id, api_model_type):"
+            echo "$MODEL_JSON" | jq -r '.models[] | "\(.provider_id)\t\(.provider_resource_id)\t\(.api_model_type)"' || true
+            show_logs
+            exit 1
+          fi
+
+          echo "✅ Connectivity OK; expected model is registered (${EXPECTED_PROVIDER} / ${EXPECTED_MODEL})"
 
       - name: Run e2e tests
         run: |

--- a/tests/e2e/configs/run-azure.yaml
+++ b/tests/e2e/configs/run-azure.yaml
@@ -30,8 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
-      allowed_models: ["gpt-4o-mini"]
-  - config: {}
+      allowed_models: ["${env.E2E_OPENAI_MODEL:gpt-4o-mini}"]
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
   files:

--- a/tests/e2e/configs/run-azure.yaml
+++ b/tests/e2e/configs/run-azure.yaml
@@ -30,6 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["gpt-4o-mini"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-bedrock.yaml
+++ b/tests/e2e/configs/run-bedrock.yaml
@@ -28,6 +28,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["${env.E2E_OPENAI_MODEL:=gpt-4o-mini}"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-rhaiis.yaml
+++ b/tests/e2e/configs/run-rhaiis.yaml
@@ -30,7 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
-      allowed_models: ["gpt-4o-mini"]
+      allowed_models: ["${env.E2E_OPENAI_MODEL:gpt-4o-mini}"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-rhaiis.yaml
+++ b/tests/e2e/configs/run-rhaiis.yaml
@@ -30,6 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["gpt-4o-mini"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-rhelai.yaml
+++ b/tests/e2e/configs/run-rhelai.yaml
@@ -30,7 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
-      allowed_models: ["gpt-4o-mini"]
+      allowed_models: ["${env.E2E_OPENAI_MODEL:gpt-4o-mini}"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-rhelai.yaml
+++ b/tests/e2e/configs/run-rhelai.yaml
@@ -30,6 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["gpt-4o-mini"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-vertexai.yaml
+++ b/tests/e2e/configs/run-vertexai.yaml
@@ -29,6 +29,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["gpt-4o-mini"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-vertexai.yaml
+++ b/tests/e2e/configs/run-vertexai.yaml
@@ -29,7 +29,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
-      allowed_models: ["gpt-4o-mini"]
+      allowed_models: ["${env.E2E_OPENAI_MODEL:gpt-4o-mini}"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-watsonx.yaml
+++ b/tests/e2e/configs/run-watsonx.yaml
@@ -30,7 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
-      allowed_models: ["gpt-4o-mini"]
+      allowed_models: ["${env.E2E_OPENAI_MODEL:gpt-4o-mini}"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/configs/run-watsonx.yaml
+++ b/tests/e2e/configs/run-watsonx.yaml
@@ -30,6 +30,7 @@ providers:
     provider_type: remote::openai
     config:
       api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["gpt-4o-mini"]
   - config: {}
     provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -103,8 +103,8 @@ def before_all(context: Context) -> None:
     print(f"Running tests in {context.deployment_mode} mode")
 
     # Check for environment variable overrides first
-    model_override = os.getenv("E2E_DEFAULT_MODEL_OVERRIDE")
-    provider_override = os.getenv("E2E_DEFAULT_PROVIDER_OVERRIDE")
+    model_override = os.getenv("E2E_DEFAULT_MODEL_OVERRIDE", "")
+    provider_override = os.getenv("E2E_DEFAULT_PROVIDER_OVERRIDE", "")
 
     context.faiss_vector_store_id = os.getenv("FAISS_VECTOR_STORE_ID")
 

--- a/tests/e2e/features/faiss.feature
+++ b/tests/e2e/features/faiss.feature
@@ -25,7 +25,7 @@ Feature: FAISS support tests
   Scenario: Query vector db using the file_search tool
     When I use "query" to ask question with authorization header
     """
-    {"query": "What is the title of the article from Paul?", "system_prompt": "You are an assistant. Always use the file_search tool to answer. Write only lowercase letters"}
+    {"query": "What is the title of the article from Paul?", "system_prompt": "You are an assistant. Always use the file_search tool to answer. Write only lowercase letters", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
      Then The status code of the response is 200
       And The response should contain following fragments

--- a/tests/e2e/features/inline_rag.feature
+++ b/tests/e2e/features/inline_rag.feature
@@ -25,7 +25,7 @@ Feature: Inline RAG (BYOK) support tests
   Scenario: Query with inline RAG returns relevant content
     When I use "query" to ask question with authorization header
     """
-    {"query": "What is the title of the article from Paul?", "system_prompt": "You are an assistant. Write only lowercase letters"}
+    {"query": "What is the title of the article from Paul?", "system_prompt": "You are an assistant. Write only lowercase letters", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
      And The response should contain following fragments
@@ -36,7 +36,7 @@ Feature: Inline RAG (BYOK) support tests
   Scenario: Inline RAG query includes referenced documents
     When I use "query" to ask question with authorization header
     """
-    {"query": "What does Paul Graham say about great work?"}
+    {"query": "What does Paul Graham say about great work?", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
      And The response should contain non-empty referenced_documents
@@ -44,7 +44,7 @@ Feature: Inline RAG (BYOK) support tests
   Scenario: Streaming query with inline RAG returns relevant content
     When I use "streaming_query" to ask question with authorization header
     """
-    {"query": "What is the title of the article from Paul?", "system_prompt": "You are an assistant. Write only lowercase letters"}
+    {"query": "What is the title of the article from Paul?", "system_prompt": "You are an assistant. Write only lowercase letters", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
      And I wait for the response to be completed


### PR DESCRIPTION
## Description
Fail test if expected model is not in the connectivity check list
Force only gpt-4o-mini as the openai model
always use the override model for provider tests

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [X] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #LCORE-1849
- Closes #LCORE-1849

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end testing validation across cloud provider environments (Azure, VertexAI, Watson X, Bedrock, RHAIIS, RHEL AI).
  * Improved connectivity checks with stricter validation of registered models and expanded diagnostic output.
  * Updated test scenarios to explicitly specify expected model and provider configurations for more accurate testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->