### PR TITLE
RSPEED-2867: Add Splunk HEC telemetry to responses endpoint

### DIFF
--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -1,13 +1,14 @@
-# pylint: disable=too-many-locals,too-many-branches,too-many-nested-blocks, too-many-arguments,too-many-positional-arguments
+# pylint: disable=too-many-locals,too-many-branches,too-many-nested-blocks,too-many-arguments,too-many-positional-arguments,too-many-lines,too-many-statements
 
 """Handler for REST API call to provide answer using Responses API (LCORE specification)."""
 
+import asyncio
 import json
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Annotated, Any, Optional, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from llama_stack_api import (
     OpenAIResponseObject,
@@ -53,6 +54,7 @@ from models.responses import (
     UnauthorizedResponse,
     UnprocessableEntityResponse,
 )
+from observability import ResponsesEventData, build_responses_event, send_splunk_event
 from utils.conversations import append_turn_items_to_conversation
 from utils.endpoints import (
     check_configuration_loaded,
@@ -89,6 +91,7 @@ from utils.responses import (
     resolve_tool_choice,
     select_model_for_responses,
 )
+from utils.rh_identity import get_rh_identity_context
 from utils.shields import run_shield_moderation
 from utils.suid import (
     normalize_conversation_id,
@@ -132,6 +135,67 @@ responses_response: dict[int | str, dict[str, Any]] = {
 }
 
 
+# Strong references for fire-and-forget telemetry tasks so they aren't
+# garbage-collected before completion (the event loop only holds weak refs).
+_background_splunk_tasks: set[asyncio.Task[None]] = set()
+
+
+def _queue_responses_splunk_event(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    background_tasks: Optional[BackgroundTasks],
+    input_text: str,
+    response_text: str,
+    conversation_id: str,
+    model: str,
+    rh_identity_context: tuple[str, str],
+    inference_time: float,
+    sourcetype: str,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    fire_and_forget: bool = False,
+) -> None:
+    """Build and queue a Splunk telemetry event for the responses endpoint.
+
+    No-op when background_tasks is None and fire_and_forget is False
+    (Splunk telemetry disabled).
+
+    Args:
+        background_tasks: FastAPI background task manager, or None if disabled.
+        input_text: User input text.
+        response_text: Response text from LLM or shield.
+        conversation_id: Conversation identifier.
+        model: Model name used for inference.
+        rh_identity_context: Tuple of (org_id, system_id) from RH identity.
+        inference_time: Request processing duration in seconds.
+        sourcetype: Splunk sourcetype for the event.
+        input_tokens: Number of prompt tokens consumed.
+        output_tokens: Number of completion tokens produced.
+        fire_and_forget: When True, dispatch via asyncio.create_task() instead
+            of background_tasks.  Use for error paths where an HTTPException
+            follows, since FastAPI discards BackgroundTasks on non-2xx responses.
+    """
+    if not fire_and_forget and background_tasks is None:
+        return
+    org_id, system_id = rh_identity_context
+    event_data = ResponsesEventData(
+        input_text=input_text,
+        response_text=response_text,
+        conversation_id=conversation_id,
+        model=model,
+        org_id=org_id,
+        system_id=system_id,
+        inference_time=inference_time,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+    event = build_responses_event(event_data)
+    if fire_and_forget:
+        task = asyncio.create_task(send_splunk_event(event, sourcetype))
+        _background_splunk_tasks.add(task)
+        task.add_done_callback(_background_splunk_tasks.discard)
+    elif background_tasks is not None:
+        background_tasks.add_task(send_splunk_event, event, sourcetype)
+
+
 @router.post(
     "/responses",
     responses=responses_response,
@@ -144,6 +208,7 @@ async def responses_endpoint_handler(
     responses_request: ResponsesRequest,
     auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
     mcp_headers: dict[str, dict[str, str]] = Depends(mcp_headers_dependency),
+    background_tasks: BackgroundTasks = BackgroundTasks(),
 ) -> ResponsesResponse | StreamingResponse:
     """
     Handle request to the /responses endpoint using Responses API (LCORE specification).
@@ -187,6 +252,7 @@ async def responses_endpoint_handler(
     )
     instructions_substituted = client_instructions is None
     started_at = datetime.now(UTC)
+    rh_identity_context = get_rh_identity_context(request)
     user_id = auth[0]
 
     await check_mcp_auth(configuration, mcp_headers)
@@ -307,6 +373,8 @@ async def responses_endpoint_handler(
         inline_rag_context=inline_rag_context,
         filter_server_tools=filter_server_tools,
         instructions_substituted=instructions_substituted,
+        background_tasks=background_tasks,
+        rh_identity_context=rh_identity_context,
     )
 
 
@@ -320,6 +388,8 @@ async def handle_streaming_response(
     inline_rag_context: RAGContext,
     filter_server_tools: bool = False,
     instructions_substituted: bool = False,
+    background_tasks: BackgroundTasks | None = None,
+    rh_identity_context: tuple[str, str] = ("", ""),
 ) -> StreamingResponse:
     """Handle streaming response from Responses API.
 
@@ -333,6 +403,8 @@ async def handle_streaming_response(
         inline_rag_context: Inline RAG context to be used for the response
         filter_server_tools: Whether to filter server-deployed MCP tool events from the stream
         instructions_substituted: Whether the server substituted the instructions
+        background_tasks: FastAPI background task manager for telemetry events
+        rh_identity_context: Tuple of (org_id, system_id) from RH identity
     Returns:
         StreamingResponse with SSE-formatted events
     """
@@ -359,6 +431,16 @@ async def handle_streaming_response(
                 user_input=request.input,
                 llm_output=[moderation_result.refusal_response],
             )
+        _queue_responses_splunk_event(
+            background_tasks=background_tasks,
+            input_text=input_text,
+            response_text=moderation_result.message,
+            conversation_id=normalize_conversation_id(api_params.conversation),
+            model=api_params.model,
+            rh_identity_context=rh_identity_context,
+            inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+            sourcetype="responses_shield_blocked",
+        )
     else:
         try:
             response = await client.responses.create(
@@ -376,16 +458,49 @@ async def handle_streaming_response(
             )
         except RuntimeError as e:  # library mode wraps 413 into runtime error
             if is_context_length_error(str(e)):
+                _queue_responses_splunk_event(
+                    background_tasks=background_tasks,
+                    input_text=input_text,
+                    response_text=str(e),
+                    conversation_id=normalize_conversation_id(api_params.conversation),
+                    model=api_params.model,
+                    rh_identity_context=rh_identity_context,
+                    inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+                    sourcetype="responses_error",
+                    fire_and_forget=True,
+                )
                 error_response = PromptTooLongResponse(model=api_params.model)
                 raise HTTPException(**error_response.model_dump()) from e
             raise e
         except APIConnectionError as e:
+            _queue_responses_splunk_event(
+                background_tasks=background_tasks,
+                input_text=input_text,
+                response_text=str(e),
+                conversation_id=normalize_conversation_id(api_params.conversation),
+                model=api_params.model,
+                rh_identity_context=rh_identity_context,
+                inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+                sourcetype="responses_error",
+                fire_and_forget=True,
+            )
             error_response = ServiceUnavailableResponse(
                 backend_name="Llama Stack",
                 cause=str(e),
             )
             raise HTTPException(**error_response.model_dump()) from e
         except (LLSApiStatusError, OpenAIAPIStatusError) as e:
+            _queue_responses_splunk_event(
+                background_tasks=background_tasks,
+                input_text=input_text,
+                response_text=str(e),
+                conversation_id=normalize_conversation_id(api_params.conversation),
+                model=api_params.model,
+                rh_identity_context=rh_identity_context,
+                inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+                sourcetype="responses_error",
+                fire_and_forget=True,
+            )
             error_response = handle_known_apistatus_errors(e, api_params.model)
             raise HTTPException(**error_response.model_dump()) from e
 
@@ -399,6 +514,9 @@ async def handle_streaming_response(
             started_at=started_at,
             api_params=api_params,
             generate_topic_summary=request.generate_topic_summary or False,
+            background_tasks=background_tasks,
+            rh_identity_context=rh_identity_context,
+            shield_blocked=(moderation_result.decision == "blocked"),
         ),
         media_type="text/event-stream",
     )
@@ -794,6 +912,9 @@ async def generate_response(
     started_at: datetime,
     api_params: ResponsesApiParams,
     generate_topic_summary: bool,
+    background_tasks: BackgroundTasks | None = None,
+    rh_identity_context: tuple[str, str] = ("", ""),
+    shield_blocked: bool = False,
 ) -> AsyncIterator[str]:
     """Stream the response from the generator and persist conversation details.
 
@@ -808,6 +929,9 @@ async def generate_response(
         started_at: Timestamp when the conversation started
         api_params: ResponsesApiParams
         generate_topic_summary: Whether to generate topic summary for new conversations
+        background_tasks: FastAPI background task manager for telemetry events
+        rh_identity_context: Tuple of (org_id, system_id) from RH identity
+        shield_blocked: Whether the request was blocked by a shield
     Yields:
         SSE-formatted strings from the generator
     """
@@ -835,6 +959,25 @@ async def generate_response(
             skip_userid_check=skip_userid_check,
             topic_summary=topic_summary,
         )
+    if not shield_blocked:
+        _queue_responses_splunk_event(
+            background_tasks=background_tasks,
+            input_text=input_text,
+            response_text=turn_summary.llm_response,
+            conversation_id=normalize_conversation_id(api_params.conversation),
+            model=api_params.model,
+            rh_identity_context=rh_identity_context,
+            inference_time=(completed_at - started_at).total_seconds(),
+            sourcetype="responses_completed",
+            input_tokens=(
+                turn_summary.token_usage.input_tokens if turn_summary.token_usage else 0
+            ),
+            output_tokens=(
+                turn_summary.token_usage.output_tokens
+                if turn_summary.token_usage
+                else 0
+            ),
+        )
 
 
 async def handle_non_streaming_response(
@@ -847,6 +990,8 @@ async def handle_non_streaming_response(
     inline_rag_context: RAGContext,
     filter_server_tools: bool = False,
     instructions_substituted: bool = False,
+    background_tasks: BackgroundTasks | None = None,
+    rh_identity_context: tuple[str, str] = ("", ""),
 ) -> ResponsesResponse:
     """Handle non-streaming response from Responses API.
 
@@ -860,6 +1005,8 @@ async def handle_non_streaming_response(
         inline_rag_context: Inline RAG context to be used for the response
         filter_server_tools: Whether to filter server-deployed MCP tool output
         instructions_substituted: Whether the server substituted the instructions
+        background_tasks: FastAPI background task manager for telemetry events
+        rh_identity_context: Tuple of (org_id, system_id) from RH identity
     Returns:
         ResponsesResponse with the completed response
     """
@@ -884,6 +1031,16 @@ async def handle_non_streaming_response(
                 user_input=request.input,
                 llm_output=[moderation_result.refusal_response],
             )
+        _queue_responses_splunk_event(
+            background_tasks=background_tasks,
+            input_text=input_text,
+            response_text=output_text,
+            conversation_id=normalize_conversation_id(api_params.conversation),
+            model=api_params.model,
+            rh_identity_context=rh_identity_context,
+            inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+            sourcetype="responses_shield_blocked",
+        )
     else:
         try:
             api_response = cast(
@@ -908,16 +1065,49 @@ async def handle_non_streaming_response(
 
         except RuntimeError as e:
             if is_context_length_error(str(e)):
+                _queue_responses_splunk_event(
+                    background_tasks=background_tasks,
+                    input_text=input_text,
+                    response_text=str(e),
+                    conversation_id=normalize_conversation_id(api_params.conversation),
+                    model=api_params.model,
+                    rh_identity_context=rh_identity_context,
+                    inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+                    sourcetype="responses_error",
+                    fire_and_forget=True,
+                )
                 error_response = PromptTooLongResponse(model=api_params.model)
                 raise HTTPException(**error_response.model_dump()) from e
             raise e
         except APIConnectionError as e:
+            _queue_responses_splunk_event(
+                background_tasks=background_tasks,
+                input_text=input_text,
+                response_text=str(e),
+                conversation_id=normalize_conversation_id(api_params.conversation),
+                model=api_params.model,
+                rh_identity_context=rh_identity_context,
+                inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+                sourcetype="responses_error",
+                fire_and_forget=True,
+            )
             error_response = ServiceUnavailableResponse(
                 backend_name="Llama Stack",
                 cause=str(e),
             )
             raise HTTPException(**error_response.model_dump()) from e
         except (LLSApiStatusError, OpenAIAPIStatusError) as e:
+            _queue_responses_splunk_event(
+                background_tasks=background_tasks,
+                input_text=input_text,
+                response_text=str(e),
+                conversation_id=normalize_conversation_id(api_params.conversation),
+                model=api_params.model,
+                rh_identity_context=rh_identity_context,
+                inference_time=(datetime.now(UTC) - started_at).total_seconds(),
+                sourcetype="responses_error",
+                fire_and_forget=True,
+            )
             error_response = handle_known_apistatus_errors(e, api_params.model)
             raise HTTPException(**error_response.model_dump()) from e
 
@@ -945,6 +1135,25 @@ async def handle_non_streaming_response(
     )
     turn_summary.rag_chunks.extend(inline_rag_context.rag_chunks)
     completed_at = datetime.now(UTC)
+    if moderation_result.decision != "blocked":
+        _queue_responses_splunk_event(
+            background_tasks=background_tasks,
+            input_text=input_text,
+            response_text=output_text,
+            conversation_id=normalize_conversation_id(api_params.conversation),
+            model=api_params.model,
+            rh_identity_context=rh_identity_context,
+            inference_time=(completed_at - started_at).total_seconds(),
+            sourcetype="responses_completed",
+            input_tokens=(
+                turn_summary.token_usage.input_tokens if turn_summary.token_usage else 0
+            ),
+            output_tokens=(
+                turn_summary.token_usage.output_tokens
+                if turn_summary.token_usage
+                else 0
+            ),
+        )
     if api_params.store:
         store_query_results(
             user_id=user_id,

--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -78,10 +78,6 @@ _INFER_HANDLED_EXCEPTIONS = (
 )
 
 
-# Backward-compatible alias so existing test imports continue to work.
-_get_rh_identity_context = get_rh_identity_context
-
-
 infer_responses: dict[int | str, dict[str, Any]] = {
     200: RlsapiV1InferResponse.openapi_response(),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),

--- a/tests/unit/app/endpoints/test_responses_splunk.py
+++ b/tests/unit/app/endpoints/test_responses_splunk.py
@@ -1,0 +1,710 @@
+# pylint: disable=redefined-outer-name, too-many-locals, too-few-public-methods
+"""Unit tests for Splunk telemetry in the /responses endpoint."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+from llama_stack_api import OpenAIResponseObject
+from llama_stack_api.openai_responses import OpenAIResponseMessage
+from llama_stack_client import APIConnectionError, AsyncLlamaStackClient
+from llama_stack_client import APIStatusError as LLSApiStatusError
+from openai._exceptions import APIStatusError as OpenAIAPIStatusError
+from pytest_mock import MockerFixture
+
+from app.endpoints.responses import (
+    _background_splunk_tasks,
+    _queue_responses_splunk_event,
+    handle_non_streaming_response,
+    handle_streaming_response,
+)
+from configuration import AppConfig
+from models.requests import ResponsesRequest
+from observability.formats.responses import ResponsesEventData
+from utils.types import RAGContext, TurnSummary
+
+MODULE = "app.endpoints.responses"
+MOCK_AUTH = (
+    "00000001-0001-0001-0001-000000000001",
+    "mock_username",
+    False,
+    "mock_token",
+)
+VALID_CONV_ID = "conv_e6afd7aaa97b49ce8f4f96a801b07893d9cb784d72e53e3c"
+VALID_CONV_ID_NORMALIZED = "e6afd7aaa97b49ce8f4f96a801b07893d9cb784d72e53e3c"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _request_with_model_and_conv(
+    input_text: str = "Hello", model: str = "provider/model1"
+) -> ResponsesRequest:
+    """Build request with model and conversation set (as handler does)."""
+    return ResponsesRequest(
+        input=input_text,
+        model=model,
+        conversation=VALID_CONV_ID,
+    )
+
+
+def _patch_handle_non_streaming_common(
+    mocker: MockerFixture, config: AppConfig
+) -> None:
+    """Patch deps used by handle_non_streaming_response (blocked and success)."""
+    mocker.patch(f"{MODULE}.configuration", config)
+    mocker.patch(f"{MODULE}.get_available_quotas", return_value={})
+    mocker.patch(
+        f"{MODULE}.get_topic_summary",
+        new=mocker.AsyncMock(return_value=None),
+    )
+    mocker.patch(f"{MODULE}.store_query_results")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="minimal_config")
+def minimal_config_fixture() -> AppConfig:
+    """Minimal AppConfig for responses endpoint tests."""
+    cfg = AppConfig()
+    cfg.init_from_dict(
+        {
+            "name": "test",
+            "service": {"host": "localhost", "port": 8080},
+            "llama_stack": {
+                "api_key": "test-key",
+                "url": "http://test.com:1234",
+                "use_as_library_client": False,
+            },
+            "user_data_collection": {},
+            "authentication": {"module": "noop"},
+            "authorization": {"access_rules": []},
+        }
+    )
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _queue_responses_splunk_event unit test
+# ---------------------------------------------------------------------------
+
+
+class TestQueueResponsesSplunkEvent:
+    """Unit tests for the _queue_responses_splunk_event helper."""
+
+    def test_noop_when_background_tasks_is_none(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Verify no-op when background_tasks is None (Splunk disabled)."""
+        mock_build = mocker.patch(f"{MODULE}.build_responses_event")
+
+        _queue_responses_splunk_event(
+            background_tasks=None,
+            input_text="user question",
+            response_text="llm answer",
+            conversation_id="conv_abc",
+            model="provider/model1",
+            rh_identity_context=("org1", "sys1"),
+            inference_time=1.23,
+            sourcetype="responses_completed",
+        )
+
+        mock_build.assert_not_called()
+
+    def test_builds_event_and_queues_background_task(
+        self,
+        mock_background_tasks: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Verify event is built from ResponsesEventData and queued via add_task."""
+        mock_build = mocker.patch(
+            f"{MODULE}.build_responses_event", return_value={"built": True}
+        )
+        mock_send = mocker.patch(f"{MODULE}.send_splunk_event")
+
+        _queue_responses_splunk_event(
+            background_tasks=mock_background_tasks,
+            input_text="user question",
+            response_text="llm answer",
+            conversation_id="conv_abc",
+            model="provider/model1",
+            rh_identity_context=("org1", "sys1"),
+            inference_time=1.23,
+            sourcetype="responses_completed",
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+        mock_build.assert_called_once()
+        event_data = mock_build.call_args[0][0]
+        assert isinstance(event_data, ResponsesEventData)
+        assert event_data.input_text == "user question"
+        assert event_data.response_text == "llm answer"
+        assert event_data.conversation_id == "conv_abc"
+        assert event_data.model == "provider/model1"
+        assert event_data.org_id == "org1"
+        assert event_data.system_id == "sys1"
+        assert event_data.inference_time == 1.23
+        assert event_data.input_tokens == 100
+        assert event_data.output_tokens == 50
+
+        mock_background_tasks.add_task.assert_called_once_with(
+            mock_send, {"built": True}, "responses_completed"
+        )
+
+    def test_fire_and_forget_dispatches_via_create_task(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """fire_and_forget=True dispatches via asyncio.create_task with GC protection."""
+        mocker.patch(f"{MODULE}.build_responses_event", return_value={"built": True})
+        # Use MagicMock (not AsyncMock) so send_splunk_event() returns a
+        # comparable return_value instead of a coroutine object.
+        mock_send = mocker.patch(f"{MODULE}.send_splunk_event", new=mocker.MagicMock())
+        mock_task = mocker.MagicMock()
+        mock_create_task = mocker.patch("asyncio.create_task", return_value=mock_task)
+
+        # Clear any leftover tasks from other tests
+        _background_splunk_tasks.clear()
+
+        _queue_responses_splunk_event(
+            background_tasks=None,
+            input_text="user question",
+            response_text="error message",
+            conversation_id="conv_abc",
+            model="provider/model1",
+            rh_identity_context=("org1", "sys1"),
+            inference_time=1.23,
+            sourcetype="responses_error",
+            fire_and_forget=True,
+        )
+
+        mock_send.assert_called_once_with({"built": True}, "responses_error")
+        mock_create_task.assert_called_once_with(mock_send.return_value)
+
+        # Task is held in the module-level set to prevent GC
+        assert mock_task in _background_splunk_tasks
+        # done_callback registered to clean up after completion
+        mock_task.add_done_callback.assert_called_once()
+
+        # Simulate task completion: callback removes from set
+        done_callback = mock_task.add_done_callback.call_args[0][0]
+        done_callback(mock_task)
+        assert mock_task not in _background_splunk_tasks
+
+
+# ---------------------------------------------------------------------------
+# Tests 2-8: Integration tests for telemetry hook paths
+# ---------------------------------------------------------------------------
+
+
+class TestSplunkTelemetryHooks:
+    """Integration tests verifying _queue_responses_splunk_event is called at each hook."""
+
+    # -- Non-streaming paths ------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_shield_blocked(
+        self,
+        minimal_config: AppConfig,
+        mock_background_tasks: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Blocked moderation fires responses_shield_blocked telemetry."""
+        request = _request_with_model_and_conv("Bad input")
+        mock_client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+
+        mock_moderation = mocker.Mock()
+        mock_moderation.decision = "blocked"
+        mock_moderation.message = "Content blocked"
+        mock_moderation.moderation_id = "mod_blocked_1"
+        mock_refusal = OpenAIResponseMessage(
+            role="assistant", content="Content blocked", type="message"
+        )
+        mock_moderation.refusal_response = mock_refusal
+
+        _patch_handle_non_streaming_common(mocker, minimal_config)
+        mock_client.conversations.items.create = mocker.AsyncMock()
+        mock_api_response = mocker.Mock()
+        mock_api_response.output = [mock_refusal]
+        mock_api_response.model_dump.return_value = {
+            "id": "resp_blocked",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "provider/model1",
+            "output": [],
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+        }
+        mocker.patch(
+            f"{MODULE}.OpenAIResponseObject.model_construct",
+            return_value=mock_api_response,
+        )
+        mock_queue = mocker.patch(f"{MODULE}._queue_responses_splunk_event")
+
+        await handle_non_streaming_response(
+            client=mock_client,
+            request=request,
+            auth=MOCK_AUTH,
+            input_text="Bad input",
+            started_at=datetime.now(UTC),
+            moderation_result=mock_moderation,
+            inline_rag_context=RAGContext(),
+            background_tasks=mock_background_tasks,
+            rh_identity_context=("org1", "sys1"),
+        )
+
+        mock_queue.assert_called_once()
+        call_kwargs = mock_queue.call_args[1]
+        assert call_kwargs["sourcetype"] == "responses_shield_blocked"
+        assert call_kwargs["background_tasks"] is mock_background_tasks
+        assert call_kwargs["rh_identity_context"] == ("org1", "sys1")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc_factory",
+        [
+            pytest.param(
+                lambda m: APIConnectionError(request=m.Mock()),
+                id="APIConnectionError",
+            ),
+            pytest.param(
+                lambda m: RuntimeError("context_length exceeded"),
+                id="RuntimeError-context-length",
+            ),
+            pytest.param(
+                lambda m: LLSApiStatusError(
+                    message="API error", response=m.Mock(request=None), body=None
+                ),
+                id="LLSApiStatusError",
+            ),
+            pytest.param(
+                lambda m: OpenAIAPIStatusError(
+                    message="API error", response=m.Mock(request=None), body=None
+                ),
+                id="OpenAIAPIStatusError",
+            ),
+        ],
+    )
+    async def test_non_streaming_error_fires_telemetry(
+        self,
+        exc_factory: Any,
+        minimal_config: AppConfig,
+        mock_background_tasks: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Each error branch fires responses_error telemetry with fire_and_forget."""
+        request = _request_with_model_and_conv("Hello")
+        mock_client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+        mock_moderation = mocker.Mock()
+        mock_moderation.decision = "passed"
+
+        mock_client.responses.create = mocker.AsyncMock(side_effect=exc_factory(mocker))
+
+        _patch_handle_non_streaming_common(mocker, minimal_config)
+        mocker.patch(
+            f"{MODULE}.normalize_conversation_id",
+            return_value=VALID_CONV_ID_NORMALIZED,
+        )
+        mocker.patch(
+            f"{MODULE}.handle_known_apistatus_errors",
+            return_value=mocker.Mock(
+                model_dump=lambda: {
+                    "status_code": 500,
+                    "detail": {"response": "Error", "cause": "API error"},
+                }
+            ),
+        )
+        mock_queue = mocker.patch(f"{MODULE}._queue_responses_splunk_event")
+
+        with pytest.raises(HTTPException):
+            await handle_non_streaming_response(
+                client=mock_client,
+                request=request,
+                auth=MOCK_AUTH,
+                input_text="Hello",
+                started_at=datetime.now(UTC),
+                moderation_result=mock_moderation,
+                inline_rag_context=RAGContext(),
+                background_tasks=mock_background_tasks,
+                rh_identity_context=("org1", "sys1"),
+            )
+
+        mock_queue.assert_called_once()
+        assert mock_queue.call_args[1]["sourcetype"] == "responses_error"
+        assert mock_queue.call_args[1]["fire_and_forget"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_success(
+        self,
+        minimal_config: AppConfig,
+        mock_background_tasks: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Successful non-streaming response fires responses_completed with token counts."""
+        request = _request_with_model_and_conv("Hello")
+        mock_client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+        mock_moderation = mocker.Mock()
+        mock_moderation.decision = "passed"
+
+        mock_api_response = mocker.Mock(spec=OpenAIResponseObject)
+        mock_api_response.output = []
+        mock_api_response.usage = mocker.Mock(
+            input_tokens=100, output_tokens=50, total_tokens=150
+        )
+        mock_api_response.model_dump.return_value = {
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "provider/model1",
+            "output": [],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+        }
+        mock_client.responses.create = mocker.AsyncMock(return_value=mock_api_response)
+
+        _patch_handle_non_streaming_common(mocker, minimal_config)
+        mocker.patch(
+            f"{MODULE}.extract_token_usage",
+            return_value=mocker.Mock(input_tokens=100, output_tokens=50),
+        )
+        mocker.patch(f"{MODULE}.consume_query_tokens")
+        mocker.patch(
+            f"{MODULE}.extract_text_from_response_items",
+            return_value="Model reply",
+        )
+        mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
+        mocker.patch(
+            f"{MODULE}.normalize_conversation_id",
+            return_value=VALID_CONV_ID_NORMALIZED,
+        )
+        mock_turn_summary = mocker.Mock()
+        mock_turn_summary.referenced_documents = []
+        mock_turn_summary.rag_chunks = []
+        mock_token_usage = mocker.Mock()
+        mock_token_usage.input_tokens = 100
+        mock_token_usage.output_tokens = 50
+        mock_turn_summary.token_usage = mock_token_usage
+        mocker.patch(f"{MODULE}.build_turn_summary", return_value=mock_turn_summary)
+        mocker.patch(f"{MODULE}.deduplicate_referenced_documents", return_value=[])
+
+        mock_queue = mocker.patch(f"{MODULE}._queue_responses_splunk_event")
+
+        await handle_non_streaming_response(
+            client=mock_client,
+            request=request,
+            auth=MOCK_AUTH,
+            input_text="Hello",
+            started_at=datetime.now(UTC),
+            moderation_result=mock_moderation,
+            inline_rag_context=RAGContext(),
+            background_tasks=mock_background_tasks,
+            rh_identity_context=("org1", "sys1"),
+        )
+
+        # The success hook fires once (blocked hook is skipped because decision != "blocked")
+        mock_queue.assert_called_once()
+        call_kwargs = mock_queue.call_args[1]
+        assert call_kwargs["sourcetype"] == "responses_completed"
+        assert call_kwargs["input_tokens"] == 100
+        assert call_kwargs["output_tokens"] == 50
+
+    # -- Streaming paths ----------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_streaming_shield_blocked(
+        self,
+        minimal_config: AppConfig,
+        mock_background_tasks: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Blocked moderation in streaming fires responses_shield_blocked telemetry."""
+        request = _request_with_model_and_conv("Bad", model="provider/model1")
+        mock_client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+
+        mock_moderation = mocker.Mock()
+        mock_moderation.decision = "blocked"
+        mock_moderation.message = "Blocked"
+        mock_moderation.moderation_id = "mod_123"
+        mock_refusal = OpenAIResponseMessage(
+            role="assistant", content="Blocked", type="message"
+        )
+        mock_moderation.refusal_response = mock_refusal
+
+        mocker.patch(f"{MODULE}.configuration", minimal_config)
+        mocker.patch(f"{MODULE}.get_available_quotas", return_value={})
+        mocker.patch(
+            f"{MODULE}.normalize_conversation_id",
+            return_value=VALID_CONV_ID_NORMALIZED,
+        )
+        mocker.patch(
+            f"{MODULE}.get_topic_summary",
+            new=mocker.AsyncMock(return_value=None),
+        )
+        mocker.patch(f"{MODULE}.store_query_results")
+        mock_client.conversations.items.create = mocker.AsyncMock()
+
+        mock_queue = mocker.patch(f"{MODULE}._queue_responses_splunk_event")
+
+        response = await handle_streaming_response(
+            client=mock_client,
+            request=request,
+            auth=MOCK_AUTH,
+            input_text="Bad",
+            started_at=datetime.now(UTC),
+            moderation_result=mock_moderation,
+            inline_rag_context=RAGContext(),
+            background_tasks=mock_background_tasks,
+            rh_identity_context=("org1", "sys1"),
+        )
+
+        assert isinstance(response, StreamingResponse)
+        # Consume the stream to trigger generate_response() completion
+        async for _chunk in response.body_iterator:
+            pass
+        mock_queue.assert_called_once()
+        assert mock_queue.call_args[1]["sourcetype"] == "responses_shield_blocked"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "exc_factory",
+        [
+            pytest.param(
+                lambda m: APIConnectionError(request=m.Mock()),
+                id="APIConnectionError",
+            ),
+            pytest.param(
+                lambda m: RuntimeError("context_length exceeded"),
+                id="RuntimeError-context-length",
+            ),
+            pytest.param(
+                lambda m: LLSApiStatusError(
+                    message="API error", response=m.Mock(request=None), body=None
+                ),
+                id="LLSApiStatusError",
+            ),
+            pytest.param(
+                lambda m: OpenAIAPIStatusError(
+                    message="API error", response=m.Mock(request=None), body=None
+                ),
+                id="OpenAIAPIStatusError",
+            ),
+        ],
+    )
+    async def test_streaming_error_fires_telemetry(
+        self,
+        exc_factory: Any,
+        minimal_config: AppConfig,
+        mock_background_tasks: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Each streaming error branch fires responses_error telemetry with fire_and_forget."""
+        request = _request_with_model_and_conv("Hello")
+        mock_client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+        mock_moderation = mocker.Mock()
+        mock_moderation.decision = "passed"
+
+        mock_client.responses.create = mocker.AsyncMock(side_effect=exc_factory(mocker))
+
+        mocker.patch(f"{MODULE}.configuration", minimal_config)
+        mocker.patch(
+            f"{MODULE}.normalize_conversation_id",
+            return_value=VALID_CONV_ID_NORMALIZED,
+        )
+        mocker.patch(
+            f"{MODULE}.handle_known_apistatus_errors",
+            return_value=mocker.Mock(
+                model_dump=lambda: {
+                    "status_code": 500,
+                    "detail": {"response": "Error", "cause": "API error"},
+                }
+            ),
+        )
+        mock_queue = mocker.patch(f"{MODULE}._queue_responses_splunk_event")
+
+        with pytest.raises(HTTPException):
+            await handle_streaming_response(
+                client=mock_client,
+                request=request,
+                auth=MOCK_AUTH,
+                input_text="Hello",
+                started_at=datetime.now(UTC),
+                moderation_result=mock_moderation,
+                inline_rag_context=RAGContext(),
+                background_tasks=mock_background_tasks,
+                rh_identity_context=("org1", "sys1"),
+            )
+
+        mock_queue.assert_called_once()
+        assert mock_queue.call_args[1]["sourcetype"] == "responses_error"
+        assert mock_queue.call_args[1]["fire_and_forget"] is True
+
+    @pytest.mark.asyncio
+    async def test_streaming_success(
+        self,
+        minimal_config: AppConfig,
+        mock_background_tasks: Any,
+        mocker: MockerFixture,
+    ) -> None:
+        """Successful streaming fires responses_completed after consuming the stream."""
+        request = _request_with_model_and_conv("Hi", model="provider/model1")
+        mock_client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+        mock_moderation = mocker.Mock()
+        mock_moderation.decision = "passed"
+
+        mock_chunk = mocker.Mock()
+        mock_chunk.type = "response.completed"
+        mock_chunk.response = mocker.Mock()
+        mock_chunk.response.id = "r1"
+        mock_chunk.response.output = []
+        mock_chunk.response.usage = mocker.Mock(
+            input_tokens=100, output_tokens=50, total_tokens=150
+        )
+        mock_chunk.model_dump.return_value = {
+            "type": "response.completed",
+            "response": {
+                "id": "r1",
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            },
+        }
+
+        async def mock_stream() -> Any:
+            """Yield a single completed chunk."""
+            yield mock_chunk
+
+        mock_client.responses.create = mocker.AsyncMock(return_value=mock_stream())
+
+        mocker.patch(f"{MODULE}.configuration", minimal_config)
+        mocker.patch(f"{MODULE}.get_available_quotas", return_value={})
+        mocker.patch(
+            f"{MODULE}.extract_token_usage",
+            return_value=mocker.Mock(input_tokens=100, output_tokens=50),
+        )
+        mocker.patch(f"{MODULE}.consume_query_tokens")
+        mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
+        mock_turn_summary = TurnSummary(referenced_documents=[])
+        mock_token_usage = mocker.Mock()
+        mock_token_usage.input_tokens = 100
+        mock_token_usage.output_tokens = 50
+        mock_turn_summary.token_usage = mock_token_usage
+        mocker.patch(f"{MODULE}.build_turn_summary", return_value=mock_turn_summary)
+        mocker.patch(
+            f"{MODULE}.get_topic_summary",
+            new=mocker.AsyncMock(return_value=None),
+        )
+        mocker.patch(f"{MODULE}.store_query_results")
+        mocker.patch(
+            f"{MODULE}.normalize_conversation_id",
+            return_value=VALID_CONV_ID_NORMALIZED,
+        )
+        mock_holder = mocker.Mock()
+        mock_holder.get_client.return_value = mock_client
+        mocker.patch(f"{MODULE}.AsyncLlamaStackClientHolder", return_value=mock_holder)
+
+        mock_queue = mocker.patch(f"{MODULE}._queue_responses_splunk_event")
+
+        response = await handle_streaming_response(
+            client=mock_client,
+            request=request,
+            auth=MOCK_AUTH,
+            input_text="Hi",
+            started_at=datetime.now(UTC),
+            moderation_result=mock_moderation,
+            inline_rag_context=RAGContext(),
+            background_tasks=mock_background_tasks,
+            rh_identity_context=("org1", "sys1"),
+        )
+
+        assert isinstance(response, StreamingResponse)
+
+        # Consume the stream to trigger generate_response() to run to completion
+        async for _chunk in response.body_iterator:
+            pass  # drain the generator so post-stream hooks fire
+
+        mock_queue.assert_called_once()
+        call_kwargs = mock_queue.call_args[1]
+        assert call_kwargs["sourcetype"] == "responses_completed"
+        assert call_kwargs["input_tokens"] == 100
+        assert call_kwargs["output_tokens"] == 50
+
+    # -- Splunk disabled (no BackgroundTasks) --------------------------------
+
+    @pytest.mark.asyncio
+    async def test_splunk_disabled_no_background_tasks(
+        self,
+        minimal_config: AppConfig,
+        mocker: MockerFixture,
+    ) -> None:
+        """When background_tasks is None, _queue_responses_splunk_event is never called."""
+        request = _request_with_model_and_conv("Bad input")
+        mock_client = mocker.AsyncMock(spec=AsyncLlamaStackClient)
+
+        mock_moderation = mocker.Mock()
+        mock_moderation.decision = "blocked"
+        mock_moderation.message = "Content blocked"
+        mock_moderation.moderation_id = "mod_disabled"
+        mock_refusal = OpenAIResponseMessage(
+            role="assistant", content="Content blocked", type="message"
+        )
+        mock_moderation.refusal_response = mock_refusal
+
+        _patch_handle_non_streaming_common(mocker, minimal_config)
+        mock_client.conversations.items.create = mocker.AsyncMock()
+        mock_api_response = mocker.Mock()
+        mock_api_response.output = [mock_refusal]
+        mock_api_response.model_dump.return_value = {
+            "id": "resp_disabled",
+            "object": "response",
+            "created_at": 0,
+            "status": "completed",
+            "model": "provider/model1",
+            "output": [],
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "input_tokens_details": {"cached_tokens": 0},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            },
+        }
+        mocker.patch(
+            f"{MODULE}.OpenAIResponseObject.model_construct",
+            return_value=mock_api_response,
+        )
+        mock_queue = mocker.patch(f"{MODULE}._queue_responses_splunk_event")
+
+        # background_tasks=None (the default) means Splunk is disabled
+        await handle_non_streaming_response(
+            client=mock_client,
+            request=request,
+            auth=MOCK_AUTH,
+            input_text="Bad input",
+            started_at=datetime.now(UTC),
+            moderation_result=mock_moderation,
+            inline_rag_context=RAGContext(),
+            background_tasks=None,
+            rh_identity_context=("org1", "sys1"),
+        )
+
+        mock_queue.assert_called_once()
+        assert mock_queue.call_args[1]["background_tasks"] is None

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -24,7 +24,6 @@ from app.endpoints.rlsapi_v1 import (
     _build_instructions,
     _compile_prompt_template,
     _get_default_model_id,
-    _get_rh_identity_context,
     _resolve_quota_subject,
     infer_endpoint,
     retrieve_simple_response,
@@ -42,6 +41,7 @@ from models.rlsapi.requests import (
 )
 from models.rlsapi.responses import RlsapiV1InferResponse
 from tests.unit.utils.auth_helpers import mock_authorization_resolvers
+from utils.rh_identity import get_rh_identity_context
 from utils.suid import check_suid
 from utils.types import ShieldModerationBlocked, ShieldModerationPassed
 
@@ -474,7 +474,7 @@ async def test_retrieve_simple_response_api_connection_error(
         await retrieve_simple_response("Test question", constants.DEFAULT_SYSTEM_PROMPT)
 
 
-# --- Test _get_rh_identity_context ---
+# --- Test get_rh_identity_context ---
 
 
 @pytest.mark.parametrize(
@@ -502,7 +502,7 @@ def test_get_rh_identity_context(
     expected_org_id: str,
     expected_system_id: str,
 ) -> None:
-    """Test _get_rh_identity_context extracts or defaults org/system IDs."""
+    """Test get_rh_identity_context extracts or defaults org/system IDs."""
     if rh_identity_setup is not None:
         mock_rh_identity = mocker.Mock(spec=RHIdentityData)
         mock_rh_identity.get_org_id.return_value = rh_identity_setup["org_id"]
@@ -511,7 +511,7 @@ def test_get_rh_identity_context(
     else:
         mock_request = mock_request_factory()
 
-    org_id, system_id = _get_rh_identity_context(mock_request)
+    org_id, system_id = get_rh_identity_context(mock_request)
 
     assert org_id == expected_org_id
     assert system_id == expected_system_id


### PR DESCRIPTION
## Description

Wire Splunk HEC telemetry into the `/responses` endpoint, covering all 6 event paths (3 streaming, 3 non-streaming). Uses the shared `ResponsesEventData` format from PR #1550 and the RH identity utility from PR #1548.

Changes in `src/app/endpoints/responses.py`:
- Add `_queue_responses_splunk_event()` helper (accepts `Optional[BackgroundTasks]`, no-ops when `None`)
- Extract `rh_identity_context` in `responses_endpoint_handler()` and thread through sub-handlers
- Add `background_tasks: BackgroundTasks` to endpoint signature (FastAPI auto-injects)
- 6 telemetry hooks: shield blocked, error, and success for both streaming and non-streaming paths
- Streaming shield path includes `shield_blocked` flag to prevent double-fire with completion event

New test file `tests/unit/app/endpoints/test_responses_splunk.py` (9 tests):
- Unit test for `_queue_responses_splunk_event` helper
- No-op test when `background_tasks is None`
- Integration tests for all 6 paths (correct sourcetype, token counts)
- Splunk-disabled scenario

Sourcetypes: `responses_completed`, `responses_error`, `responses_shield_blocked`

Part 3/3 of RSPEED-2867 (builds on #1548 and #1550, both merged).

## Type of change

- [x] New feature
- [x] Unit tests improvement

## Tools used to create PR

- Assisted-by: Claude (via OpenCode)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: RSPEED-2867
- Depends on: #1548 (merged), #1550 (merged)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Run the new test file:
   ```bash
   uv run pytest tests/unit/app/endpoints/test_responses_splunk.py -v
   ```
   All 9 tests pass.

2. Run the full test suite:
   ```bash
   uv run make test-unit
   ```
   2063 passed, 1 skipped.

3. Linting:
   ```bash
   uv run make format && uv run make verify
   ```
   All linters pass (black, pylint, pyright, ruff, pydocstyle, mypy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced telemetry collection for response handling, capturing blocked requests, error events, and successful completions with associated token usage metrics.

* **Tests**
  * Added comprehensive test suite for response telemetry functionality, covering non-streaming and streaming handlers with multiple execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->