### PR TITLE
LCORE-1463: Fixed MCP E2E Tests

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -129,10 +129,12 @@ async def query_endpoint_handler(
     """
     check_configuration_loaded(configuration)
 
-    await check_mcp_auth(configuration, mcp_headers)
-
     started_at = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     user_id, _, _skip_userid_check, token = auth
+
+    # Check MCP Auth
+    await check_mcp_auth(configuration, mcp_headers, token, request.headers)
+
     # Check token availability
     check_tokens_available(configuration.quota_limiters, user_id)
 

--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -253,9 +253,9 @@ async def responses_endpoint_handler(
     instructions_substituted = client_instructions is None
     started_at = datetime.now(UTC)
     rh_identity_context = get_rh_identity_context(request)
-    user_id = auth[0]
+    user_id, _, _, token = auth
 
-    await check_mcp_auth(configuration, mcp_headers)
+    await check_mcp_auth(configuration, mcp_headers, token, request.headers)
 
     # Check token availability
     check_tokens_available(configuration.quota_limiters, user_id)

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -184,10 +184,11 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
     """
     check_configuration_loaded(configuration)
 
-    await check_mcp_auth(configuration, mcp_headers)
-
     user_id, _user_name, _skip_userid_check, token = auth
     started_at = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Check MCP Auth
+    await check_mcp_auth(configuration, mcp_headers, token, request.headers)
 
     # Check token availability
     check_tokens_available(configuration.quota_limiters, user_id)

--- a/src/app/endpoints/tools.py
+++ b/src/app/endpoints/tools.py
@@ -137,7 +137,8 @@ async def tools_endpoint_handler(  # pylint: disable=too-many-locals,too-many-st
         configuration, mcp_headers, request.headers, token
     )
 
-    await check_mcp_auth(configuration, complete_mcp_headers)
+    # Check MCP Auth
+    await check_mcp_auth(configuration, mcp_headers, token, request.headers)
 
     toolgroups_response = []
     try:

--- a/src/utils/mcp_oauth_probe.py
+++ b/src/utils/mcp_oauth_probe.py
@@ -5,6 +5,7 @@ Used by endpoints that call MCP-backed services so clients receive a proper
 """
 
 import asyncio
+from collections.abc import Mapping
 from typing import Optional
 
 import aiohttp
@@ -14,35 +15,47 @@ import constants
 from configuration import AppConfig
 from log import get_logger
 from models.responses import UnauthorizedResponse
-from utils.mcp_headers import McpHeaders
+from utils.mcp_headers import McpHeaders, build_mcp_headers
 
 logger = get_logger(__name__)
 
 
-async def check_mcp_auth(configuration: AppConfig, mcp_headers: McpHeaders) -> None:
-    """Probe each configured MCP server that expects OAuth or has auth headers.
+async def check_mcp_auth(
+    configuration: AppConfig,
+    mcp_headers: McpHeaders,
+    token: str,
+    request_headers: Optional[Mapping[str, str]] = None,
+) -> None:
+    """Probe each configured MCP server that expects authentication.
 
-    For every MCP server that has an Authorization header in mcp_headers or
-    has OAuth in its resolved_authorization_headers, performs a probe request.
-    If the server indicates OAuth is required, raises 401 with
-    WWW-Authenticate (or 401 without header on probe failure).
+    Builds complete MCP headers by merging client-provided headers with
+    resolved authorization headers (file-based, kubernetes, oauth, or client).
+    For every MCP server that has an Authorization header or has authentication
+    configured, performs a probe request. If the server indicates authentication
+    failure, raises 401 with WWW-Authenticate (or 401 without header on probe failure).
 
     Parameters:
     ----------
         configuration: Application config containing mcp_servers.
-        mcp_headers: Per-server headers; keys are MCP server names.
+        mcp_headers: Per-server headers from client; keys are MCP server names.
+        token: Authentication token from the request (used for kubernetes auth).
+        request_headers: Headers from the incoming HTTP request for propagation.
 
     Returns:
     -------
-        None when no server requires OAuth or probe does not trigger 401.
+        None when no server requires authentication or probe does not trigger 401.
 
     Raises:
     ------
-        HTTPException: 401 when an MCP server requires OAuth (from probe_mcp).
+        HTTPException: 401 when an MCP server requires authentication (from probe_mcp).
     """
+    complete_headers = build_mcp_headers(
+        configuration, mcp_headers or {}, request_headers, token
+    )
+
     probes = []
     for mcp_server in configuration.mcp_servers:
-        headers = mcp_headers.get(mcp_server.name, {})
+        headers = complete_headers.get(mcp_server.name, {})
         auth_header = headers.get("Authorization")
         if auth_header is not None:
             authorization = (

--- a/tests/e2e/features/mcp.feature
+++ b/tests/e2e/features/mcp.feature
@@ -73,7 +73,6 @@ Feature: MCP tests
         }
     """
 
-  @skip #TODO: LCORE-1463
   @InvalidMCPFileAuthConfig
   Scenario: Check if query endpoint reports error when MCP file-based invalid auth token is passed
     Given MCP toolgroups are reset for a new MCP configuration
@@ -95,7 +94,6 @@ Feature: MCP tests
         }
     """
 
-  @skip #TODO: LCORE-1463
   @InvalidMCPFileAuthConfig
   Scenario: Check if streaming_query endpoint reports error when MCP file-based invalid auth token is passed
     Given MCP toolgroups are reset for a new MCP configuration
@@ -181,7 +179,6 @@ Feature: MCP tests
         }
     """
 
-  @skip #TODO: LCORE-1463
   @MCPKubernetesAuthConfig
   Scenario: Check if query endpoint reports error when MCP kubernetes invalid auth token is passed
     Given MCP toolgroups are reset for a new MCP configuration
@@ -203,7 +200,6 @@ Feature: MCP tests
         }
     """
 
-  @skip #TODO: LCORE-1463
   @MCPKubernetesAuthConfig
   Scenario: Check if streaming_query endpoint reports error when MCP kubernetes invalid auth token is passed
     Given MCP toolgroups are reset for a new MCP configuration


### PR DESCRIPTION
## Description

Fixes MCP authentication probing by consolidating header building logic inside `check_mcp_auth()`. Previously, endpoints inconsistently built MCP headers before calling the probe function, causing authentication failures in some scenarios.

Changes:
- Updated `check_mcp_auth()` to accept `token` and `request_headers` parameters and build complete MCP headers internally using `build_mcp_headers()`
- Updated all calling endpoints (query, streaming_query, responses, tools) to pass the required authentication context
- Unskipped 4 E2E test scenarios that were blocked by this bug (LCORE-1463)

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: Claude Code
- Generated by: N/A

## Related Tickets & Documents

- Closes LCORE-1463
- Related

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

1. Run the previously-skipped MCP authentication E2E tests:
   ```bash
   make test-e2e
   ```
2. Verify the unskipped scenarios pass:
"Check if query endpoint reports error when MCP file-based invalid auth token is passed"
"Check if streaming_query endpoint reports error when MCP file-based invalid auth token is passed"
"Check if query endpoint reports error when MCP kubernetes invalid auth token is passed"
"Check if streaming_query endpoint reports error when MCP kubernetes invalid auth token is passed"
3. Test MCP authentication manually with various auth types (file-based, kubernetes, oauth)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced MCP authentication validation to properly handle token extraction and request context across query, streaming, and tool endpoints.

* **Tests**
  * Enabled previously skipped authentication tests for invalid MCP tokens across file-based and Kubernetes configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->