### PR TITLE
LCORE-1375: use Optional type hint across sources

### DIFF
--- a/src/app/endpoints/prompts.py
+++ b/src/app/endpoints/prompts.py
@@ -1,6 +1,6 @@
 """Handler for REST API calls to manage Llama Stack stored prompt templates."""
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from llama_stack_client import APIConnectionError, BadRequestError
@@ -183,7 +183,7 @@ async def get_prompt_handler(
     request: Request,
     prompt_id: str,
     auth: Annotated[AuthTuple, Depends(get_auth_dependency())],
-    version: int | None = None,
+    version: Optional[int] = None,
 ) -> PromptResourceResponse:
     """
     Handle requests to the GET /prompts/{prompt_id} endpoint.

--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -388,7 +388,7 @@ async def handle_streaming_response(
     inline_rag_context: RAGContext,
     filter_server_tools: bool = False,
     instructions_substituted: bool = False,
-    background_tasks: BackgroundTasks | None = None,
+    background_tasks: Optional[BackgroundTasks] = None,
     rh_identity_context: tuple[str, str] = ("", ""),
 ) -> StreamingResponse:
     """Handle streaming response from Responses API.
@@ -912,7 +912,7 @@ async def generate_response(
     started_at: datetime,
     api_params: ResponsesApiParams,
     generate_topic_summary: bool,
-    background_tasks: BackgroundTasks | None = None,
+    background_tasks: Optional[BackgroundTasks] = None,
     rh_identity_context: tuple[str, str] = ("", ""),
     shield_blocked: bool = False,
 ) -> AsyncIterator[str]:
@@ -990,7 +990,7 @@ async def handle_non_streaming_response(
     inline_rag_context: RAGContext,
     filter_server_tools: bool = False,
     instructions_substituted: bool = False,
-    background_tasks: BackgroundTasks | None = None,
+    background_tasks: Optional[BackgroundTasks] = None,
     rh_identity_context: tuple[str, str] = ("", ""),
 ) -> ResponsesResponse:
     """Handle non-streaming response from Responses API.

--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -476,7 +476,7 @@ def _is_verbose_enabled(infer_request: RlsapiV1InferRequest) -> bool:
     )
 
 
-def _resolve_quota_subject(request: Request, auth: AuthTuple) -> str | None:
+def _resolve_quota_subject(request: Request, auth: AuthTuple) -> Optional[str]:
     """Resolve the quota subject identifier based on rlsapi_v1 configuration.
 
     Returns None when quota enforcement is disabled (quota_subject not set),

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -880,7 +880,7 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
 
 
 def stream_http_error_event(
-    error: AbstractErrorResponse, media_type: str | None = MEDIA_TYPE_JSON
+    error: AbstractErrorResponse, media_type: Optional[str] = MEDIA_TYPE_JSON
 ) -> str:
     """
     Create an SSE-formatted error response for generic LLM or API errors.

--- a/src/app/endpoints/tools.py
+++ b/src/app/endpoints/tools.py
@@ -1,6 +1,6 @@
 """Handler for REST API call to list available tools from MCP servers."""
 
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from llama_stack_client import APIConnectionError, BadRequestError
@@ -35,7 +35,7 @@ router = APIRouter(tags=["tools"])
 
 
 def _input_schema_to_parameters(
-    schema: dict[str, Any] | None,
+    schema: Optional[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Convert a JSON Schema input_schema to a flat list of parameter dicts.
 

--- a/src/app/endpoints/vector_stores.py
+++ b/src/app/endpoints/vector_stores.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 from io import BytesIO
-from typing import Annotated, Any
+from typing import Annotated, Any, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
 from llama_stack_client import (
@@ -559,7 +559,7 @@ async def add_file_to_vector_store(  # pylint: disable=too-many-locals,too-many-
         max_retries = 3
         retry_delay = 0.5  # seconds
         vs_file = None
-        last_lock_error: Exception | None = None
+        last_lock_error: Optional[Exception] = None
 
         for attempt in range(max_retries):
             try:

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -2210,14 +2210,14 @@ class NotFoundResponse(AbstractErrorResponse):
         }
     }
 
-    def __init__(self, *, resource: str, resource_id: str | None = None):
+    def __init__(self, *, resource: str, resource_id: Optional[str] = None):
         """
         Create a NotFoundResponse for a missing resource and set the HTTP status to 404.
 
         Parameters:
         ----------
             resource (str): Resource type that was not found (e.g., "conversation", "model").
