### PR TITLE
LCORE-1880: Refactor 400 response

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2433,6 +2433,26 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format",
+                        "content": {
+                            "application/json": {
+                                "examples": {
+                                    "prompt_id": {
+                                        "value": {
+                                            "detail": {
+                                                "cause": "The prompt ID pmpt_1234567890abcdef has invalid format.",
+                                                "response": "Invalid prompt ID format"
+                                            }
+                                        }
+                                    }
+                                },
+                                "schema": {
+                                    "$ref": "#/components/schemas/BadRequestResponse"
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Unauthorized",
                         "content": {
@@ -2657,6 +2677,26 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Invalid request format",
+                        "content": {
+                            "application/json": {
+                                "examples": {
+                                    "prompt_id": {
+                                        "value": {
+                                            "detail": {
+                                                "cause": "The prompt ID pmpt_1234567890abcdef has invalid format.",
+                                                "response": "Invalid prompt ID format"
+                                            }
+                                        }
+                                    }
+                                },
+                                "schema": {
+                                    "$ref": "#/components/schemas/BadRequestResponse"
+                                }
+                            }
+                        }
+                    },
                     "401": {
                         "description": "Unauthorized",
                         "content": {
@@ -2874,6 +2914,26 @@
                                             "success": false
                                         }
                                     }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request format",
+                        "content": {
+                            "application/json": {
+                                "examples": {
+                                    "prompt_id": {
+                                        "value": {
+                                            "detail": {
+                                                "cause": "The prompt ID pmpt_1234567890abcdef has invalid format.",
+                                                "response": "Invalid prompt ID format"
+                                            }
+                                        }
+                                    }
+                                },
+                                "schema": {
+                                    "$ref": "#/components/schemas/BadRequestResponse"
                                 }
                             }
                         }
@@ -4352,26 +4412,6 @@
                                     "id": "file_abc123",
                                     "object": "file",
                                     "purpose": "assistants"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request format",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/BadRequestResponse"
-                                },
-                                "examples": {
-                                    "file_upload": {
-                                        "value": {
-                                            "detail": {
-                                                "cause": "File upload rejected: Invalid file format",
-                                                "response": "Invalid file upload"
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         }
@@ -7029,14 +7069,6 @@
                                                 "response": "Invalid conversation ID format"
                                             }
                                         }
-                                    },
-                                    "file_upload": {
-                                        "value": {
-                                            "detail": {
-                                                "cause": "File upload rejected: Invalid file format",
-                                                "response": "Invalid file upload"
-                                            }
-                                        }
                                     }
                                 },
                                 "schema": {
@@ -7294,14 +7326,6 @@
                                                 "response": "Invalid conversation ID format"
                                             }
                                         }
-                                    },
-                                    "file_upload": {
-                                        "value": {
-                                            "detail": {
-                                                "cause": "File upload rejected: Invalid file format",
-                                                "response": "Invalid file upload"
-                                            }
-                                        }
                                     }
                                 },
                                 "schema": {
@@ -7536,14 +7560,6 @@
                                             "detail": {
                                                 "cause": "The conversation ID 123e4567-e89b-12d3-a456-426614174000 has invalid format.",
                                                 "response": "Invalid conversation ID format"
-                                            }
-                                        }
-                                    },
-                                    "file_upload": {
-                                        "value": {
-                                            "detail": {
-                                                "cause": "File upload rejected: Invalid file format",
-                                                "response": "Invalid file upload"
                                             }
                                         }
                                     }
@@ -7959,14 +7975,6 @@
                                                 "response": "Invalid conversation ID format"
                                             }
                                         }
-                                    },
-                                    "file_upload": {
-                                        "value": {
-                                            "detail": {
-                                                "cause": "File upload rejected: Invalid file format",
-                                                "response": "Invalid file upload"
-                                            }
-                                        }
                                     }
                                 },
                                 "schema": {
@@ -8188,14 +8196,6 @@
                                                 "response": "Invalid conversation ID format"
                                             }
                                         }
