### PR TITLE
docs(okp): add RH_SERVER_OKP and change recommended OKP port to 8081

### DIFF
--- a/docs/okp_guide.md
+++ b/docs/okp_guide.md
@@ -47,21 +47,21 @@ OKP (Offline Knowledge Portal) provides a Solr-backed RAG source that Lightspeed
 Start the OKP RAG service with Podman:
 
 ```bash
-podman run --rm -d -p 8983:8080 registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
+podman run --rm -d -p 8081:8080 registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
 ```
 
 > **Note:** Remove `-d` to run in the foreground.
 
-* The service listens on **port 8983** on the host (mapped from 8080 in the container).
+* The service listens on **port 8081** on the host (mapped from 8080 in the container).  Lightspeed Stack itself listens on `8080`, so this avoids port conflicts.
 * Confirm it is running by opening in a browser or with `curl`:
 
   ```bash
-  curl -s http://localhost:8983
+  curl -s http://localhost:8081
   ```
 
-  Or visit: **http://localhost:8983**
+  Or visit: **http://localhost:8081**
 
-> **Note:** Lightspeed stack will automatically enrich the llamastack configuration to add the necessary providers/resources for referencing OKP.  This assumes your OKP instance is running on localhost:8983.  If you need a different OKP url, you can set the SOLR_URL environment variable with the correct url prior to launching Lightspeed stack and that value will be used instead.
+> **Note:** Lightspeed stack will automatically enrich the llamastack configuration to add the necessary providers/resources for referencing OKP.  This assumes your OKP instance is running on localhost:8081.  If you need a different OKP url, you can set the SOLR_URL environment variable with the correct url prior to launching Lightspeed stack and that value will be used instead.
 ---
 
 ## Step 2: Setup llamastack config environment variables
@@ -71,6 +71,7 @@ Set the required environment variables. The external providers path must point t
 ```bash
 export EXTERNAL_PROVIDERS_DIR=../lightspeed-providers/resources/external_providers
 export OPENAI_API_KEY=<your-openai-api-key>
+export RH_SERVER_OKP=http://localhost:8081
 ```
 
 Adjust `EXTERNAL_PROVIDERS_DIR` if your lightspeed-providers repo is in a different location relative to your lightspeed-stack directory.
@@ -105,6 +106,7 @@ rag:
   inline:
   - okp
 okp:
+  rhokp_url: ${env.RH_SERVER_OKP}
   offline: true
 ```
 
@@ -115,6 +117,7 @@ rag:
   tool:
   - okp
 okp:
+  rhokp_url: ${env.RH_SERVER_OKP}
   offline: true
 ```
 
@@ -197,7 +200,7 @@ Example response excerpt:
 
 If you see no RAG context, verify:
 
-1. OKP is up at http://localhost:8983
+1. OKP is up at http://localhost:8081
 2. `lightspeed-stack.yaml` has `okp` under `rag.inline` and/or `rag.tool` as in Step 4
 
 ---


### PR DESCRIPTION
## Description

Update the OKP guide.

 - Add missing `rhokp_url` field, set to the standard `RH_SERVER_OKP` env var.
 - Change recommended OKP port mapping from `8983` to `8081`.  `8983` is suboptimal because that is the standard port for Apache Solr, but RHOKP != Solr.  RHOKP does include a Solr server, but is not equivalent to it.  `8081` avoids the conflict with LCORE's default of `8080`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: none
- Generated by: none

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.

Documentation steps verified by setting up LCORE+OKP on a fresh machine.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OKP service port configuration from 8983 to 8081
  * Added environment variable configuration guidance
  * Updated verification steps and troubleshooting procedures to reflect new port mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->