### PR TITLE
RSPEED-2867: Add ResponsesEventData format and builder

### DIFF
--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -8,7 +8,18 @@ Event formats are in the formats subpackage - see formats.rlsapi for the
 default implementation, or create your own format module.
 """
 
-from observability.formats import InferenceEventData, build_inference_event
+from observability.formats import (
+    InferenceEventData,
+    ResponsesEventData,
+    build_inference_event,
+    build_responses_event,
+)
 from observability.splunk import send_splunk_event
 
-__all__ = ["InferenceEventData", "build_inference_event", "send_splunk_event"]
+__all__ = [
+    "InferenceEventData",
+    "build_inference_event",
+    "ResponsesEventData",
+    "build_responses_event",
+    "send_splunk_event",
+]

--- a/src/observability/formats/__init__.py
+++ b/src/observability/formats/__init__.py
@@ -4,6 +4,12 @@ Each submodule provides format-specific event builders. The rlsapi module
 provides the default format matching Red Hat's rlsapi v1 specification.
 """
 
+from observability.formats.responses import ResponsesEventData, build_responses_event
 from observability.formats.rlsapi import InferenceEventData, build_inference_event
 
-__all__ = ["InferenceEventData", "build_inference_event"]
+__all__ = [
+    "InferenceEventData",
+    "build_inference_event",
+    "ResponsesEventData",
+    "build_responses_event",
+]

