### PR TITLE
LCORE-2034: Refactored delete response models

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2996,16 +2996,16 @@
                                 "examples": {
                                     "deleted": {
                                         "value": {
+                                            "deleted": true,
                                             "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
-                                            "response": "Prompt deleted successfully",
-                                            "success": true
+                                            "response": "Prompt deleted successfully"
                                         }
                                     },
-                                    "not_deleted": {
+                                    "not found": {
                                         "value": {
+                                            "deleted": false,
                                             "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
-                                            "response": "Prompt cannot be deleted",
-                                            "success": false
+                                            "response": "Prompt not found"
                                         }
                                     }
                                 }
@@ -7565,15 +7565,15 @@
                                     "deleted": {
                                         "value": {
                                             "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                                            "response": "Conversation deleted successfully",
-                                            "success": true
+                                            "deleted": true,
+                                            "response": "Conversation deleted successfully"
                                         }
                                     },
                                     "not found": {
                                         "value": {
                                             "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                                            "response": "Conversation can not be deleted",
-                                            "success": true
+                                            "deleted": false,
+                                            "response": "Conversation not found"
                                         }
                                     }
                                 }
@@ -8475,15 +8475,15 @@
                                     "deleted": {
                                         "value": {
                                             "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                                            "response": "Conversation deleted successfully",
-                                            "success": true
+                                            "deleted": true,
+                                            "response": "Conversation deleted successfully"
                                         }
                                     },
                                     "not found": {
                                         "value": {
                                             "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                                            "response": "Conversation can not be deleted",
-                                            "success": true
+                                            "deleted": false,
+                                            "response": "Conversation not found"
                                         }
                                     }
                                 }
@@ -11871,56 +11871,61 @@
             },
             "ConversationDeleteResponse": {
                 "properties": {
-                    "conversation_id": {
-                        "type": "string",
-                        "title": "Conversation Id",
-                        "description": "The conversation ID (UUID) that was deleted.",
-                        "examples": [
-                            "123e4567-e89b-12d3-a456-426614174000"
-                        ]
-                    },
-                    "success": {
+                    "deleted": {
                         "type": "boolean",
-                        "title": "Success",
+                        "title": "Deleted",
                         "description": "Whether the deletion was successful.",
                         "examples": [
                             true,
                             false
                         ]
                     },
+                    "conversation_id": {
+                        "type": "string",
+                        "title": "Conversation Id",
+                        "description": "Conversation identifier that was passed to delete.",
+                        "examples": [
+                            "123e4567-e89b-12d3-a456-426614174000"
+                        ]
+                    },
                     "response": {
                         "type": "string",
                         "title": "Response",
-                        "description": "A message about the deletion result.",
-                        "examples": [
-                            "Conversation deleted successfully",
-                            "Conversation cannot be deleted"
-                        ]
+                        "description": "Human-readable outcome of the delete operation.",
+                        "readOnly": true
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "title": "Success",
+                        "description": "DEPRECATED: Successful response flag. Will be removed in a future release.",
+                        "deprecated": true,
+                        "readOnly": true
                     }
                 },
                 "type": "object",
                 "required": [
+                    "deleted",
                     "conversation_id",
-                    "success",
-                    "response"
+                    "response",
+                    "success"
                 ],
                 "title": "ConversationDeleteResponse",
-                "description": "Model representing a response for deleting a conversation.\n\nAttributes:\n    conversation_id: The conversation ID (UUID) that was deleted.\n    success: Whether the deletion was successful.\n    response: A message about the deletion result.",
+                "description": "Response for deleting a conversation.",
                 "examples": [
                     {
                         "label": "deleted",
                         "value": {
                             "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                            "response": "Conversation deleted successfully",
-                            "success": true
+                            "deleted": true,
+                            "response": "Conversation deleted successfully"
                         }
                     },
                     {
                         "label": "not found",
                         "value": {
                             "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                            "response": "Conversation can not be deleted",
-                            "success": true
+                            "deleted": false,
+                            "response": "Conversation not found"
                         }
                     }
                 ]
@@ -15958,6 +15963,15 @@
             },
             "PromptDeleteResponse": {
                 "properties": {
+                    "deleted": {
+                        "type": "boolean",
+                        "title": "Deleted",
+                        "description": "Whether the deletion was successful.",
+                        "examples": [
+                            true,
+                            false
+                        ]
+                    },
                     "prompt_id": {
                         "type": "string",
                         "title": "Prompt Id",
@@ -15966,30 +15980,26 @@
                             "pmpt_0123456789abcdef0123456789abcdef01234567"
                         ]
                     },
-                    "success": {
-                        "type": "boolean",
-                        "title": "Success",
-                        "description": "Whether Llama Stack deleted the prompt.",
-                        "examples": [
-                            true,
-                            false
-                        ]
-                    },
                     "response": {
                         "type": "string",
                         "title": "Response",
-                        "description": "Human-readable outcome.",
-                        "examples": [
-                            "Prompt deleted successfully",
-                            "Prompt cannot be deleted"
-                        ]
+                        "description": "Human-readable outcome of the delete operation.",
+                        "readOnly": true
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "title": "Success",
+                        "description": "DEPRECATED: Successful response flag. Will be removed in a future release.",
+                        "deprecated": true,
+                        "readOnly": true
                     }
                 },
                 "type": "object",
                 "required": [
+                    "deleted",
                     "prompt_id",
-                    "success",
-                    "response"
+                    "response",
+                    "success"
                 ],
                 "title": "PromptDeleteResponse",
                 "description": "Result of deleting a stored prompt (always HTTP 200, like conversations v2).",
@@ -15997,17 +16007,17 @@
                     {
                         "label": "deleted",
                         "value": {
+                            "deleted": true,
                             "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
-                            "response": "Prompt deleted successfully",
-                            "success": true
+                            "response": "Prompt deleted successfully"
                         }
                     },
                     {
-                        "label": "not_deleted",
+                        "label": "not found",
                         "value": {
+                            "deleted": false,
                             "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
-                            "response": "Prompt cannot be deleted",
-                            "success": false
+                            "response": "Prompt not found"
                         }
                     }
                 ]

