### PR TITLE
LCORE-2034: Unified mcp registration endpoints

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1229,6 +1229,14 @@
                                                 "response": "Configuration is not loaded"
                                             }
                                         }
+                                    },
+                                    "mcp server registration": {
+                                        "value": {
+                                            "detail": {
+                                                "cause": "Could not register the MCP server with the remote service.",
+                                                "response": "Failed to register MCP server"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1302,9 +1310,21 @@
                                 "schema": {
                                     "$ref": "#/components/schemas/MCPServerDeleteResponse"
                                 },
-                                "example": {
-                                    "message": "MCP server 'test-mcp-server' unregistered successfully",
-                                    "name": "test-mcp-server"
+                                "examples": {
+                                    "deleted": {
+                                        "value": {
+                                            "deleted": true,
+                                            "name": "mcp-server",
+                                            "response": "MCP server deleted successfully"
+                                        }
+                                    },
+                                    "not found": {
+                                        "value": {
+                                            "deleted": false,
+                                            "name": "mcp-server",
+                                            "response": "MCP server not found"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -1397,30 +1417,18 @@
                                                 "response": "User does not have permission to access this endpoint"
                                             }
                                         }
-                                    }
-                                },
-                                "schema": {
-                                    "$ref": "#/components/schemas/ForbiddenResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Resource not found",
-                        "content": {
-                            "application/json": {
-                                "examples": {
-                                    "mcp server": {
+                                    },
+                                    "mcp server static": {
                                         "value": {
                                             "detail": {
-                                                "cause": "Mcp Server with ID test-mcp-server does not exist",
-                                                "response": "Mcp Server not found"
+                                                "cause": "MCP server 'my-mcp' is defined in configuration and cannot be removed via the API.",
+                                                "response": "Cannot delete statically configured MCP server"
                                             }
                                         }
                                     }
                                 },
                                 "schema": {
-                                    "$ref": "#/components/schemas/NotFoundResponse"
+                                    "$ref": "#/components/schemas/ForbiddenResponse"
                                 }
                             }
                         }
@@ -10602,7 +10610,7 @@
                 ],
                 "summary": "Handle A2A Jsonrpc",
                 "description": "Handle A2A JSON-RPC requests following the A2A protocol specification.\n\nThis endpoint uses the DefaultRequestHandler from the A2A SDK to handle\nall JSON-RPC requests including message/send, message/stream, etc.\n\nThe A2A SDK application is created per-request to include authentication\ncontext while still leveraging FastAPI's authorization middleware.\n\nAutomatically detects streaming requests (message/stream JSON-RPC method)\nand returns a StreamingResponse to enable real-time chunk delivery.\n\nArgs:\n    request: FastAPI request object\n    auth: Authentication tuple\n    mcp_headers: MCP headers for context propagation\n\nReturns:\n    JSON-RPC response or streaming response",
-                "operationId": "handle_a2a_jsonrpc_a2a_get",
+                "operationId": "handle_a2a_jsonrpc_a2a_post",
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -10620,7 +10628,7 @@
                 ],
                 "summary": "Handle A2A Jsonrpc",
                 "description": "Handle A2A JSON-RPC requests following the A2A protocol specification.\n\nThis endpoint uses the DefaultRequestHandler from the A2A SDK to handle\nall JSON-RPC requests including message/send, message/stream, etc.\n\nThe A2A SDK application is created per-request to include authentication\ncontext while still leveraging FastAPI's authorization middleware.\n\nAutomatically detects streaming requests (message/stream JSON-RPC method)\nand returns a StreamingResponse to enable real-time chunk delivery.\n\nArgs:\n    request: FastAPI request object\n    auth: Authentication tuple\n    mcp_headers: MCP headers for context propagation\n\nReturns:\n    JSON-RPC response or streaming response",
-                "operationId": "handle_a2a_jsonrpc_a2a_get",
+                "operationId": "handle_a2a_jsonrpc_a2a_post",
                 "responses": {
                     "200": {
                         "description": "Successful Response",
@@ -13181,6 +13189,13 @@
                             "response": "This instance does not permit overriding model/provider in the query request (missing permission: MODEL_OVERRIDE). Please remove the model and provider fields from your request."
                         },
                         "label": "model override"
+                    },
+                    {
+                        "detail": {
+                            "cause": "MCP server 'my-mcp' is defined in configuration and cannot be removed via the API.",
+                            "response": "Cannot delete statically configured MCP server"
+                        },
+                        "label": "mcp server static"
                     }
                 ]
             },
@@ -13425,6 +13440,13 @@
                             "response": "Configuration is not loaded"
                         },
                         "label": "configuration"