--- a/src/observability/formats/responses.py
+++ b/src/observability/formats/responses.py
@@ -1,0 +1,48 @@
+"""Event builders for Responses API Splunk format.
+
+This module provides event builders specific to the Responses API telemetry format.
+To implement a custom format, create a new module in this package with your own
+event builder function that returns a dict, then pass the result to send_splunk_event().
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from configuration import configuration
+
+
+@dataclass
+class ResponsesEventData:  # pylint: disable=too-many-instance-attributes
+    """Data required to build a responses telemetry event."""
+
+    input_text: str
+    response_text: str
+    conversation_id: str
+    model: str
+    org_id: str
+    system_id: str
+    inference_time: float
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+def build_responses_event(data: ResponsesEventData) -> dict[str, Any]:
+    """Build a responses telemetry event payload matching responses format.
+
+    Args:
+        data: The responses event data.
+
+    Returns:
+        A dictionary matching the responses Splunk event format.
+    """
+    return {
+        "input_text": data.input_text,
+        "response_text": data.response_text,
+        "conversation_id": data.conversation_id,
+        "inference_time": data.inference_time,
+        "model": data.model,
+        "deployment": configuration.deployment_environment,
+        "org_id": data.org_id,
+        "system_id": data.system_id,
+        "total_llm_tokens": data.input_tokens + data.output_tokens,
+    }

--- a/tests/unit/observability/formats/README.md
+++ b/tests/unit/observability/formats/README.md
@@ -6,3 +6,6 @@ Unit tests for observability event format builders.
 ## [test_rlsapi.py](test_rlsapi.py)
 Unit tests for rlsapi v1 event builders.
 
+## [test_responses.py](test_responses.py)
+Unit tests for responses event format builders.
+

--- a/tests/unit/observability/formats/test_responses.py
+++ b/tests/unit/observability/formats/test_responses.py
@@ -1,0 +1,99 @@
+"""Unit tests for responses event builders."""
+
+import pytest
+from pytest_mock import MockerFixture
+
+from observability.formats.responses import ResponsesEventData, build_responses_event
+
+
+@pytest.fixture(name="sample_event_data")
+def sample_event_data_fixture() -> ResponsesEventData:
+    """Create sample responses event data for testing."""
+    return ResponsesEventData(
+        input_text="How do I configure SSH?",
+        response_text="To configure SSH, edit /etc/ssh/sshd_config...",
+        conversation_id="conv-abc-123",
+        model="granite-3-8b-instruct",
+        org_id="12345678",
+        system_id="abc-def-123",
+        inference_time=2.34,
+    )
+
+
+def test_builds_event_with_all_fields(
+    mocker: MockerFixture, sample_event_data: ResponsesEventData
+) -> None:
+    """Test event contains all required fields and placeholders."""
+    mock_config = mocker.patch("observability.formats.responses.configuration")
+    mock_config.deployment_environment = "production"
+
+    event = build_responses_event(sample_event_data)
+
+    assert event["input_text"] == "How do I configure SSH?"
+    assert event["response_text"] == "To configure SSH, edit /etc/ssh/sshd_config..."
+    assert event["conversation_id"] == "conv-abc-123"
+    assert event["inference_time"] == 2.34
+    assert event["model"] == "granite-3-8b-instruct"
+    assert event["org_id"] == "12345678"
+    assert event["system_id"] == "abc-def-123"
+    assert event["deployment"] == "production"
+    assert event["total_llm_tokens"] == 0
+
+
+def test_builds_event_with_token_counts(mocker: MockerFixture) -> None:
+    """Test total_llm_tokens is computed from input and output token counts."""
+    mock_config = mocker.patch("observability.formats.responses.configuration")
+    mock_config.deployment_environment = "production"
+
+    data = ResponsesEventData(
+        input_text="test",
+        response_text="test",
+        conversation_id="conv-123",
+        inference_time=1.0,
+        model="test-model",
+        org_id="org1",
+        system_id="sys1",
+        input_tokens=150,
+        output_tokens=75,
+    )
+
+    event = build_responses_event(data)
+
+    assert event["total_llm_tokens"] == 225
+
+
+def test_handles_auth_disabled_values(mocker: MockerFixture) -> None:
+    """Test event handles auth_disabled placeholder values."""
+    data = ResponsesEventData(
+        input_text="test",
+        response_text="test",
+        conversation_id="conv-456",
+        inference_time=1.0,
+        model="test-model",
+        org_id="auth_disabled",
+        system_id="auth_disabled",
+    )
+
+    mock_config = mocker.patch("observability.formats.responses.configuration")
+    mock_config.deployment_environment = "test"
+
+    event = build_responses_event(data)
+
+    assert event["org_id"] == "auth_disabled"
+    assert event["system_id"] == "auth_disabled"
+
+
+def test_default_token_values() -> None:
+    """Test default token values are zero."""
+    data = ResponsesEventData(
+        input_text="test",
+        response_text="test",
+        conversation_id="conv-789",
+        inference_time=1.0,
+        model="test-model",
+        org_id="org1",
+        system_id="sys1",
+    )
+
+    assert data.input_tokens == 0
+    assert data.output_tokens == 0


### PR DESCRIPTION
## Description

Add `ResponsesEventData` dataclass and `build_responses_event()` builder for Responses API Splunk telemetry, following the same pattern as `InferenceEventData`/`build_inference_event()` in `rlsapi.py`.

Part 2 of the RSPEED-2867 Splunk HEC telemetry work. This PR adds the event data format that PR 3 will use to build telemetry events in the `/responses` endpoint.

**New file:** `src/observability/formats/responses.py`
- `ResponsesEventData` with fields: `input_text`, `response_text`, `conversation_id`, `model`, `org_id`, `system_id`, `inference_time`, `input_tokens`, `output_tokens`
- `build_responses_event()` adds `deployment` from config and computes `total_llm_tokens`

Export chains updated in `observability.formats` and `observability` packages.

**Dependencies:** None (independent of PR #1548)

## Type of change

- [x] New feature

## Tools used to create PR

- Assisted-by: Claude (Sisyphus agent via OpenCode)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2867](https://redhat.atlassian.net/browse/RSPEED-2867)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `uv run pytest tests/unit/observability/formats/test_responses.py -v` - 4 tests covering field construction, token defaults, auth_disabled values, and total_llm_tokens computation
- All existing tests pass (`uv run make test-unit` - 2033 passed)
- `uv run make verify` passes all linters