--- a/src/app/endpoints/conversations_v1.py
+++ b/src/app/endpoints/conversations_v1.py
@@ -377,7 +377,7 @@ async def delete_conversation_endpoint_handler(
             conversation_id=llama_stack_conv_id
         )
         logger.info(
-            "Remote deletion of %s successful (remote_deleted=%s)",
+            "Remote deletion of %s: success=%s",
             normalized_conv_id,
             delete_response.deleted,
         )

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -29,10 +29,11 @@ from llama_stack_api.openai_responses import (
 from llama_stack_api.openai_responses import (
     OpenAIResponseUsage as Usage,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 from pydantic_core import SchemaError
 
 from constants import MEDIA_TYPE_EVENT_STREAM
+from log import get_logger
 from models.config import Action, Configuration
 from quota.quota_exceed_error import QuotaExceedError
 from utils.types import RAGChunk, ReferencedDocument, ToolCallSummary, ToolResultSummary
@@ -64,6 +65,8 @@ UNAUTHORIZED_OPENAPI_EXAMPLES_WITH_MCP_OAUTH: list[str] = [
     "mcp oauth",
 ]
 
+logger = get_logger(__name__)
+
 
 class AbstractSuccessfulResponse(BaseModel):
     """Base class for all successful response models."""
@@ -82,6 +85,65 @@ class AbstractSuccessfulResponse(BaseModel):
             "description": SUCCESSFUL_RESPONSE_DESCRIPTION,
             "model": cls,
             "content": content,
+        }
+
+
+class AbstractDeleteResponse(BaseModel):
+    """Base model for successful delete responses."""
+
+    deleted: bool = Field(
+        ...,
+        description="Whether the deletion was successful.",
+        examples=[True, False],
+    )
+    resource_name: ClassVar[str]
+
+    @computed_field
+    def response(self) -> str:
+        """Human-readable outcome of the delete operation."""
+        return (
+            f"{self.resource_name} deleted successfully"
+            if self.deleted
+            else f"{self.resource_name} not found"
+        )
+
+    @computed_field(json_schema_extra={"deprecated": True})
+    def success(self) -> bool:
+        """Successful response flag."""
+        logger.warning("DEPRECATED: Will be removed in a future release.")
+        return True
+
+    @classmethod
+    def openapi_response(cls) -> dict[str, Any]:
+        """Build FastAPI/OpenAPI metadata with named application/json examples.
+
+        Returns:
+            A response dict with description, model, and content keys.
+
+        Raises:
+            SchemaError: If the model JSON schema has no examples list.
+        """
+        schema = cls.model_json_schema()
+        model_examples = schema.get("examples")
+        if not model_examples:
+            raise SchemaError(f"Examples not found in {cls.__name__}")
+
+        examples: dict[str, dict[str, Any]] = {}
+        for index, example in enumerate(model_examples):
+            if "label" not in example:
+                raise SchemaError(
+                    f"Example at index {index} in {cls.__name__} has no label"
+                )
+            if "value" not in example:
+                raise SchemaError(
+                    f"Example at index {index} in {cls.__name__} has no value"
+                )
+            examples[example["label"]] = {"value": example["value"]}
+
+        return {
+            "description": SUCCESSFUL_RESPONSE_DESCRIPTION,
+            "model": cls,
+            "content": {"application/json": {"examples": examples}},
         }
 
 
@@ -1113,54 +1175,15 @@ class ConversationResponse(AbstractSuccessfulResponse):
     }
 
 
