### PR TITLE
LCORE-1931: Use HttpUrl instead of plain string

### DIFF
--- a/tests/unit/app/endpoints/test_conversations_v2.py
+++ b/tests/unit/app/endpoints/test_conversations_v2.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import pytest
 from fastapi import HTTPException, status
+from pydantic import HttpUrl
 from pytest_mock import MockerFixture, MockType
 
 from app.endpoints.conversations_v2 import (
@@ -98,12 +99,12 @@ class TestBuildConversationTurnFromCacheEntry:
         """Test that referenced_documents from cache are included in the assistant message."""
         ref_docs = [
             ReferencedDocument(
-                doc_url="https://docs.example.com/page1",
+                doc_url=HttpUrl("https://docs.example.com/page1"),
                 doc_title="Page 1",
                 source="vs_abc123",
             ),
             ReferencedDocument(
-                doc_url="https://docs.example.com/page2",
+                doc_url=HttpUrl("https://docs.example.com/page2"),
                 doc_title="Page 2",
                 source="vs_abc123",
             ),
@@ -197,7 +198,7 @@ class TestBuildConversationTurnFromCacheEntry:
         """Test that model_dump(exclude_none=True) includes referenced_documents when present."""
         ref_docs = [
             ReferencedDocument(
-                doc_url="https://docs.example.com/page1",
+                doc_url=HttpUrl("https://docs.example.com/page1"),
                 doc_title="Page 1",
             ),
         ]
@@ -564,12 +565,12 @@ class TestGetConversationEndpoint:
         mocker.patch("app.endpoints.conversations_v2.check_suid", return_value=True)
         ref_docs = [
             ReferencedDocument(
-                doc_url="https://docs.example.com/intro",
+                doc_url=HttpUrl("https://docs.example.com/intro"),
                 doc_title="Introduction",
                 source="vs_abc123",
             ),
             ReferencedDocument(
-                doc_url="https://docs.example.com/guide",
+                doc_url=HttpUrl("https://docs.example.com/guide"),
                 doc_title="User Guide",
                 source="vs_abc123",
             ),

--- a/tests/unit/models/responses/test_rag_chunk.py
+++ b/tests/unit/models/responses/test_rag_chunk.py
@@ -1,5 +1,7 @@
 """Unit tests for RAGChunk and RAGContext models."""
 
+from pydantic import HttpUrl
+
 from models.responses import ReferencedDocument
 from utils.types import RAGChunk, RAGContext
 
@@ -123,6 +125,7 @@ class TestRAGChunk:
             content="Test content", source="test-source", attributes=attributes
         )
         assert chunk.attributes == attributes
+        assert chunk.attributes is not None
         assert chunk.attributes["doc_url"] == "https://example.com/doc"
 
     def test_attributes_none(self) -> None:
@@ -164,12 +167,12 @@ class TestRAGContext:
         docs = [
             ReferencedDocument(
                 doc_title="Doc 1",
-                doc_url="https://example.com/doc1",
+                doc_url=HttpUrl("https://example.com/doc1"),
                 source="source1",
             ),
             ReferencedDocument(
                 doc_title="Doc 2",
-                doc_url="https://example.com/doc2",
+                doc_url=HttpUrl("https://example.com/doc2"),
                 source="source2",
             ),
         ]
@@ -182,7 +185,9 @@ class TestRAGContext:
         """Test RAGContext with all fields populated."""
         chunks = [RAGChunk(content="Test chunk", source="source1", score=0.95)]
         docs = [
-            ReferencedDocument(doc_title="Test Doc", doc_url="https://example.com/doc")
+            ReferencedDocument(
+                doc_title="Test Doc", doc_url=HttpUrl("https://example.com/doc")
+            )
         ]
         context = RAGContext(
             context_text="Formatted context",


### PR DESCRIPTION
## Description

LCORE-1931: Use `HttpUrl` instead of plain string

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1931


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage and type safety validation for document URL handling in conversation and response models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->