### PR TITLE
feat: add Action.RESPONSES for /responses endpoint authorization

### DIFF
--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -204,7 +204,7 @@ def _queue_responses_splunk_event(  # pylint: disable=too-many-arguments,too-man
     response_model=None,
     summary="Responses Endpoint Handler",
 )
-@authorize(Action.QUERY)
+@authorize(Action.RESPONSES)
 async def responses_endpoint_handler(
     request: Request,
     responses_request: ResponsesRequest,

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -991,6 +991,9 @@ class Action(str, Enum):
     # Access the query endpoint
     QUERY = "query"
 
+    # Access the responses endpoint
+    RESPONSES = "responses"
+
     # Access the streaming query endpoint
     STREAMING_QUERY = "streaming_query"
 

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -163,7 +163,7 @@ def _patch_handle_non_streaming_common(
 def dummy_request_fixture() -> Request:
     """Minimal FastAPI Request with authorized_actions for responses endpoint."""
     req = Request(scope={"type": "http", "headers": []})
-    req.state.authorized_actions = {Action.QUERY, Action.READ_OTHERS_CONVERSATIONS}
+    req.state.authorized_actions = {Action.RESPONSES, Action.READ_OTHERS_CONVERSATIONS}
     return req
 
 

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -635,6 +635,40 @@ class TestResponsesEndpointHandler:
         assert call_kwargs["request"].tools is None
         assert call_kwargs["request"].tool_choice is None
 
+    @pytest.mark.asyncio
+    async def test_responses_endpoint_rejects_without_responses_action(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Verify that requests lacking Action.RESPONSES are rejected with 403.
+
+        Constructs a request whose authorized_actions includes Action.QUERY and
+        Action.READ_OTHERS_CONVERSATIONS but NOT Action.RESPONSES, then asserts
+        the @authorize(Action.RESPONSES) decorator raises HTTPException 403.
+        """
+        req = Request(scope={"type": "http", "headers": []})
+        req.state.authorized_actions = {Action.QUERY, Action.READ_OTHERS_CONVERSATIONS}
+
+        mock_role_resolver = mocker.AsyncMock()
+        mock_role_resolver.resolve_roles = mocker.AsyncMock(return_value=set())
+
+        mock_access_resolver = mocker.Mock()
+        mock_access_resolver.check_access.return_value = False
+
+        mocker.patch(
+            "authorization.middleware.get_authorization_resolvers",
+            return_value=(mock_role_resolver, mock_access_resolver),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await responses_endpoint_handler(
+                request=req,
+                responses_request=ResponsesRequest(input="Hello"),
+                auth=MOCK_AUTH,
+                mcp_headers={},
+            )
+        assert exc_info.value.status_code == 403
+
 
 class TestHandleNonStreamingResponse:
     """Unit tests for handle_non_streaming_response."""


### PR DESCRIPTION
## Summary

- Add `Action.RESPONSES = "responses"` to the `Action` enum in `src/models/config.py`, immediately after `Action.QUERY = "query"`, following the existing comment-per-constant style.
- Change `@authorize(Action.QUERY)` → `@authorize(Action.RESPONSES)` on the `/responses` endpoint handler in `src/app/endpoints/responses.py`.
- Update `dummy_request_fixture` in `tests/unit/app/endpoints/test_responses.py` to use `Action.RESPONSES` instead of `Action.QUERY`.

## Why

Previously both `/query` and `/responses` were guarded by `Action.QUERY`. This meant:
- Granting `query` permission gave access to **both** endpoints.
- The two endpoints could not be authorized independently.

With this change:
- `query` → controls `/query` endpoint only.
- `responses` → controls `/responses` endpoint only.

## ⚠️ Deployment Sequencing (IMPORTANT)

**The lscore-deploy MR that adds `responses` to the allowed actions list MUST be deployed BEFORE this PR is deployed.**

If lightspeed-stack is deployed first, the `/responses` endpoint will return **403 Forbidden** for all users because the deployment config will not yet include the new `responses` action. The lscore-deploy MR for this is being opened simultaneously.

## Changes

| File | Change |
|------|--------|
| `src/models/config.py` | Add `RESPONSES = "responses"` to `Action` enum after `QUERY` |
| `src/app/endpoints/responses.py` | `@authorize(Action.QUERY)` → `@authorize(Action.RESPONSES)` |
| `tests/unit/app/endpoints/test_responses.py` | `Action.QUERY` → `Action.RESPONSES` in `dummy_request_fixture` |

## Verification

- `uv run make format` ✅
- `uv run make verify` ✅ (pylint 10.00/10, pyright 0 errors, ruff clean, black clean, pydocstyle clean; pre-existing `check-types` failure in `dev-tools/` unrelated to this change)
- `uv run make test-unit` ✅ (2067 passed; 1 pre-existing failure in `test_user_data_collection_wrong_directory_path` unrelated to this change)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the authorization permission scope for the responses endpoint to enforce more specific and appropriate access control requirements. This ensures that user permissions are properly validated when processing response-related requests and operations across the application.

* **Tests**
  * Updated test fixtures to verify the corrected authorization requirements for the responses endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->