-class ConversationDeleteResponse(AbstractSuccessfulResponse):
-    """Model representing a response for deleting a conversation.
+class ConversationDeleteResponse(AbstractDeleteResponse):
+    """Response for deleting a conversation."""
 
-    Attributes:
-        conversation_id: The conversation ID (UUID) that was deleted.
-        success: Whether the deletion was successful.
-        response: A message about the deletion result.
-    """
-
+    resource_name: ClassVar[str] = "Conversation"
     conversation_id: str = Field(
         ...,
-        description="The conversation ID (UUID) that was deleted.",
+        description="Conversation identifier that was passed to delete.",
         examples=["123e4567-e89b-12d3-a456-426614174000"],
     )
-    success: bool = Field(
-        ..., description="Whether the deletion was successful.", examples=[True, False]
-    )
-    response: str = Field(
-        ...,
-        description="A message about the deletion result.",
-        examples=[
-            "Conversation deleted successfully",
-            "Conversation cannot be deleted",
-        ],
-    )
-
-    def __init__(self, *, deleted: bool, conversation_id: str) -> None:
-        """
-        Initialize a ConversationDeleteResponse and populate its public fields.
-
-        If `deleted` is True the response message is "Conversation deleted
-        successfully"; otherwise it is "Conversation cannot be deleted".
-
-        Parameters:
-        ----------
-            deleted (bool): Whether the conversation was successfully deleted.
-            conversation_id (str): The ID of the conversation.
-        """
-        response_msg = (
-            "Conversation deleted successfully"
-            if deleted
-            else "Conversation cannot be deleted"
-        )
-        super().__init__(
-            conversation_id=conversation_id,  # type: ignore[call-arg]
-            success=True,  # type: ignore[call-arg]
-            response=response_msg,  # type: ignore[call-arg]
-        )
 
     model_config = {
         "json_schema_extra": {
@@ -1169,7 +1192,7 @@ class ConversationDeleteResponse(AbstractSuccessfulResponse):
                     "label": "deleted",
                     "value": {
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                        "success": True,
+                        "deleted": True,
                         "response": "Conversation deleted successfully",
                     },
                 },
@@ -1177,55 +1200,13 @@ class ConversationDeleteResponse(AbstractSuccessfulResponse):
                     "label": "not found",
                     "value": {
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
-                        "success": True,
-                        "response": "Conversation can not be deleted",
+                        "deleted": False,
+                        "response": "Conversation not found",
                     },
                 },
             ]
         }
     }