+                    },
+                    {
+                        "detail": {
+                            "cause": "Could not register the MCP server with the remote service.",
+                            "response": "Failed to register MCP server"
+                        },
+                        "label": "mcp server registration"
                     },
                     {
                         "detail": {
@@ -13763,28 +13785,62 @@
             },
             "MCPServerDeleteResponse": {
                 "properties": {
+                    "deleted": {
+                        "type": "boolean",
+                        "title": "Deleted",
+                        "description": "Whether the deletion was successful.",
+                        "examples": [
+                            true,
+                            false
+                        ]
+                    },
                     "name": {
                         "type": "string",
                         "title": "Name",
-                        "description": "Deleted MCP server name"
+                        "description": "MCP server name that was passed to delete.",
+                        "examples": [
+                            "test-mcp-server"
+                        ]
                     },
-                    "message": {
+                    "response": {
                         "type": "string",
-                        "title": "Message",
-                        "description": "Status message"
+                        "title": "Response",
+                        "description": "Human-readable outcome of the delete operation.",
+                        "readOnly": true
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "title": "Success",
+                        "description": "Successful response flag.",
+                        "deprecated": true,
+                        "readOnly": true
                     }
                 },
                 "type": "object",
                 "required": [
+                    "deleted",
                     "name",
-                    "message"
+                    "response",
+                    "success"
                 ],
                 "title": "MCPServerDeleteResponse",
-                "description": "Response for a successful MCP server deletion.",
+                "description": "Result of unregistering an MCP server (HTTP 200 with delete outcome).",
                 "examples": [
                     {
-                        "message": "MCP server 'test-mcp-server' unregistered successfully",
-                        "name": "test-mcp-server"
+                        "label": "deleted",
+                        "value": {
+                            "deleted": true,
+                            "name": "mcp-server",
+                            "response": "MCP server deleted successfully"
+                        }
+                    },
+                    {
+                        "label": "not found",
+                        "value": {
+                            "deleted": false,
+                            "name": "mcp-server",
+                            "response": "MCP server not found"
+                        }
                     }
                 ]
             },
@@ -14252,13 +14308,6 @@
                             "response": "Streaming Request not found"
                         },
                         "label": "streaming request"
-                    },
-                    {
-                        "detail": {
-                            "cause": "Mcp Server with ID test-mcp-server does not exist",
-                            "response": "Mcp Server not found"
-                        },
-                        "label": "mcp server"
                     },
                     {
                         "detail": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1229,6 +1229,14 @@
                                                 "response": "Configuration is not loaded"
                                             }
                                         }
+                                    },
+                                    "mcp server registration": {
+                                        "value": {
+                                            "detail": {
+                                                "cause": "Could not register the MCP server with the remote service.",
+                                                "response": "Failed to register MCP server"
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -1397,30 +1405,18 @@
                                                 "response": "User does not have permission to access this endpoint"
                                             }
                                         }
-                                    }
-                                },
-                                "schema": {
-                                    "$ref": "#/components/schemas/ForbiddenResponse"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Resource not found",
-                        "content": {
-                            "application/json": {
-                                "examples": {
-                                    "mcp server": {
+                                    },
+                                    "mcp server static": {
                                         "value": {
                                             "detail": {
-                                                "cause": "Mcp Server with ID test-mcp-server does not exist",
-                                                "response": "Mcp Server not found"
+                                                "cause": "MCP server 'my-mcp' is defined in configuration and cannot be removed via the API.",
+                                                "response": "Cannot delete statically configured MCP server"
                                             }
                                         }
                                     }
                                 },
                                 "schema": {
-                                    "$ref": "#/components/schemas/NotFoundResponse"
+                                    "$ref": "#/components/schemas/ForbiddenResponse"
                                 }
                             }
                         }
@@ -13221,6 +13217,13 @@
                             "response": "This instance does not permit overriding model/provider in the query request (missing permission: model_override). Please remove the model and provider fields from your request."
                         },
                         "label": "model override"
+                    },
+                    {
+                        "detail": {
+                            "cause": "MCP server 'my-mcp' is defined in configuration and cannot be removed via the API.",
+                            "response": "Cannot delete statically configured MCP server"
+                        },
+                        "label": "mcp server static"
                     }
                 ]
             },
@@ -13514,6 +13517,13 @@
                             "response": "Internal server error"
                         },
                         "label": "invalid cluster version"
+                    },
+                    {
+                        "detail": {
+                            "cause": "Could not register the MCP server with the remote service.",
+                            "response": "Failed to register MCP server"
+                        },
+                        "label": "mcp server registration"
                     }
                 ]
             },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1310,9 +1310,21 @@
                                 "schema": {
                                     "$ref": "#/components/schemas/MCPServerDeleteResponse"
                                 },
