### PR TITLE
Fix OKP Solr RAG URL enrichment

### DIFF
--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -9,6 +9,7 @@ import os
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urljoin
 
 import yaml
 from azure.core.exceptions import ClientAuthenticationError
@@ -468,9 +469,10 @@ def enrich_solr(  # pylint: disable=too-many-locals
     )
 
     rhokp_raw = okp_config.get("rhokp_url")
-    solr_url = (
+    base_url = (
         str(rhokp_raw) if rhokp_raw is not None else constants.RH_SERVER_OKP_DEFAULT_URL
     )
+    solr_url = urljoin(base_url, "/solr")
 
     logger.info("Enriching Llama Stack config with OKP")
 

--- a/src/utils/vector_search.py
+++ b/src/utils/vector_search.py
@@ -7,6 +7,7 @@ and processing RAG chunks that is shared between query_v2.py and streaming_query
 import asyncio
 import traceback
 from typing import Any, Optional, cast
+from urllib.parse import urljoin
 
 from llama_stack_api.openai_responses import (
     OpenAIResponseMessage as ResponseMessage,
@@ -565,27 +566,18 @@ async def build_rag_context(
 
 
 def _join_okp_doc_url(base_url: AnyUrl, reference: Optional[str]) -> str:
-    """Build a well-formed document URL from base and reference.
-
-    If reference is None or empty, returns ''.
-    If reference already starts with 'http', returns reference unchanged.
-    Otherwise normalizes ``base_url`` to end with a single '/', strips any leading
-    '/' from reference, and concatenates.
+    """Build a well-formed document URL from base and reference path.
 
     Args:
         base_url: OKP base URL.
-        reference: Document path or full URL.
+        reference: Origin-relative document path (e.g. ``/docs/foo``).
 
     Returns:
-        Well-formed doc_url string.
+        Well-formed doc_url string, or empty string if reference is empty.
     """
     if not reference:
         return ""
-    if reference.startswith("http"):
-        return reference
-    base = str(base_url).rstrip("/") + "/"
-    ref = reference.lstrip("/")
-    return base + ref
+    return urljoin(str(base_url), reference)
 
 
 def _build_document_url(


### PR DESCRIPTION
This is an alternative to #1431

## Summary
- Fixes some areas where the code was confused about the distinction between `RH_SERVER_OKP` URL and the Solr RAG URL.  `RH_SERVER_OKP` is meant to be the base URL of the OKP instance, and reference links can be joined onto it (ex: `$(RH_SERVER_OKP)/articles/1234`), and the Solr URL can also be joined onto it (ex: `$(RH_SERVER_OKP)/solr`).
- Replace manual string concatenation for URL construction with `urllib.parse.urljoin` in both `llama_stack_configuration.py` (solr URL from `rhokp_url`) and `utils/vector_search.py` (OKP document URLs).
- Removes custom logic for stripping/appending slashes and handling absolute URLs, since `urljoin` handles all of that correctly.

## Test plan
- [x] Verify solr URL is correctly constructed from `rhokp_url` config
- [x] Verify OKP document URLs are correctly built from base URL + reference path
- [x] Run `uv run make test-unit` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved URL construction logic in internal components for better standardization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->