-
-    @classmethod
-    def openapi_response(cls) -> dict[str, Any]:
-        """
-        Build an OpenAPI-compatible FastAPI response dict using the model's examples.
-
-        Extracts labeled examples from the model's JSON schema `examples` and
-        places them under `application/json` -> `examples`. The returned
-        mapping includes a `description` ("Successful response"), the `model`
-        (the class itself), and `content` containing the assembled examples.
-
-        Returns:
-            response (dict[str, Any]): A dict with keys `description`, `model`,
-            and `content` suitable for FastAPI/OpenAPI response registration.
-
-        Raises:
-            SchemaError: If any example in the model's JSON schema is missing a
-                         required `label` or `value`.
-        """
-        schema = cls.model_json_schema()
-        model_examples = schema.get("examples", [])
-
-        named_examples: dict[str, Any] = {}
-
-        for ex in model_examples:
-            label = ex.get("label")
-            if label is None:
-                raise SchemaError(f"Example {ex} in {cls.__name__} has no label")
-
-            value = ex.get("value")
-            if value is None:
-                raise SchemaError(f"Example '{label}' in {cls.__name__} has no value")
-
-            named_examples[label] = {"value": value}
-
-        content = {"application/json": {"examples": named_examples or None}}
-
-        return {
-            "description": SUCCESSFUL_RESPONSE_DESCRIPTION,
-            "model": cls,
-            "content": content,
-        }
 
 
 class ConversationDetails(BaseModel):
@@ -3044,43 +3025,15 @@ class PromptsListResponse(AbstractSuccessfulResponse):
     }
 
 
-class PromptDeleteResponse(AbstractSuccessfulResponse):
+class PromptDeleteResponse(AbstractDeleteResponse):
     """Result of deleting a stored prompt (always HTTP 200, like conversations v2)."""
 
+    resource_name: ClassVar[str] = "Prompt"
     prompt_id: str = Field(
         ...,
         description="Prompt identifier that was passed to delete.",
         examples=["pmpt_0123456789abcdef0123456789abcdef01234567"],
     )
-    success: bool = Field(
-        ...,
-        description="Whether Llama Stack deleted the prompt.",
-        examples=[True, False],
-    )
-    response: str = Field(
-        ...,
-        description="Human-readable outcome.",
-        examples=[
-            "Prompt deleted successfully",
-            "Prompt cannot be deleted",
-        ],
-    )
-
-    def __init__(self, *, deleted: bool, prompt_id: str) -> None:
-        """Build delete outcome from Llama Stack result.
-
-        Parameters:
-            deleted: True if the backend removed the prompt.
-            prompt_id: Prompt id from the request path.
-        """
-        response_msg = (
-            "Prompt deleted successfully" if deleted else "Prompt cannot be deleted"
-        )
-        super().__init__(
-            prompt_id=prompt_id,  # type: ignore[call-arg]
-            success=deleted,  # type: ignore[call-arg]
-            response=response_msg,  # type: ignore[call-arg]
-        )
 
     model_config = {
         "json_schema_extra": {
@@ -3089,48 +3042,21 @@ class PromptDeleteResponse(AbstractSuccessfulResponse):
                     "label": "deleted",
                     "value": {
                         "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
-                        "success": True,
+                        "deleted": True,
                         "response": "Prompt deleted successfully",
                     },
                 },
                 {
-                    "label": "not_deleted",
+                    "label": "not found",
                     "value": {
                         "prompt_id": "pmpt_0123456789abcdef0123456789abcdef01234567",
-                        "success": False,
-                        "response": "Prompt cannot be deleted",
+                        "deleted": False,
+                        "response": "Prompt not found",
                     },
                 },
             ]
         }
     }