-                                    },
-                                    "file_upload": {
-                                        "value": {
-                                            "detail": {
-                                                "cause": "File upload rejected: Invalid file format",
-                                                "response": "Invalid file upload"
-                                            }
-                                        }
                                     }
                                 },
                                 "schema": {
@@ -8394,14 +8394,6 @@
                                             "detail": {
                                                 "cause": "The conversation ID 123e4567-e89b-12d3-a456-426614174000 has invalid format.",
                                                 "response": "Invalid conversation ID format"
-                                            }
-                                        }
-                                    },
-                                    "file_upload": {
-                                        "value": {
-                                            "detail": {
-                                                "cause": "File upload rejected: Invalid file format",
-                                                "response": "Invalid file upload"
                                             }
                                         }
                                     }
@@ -9946,7 +9938,7 @@
                 ],
                 "summary": "Handle A2A Jsonrpc",
                 "description": "Handle A2A JSON-RPC requests following the A2A protocol specification.\n\nThis endpoint uses the DefaultRequestHandler from the A2A SDK to handle\nall JSON-RPC requests including message/send, message/stream, etc.\n\nThe A2A SDK application is created per-request to include authentication\ncontext while still leveraging FastAPI's authorization middleware.\n\nAutomatically detects streaming requests (message/stream JSON-RPC method)\nand returns a StreamingResponse to enable real-time chunk delivery.\n\nArgs:\n    request: FastAPI request object\n    auth: Authentication tuple\n    mcp_headers: MCP headers for context propagation\n\nReturns:\n    JSON-RPC response or streaming response",
-                "operationId": "handle_a2a_jsonrpc_a2a_post",
+                "operationId": "handle_a2a_jsonrpc_a2a_get",
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -9964,7 +9956,7 @@
                 ],
                 "summary": "Handle A2A Jsonrpc",
                 "description": "Handle A2A JSON-RPC requests following the A2A protocol specification.\n\nThis endpoint uses the DefaultRequestHandler from the A2A SDK to handle\nall JSON-RPC requests including message/send, message/stream, etc.\n\nThe A2A SDK application is created per-request to include authentication\ncontext while still leveraging FastAPI's authorization middleware.\n\nAutomatically detects streaming requests (message/stream JSON-RPC method)\nand returns a StreamingResponse to enable real-time chunk delivery.\n\nArgs:\n    request: FastAPI request object\n    auth: Authentication tuple\n    mcp_headers: MCP headers for context propagation\n\nReturns:\n    JSON-RPC response or streaming response",
-                "operationId": "handle_a2a_jsonrpc_a2a_post",
+                "operationId": "handle_a2a_jsonrpc_a2a_get",
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -11028,10 +11020,10 @@
                     },
                     {
                         "detail": {
-                            "cause": "File upload rejected: Invalid file format",
-                            "response": "Invalid file upload"
+                            "cause": "The prompt ID pmpt_1234567890abcdef has invalid format.",
+                            "response": "Invalid prompt ID format"
                         },
-                        "label": "file_upload"
+                        "label": "prompt_id"
                     }
                 ]
             },

