### PR TITLE
LCORE-1583: Add safety_identifier into internal ResponsesApiParams model

### DIFF
--- a/src/utils/types.py
+++ b/src/utils/types.py
@@ -214,6 +214,10 @@ class ResponsesApiParams(BaseModel):
         default=None,
         description="Reasoning configuration for the response",
     )
+    safety_identifier: Optional[str] = Field(
+        default=None,
+        description="Stable identifier for safety monitoring and abuse detection",
+    )
     store: bool = Field(description="Whether to store the response")
     stream: bool = Field(description="Whether to stream the response")
     temperature: Optional[float] = Field(


### PR DESCRIPTION
## Description

Adds missing `safety_identifier` attribute into `ResponsesApiParams`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A

## Related Tickets & Documents

- Related Issue # [LCORE-1583](https://redhat.atlassian.net/browse/LCORE-1583)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional safety identifier parameter to API requests for enhanced monitoring and abuse detection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->