-            resource_id (str | None): Identifier of the missing resource. If None, indicates
+            resource_id (Optional[str]): Identifier of the missing resource. If None, indicates
                 the resource type is not configured (e.g., no model selected).
         """
         response = f"{resource.title()} not found"
@@ -2382,7 +2382,7 @@ class PromptTooLongResponse(AbstractErrorResponse):
         self,
         *,
         response: str = "Prompt is too long",
-        model: str | None = None,
+        model: Optional[str] = None,
     ) -> None:
         """Initialize a PromptTooLongResponse.
 

--- a/src/utils/query.py
+++ b/src/utils/query.py
@@ -105,8 +105,8 @@ def store_conversation_into_cache(
 
 
 def validate_model_provider_override(
-    model: str | None,
-    provider: str | None,
+    model: Optional[str],
+    provider: Optional[str],
     authorized_actions: set[Action] | frozenset[Action],
 ) -> None:
     """Validate whether model/provider overrides are allowed by RBAC.

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -524,7 +524,7 @@ def mcp_strip_name_from_allowlist_entries(
 
 def mcp_project_allowed_tools_to_names(
     tool: InputToolMCP, names: list[str]
-) -> list[str] | None:
+) -> Optional[list[str]]:
     """Intersect allowlist tool names with the MCP tool allowed_tools constraint.
 
     Parameters:

--- a/src/utils/stream_interrupts.py
+++ b/src/utils/stream_interrupts.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from enum import Enum
 from threading import Lock
-from typing import Any
+from typing import Any, Optional
 
 from log import get_logger
 from utils.types import Singleton
@@ -27,7 +27,7 @@ class ActiveStream:
 
     user_id: str
     task: asyncio.Task[None]
-    on_interrupt: Callable[[], Coroutine[Any, Any, None]] | None = field(
+    on_interrupt: Optional[Callable[[], Coroutine[Any, Any, None]]] = field(
         default=None, repr=False
     )
 
@@ -54,7 +54,7 @@ class StreamInterruptRegistry(metaclass=Singleton):
         request_id: str,
         user_id: str,
         task: asyncio.Task[None],
-        on_interrupt: Callable[[], Coroutine[Any, Any, None]] | None = None,
+        on_interrupt: Optional[Callable[[], Coroutine[Any, Any, None]]] = None,
     ) -> None:
         """Register an active stream task for interrupt support.
 
@@ -124,7 +124,7 @@ class StreamInterruptRegistry(metaclass=Singleton):
         with self._lock:
             self._streams.pop(request_id, None)
 
-    def get_stream(self, request_id: str) -> ActiveStream | None:
+    def get_stream(self, request_id: str) -> Optional[ActiveStream]:
         """Get currently registered stream metadata for tests/introspection.
 
         Parameters:
@@ -133,7 +133,7 @@ class StreamInterruptRegistry(metaclass=Singleton):
 
         Returns:
         -------
-            ActiveStream | None: Registered stream metadata, or None when absent.
+            Optional[ActiveStream]: Registered stream metadata, or None when absent.
         """
         with self._lock:
             return self._streams.get(request_id)

--- a/src/utils/transcripts.py
+++ b/src/utils/transcripts.py
@@ -9,6 +9,7 @@ import json
 import os
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Optional
 
 from fastapi import HTTPException
 
@@ -105,9 +106,9 @@ def create_transcript_metadata(  # pylint: disable=too-many-arguments,too-many-p
     user_id: str,
     conversation_id: str,
     model_id: str,
-    provider_id: str | None,
-    query_provider: str | None,
-    query_model: str | None,
+    provider_id: Optional[str],
+    query_provider: Optional[str],
+    query_model: Optional[str],
 ) -> TranscriptMetadata:
     """Create a TranscriptMetadata BaseModel instance.
 

--- a/tests/e2e/features/steps/common.py
+++ b/tests/e2e/features/steps/common.py
@@ -1,6 +1,7 @@
 """Implementation of common test steps."""
 
 import os
+from typing import Optional
 
 from behave import given  # pyright: ignore[reportAttributeAccessIssue]
 from behave.runner import Context
@@ -18,7 +19,7 @@ from tests.e2e.utils.utils import (
 # Behave may clear user attributes on ``context`` between scenarios; keep the
 # last applied config basename here so Background can skip re-applying the same
 # YAML across scenarios in one feature. Mutate the dict entry (no global).
-_active_lightspeed_stack_config_basename: dict[str, str | None] = {"basename": None}
+_active_lightspeed_stack_config_basename: dict[str, Optional[str]] = {"basename": None}
 
 
 def reset_active_lightspeed_stack_config_basename() -> None:

--- a/tests/e2e/features/steps/proxy.py
+++ b/tests/e2e/features/steps/proxy.py
@@ -20,7 +20,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import trustme
 import yaml
@@ -51,7 +51,7 @@ def _is_docker_mode() -> bool:
     return "llama-stack" in result.stdout
 
 
-def _host_special_dns_from_container(hostname: str) -> str | None:
+def _host_special_dns_from_container(hostname: str) -> Optional[str]:
     """Resolve a host-gateway hostname inside llama-stack to an IPv4 address.
 
     Docker exposes ``host.docker.internal`` or ``host.containers.internal``

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import subprocess
 import time
-from typing import Any
+from typing import Any, Optional
 
 import jsonschema
 import requests
@@ -246,7 +246,7 @@ RESPONSES_SSE_TERMINAL_EVENT_TYPES = frozenset(
 
 def parse_responses_sse_final_response_object(text: str) -> dict[str, Any]:
     """Return the ``response`` object from the last terminal LCORE ``/responses`` SSE event."""
-    last: dict[str, Any] | None = None
+    last: Optional[dict[str, Any]] = None
     for line in text.splitlines():
         stripped = line.strip()
         if not stripped.startswith("data:"):

--- a/tests/unit/app/endpoints/test_prompts.py
+++ b/tests/unit/app/endpoints/test_prompts.py
@@ -1,6 +1,6 @@
 """Unit tests for the /prompts REST API endpoints."""
 
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from fastapi import HTTPException, Request, status
@@ -33,9 +33,9 @@ def _sample_prompt(
     prompt_id: str,
     version: int,
     *,
-    is_default: bool | None = True,
-    prompt: str | None = "hello",
-    variables: list[str] | None = None,
+    is_default: Optional[bool] = True,
+    prompt: Optional[str] = "hello",
+    variables: Optional[list[str]] = None,
 ) -> Prompt:
     """Build a Llama Stack SDK Prompt for test return values."""
     return Prompt(

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -2,7 +2,7 @@
 """Unit tests for the /responses REST API endpoint (LCORE Responses API)."""
 
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 import pytest
 from fastapi import HTTPException, Request
@@ -78,7 +78,7 @@ def _patch_resolve_response_context(
     mocker: MockerFixture,
     *,
     conversation: str = "conv_new",
-    user_conversation: UserConversation | None = None,
+    user_conversation: Optional[UserConversation] = None,
     generate_topic_summary: bool = False,
 ) -> None:
     """Patch resolve_response_context to return the given conversation context."""

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -8,7 +8,7 @@
 
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from fastapi import HTTPException, status
@@ -498,7 +498,7 @@ async def test_retrieve_simple_response_api_connection_error(
 def test_get_rh_identity_context(
     mocker: MockerFixture,
     mock_request_factory: Callable[..., Any],
-    rh_identity_setup: dict[str, str] | None,
+    rh_identity_setup: Optional[dict[str, str]],
     expected_org_id: str,
     expected_system_id: str,
 ) -> None:
@@ -978,9 +978,9 @@ async def test_infer_queues_splunk_event_on_success(
 def test_resolve_quota_subject(
     mocker: MockerFixture,
     mock_request_factory: Callable[..., Any],
-    quota_subject: str | None,
-    rh_identity_setup: dict[str, str] | None,
-    expected: str | None,
+    quota_subject: Optional[str],
+    rh_identity_setup: Optional[dict[str, str]],
+    expected: Optional[str],
 ) -> None:
     """Test _resolve_quota_subject resolves correct ID based on config and identity."""
     rlsapi_v1_mock = mocker.Mock()

--- a/tests/unit/utils/test_mcp_headers.py
+++ b/tests/unit/utils/test_mcp_headers.py
@@ -1,5 +1,7 @@
 """Unit tests for MCP headers utility functions."""
 
+from typing import Optional
+
 import pytest
 from fastapi import Request
 from pytest_mock import MockerFixture
@@ -338,8 +340,8 @@ class TestBuildServerHeaders:
 
     def _make_server(
         self,
-        resolved_auth: dict[str, str] | None = None,
-        headers: list[str] | None = None,
+        resolved_auth: Optional[dict[str, str]] = None,
+        headers: Optional[list[str]] = None,
     ) -> ModelContextProtocolServer:
         """Create a ModelContextProtocolServer with given auth and allowlist headers."""
         server = ModelContextProtocolServer(

--- a/tests/unit/utils/test_rh_identity.py
+++ b/tests/unit/utils/test_rh_identity.py
@@ -1,5 +1,7 @@
 """Unit tests for utils/rh_identity module."""
 
+from typing import Optional
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -43,7 +45,7 @@ def test_auth_disabled_constant() -> None:
 )
 def test_get_rh_identity_context(
     mocker: MockerFixture,
-    rh_identity_setup: dict[str, str] | None,
+    rh_identity_setup: Optional[dict[str, str]],
     expected_org_id: str,
     expected_system_id: str,
 ) -> None:


### PR DESCRIPTION
## Description

LCORE-1375: use Optional type hint across sources

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1375