-
-    @classmethod
-    def openapi_response(cls) -> dict[str, Any]:
-        """Build the response spec for HTTP 200 with labeled JSON examples."""
-        schema = cls.model_json_schema()
-        model_examples = schema.get("examples", [])
-
-        named_examples: dict[str, Any] = {}
-
-        for ex in model_examples:
-            label = ex.get("label")
-            if label is None:
-                raise SchemaError(f"Example {ex} in {cls.__name__} has no label")
-
-            value = ex.get("value")
-            if value is None:
-                raise SchemaError(f"Example '{label}' in {cls.__name__} has no value")
-
-            named_examples[label] = {"value": value}
-
-        content = {"application/json": {"examples": named_examples or None}}
-
-        return {
-            "description": SUCCESSFUL_RESPONSE_DESCRIPTION,
-            "model": cls,
-            "content": content,
-        }
 
 
 class FileResponse(AbstractSuccessfulResponse):

--- a/tests/e2e/features/conversation_cache_v2.feature
+++ b/tests/e2e/features/conversation_cache_v2.feature
@@ -183,7 +183,7 @@ Feature: Conversation Cache V2 API tests
      And The returned conversation details have expected conversation_id
      And The body of the response, ignoring the "conversation_id" field, is the following
       """
-      {"success": true, "response": "Conversation deleted successfully"}
+      {"success": true, "response": "Conversation deleted successfully", "deleted": true}
       """
      When I use REST API conversation endpoint with conversation_id from above using HTTP GET method
      Then The status code of the response is 404
@@ -203,7 +203,7 @@ Feature: Conversation Cache V2 API tests
      Then The status code of the response is 200
      And The body of the response, ignoring the "conversation_id" field, is the following
       """
-      {"success": true, "response": "Conversation cannot be deleted"}
+      {"success": true, "response": "Conversation not found", "deleted": false}
       """
 
   # ====================================================================

--- a/tests/e2e/features/conversations.feature
+++ b/tests/e2e/features/conversations.feature
@@ -107,7 +107,7 @@ Feature: conversations endpoint API tests
      And The returned conversation details have expected conversation_id
      And The body of the response, ignoring the "conversation_id" field, is the following
       """
-      {"success": true, "response": "Conversation deleted successfully"}
+      {"success": true, "response": "Conversation deleted successfully", "deleted": true}
       """
      And I use REST API conversation endpoint with conversation_id from above using HTTP GET method
      Then The status code of the response is 404
@@ -123,5 +123,5 @@ Feature: conversations endpoint API tests
      Then The status code of the response is 200
      And The body of the response, ignoring the "conversation_id" field, is the following
       """
-      {"success": true, "response": "Conversation cannot be deleted"}
+      {"success": true, "response": "Conversation not found", "deleted": false}
       """

--- a/tests/e2e/features/llama_stack_disrupted.feature
+++ b/tests/e2e/features/llama_stack_disrupted.feature
@@ -205,7 +205,7 @@ Feature: Llama Stack connection disrupted
     And The returned conversation details have expected conversation_id
     And The body of the response, ignoring the "conversation_id" field, is the following
     """
-    {"success": true, "response": "Conversation deleted successfully"}
+    {"success": true, "response": "Conversation deleted successfully", "deleted": true}
     """
     When I use REST API conversation endpoint with conversation_id from above using HTTP GET method
     Then The status code of the response is 404

