### PR TITLE
RSPEED-2943: refactor endpoint path strings into centralized constants

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -22,6 +22,7 @@ from authorization.azure_token_manager import AzureEntraIDManager
 from authorization.middleware import authorize
 from client import AsyncLlamaStackClientHolder
 from configuration import configuration
+from constants import ENDPOINT_PATH_QUERY
 from log import get_logger
 from models.common.responses.responses_api_params import ResponsesApiParams
 from models.config import Action
@@ -170,7 +171,7 @@ async def query_endpoint_handler(
 
     # Moderation input is the raw user content (query + attachments) without injected RAG
     # context, to avoid false positives from retrieved document content.
-    endpoint_path = "/v1/query"
+    endpoint_path = ENDPOINT_PATH_QUERY
     moderation_input = prepare_input(query_request)
     moderation_result = await run_shield_moderation(
         client, moderation_input, endpoint_path, query_request.shield_ids

--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -36,7 +36,7 @@ from authorization.azure_token_manager import AzureEntraIDManager
 from authorization.middleware import authorize
 from client import AsyncLlamaStackClientHolder
 from configuration import configuration
-from constants import SUBSTITUTED_INSTRUCTIONS_PLACEHOLDER
+from constants import ENDPOINT_PATH_RESPONSES, SUBSTITUTED_INSTRUCTIONS_PLACEHOLDER
 from log import get_logger
 from models.common.responses.responses_api_params import ResponsesApiParams
 from models.common.responses.responses_context import ResponsesContext
@@ -329,7 +329,7 @@ async def responses_endpoint_handler(
     )
     attachments_text = extract_attachments_text(original_request.input)
 
-    endpoint_path = "/v1/responses"
+    endpoint_path = ENDPOINT_PATH_RESPONSES
     moderation_result = await run_shield_moderation(
         client,
         input_text + "\n\n" + attachments_text,

--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -22,6 +22,7 @@ from authentication.interface import AuthTuple
 from authorization.middleware import authorize
 from client import AsyncLlamaStackClientHolder
 from configuration import configuration
+from constants import ENDPOINT_PATH_INFER
 from log import get_logger
 from metrics import recording
 from models.config import Action
@@ -241,7 +242,7 @@ async def retrieve_simple_response(
     instructions: str,
     tools: Optional[list[Any]] = None,
     model_id: Optional[str] = None,
-    endpoint_path: str = "/v1/infer",
+    endpoint_path: str = ENDPOINT_PATH_INFER,
 ) -> str:
     """Retrieve a simple response from the LLM for a stateless query.
 
@@ -678,7 +679,7 @@ async def infer_endpoint(  # pylint: disable=R0914
     if quota_id is not None:
         check_tokens_available(configuration.quota_limiters, quota_id)
 
-    endpoint_path = "/v1/infer"
+    endpoint_path = ENDPOINT_PATH_INFER
 
     request_id = get_suid()
 

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -47,6 +47,7 @@ from authorization.middleware import authorize
 from client import AsyncLlamaStackClientHolder
 from configuration import configuration
 from constants import (
+    ENDPOINT_PATH_STREAMING_QUERY,
     INTERRUPTED_RESPONSE_MESSAGE,
     LLM_TOKEN_EVENT,
     LLM_TOOL_CALL_EVENT,
@@ -227,7 +228,7 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
     # Moderation input is the raw user content (query + attachments) without injected RAG
     # context, to avoid false positives from retrieved document content.
     moderation_input = prepare_input(query_request)
-    endpoint_path = "/v1/streaming_query"
+    endpoint_path = ENDPOINT_PATH_STREAMING_QUERY
     moderation_result = await run_shield_moderation(
         client, moderation_input, endpoint_path, query_request.shield_ids
     )

--- a/src/constants.py
+++ b/src/constants.py
@@ -244,6 +244,13 @@ DEFAULT_VIOLATION_MESSAGE: Final[str] = (
 # system prompt for the client's instructions.  Avoids leaking the actual
 # server prompt back to the client.
 SUBSTITUTED_INSTRUCTIONS_PLACEHOLDER: Final[str] = "<server prompt applied>"
+
+# API endpoint path constants used for metric labeling across endpoint handlers.
+ENDPOINT_PATH_INFER: Final[str] = "/v1/infer"
+ENDPOINT_PATH_QUERY: Final[str] = "/v1/query"
+ENDPOINT_PATH_STREAMING_QUERY: Final[str] = "/v1/streaming_query"
+ENDPOINT_PATH_RESPONSES: Final[str] = "/v1/responses"
+
 # Input size limits for API request validation
 # Maximum character length for the question field in /v1/infer requests (32 KiB)
 RLSAPI_V1_QUESTION_MAX_LENGTH: Final[int] = 32_768


### PR DESCRIPTION
## Description

Move hardcoded `endpoint_path` string literals from individual endpoint handlers into shared `Final[str]` constants in `constants.py`. This makes metric labeling paths consistent and easier to maintain across the infer, query, streaming_query, and responses endpoints.

## Type of change

- [x] Refactor

## Tools used to create PR

- Assisted-by: Claude (Sisyphus agent via OpenCode)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [RSPEED-2943](https://issues.redhat.com/browse/RSPEED-2943)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- Ran `uv run make verify` (pylint, pyright, ruff, mypy, black, pydocstyle) - all clean.
- Ran `uv run make test-unit` - 77 tests passing.
- No behavioral changes, purely mechanical string extraction to constants.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Consolidated endpoint path definitions into centralized constants for consistent usage across all endpoint handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->