--- a/src/app/endpoints/conversations_v1.py
+++ b/src/app/endpoints/conversations_v1.py
@@ -58,7 +58,7 @@ router = APIRouter(tags=["conversations_v1"])
 
 conversation_get_responses: dict[int | str, dict[str, Any]] = {
     200: ConversationResponse.openapi_response(),
-    400: BadRequestResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["conversation_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["conversation read", "endpoint"]),
     404: NotFoundResponse.openapi_response(examples=["conversation"]),
@@ -70,7 +70,7 @@ conversation_get_responses: dict[int | str, dict[str, Any]] = {
 
 conversation_delete_responses: dict[int | str, dict[str, Any]] = {
     200: ConversationDeleteResponse.openapi_response(),
-    400: BadRequestResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["conversation_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(
         examples=["conversation delete", "endpoint"]
@@ -92,7 +92,7 @@ conversations_list_responses: dict[int | str, dict[str, Any]] = {
 
 conversation_update_responses: dict[int | str, dict[str, Any]] = {
     200: ConversationUpdateResponse.openapi_response(),
-    400: BadRequestResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["conversation_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
     404: NotFoundResponse.openapi_response(examples=["conversation"]),

--- a/src/app/endpoints/conversations_v2.py
+++ b/src/app/endpoints/conversations_v2.py
@@ -34,7 +34,7 @@ router = APIRouter(tags=["conversations_v2"])
 
 conversation_get_responses: dict[int | str, dict[str, Any]] = {
     200: ConversationResponse.openapi_response(),
-    400: BadRequestResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["conversation_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
     404: NotFoundResponse.openapi_response(examples=["conversation"]),
@@ -45,7 +45,7 @@ conversation_get_responses: dict[int | str, dict[str, Any]] = {
 
 conversation_delete_responses: dict[int | str, dict[str, Any]] = {
     200: ConversationDeleteResponse.openapi_response(),
-    400: BadRequestResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["conversation_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
     500: InternalServerErrorResponse.openapi_response(
@@ -64,7 +64,7 @@ conversations_list_responses: dict[int | str, dict[str, Any]] = {
 
 conversation_update_responses: dict[int | str, dict[str, Any]] = {
     200: ConversationUpdateResponse.openapi_response(),
-    400: BadRequestResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["conversation_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
     404: NotFoundResponse.openapi_response(examples=["conversation"]),

--- a/src/app/endpoints/prompts.py
+++ b/src/app/endpoints/prompts.py
@@ -17,6 +17,7 @@ from models.config import Action
 from models.requests import PromptCreateRequest, PromptUpdateRequest
 from models.responses import (
     UNAUTHORIZED_OPENAPI_EXAMPLES,
+    BadRequestResponse,
     ForbiddenResponse,
     InternalServerErrorResponse,
     NotFoundResponse,
@@ -28,6 +29,7 @@ from models.responses import (
 )
 from utils.endpoints import check_configuration_loaded
 from utils.query import handle_known_apistatus_errors
+from utils.suid import check_suid_prompt
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["prompts"])
@@ -52,6 +54,7 @@ prompt_list_responses: dict[int | str, dict[str, Any]] = {
 
 prompt_get_responses: dict[int | str, dict[str, Any]] = {
     200: PromptResourceResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["prompt_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt read"]),
     404: NotFoundResponse.openapi_response(examples=["prompt"]),
@@ -61,6 +64,7 @@ prompt_get_responses: dict[int | str, dict[str, Any]] = {
 
 prompt_update_responses: dict[int | str, dict[str, Any]] = {
     200: PromptResourceResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["prompt_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt manage"]),
     404: NotFoundResponse.openapi_response(examples=["prompt"]),
@@ -70,6 +74,7 @@ prompt_update_responses: dict[int | str, dict[str, Any]] = {
 
 prompt_delete_responses: dict[int | str, dict[str, Any]] = {
     200: PromptDeleteResponse.openapi_response(),
+    400: BadRequestResponse.openapi_response(examples=["prompt_id"]),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint", "prompt manage"]),
     500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
@@ -208,6 +213,11 @@ async def get_prompt_handler(
 
     check_configuration_loaded(configuration)
 
+    if not check_suid_prompt(prompt_id):
+        logger.error("Invalid prompt ID format: %s", prompt_id)
+        response = BadRequestResponse(resource="prompt", resource_id=prompt_id)
+        raise HTTPException(**response.model_dump())
+
     try:
         client = AsyncLlamaStackClientHolder().get_client()
         if version is not None:
@@ -268,6 +278,11 @@ async def update_prompt_handler(
 
     check_configuration_loaded(configuration)
 
+    if not check_suid_prompt(prompt_id):
+        logger.error("Invalid prompt ID format: %s", prompt_id)
+        response = BadRequestResponse(resource="prompt", resource_id=prompt_id)
+        raise HTTPException(**response.model_dump())
+
     try:
         client = AsyncLlamaStackClientHolder().get_client()
         payload = body.model_dump(exclude_none=True, exclude_unset=True)
@@ -323,6 +338,11 @@ async def delete_prompt_handler(
     _ = request
 
     check_configuration_loaded(configuration)
+
+    if not check_suid_prompt(prompt_id):
+        logger.error("Invalid prompt ID format: %s", prompt_id)
+        response = BadRequestResponse(resource="prompt", resource_id=prompt_id)
+        raise HTTPException(**response.model_dump())
 
     try:
         client = AsyncLlamaStackClientHolder().get_client()

--- a/src/app/endpoints/vector_stores.py
+++ b/src/app/endpoints/vector_stores.py
@@ -30,7 +30,6 @@ from models.requests import (
 )
 from models.responses import (
     UNAUTHORIZED_OPENAPI_EXAMPLES,
-    BadRequestResponse,
     FileResponse,
     FileTooLargeResponse,
     ForbiddenResponse,
@@ -70,7 +69,6 @@ vector_store_responses: dict[int | str, dict[str, Any]] = {
 
 file_responses: dict[int | str, dict[str, Any]] = {
     200: FileResponse.openapi_response(),
-    400: BadRequestResponse.openapi_response(examples=["file_upload"]),
     413: FileTooLargeResponse.openapi_response(),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint"]),

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -1830,10 +1830,10 @@ class BadRequestResponse(AbstractErrorResponse):
                     },
                 },
                 {
-                    "label": "file_upload",
+                    "label": "prompt_id",
                     "detail": {
-                        "response": "Invalid file upload",
-                        "cause": "File upload rejected: Invalid file format",
+                        "response": "Invalid prompt ID format",
+                        "cause": "The prompt ID pmpt_1234567890abcdef has invalid format.",
                     },
                 },
             ]

--- a/src/utils/suid.py
+++ b/src/utils/suid.py
@@ -116,3 +116,25 @@ def is_moderation_id(suid: str) -> bool:
     Returns True if the string starts with 'modr'.
     """
     return suid.startswith("modr")
+
+
+def check_suid_prompt(suid: str) -> bool:
+    """Check if given string is a prompt ID.
+
+    Parameters:
+        suid: Candidate string to validate.
+
+    Returns:
+        True if the string matches the prompt ID format; otherwise False.
+    """
+    prefix = "pmpt_"
+    if not suid.startswith(prefix):
+        return False
+    hex_part = suid.removeprefix(prefix)
+    if len(hex_part) != 48:
+        return False
+    try:
+        int(hex_part, 16)
+    except ValueError:
+        return False
+    return True

--- a/tests/unit/app/endpoints/test_prompts.py
+++ b/tests/unit/app/endpoints/test_prompts.py
@@ -23,6 +23,11 @@ from tests.unit.utils.auth_helpers import mock_authorization_resolvers
 
 MOCK_AUTH: AuthTuple = ("mock_user_id", "mock_username", False, "mock_token")
 
+# Valid ``pmpt_`` + 48 hex digits (matches ``check_suid_prompt`` / Llama Stack).
+VALID_PMPT_ID = "pmpt_5c76d7f7c633ef97477adeb2f642150d8d08e8a6526e9909"
+VALID_PMPT_ID_B = "pmpt_111111111111111111111111111111111111111111111111"
+VALID_PMPT_ID_NOT_FOUND = "pmpt_ffffffffffffffffffffffffffffffffffffffffffffffff"
+
 
 def _sample_prompt(
     prompt_id: str,
@@ -105,7 +110,7 @@ async def test_create_prompt_success(
     """create_prompt delegates to client.prompts.create."""
     _, mock_prompts = prompts_client_mocks
     mock_prompts.create.return_value = _sample_prompt(
-        "pmpt_abc", 1, prompt="Hi {{n}}", variables=["n"]
+        VALID_PMPT_ID, 1, prompt="Hi {{n}}", variables=["n"]
     )
 
     result = await create_prompt_handler(
@@ -114,7 +119,7 @@ async def test_create_prompt_success(
         body=PromptCreateRequest(prompt="Hi {{n}}", variables=["n"]),
     )
 
-    assert result.prompt_id == "pmpt_abc"
+    assert result.prompt_id == VALID_PMPT_ID
     assert result.version == 1
     mock_prompts.create.assert_awaited_once_with(prompt="Hi {{n}}", variables=["n"])
 
@@ -126,17 +131,17 @@ async def test_get_prompt_with_version(
 ) -> None:
     """get_prompt passes version when provided."""
     _, mock_prompts = prompts_client_mocks
-    mock_prompts.retrieve.return_value = _sample_prompt("pmpt_abc", 2)
+    mock_prompts.retrieve.return_value = _sample_prompt(VALID_PMPT_ID, 2)
 
     result = await get_prompt_handler(
         request=prompts_http_request,
-        prompt_id="pmpt_abc",
+        prompt_id=VALID_PMPT_ID,
         auth=MOCK_AUTH,
         version=2,
     )
 
     assert result.version == 2
-    mock_prompts.retrieve.assert_awaited_once_with("pmpt_abc", version=2)
+    mock_prompts.retrieve.assert_awaited_once_with(VALID_PMPT_ID, version=2)
 
 
 @pytest.mark.asyncio
@@ -146,15 +151,15 @@ async def test_get_prompt_without_version_omits_kwarg(
 ) -> None:
     """get_prompt calls retrieve with prompt_id only when version is omitted."""
     _, mock_prompts = prompts_client_mocks
-    mock_prompts.retrieve.return_value = _sample_prompt("pmpt_abc", 1)
+    mock_prompts.retrieve.return_value = _sample_prompt(VALID_PMPT_ID, 1)
 
     await get_prompt_handler(
         request=prompts_http_request,
-        prompt_id="pmpt_abc",
+        prompt_id=VALID_PMPT_ID,
         auth=MOCK_AUTH,
     )
 
-    mock_prompts.retrieve.assert_awaited_once_with("pmpt_abc")
+    mock_prompts.retrieve.assert_awaited_once_with(VALID_PMPT_ID)
 
 
 @pytest.mark.asyncio
@@ -164,21 +169,21 @@ async def test_update_prompt_success(
 ) -> None:
     """update_prompt forwards body fields to the client."""
     _, mock_prompts = prompts_client_mocks
-    mock_prompts.update.return_value = _sample_prompt("pmpt_abc", 2)
+    mock_prompts.update.return_value = _sample_prompt(VALID_PMPT_ID, 2)
 
     body = PromptUpdateRequest(
         prompt="new", version=1, set_as_default=True, variables=None
     )
     result = await update_prompt_handler(
         request=prompts_http_request,
-        prompt_id="pmpt_abc",
+        prompt_id=VALID_PMPT_ID,
         auth=MOCK_AUTH,
         body=body,
     )
 
     assert result.version == 2
     mock_prompts.update.assert_awaited_once_with(
-        "pmpt_abc", prompt="new", version=1, set_as_default=True
+        VALID_PMPT_ID, prompt="new", version=1, set_as_default=True
     )
 
 
@@ -192,14 +197,14 @@ async def test_delete_prompt_success(
 
     result = await delete_prompt_handler(
         request=prompts_http_request,
-        prompt_id="pmpt_abc",
+        prompt_id=VALID_PMPT_ID,
         auth=MOCK_AUTH,
     )
 
     assert isinstance(result, PromptDeleteResponse)
     assert result.success is True
-    assert result.prompt_id == "pmpt_abc"
-    mock_prompts.delete.assert_awaited_once_with("pmpt_abc")
+    assert result.prompt_id == VALID_PMPT_ID
+    mock_prompts.delete.assert_awaited_once_with(VALID_PMPT_ID)
 
 
 @pytest.mark.asyncio
@@ -218,12 +223,12 @@ async def test_delete_prompt_not_found_returns_body(
 
     result = await delete_prompt_handler(
         request=prompts_http_request,
-        prompt_id="pmpt_missing",
+        prompt_id=VALID_PMPT_ID_NOT_FOUND,
         auth=MOCK_AUTH,
     )
 
     assert result.success is False
-    assert result.prompt_id == "pmpt_missing"
+    assert result.prompt_id == VALID_PMPT_ID_NOT_FOUND
 
 
 @pytest.mark.asyncio
@@ -234,14 +239,14 @@ async def test_list_prompts_success(
     """list_prompts maps client.prompts.list to PromptsListResponse."""
     _, mock_prompts = prompts_client_mocks
     mock_prompts.list.return_value = [
-        _sample_prompt("pmpt_a", 1),
-        _sample_prompt("pmpt_b", 2, is_default=False),
+        _sample_prompt(VALID_PMPT_ID, 1),
+        _sample_prompt(VALID_PMPT_ID_B, 2, is_default=False),
     ]
 
     out = await list_prompts_handler(request=prompts_http_request, auth=MOCK_AUTH)
 
     assert len(out.data) == 2
-    assert out.data[0].prompt_id == "pmpt_a"
+    assert out.data[0].prompt_id == VALID_PMPT_ID
     mock_prompts.list.assert_awaited_once()
 
 
@@ -257,7 +262,7 @@ async def test_get_prompt_api_connection_error(
     with pytest.raises(HTTPException) as exc_info:
         await get_prompt_handler(
             request=prompts_http_request,
-            prompt_id="pmpt_abc",
+            prompt_id=VALID_PMPT_ID,
             auth=MOCK_AUTH,
         )
 
@@ -281,7 +286,7 @@ async def test_get_prompt_bad_request_maps_to_404(
     with pytest.raises(HTTPException) as exc_info:
         await get_prompt_handler(
             request=prompts_http_request,
-            prompt_id="pmpt_missing",
+            prompt_id=VALID_PMPT_ID_NOT_FOUND,
             auth=MOCK_AUTH,
         )
 
@@ -290,7 +295,7 @@ async def test_get_prompt_bad_request_maps_to_404(
     assert detail["response"] == "Prompt not found"  # type: ignore[index]
     assert (
         detail["cause"]  # type: ignore[index]
-        == "Prompt with ID pmpt_missing does not exist"
+        == f"Prompt with ID {VALID_PMPT_ID_NOT_FOUND} does not exist"
     )
 
 
@@ -314,7 +319,7 @@ async def test_update_prompt_bad_request_maps_to_404(
     with pytest.raises(HTTPException) as exc_info:
         await update_prompt_handler(
             request=prompts_http_request,
-            prompt_id="pmpt_missing",
+            prompt_id=VALID_PMPT_ID_NOT_FOUND,
             auth=MOCK_AUTH,
             body=body,
         )
@@ -324,6 +329,57 @@ async def test_update_prompt_bad_request_maps_to_404(
     assert detail["response"] == "Prompt not found"  # type: ignore[index]
     assert (
         detail["cause"]  # type: ignore[index]
-        == "Prompt with ID pmpt_missing does not exist"
+        == f"Prompt with ID {VALID_PMPT_ID_NOT_FOUND} does not exist"
     )
     mock_prompts.update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_prompt_invalid_id_returns_400(
+    prompts_http_request: Request,
+) -> None:
+    """get_prompt returns 400 when path prompt_id is not pmpt_ + 48 hex."""
+    with pytest.raises(HTTPException) as exc_info:
+        await get_prompt_handler(
+            request=prompts_http_request,
+            prompt_id="pmpt_tooshort",
+            auth=MOCK_AUTH,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+    detail = exc_info.value.detail
+    assert detail["response"] == "Invalid prompt ID format"  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_update_prompt_invalid_id_returns_400(
+    prompts_http_request: Request,
+) -> None:
+    """update_prompt returns 400 for an invalid prompt_id path segment."""
+    body = PromptUpdateRequest(
+        prompt="x", version=1, set_as_default=False, variables=None
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await update_prompt_handler(
+            request=prompts_http_request,
+            prompt_id="not_a_prompt_id",
+            auth=MOCK_AUTH,
+            body=body,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_delete_prompt_invalid_id_returns_400(
+    prompts_http_request: Request,
+) -> None:
+    """delete_prompt returns 400 for an invalid prompt_id path segment."""
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_prompt_handler(
+            request=prompts_http_request,
+            prompt_id="pmpt_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+            auth=MOCK_AUTH,
+        )
+
+    assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/models/responses/test_error_responses.py
+++ b/tests/unit/models/responses/test_error_responses.py
@@ -85,12 +85,16 @@ class TestBadRequestResponse:
 
         # Verify example structure
         assert "conversation_id" in examples
-        assert "file_upload" in examples
+        assert "prompt_id" in examples
         conversation_example = examples["conversation_id"]
         assert "value" in conversation_example
         assert "detail" in conversation_example["value"]
         assert conversation_example["value"]["detail"]["response"] == (
             "Invalid conversation ID format"
+        )
+        prompt_example = examples["prompt_id"]
+        assert (
+            prompt_example["value"]["detail"]["response"] == "Invalid prompt ID format"
         )
 
     def test_openapi_response_with_explicit_examples(self) -> None:


### PR DESCRIPTION
## Description

This PR refactors 400 error responses:
- Removes `file_upload` example that should be only under 413 status code
- Adds prompt id validators and corresponding 400 error responses
- Updates unit tests to use valid prompt id formats
- Updates OpenAPI schema

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # [LCORE-1880](https://redhat.atlassian.net/browse/LCORE-1880)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API error response documentation with improved examples and clearer descriptions of invalid request formats.

* **Bug Fixes**
  * Added request validation to catch invalid inputs and provide better error feedback to API consumers.

* **Tests**
  * Enhanced test coverage for request validation and error response scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->