--- a/tests/integration/endpoints/test_conversations_v2_integration.py
+++ b/tests/integration/endpoints/test_conversations_v2_integration.py
@@ -638,7 +638,7 @@ async def test_delete_conversation_removes_from_cache(
 
     # Verify response
     assert response.conversation_id == TEST_CONVERSATION_ID
-    assert response.success is True
+    assert response.deleted is True
 
     # Verify conversation was deleted by attempting to get it (should return 404)
     with pytest.raises(HTTPException) as exc_info:
@@ -681,9 +681,8 @@ async def test_delete_conversation_non_existent_returns_success(
 
     # Verify response (note: success is always True per implementation)
     assert response.conversation_id == TEST_NON_EXISTENT_ID
-    assert response.success is True
-    # Response message indicates deletion status
-    assert "cannot be deleted" in response.response.lower()
+    assert response.deleted is False
+    assert "not found" in response.model_dump()["response"]
 
 
 # ==========================================

--- a/tests/unit/app/endpoints/test_conversations.py
+++ b/tests/unit/app/endpoints/test_conversations.py
@@ -1156,7 +1156,7 @@ class TestDeleteConversationEndpoint:
 
         assert isinstance(response, ConversationDeleteResponse)
         assert response.conversation_id == VALID_CONVERSATION_ID
-        assert response.success is True
+        assert response.deleted is True
         assert "deleted successfully" in response.response
 
     @pytest.mark.asyncio
@@ -1256,7 +1256,7 @@ class TestDeleteConversationEndpoint:
 
         assert isinstance(response, ConversationDeleteResponse)
         assert response.conversation_id == VALID_CONVERSATION_ID
-        assert response.success is True
+        assert response.deleted is True
         assert "deleted successfully" in response.response
 
     @pytest.mark.asyncio
@@ -1294,7 +1294,7 @@ class TestDeleteConversationEndpoint:
 
         assert isinstance(response, ConversationDeleteResponse)
         assert response.conversation_id == VALID_CONVERSATION_ID
-        assert response.success is True
+        assert response.deleted is True
         assert "deleted successfully" in response.response
         mock_delete.assert_called_once()
         mock_client.conversations.delete.assert_called_once()
@@ -1336,8 +1336,8 @@ class TestDeleteConversationEndpoint:
 
         assert isinstance(response, ConversationDeleteResponse)
         assert response.conversation_id == VALID_CONVERSATION_ID
-        assert response.success is True
-        assert "cannot be deleted" in response.response  # Not found locally
+        assert response.deleted is False
+        assert "not found" in response.response  # Not found locally
 
     @pytest.mark.asyncio
     async def test_sqlalchemy_error_in_delete(

--- a/tests/unit/app/endpoints/test_conversations_v2.py
+++ b/tests/unit/app/endpoints/test_conversations_v2.py
@@ -760,7 +760,7 @@ class TestDeleteConversationEndpoint:
 
         assert response is not None
         assert response.conversation_id == VALID_CONVERSATION_ID
-        assert response.success is True
+        assert response.deleted is True
         assert response.response == "Conversation deleted successfully"
 
     @pytest.mark.asyncio
@@ -781,8 +781,8 @@ class TestDeleteConversationEndpoint:
 
         assert response is not None
         assert response.conversation_id == VALID_CONVERSATION_ID
-        assert response.success is True
-        assert response.response == "Conversation cannot be deleted"
+        assert response.deleted is False
+        assert response.response == "Conversation not found"
 
     @pytest.mark.asyncio
     async def test_with_skip_userid_check(
@@ -802,6 +802,7 @@ class TestDeleteConversationEndpoint:
         mock_authorization_resolvers(mocker)
         mocker.patch("app.endpoints.conversations_v2.configuration", mock_configuration)
         mocker.patch("app.endpoints.conversations_v2.check_suid", return_value=True)
+        mock_configuration.conversation_cache.delete.return_value = True
         mock_auth_with_skip = ("mock_user_id", "mock_username", True, "mock_token")
 
         await delete_conversation_endpoint_handler(

--- a/tests/unit/app/endpoints/test_prompts.py
+++ b/tests/unit/app/endpoints/test_prompts.py
@@ -202,7 +202,7 @@ async def test_delete_prompt_success(
     )
 
     assert isinstance(result, PromptDeleteResponse)
-    assert result.success is True
+    assert result.deleted is True
     assert result.prompt_id == VALID_PMPT_ID
     mock_prompts.delete.assert_awaited_once_with(VALID_PMPT_ID)
 
@@ -213,7 +213,7 @@ async def test_delete_prompt_not_found_returns_body(
     prompts_http_request: Request,
     mocker: MockerFixture,
 ) -> None:
-    """delete_prompt returns success=False on Llama Stack BadRequestError (v2 style)."""
+    """delete_prompt returns deleted=False on Llama Stack BadRequestError (v2 style)."""
     _, mock_prompts = prompts_client_mocks
     mock_response = mocker.Mock()
     mock_response.request = mocker.Mock()
@@ -227,7 +227,7 @@ async def test_delete_prompt_not_found_returns_body(
         auth=MOCK_AUTH,
     )
 
-    assert result.success is False
+    assert result.deleted is False
     assert result.prompt_id == VALID_PMPT_ID_NOT_FOUND
 
 

--- a/tests/unit/models/responses/test_successful_responses.py
+++ b/tests/unit/models/responses/test_successful_responses.py
@@ -716,26 +716,26 @@ class TestConversationDeleteResponse:
         response = ConversationDeleteResponse(
             deleted=True, conversation_id="123e4567-e89b-12d3-a456-426614174000"
         )
-        assert isinstance(response, AbstractSuccessfulResponse)
+        assert isinstance(response, ConversationDeleteResponse)
         assert response.conversation_id == "123e4567-e89b-12d3-a456-426614174000"
-        assert response.success is True
-        assert response.response == "Conversation deleted successfully"
+        assert response.deleted is True
+        assert response.model_dump()["response"] == "Conversation deleted successfully"
 
     def test_constructor_not_deleted(self) -> None:
         """Test ConversationDeleteResponse when conversation cannot be deleted."""
         response = ConversationDeleteResponse(deleted=False, conversation_id="conv-123")
-        assert response.success is True
-        assert response.response == "Conversation cannot be deleted"
+        assert response.deleted is False
+        assert response.model_dump()["response"] == "Conversation not found"
 
     def test_missing_required_parameters(self) -> None:
-        """Test ConversationDeleteResponse raises TypeError when required fields missing."""
-        with pytest.raises(TypeError):
+        """Test ConversationDeleteResponse raises ValidationError when required fields missing."""
+        with pytest.raises(ValidationError):
             ConversationDeleteResponse()  # pylint: disable=missing-kwoa # pyright: ignore
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             ConversationDeleteResponse(  # pylint: disable=missing-kwoa # pyright: ignore[reportCallIssue]
                 deleted=True
             )
-        with pytest.raises(TypeError):
+        with pytest.raises(ValidationError):
             ConversationDeleteResponse(  # pylint: disable=missing-kwoa # pyright: ignore[reportCallIssue]
                 conversation_id="conv-123"
             )
@@ -767,7 +767,7 @@ class TestConversationDeleteResponse:
             deleted_example["value"]["conversation_id"]
             == "123e4567-e89b-12d3-a456-426614174000"
         )
-        assert deleted_example["value"]["success"] is True
+        assert deleted_example["value"]["deleted"] is True
         assert (
             deleted_example["value"]["response"] == "Conversation deleted successfully"
         )
@@ -778,10 +778,8 @@ class TestConversationDeleteResponse:
         assert not_found_example["value"]["conversation_id"] == (
             "123e4567-e89b-12d3-a456-426614174000"
         )
-        assert not_found_example["value"]["success"] is True
-        assert (
-            not_found_example["value"]["response"] == "Conversation can not be deleted"
-        )
+        assert not_found_example["value"]["deleted"] is False
+        assert not_found_example["value"]["response"] == "Conversation not found"
 
     def test_openapi_response_missing_label(self) -> None:
         """Test openapi_response() raises SchemaError when example has no label.


### PR DESCRIPTION
## Description

Introduces abstract delete response model. Unifies conversation and prompt deletion models by inheriting from it.
Abstract delete response exposes `deleted` flag signaling if deletion was successful followed by corresponding `response` message and resource ID. The model preserves legacy `success` attribute that is always `True` for backward compatibility purposes with deprecation warnings, signaling that this attribute will be removed in the next release. 

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # [LCORE-2034](https://redhat.atlassian.net/browse/LCORE-2034)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Delete endpoint response schemas have been updated to include a `deleted` boolean field, which explicitly indicates whether a resource deletion was successful.
* The `success` field in delete responses has been deprecated; applications should use the `deleted` field instead.
* Response messages for failed deletions have been clarified to better communicate when requested resources are not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->