-                                "example": {
-                                    "message": "MCP server 'test-mcp-server' unregistered successfully",
-                                    "name": "test-mcp-server"
+                                "examples": {
+                                    "deleted": {
+                                        "value": {
+                                            "deleted": true,
+                                            "name": "mcp-server",
+                                            "response": "MCP server deleted successfully"
+                                        }
+                                    },
+                                    "not found": {
+                                        "value": {
+                                            "deleted": false,
+                                            "name": "mcp-server",
+                                            "response": "MCP server not found"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -13813,28 +13825,54 @@
             },
             "MCPServerDeleteResponse": {
                 "properties": {
+                    "deleted": {
+                        "type": "boolean",
+                        "title": "Deleted",
+                        "description": "Whether the deletion was successful.",
+                        "examples": [
+                            true,
+                            false
+                        ]
+                    },
                     "name": {
                         "type": "string",
                         "title": "Name",
-                        "description": "Deleted MCP server name"
+                        "description": "MCP server name that was passed to delete.",
+                        "examples": [
+                            "test-mcp-server"
+                        ]
                     },
-                    "message": {
+                    "response": {
                         "type": "string",
-                        "title": "Message",
-                        "description": "Status message"
+                        "title": "Response",
+                        "description": "Human-readable outcome of the delete operation.",
+                        "readOnly": true
                     }
                 },
                 "type": "object",
                 "required": [
+                    "deleted",
                     "name",
-                    "message"
+                    "response"
                 ],
                 "title": "MCPServerDeleteResponse",
-                "description": "Response for a successful MCP server deletion.\n\nAttributes:\n    name: Deleted MCP server name.\n    message: Status message.",
+                "description": "Response indicating the outcome of an MCP server delete operation.\n\nAttributes:\n    name: Name of the MCP server targeted for deletion.\n    deleted: Whether the server was successfully deleted (True) or not found (False).\n    response: Description of the result, e.g. \"MCP server deleted successfully\".",
                 "examples": [
                     {
-                        "message": "MCP server 'test-mcp-server' unregistered successfully",
-                        "name": "test-mcp-server"
+                        "label": "deleted",
+                        "value": {
+                            "deleted": true,
+                            "name": "mcp-server",
+                            "response": "MCP server deleted successfully"
+                        }
+                    },
+                    {
+                        "label": "not found",
+                        "value": {
+                            "deleted": false,
+                            "name": "mcp-server",
+                            "response": "MCP server not found"
+                        }
                     }
                 ]
             },

--- a/src/app/endpoints/mcp_servers.py
+++ b/src/app/endpoints/mcp_servers.py
@@ -3,7 +3,8 @@
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from llama_stack_client import APIConnectionError
+from llama_stack_api.common.errors import ToolGroupNotFoundError
+from llama_stack_client import APIConnectionError, APIStatusError
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -22,7 +23,6 @@ from models.responses import (
     MCPServerInfo,
     MCPServerListResponse,
     MCPServerRegistrationResponse,
-    NotFoundResponse,
     ServiceUnavailableResponse,
     UnauthorizedResponse,
 )
@@ -37,7 +37,9 @@ register_responses: dict[int | str, dict[str, Any]] = {
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
     409: ConflictResponse.openapi_response(examples=["mcp server"]),
-    500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
+    500: InternalServerErrorResponse.openapi_response(
+        examples=["configuration", "mcp server registration"]
+    ),
     503: ServiceUnavailableResponse.openapi_response(
         examples=["llama stack", "kubernetes api"]
     ),
@@ -107,10 +109,7 @@ async def register_mcp_server_handler(
     except Exception as e:  # pylint: disable=broad-exception-caught
         configuration.remove_mcp_server(body.name)
         logger.error("Failed to register MCP toolgroup: %s", e)
-        error_response = InternalServerErrorResponse(
-            response="Failed to register MCP server",
-            cause=str(e),
-        )
+        error_response = InternalServerErrorResponse.mcp_server_registration_failed()
         raise HTTPException(**error_response.model_dump()) from e
 
     logger.info("Dynamically registered MCP server: %s at %s", body.name, body.url)
@@ -176,8 +175,7 @@ async def list_mcp_servers_handler(
 delete_responses: dict[int | str, dict[str, Any]] = {
     200: MCPServerDeleteResponse.openapi_response(),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
-    403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
-    404: NotFoundResponse.openapi_response(examples=["mcp server"]),
+    403: ForbiddenResponse.openapi_response(examples=["endpoint", "mcp server static"]),
     500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
     503: ServiceUnavailableResponse.openapi_response(
         examples=["llama stack", "kubernetes api"]
@@ -216,16 +214,17 @@ async def delete_mcp_server_handler(
     check_configuration_loaded(configuration)
 
     if not configuration.is_dynamic_mcp_server(name):
-        found = any(s.name == name for s in configuration.mcp_servers)
-        if found:
-            response = ForbiddenResponse(
-                response="Cannot delete statically configured MCP server",
-                cause=f"MCP server '{name}' was configured in lightspeed-stack.yaml "
-                "and cannot be removed via the API.",
-            )
-        else:
-            response = NotFoundResponse(resource="MCP server", resource_id=name)
-        raise HTTPException(**response.model_dump())
+        static_mcp_names = {s.name for s in configuration.mcp_servers}
+        if name in static_mcp_names:
+            response = ForbiddenResponse.mcp_server_static_config(name)
+            raise HTTPException(**response.model_dump())
+
+    try:
+        configuration.remove_mcp_server(name)
+        local_deleted = True
+    except ValueError as e:
+        logger.error("Failed to remove MCP server from configuration: %s", e)
+        local_deleted = False
 
     try:
         client = AsyncLlamaStackClientHolder().get_client()
@@ -233,29 +232,12 @@ async def delete_mcp_server_handler(
             toolgroup_id=name
         )
     except APIConnectionError as e:
-        logger.error("Failed to unregister MCP toolgroup from Llama Stack: %s", e)
+        logger.error("Failed to connect to Llama Stack: %s", e)
         svc_response = ServiceUnavailableResponse(
             backend_name="Llama Stack", cause=str(e)
         )
         raise HTTPException(**svc_response.model_dump()) from e
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.warning(
-            "Llama Stack toolgroup unregister failed for '%s', "
-            "proceeding with local removal: %s",
-            name,
-            e,
-        )
+    except (APIStatusError, ToolGroupNotFoundError):
+        logger.warning("MCP server not found, treating as already deleted.")
 
-    try:
-        configuration.remove_mcp_server(name)
-    except ValueError as e:
-        logger.error("Failed to remove MCP server from configuration: %s", e)
-        response = NotFoundResponse(resource="MCP server", resource_id=name)
-        raise HTTPException(**response.model_dump()) from e
-
-    logger.info("Dynamically unregistered MCP server: %s", name)
-
-    return MCPServerDeleteResponse(
-        name=name,
-        message=f"MCP server '{name}' unregistered successfully",
-    )
+    return MCPServerDeleteResponse(deleted=local_deleted, name=name)

--- a/src/app/endpoints/mcp_servers.py
+++ b/src/app/endpoints/mcp_servers.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from llama_stack_api.common.errors import ToolGroupNotFoundError
-from llama_stack_client import APIConnectionError, APIStatusError
+from llama_stack_client import APIConnectionError, NotFoundError
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -222,13 +222,6 @@ async def delete_mcp_server_handler(
             raise HTTPException(**response.model_dump())
 
     try:
-        configuration.remove_mcp_server(name)
-        local_deleted = True
-    except ValueError as e:
-        logger.error("Failed to remove MCP server from configuration: %s", e)
-        local_deleted = False
-
-    try:
         client = AsyncLlamaStackClientHolder().get_client()
         await client.toolgroups.unregister(  # pyright: ignore[reportDeprecated]
             toolgroup_id=name
@@ -239,7 +232,14 @@ async def delete_mcp_server_handler(
             backend_name="Llama Stack", cause=str(e)
         )
         raise HTTPException(**svc_response.model_dump()) from e
-    except (APIStatusError, ToolGroupNotFoundError):
+    except (ToolGroupNotFoundError, NotFoundError):
         logger.warning("MCP server not found, treating as already deleted.")
+
+    try:
+        configuration.remove_mcp_server(name)
+        local_deleted = True
+    except ValueError as e:
+        logger.error("Failed to remove MCP server from configuration: %s", e)
+        local_deleted = False
 
     return MCPServerDeleteResponse(deleted=local_deleted, name=name)

--- a/src/app/endpoints/mcp_servers.py
+++ b/src/app/endpoints/mcp_servers.py
@@ -3,7 +3,8 @@
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from llama_stack_client import APIConnectionError
+from llama_stack_api.common.errors import ToolGroupNotFoundError
+from llama_stack_client import APIConnectionError, APIStatusError
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -17,7 +18,6 @@ from models.api.responses.error import (
     ConflictResponse,
     ForbiddenResponse,
     InternalServerErrorResponse,
-    NotFoundResponse,
     ServiceUnavailableResponse,
     UnauthorizedResponse,
 )
@@ -39,7 +39,9 @@ register_responses: dict[int | str, dict[str, Any]] = {
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
     403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
     409: ConflictResponse.openapi_response(examples=["mcp server"]),
-    500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
+    500: InternalServerErrorResponse.openapi_response(
+        examples=["configuration", "mcp server registration"]
+    ),
     503: ServiceUnavailableResponse.openapi_response(
         examples=["llama stack", "kubernetes api"]
     ),
@@ -109,10 +111,7 @@ async def register_mcp_server_handler(
     except Exception as e:  # pylint: disable=broad-exception-caught
         configuration.remove_mcp_server(body.name)
         logger.error("Failed to register MCP toolgroup: %s", e)
-        error_response = InternalServerErrorResponse(
-            response="Failed to register MCP server",
-            cause=str(e),
-        )
+        error_response = InternalServerErrorResponse.mcp_server_registration_failed()
         raise HTTPException(**error_response.model_dump()) from e
 
     logger.info("Dynamically registered MCP server: %s at %s", body.name, body.url)
@@ -178,8 +177,7 @@ async def list_mcp_servers_handler(
 delete_responses: dict[int | str, dict[str, Any]] = {
     200: MCPServerDeleteResponse.openapi_response(),
     401: UnauthorizedResponse.openapi_response(examples=UNAUTHORIZED_OPENAPI_EXAMPLES),
-    403: ForbiddenResponse.openapi_response(examples=["endpoint"]),
-    404: NotFoundResponse.openapi_response(examples=["mcp server"]),
+    403: ForbiddenResponse.openapi_response(examples=["endpoint", "mcp server static"]),
     500: InternalServerErrorResponse.openapi_response(examples=["configuration"]),
     503: ServiceUnavailableResponse.openapi_response(
         examples=["llama stack", "kubernetes api"]
@@ -218,16 +216,17 @@ async def delete_mcp_server_handler(
     check_configuration_loaded(configuration)
 
     if not configuration.is_dynamic_mcp_server(name):
-        found = any(s.name == name for s in configuration.mcp_servers)
-        if found:
-            response = ForbiddenResponse(
-                response="Cannot delete statically configured MCP server",
-                cause=f"MCP server '{name}' was configured in lightspeed-stack.yaml "
-                "and cannot be removed via the API.",
-            )
-        else:
-            response = NotFoundResponse(resource="MCP server", resource_id=name)
-        raise HTTPException(**response.model_dump())
+        static_mcp_names = {s.name for s in configuration.mcp_servers}
+        if name in static_mcp_names:
+            response = ForbiddenResponse.mcp_server_static_config(name)
+            raise HTTPException(**response.model_dump())
+
+    try:
+        configuration.remove_mcp_server(name)
+        local_deleted = True
+    except ValueError as e:
+        logger.error("Failed to remove MCP server from configuration: %s", e)
+        local_deleted = False
 
     try:
         client = AsyncLlamaStackClientHolder().get_client()
@@ -235,29 +234,12 @@ async def delete_mcp_server_handler(
             toolgroup_id=name
         )
     except APIConnectionError as e:
-        logger.error("Failed to unregister MCP toolgroup from Llama Stack: %s", e)
+        logger.error("Failed to connect to Llama Stack: %s", e)
         svc_response = ServiceUnavailableResponse(
             backend_name="Llama Stack", cause=str(e)
         )
         raise HTTPException(**svc_response.model_dump()) from e
-    except Exception as e:  # pylint: disable=broad-exception-caught
-        logger.warning(
-            "Llama Stack toolgroup unregister failed for '%s', "
-            "proceeding with local removal: %s",
-            name,
-            e,
-        )
+    except (APIStatusError, ToolGroupNotFoundError):
+        logger.warning("MCP server not found, treating as already deleted.")
 
-    try:
-        configuration.remove_mcp_server(name)
-    except ValueError as e:
-        logger.error("Failed to remove MCP server from configuration: %s", e)
-        response = NotFoundResponse(resource="MCP server", resource_id=name)
-        raise HTTPException(**response.model_dump()) from e
-
-    logger.info("Dynamically unregistered MCP server: %s", name)
-
-    return MCPServerDeleteResponse(
-        name=name,
-        message=f"MCP server '{name}' unregistered successfully",
-    )
+    return MCPServerDeleteResponse(deleted=local_deleted, name=name)

--- a/src/models/api/responses/error/forbidden.py
+++ b/src/models/api/responses/error/forbidden.py
@@ -85,6 +85,16 @@ class ForbiddenResponse(AbstractErrorResponse):
                         ),
                     },
                 },
+                {
+                    "label": "mcp server static",
+                    "detail": {
+                        "response": "Cannot delete statically configured MCP server",
+                        "cause": (
+                            "MCP server 'my-mcp' is defined in configuration "
+                            "and cannot be removed via the API."
+                        ),
+                    },
+                },
             ]
         }
     }
@@ -154,6 +164,25 @@ class ForbiddenResponse(AbstractErrorResponse):
             cause=(
                 f"User lacks {Action.MODEL_OVERRIDE.value} permission required "
                 "to override model/provider."
+            ),
+        )
+    
+    @classmethod
+    def mcp_server_static_config(cls, server_name: str) -> Self:
+        """Create a ForbiddenResponse indicating the client tried to delete a statically configured MCP server.
+
+        Args:
+            server_name: The name of the MCP server that is statically configured.
+
+        Returns:
+            Error response with response "Cannot delete statically configured MCP server" and cause
+            "MCP server 'server_name' is defined in configuration and cannot be removed via the API."
+        """
+        return cls(
+            response="Cannot delete statically configured MCP server",
+            cause=(
+                f"MCP server '{server_name}' is defined in configuration "
+                "and cannot be removed via the API."
             ),
         )
 

--- a/src/models/api/responses/error/forbidden.py
+++ b/src/models/api/responses/error/forbidden.py
@@ -166,17 +166,17 @@ class ForbiddenResponse(AbstractErrorResponse):
                 "to override model/provider."
             ),
         )
-    
+
     @classmethod
     def mcp_server_static_config(cls, server_name: str) -> Self:
-        """Create a ForbiddenResponse indicating the client tried to delete a statically configured MCP server.
+        """Create a response for an attempt to delete a statically configured MCP server.
 
         Args:
             server_name: The name of the MCP server that is statically configured.
 
         Returns:
-            Error response with response "Cannot delete statically configured MCP server" and cause
-            "MCP server 'server_name' is defined in configuration and cannot be removed via the API."
+            A ``ForbiddenResponse`` with the static-delete user message and a cause
+            that names ``server_name`` and states it cannot be removed via the API.
         """
         return cls(
             response="Cannot delete statically configured MCP server",

--- a/src/models/api/responses/error/internal.py
+++ b/src/models/api/responses/error/internal.py
@@ -80,6 +80,15 @@ class InternalServerErrorResponse(AbstractErrorResponse):
                         "cause": "Missing or invalid 'clusterID' in ClusterVersion",
                     },
                 },
+                {
+                    "label": "mcp server registration",
+                    "detail": {
+                        "response": "Failed to register MCP server",
+                        "cause": (
+                            "Could not register the MCP server with the remote service."
+                        ),
+                    },
+                },
             ]
         }
     }
@@ -172,6 +181,20 @@ class InternalServerErrorResponse(AbstractErrorResponse):
         return cls(
             response="Database query failed",
             cause="Failed to query the database",
+        )
+    
+    @classmethod
+    def mcp_server_registration_failed(cls) -> Self:
+        """
+        Create an InternalServerErrorResponse representing a failed MCP server registration.
+
+        Returns:
+            Error response with response "Failed to register MCP server" and cause
+            "Could not register the MCP server with the remote service."
+        """
+        return cls(
+            response="Failed to register MCP server",
+            cause=("Could not register the MCP server with the remote service."),
         )
 
     def __init__(self, *, response: str, cause: str) -> None:

--- a/src/models/api/responses/error/internal.py
+++ b/src/models/api/responses/error/internal.py
@@ -182,7 +182,7 @@ class InternalServerErrorResponse(AbstractErrorResponse):
             response="Database query failed",
             cause="Failed to query the database",
         )
-    
+
     @classmethod
     def mcp_server_registration_failed(cls) -> Self:
         """

--- a/src/models/api/responses/successful/mcp_servers.py
+++ b/src/models/api/responses/successful/mcp_servers.py
@@ -1,8 +1,13 @@
 """Successful responses for MCP server registration and listing."""
 
+from typing import ClassVar
+
 from pydantic import Field
 
-from models.api.responses.successful.bases import AbstractSuccessfulResponse
+from models.api.responses.successful.bases import (
+    AbstractDeleteResponse,
+    AbstractSuccessfulResponse,
+)
 from models.common.mcp import MCPServerAuthInfo, MCPServerInfo
 
 
@@ -103,24 +108,41 @@ class MCPServerListResponse(AbstractSuccessfulResponse):
     }
 
 
-class MCPServerDeleteResponse(AbstractSuccessfulResponse):
-    """Response for a successful MCP server deletion.
+class MCPServerDeleteResponse(AbstractDeleteResponse):
+    """Response indicating the outcome of an MCP server delete operation.
 
     Attributes:
-        name: Deleted MCP server name.
-        message: Status message.
+        name: Name of the MCP server targeted for deletion.
+        deleted: Whether the server was successfully deleted (True) or not found (False).
+        response: Description of the result, e.g. "MCP server deleted successfully".
     """
 
-    name: str = Field(..., description="Deleted MCP server name")
-    message: str = Field(..., description="Status message")
+    resource_name: ClassVar[str] = "MCP server"
+    name: str = Field(
+        ...,
+        description="MCP server name that was passed to delete.",
+        examples=["test-mcp-server"],
+    )
 
     model_config = {
         "json_schema_extra": {
             "examples": [
                 {
-                    "name": "test-mcp-server",
-                    "message": "MCP server 'test-mcp-server' unregistered successfully",
-                }
+                    "label": "deleted",
+                    "value": {
+                        "name": "mcp-server",
+                        "deleted": True,
+                        "response": "MCP server deleted successfully",
+                    },
+                },
+                {
+                    "label": "not found",
+                    "value": {
+                        "name": "mcp-server",
+                        "deleted": False,
+                        "response": "MCP server not found",
+                    },
+                },
             ]
         }
     }

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -326,19 +326,35 @@ class MCPServerListResponse(AbstractSuccessfulResponse):
     }
 
 
-class MCPServerDeleteResponse(AbstractSuccessfulResponse):
-    """Response for a successful MCP server deletion."""
+class MCPServerDeleteResponse(AbstractDeleteResponse):
+    """Result of unregistering an MCP server (HTTP 200 with delete outcome)."""
 
-    name: str = Field(..., description="Deleted MCP server name")
-    message: str = Field(..., description="Status message")
+    resource_name: ClassVar[str] = "MCP server"
+    name: str = Field(
+        ...,
+        description="MCP server name that was passed to delete.",
+        examples=["test-mcp-server"],
+    )
 
     model_config = {
         "json_schema_extra": {
             "examples": [
                 {
-                    "name": "test-mcp-server",
-                    "message": "MCP server 'test-mcp-server' unregistered successfully",
-                }
+                    "label": "deleted",
+                    "value": {
+                        "name": "mcp-server",
+                        "deleted": True,
+                        "response": "MCP server deleted successfully",
+                    },
+                },
+                {
+                    "label": "not found",
+                    "value": {
+                        "name": "mcp-server",
+                        "deleted": False,
+                        "response": "MCP server not found",
+                    },
+                },
             ]
         }
     }
@@ -2006,6 +2022,16 @@ class ForbiddenResponse(AbstractErrorResponse):
                         ),
                     },
                 },
+                {
+                    "label": "mcp server static",
+                    "detail": {
+                        "response": "Cannot delete statically configured MCP server",
+                        "cause": (
+                            "MCP server 'my-mcp' is defined in configuration "
+                            "and cannot be removed via the API."
+                        ),
+                    },
+                },
             ]
         }
     }
@@ -2035,6 +2061,27 @@ class ForbiddenResponse(AbstractErrorResponse):
             f"{action} conversation with ID {resource_id}"
         )
         return cls(response=response, cause=cause)
+
+    @classmethod
+    def mcp_server_static_config(cls, server_name: str) -> "ForbiddenResponse":
+        """
+        Return 403 when the client tries to delete an MCP server that exists only in static config.
+
+        Parameters:
+        ----------
+            server_name (str): MCP server name from the request path.
+
+        Returns:
+        -------
+            ForbiddenResponse: Standard 403 with a fixed summary and a cause naming the server.
+        """
+        return cls(
+            response="Cannot delete statically configured MCP server",
+            cause=(
+                f"MCP server '{server_name}' is defined in configuration "
+                "and cannot be removed via the API."
+            ),
+        )
 
     @classmethod
     def endpoint(cls, user_id: str) -> "ForbiddenResponse":
@@ -2154,13 +2201,6 @@ class NotFoundResponse(AbstractErrorResponse):
                             "Streaming Request with ID "
                             "123e4567-e89b-12d3-a456-426614174000 does not exist"
                         ),
-                    },
-                },
-                {
-                    "label": "mcp server",
-                    "detail": {
-                        "response": "Mcp Server not found",
-                        "cause": "Mcp Server with ID test-mcp-server does not exist",
                     },
                 },
                 {
@@ -2658,6 +2698,15 @@ class InternalServerErrorResponse(AbstractErrorResponse):
                     },
                 },
                 {
+                    "label": "mcp server registration",
+                    "detail": {
+                        "response": "Failed to register MCP server",
+                        "cause": (
+                            "Could not register the MCP server with the remote service."
+                        ),
+                    },
+                },
+                {
                     "label": "feedback storage",
                     "detail": {
                         "response": "Failed to store feedback",
@@ -2803,6 +2852,22 @@ class InternalServerErrorResponse(AbstractErrorResponse):
         return cls(
             response="Database query failed",
             cause="Failed to query the database",
+        )
+
+    @classmethod
+    def mcp_server_registration_failed(cls) -> "InternalServerErrorResponse":
+        """
+        Return a generic 500 when dynamic MCP registration fails after local persistence.
+
+        Omits backend exception text so clients do not receive internal error details.
+
+        Returns:
+        -------
+            InternalServerErrorResponse: Standard failed-registration payload.
+        """
+        return cls(
+            response="Failed to register MCP server",
+            cause=("Could not register the MCP server with the remote service."),
         )
 
     def __init__(self, *, response: str, cause: str) -> None:

--- a/tests/e2e/features/mcp_servers_api.feature
+++ b/tests/e2e/features/mcp_servers_api.feature
@@ -56,8 +56,7 @@ Feature: MCP Server Management API tests
     {
         "deleted": false,
         "name": "non-existent-server",
-        "response": "MCP server not found",
-        "success": true
+        "response": "MCP server not found"
     }
     """
 
@@ -116,8 +115,7 @@ Feature: MCP Server Management API tests
     {
         "deleted": false,
         "name": "e2e-lifecycle-server",
-        "response": "MCP server not found",
-        "success": true
+        "response": "MCP server not found"
     }
     """
     When I access REST API endpoint "mcp-servers" using HTTP GET method

--- a/tests/e2e/features/mcp_servers_api.feature
+++ b/tests/e2e/features/mcp_servers_api.feature
@@ -48,10 +48,18 @@ Feature: MCP Server Management API tests
     Then The status code of the response is 403
     And The body of the response contains statically configured
 
-  Scenario: Delete non-existent MCP server returns 404
+  Scenario: Delete non-existent MCP server returns 200 with not-found outcome
     When I access REST API endpoint "mcp-servers/non-existent-server" using HTTP DELETE method
-    Then The status code of the response is 404
-    And The body of the response contains Mcp Server not found
+    Then The status code of the response is 200
+    And The body of the response is the following
+    """
+    {
+        "deleted": false,
+        "name": "non-existent-server",
+        "response": "MCP server not found",
+        "success": true
+    }
+    """
 
   Scenario: Register MCP server with missing required fields returns 422
     When I access REST API endpoint "mcp-servers" using HTTP POST method
@@ -100,9 +108,18 @@ Feature: MCP Server Management API tests
     When I access REST API endpoint "mcp-servers/e2e-lifecycle-server" using HTTP DELETE method
     Then The status code of the response is 200
     And The body of the response contains e2e-lifecycle-server
-    And The body of the response contains unregistered successfully
+    And The body of the response contains deleted successfully
     When I access REST API endpoint "mcp-servers/e2e-lifecycle-server" using HTTP DELETE method
-    Then The status code of the response is 404
+    Then The status code of the response is 200
+    And The body of the response is the following
+    """
+    {
+        "deleted": false,
+        "name": "e2e-lifecycle-server",
+        "response": "MCP server not found",
+        "success": true
+    }
+    """
     When I access REST API endpoint "mcp-servers" using HTTP GET method
     Then The status code of the response is 200
     And the body of the response has the following structure

--- a/tests/integration/test_openapi_json.py
+++ b/tests/integration/test_openapi_json.py
@@ -237,7 +237,7 @@ def test_servers_section_present_from_url(spec_from_url: dict[str, Any]) -> None
         (
             "/v1/mcp-servers/{name}",
             "delete",
-            {"200", "401", "403", "404", "500", "503"},
+            {"200", "401", "403", "500", "503"},
         ),
         ("/v1/query", "post", {"200", "401", "403", "404", "422", "429", "500", "503"}),
         (
@@ -341,7 +341,7 @@ def test_paths_and_responses_exist_from_file(
         (
             "/v1/mcp-servers/{name}",
             "delete",
-            {"200", "401", "403", "404", "500", "503"},
+            {"200", "401", "403", "500", "503"},
         ),
         ("/v1/query", "post", {"200", "401", "403", "404", "422", "429", "500", "503"}),
         (

--- a/tests/unit/app/endpoints/test_mcp_servers.py
+++ b/tests/unit/app/endpoints/test_mcp_servers.py
@@ -188,6 +188,36 @@ async def test_register_mcp_server_llama_stack_failure(
 
 
 @pytest.mark.asyncio
+async def test_register_mcp_server_toolgroup_failure_returns_500(
+    mocker: MockerFixture,
+    mock_configuration: Configuration,
+) -> None:
+    """Registration returns generic 500 without leaking toolgroup exception text."""
+    app_config = _make_app_config(mocker, mock_configuration)
+    client = _mock_client(mocker)
+    client.toolgroups.register.side_effect = RuntimeError("upstream secret detail")
+
+    body = MCPServerRegistrationRequest(
+        name="boom-server",
+        url="http://localhost:8888/mcp",
+        provider_id="MCP provider ID",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await mcp_servers.register_mcp_server_handler(
+            request=mocker.Mock(), body=body, auth=MOCK_AUTH
+        )
+    assert exc_info.value.status_code == 500
+    raw_detail = exc_info.value.detail
+    assert isinstance(raw_detail, dict)
+    detail: dict[str, Any] = raw_detail
+    assert detail["response"] == "Failed to register MCP server"
+
+    assert not app_config.is_dynamic_mcp_server("boom-server")
+    assert not any(s.name == "boom-server" for s in app_config.mcp_servers)
+
+
+@pytest.mark.asyncio
 async def test_register_mcp_server_with_all_fields(
     mocker: MockerFixture,
     mock_configuration: Configuration,
@@ -288,7 +318,8 @@ async def test_delete_dynamic_mcp_server_success(
 
     assert isinstance(result, MCPServerDeleteResponse)
     assert result.name == "to-delete"
-    assert "unregistered successfully" in result.message
+    assert result.deleted is True
+    assert result.response == "MCP server deleted successfully"
 
     assert not app_config.is_dynamic_mcp_server("to-delete")
     assert not any(s.name == "to-delete" for s in app_config.mcp_servers)
@@ -317,15 +348,19 @@ async def test_delete_nonexistent_mcp_server(
     mocker: MockerFixture,
     mock_configuration: Configuration,
 ) -> None:
-    """Test that deleting a non-existent server returns 404."""
+    """Deleting an unknown name returns 200 with deleted=False (idempotent delete)."""
     _make_app_config(mocker, mock_configuration)
-    _mock_client(mocker)
+    client = _mock_client(mocker)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await mcp_servers.delete_mcp_server_handler(
-            request=mocker.Mock(), name="no-such-server", auth=MOCK_AUTH
-        )
-    assert exc_info.value.status_code == 404
+    result = await mcp_servers.delete_mcp_server_handler(
+        request=mocker.Mock(), name="no-such-server", auth=MOCK_AUTH
+    )
+
+    assert isinstance(result, MCPServerDeleteResponse)
+    assert result.name == "no-such-server"
+    assert result.deleted is False
+    assert result.response == "MCP server not found"
+    client.toolgroups.unregister.assert_called_once_with(toolgroup_id="no-such-server")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/models/responses/test_error_responses.py
+++ b/tests/unit/models/responses/test_error_responses.py
@@ -277,7 +277,7 @@ class TestForbiddenResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 7
+        assert expected_count == 8
 
         # Verify all labeled examples are present
         assert "conversation read" in examples
@@ -287,6 +287,7 @@ class TestForbiddenResponse:
         assert "prompt manage" in examples
         assert "feedback" in examples
         assert "model override" in examples
+        assert "mcp server static" in examples
 
         # Verify example structure for one example
         feedback_example = examples["feedback"]
@@ -517,7 +518,7 @@ class TestNotFoundResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 9
+        assert expected_count == 8
 
         # Verify all labeled examples are present
         assert "conversation" in examples
@@ -525,7 +526,6 @@ class TestNotFoundResponse:
         assert "model" in examples
         assert "rag" in examples
         assert "streaming request" in examples
-        assert "mcp server" in examples
         assert "vector store" in examples
         assert "file" in examples
         assert "prompt" in examples
@@ -622,6 +622,17 @@ class TestInternalServerErrorResponse:
         assert response.detail.response == "Database query failed"
         assert response.detail.cause == "Failed to query the database"
 
+    def test_factory_mcp_server_registration_failed(self) -> None:
+        """Test InternalServerErrorResponse.mcp_server_registration_failed() factory."""
+        response = InternalServerErrorResponse.mcp_server_registration_failed()
+        assert isinstance(response, AbstractErrorResponse)
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert isinstance(response.detail, DetailModel)
+        assert response.detail.response == "Failed to register MCP server"
+        assert response.detail.cause == (
+            "Could not register the MCP server with the remote service."
+        )
+
     def test_openapi_response(self) -> None:
         """Test InternalServerErrorResponse.openapi_response() method."""
         schema = InternalServerErrorResponse.model_json_schema()
@@ -636,11 +647,12 @@ class TestInternalServerErrorResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 9
+        assert expected_count == 10
 
         # Verify all labeled examples are present
         assert "internal" in examples
         assert "configuration" in examples
+        assert "mcp server registration" in examples
         assert "feedback storage" in examples
         assert "query" in examples
         assert "conversation cache" in examples

--- a/tests/unit/models/responses/test_error_responses.py
+++ b/tests/unit/models/responses/test_error_responses.py
@@ -518,7 +518,7 @@ class TestNotFoundResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 8
+        assert expected_count == 9
 
         # Verify all labeled examples are present
         assert "conversation" in examples
@@ -529,6 +529,7 @@ class TestNotFoundResponse:
         assert "vector store" in examples
         assert "file" in examples
         assert "prompt" in examples
+        assert "mcp server" in examples
 
         # Verify example structure for one example
         conversation_example = examples["conversation"]

--- a/tests/unit/models/responses/test_error_responses.py
+++ b/tests/unit/models/responses/test_error_responses.py
@@ -275,7 +275,7 @@ class TestForbiddenResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 7
+        assert expected_count == 8
 
         # Verify all labeled examples are present
         assert "conversation read" in examples
@@ -285,6 +285,7 @@ class TestForbiddenResponse:
         assert "prompt manage" in examples
         assert "feedback" in examples
         assert "model override" in examples
+        assert "mcp server static" in examples
 
         # Verify example structure for one example
         feedback_example = examples["feedback"]
@@ -515,7 +516,7 @@ class TestNotFoundResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 9
+        assert expected_count == 8
 
         # Verify all labeled examples are present
         assert "conversation" in examples
@@ -523,7 +524,6 @@ class TestNotFoundResponse:
         assert "model" in examples
         assert "rag" in examples
         assert "streaming request" in examples
-        assert "mcp server" in examples
         assert "vector store" in examples
         assert "file" in examples
         assert "prompt" in examples
@@ -620,6 +620,17 @@ class TestInternalServerErrorResponse:
         assert response.detail.response == "Database query failed"
         assert response.detail.cause == "Failed to query the database"
 
+    def test_factory_mcp_server_registration_failed(self) -> None:
+        """Test InternalServerErrorResponse.mcp_server_registration_failed() factory."""
+        response = InternalServerErrorResponse.mcp_server_registration_failed()
+        assert isinstance(response, AbstractErrorResponse)
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert isinstance(response.detail, DetailModel)
+        assert response.detail.response == "Failed to register MCP server"
+        assert response.detail.cause == (
+            "Could not register the MCP server with the remote service."
+        )
+
     def test_openapi_response(self) -> None:
         """Test InternalServerErrorResponse.openapi_response() method."""
         schema = InternalServerErrorResponse.model_json_schema()
@@ -634,11 +645,12 @@ class TestInternalServerErrorResponse:
 
         # Verify example count matches schema examples count
         assert len(examples) == expected_count
-        assert expected_count == 9
+        assert expected_count == 10
 
         # Verify all labeled examples are present
         assert "internal" in examples
         assert "configuration" in examples
+        assert "mcp server registration" in examples
         assert "feedback storage" in examples
         assert "query" in examples
         assert "conversation cache" in examples


### PR DESCRIPTION
## Description

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # [LCORE-2034](https://redhat.atlassian.net/browse/LCORE-2034)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * MCP server delete endpoint now returns HTTP 200 with structured response (`deleted` boolean and `response` message) instead of HTTP 404 for non-existent servers.
  * Statically configured MCP servers cannot be deleted and return HTTP 403.
  * Improved error details for MCP server registration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->