### PR TITLE
LCORE-1880: Refactor of responses models dumping

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13569,6 +13569,105 @@
                     }
                 ]
             },
+            "InputToolMCP": {
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "const": "mcp",
+                        "title": "Type",
+                        "default": "mcp"
+                    },
+                    "server_label": {
+                        "type": "string",
+                        "title": "Server Label"
+                    },
+                    "connector_id": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Connector Id"
+                    },
+                    "server_url": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Server Url"
+                    },
+                    "headers": {
+                        "anyOf": [
+                            {
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Headers"
+                    },
+                    "authorization": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Authorization"
+                    },
+                    "require_approval": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "const": "always"
+                            },
+                            {
+                                "type": "string",
+                                "const": "never"
+                            },
+                            {
+                                "$ref": "#/components/schemas/ApprovalFilter-Input"
+                            }
+                        ],
+                        "title": "Require Approval",
+                        "default": "never"
+                    },
+                    "allowed_tools": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "type": "string"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AllowedToolsFilter"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Allowed Tools"
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "server_label"
+                ],
+                "title": "InputToolMCP",
+                "description": "MCP input tool with authorization included when serializing request bodies."
+            },
             "InternalServerErrorResponse": {
                 "properties": {
                     "status_code": {
@@ -15280,105 +15379,6 @@
                 ],
                 "title": "OpenAIResponseInputToolFunction",
                 "description": "Function tool configuration for OpenAI response inputs.\n\n:param type: Tool type identifier, always \"function\"\n:param name: Name of the function that can be called\n:param description: (Optional) Description of what the function does\n:param parameters: (Optional) JSON schema defining the function's parameters\n:param strict: (Optional) Whether to enforce strict parameter validation"
-            },
-            "OpenAIResponseInputToolMCP": {
-                "properties": {
-                    "type": {
-                        "type": "string",
-                        "const": "mcp",
-                        "title": "Type",
-                        "default": "mcp"
-                    },
-                    "server_label": {
-                        "type": "string",
-                        "title": "Server Label"
-                    },
-                    "connector_id": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Connector Id"
-                    },
-                    "server_url": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Server Url"
-                    },
-                    "headers": {
-                        "anyOf": [
-                            {
-                                "additionalProperties": true,
-                                "type": "object"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Headers"
-                    },
-                    "authorization": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Authorization"
-                    },
-                    "require_approval": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "const": "always"
-                            },
-                            {
-                                "type": "string",
-                                "const": "never"
-                            },
-                            {
-                                "$ref": "#/components/schemas/ApprovalFilter-Input"
-                            }
-                        ],
-                        "title": "Require Approval",
-                        "default": "never"
-                    },
-                    "allowed_tools": {
-                        "anyOf": [
-                            {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            {
-                                "$ref": "#/components/schemas/AllowedToolsFilter"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Allowed Tools"
-                    }
-                },
-                "type": "object",
-                "required": [
-                    "server_label"
-                ],
-                "title": "OpenAIResponseInputToolMCP",
-                "description": "Model Context Protocol (MCP) tool configuration for OpenAI response inputs.\n\n:param type: Tool type identifier, always \"mcp\"\n:param server_label: Label to identify this MCP server\n:param connector_id: (Optional) ID of the connector to use for this MCP server\n:param server_url: (Optional) URL endpoint of the MCP server\n:param headers: (Optional) HTTP headers to include when connecting to the server\n:param authorization: (Optional) OAuth access token for authenticating with the MCP server\n:param require_approval: Approval requirement for tool calls (\"always\", \"never\", or filter)\n:param allowed_tools: (Optional) Restriction on which tools can be used from this server"
             },
             "OpenAIResponseInputToolWebSearch": {
                 "properties": {
@@ -18167,7 +18167,7 @@
                                             "$ref": "#/components/schemas/OpenAIResponseInputToolFunction"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/OpenAIResponseInputToolMCP"
+                                            "$ref": "#/components/schemas/InputToolMCP"
                                         }
                                     ],
                                     "discriminator": {
@@ -18175,7 +18175,7 @@
                                         "mapping": {
                                             "file_search": "#/components/schemas/OpenAIResponseInputToolFileSearch",
                                             "function": "#/components/schemas/OpenAIResponseInputToolFunction",
-                                            "mcp": "#/components/schemas/OpenAIResponseInputToolMCP",
+                                            "mcp": "#/components/schemas/InputToolMCP",
                                             "web_search": "#/components/schemas/OpenAIResponseInputToolWebSearch",
                                             "web_search_2025_08_26": "#/components/schemas/OpenAIResponseInputToolWebSearch",
                                             "web_search_preview": "#/components/schemas/OpenAIResponseInputToolWebSearch",

--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -455,12 +455,7 @@ async def responses_endpoint_handler(
             original_request.input, inline_rag_context.context_text
         )
 
-    api_params = ResponsesApiParams.model_validate(
-        {
-            **updated_request.model_dump(exclude={"tools"}),
-            "tools": updated_request.tools,
-        }
-    )
+    api_params = ResponsesApiParams.model_validate(updated_request.model_dump())
     context = ResponsesContext(
         client=client,
         auth=auth,

--- a/src/models/api/requests/responses_openai.py
+++ b/src/models/api/requests/responses_openai.py
@@ -4,9 +4,6 @@ import json
 from typing import Any, Optional, Self
 
 from llama_stack_api.openai_responses import (
-    OpenAIResponseInputTool as InputTool,
-)
-from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolChoice as ToolChoice,
 )
 from llama_stack_api.openai_responses import (
@@ -22,7 +19,7 @@ from pydantic import BaseModel, field_validator, model_validator
 
 from constants import RESPONSES_REQUEST_MAX_SIZE
 from models.common.query import SolrVectorSearchRequest
-from models.common.responses.types import IncludeParameter, ResponseInput
+from models.common.responses.types import IncludeParameter, InputTool, ResponseInput
 from utils import suid
 
 

--- a/src/models/common/responses/__init__.py
+++ b/src/models/common/responses/__init__.py
@@ -7,6 +7,8 @@ from models.common.responses.responses_conversation_context import (
 )
 from models.common.responses.types import (
     IncludeParameter,
+    InputTool,
+    InputToolMCP,
     ResponseInput,
     ResponseItem,
 )
@@ -15,6 +17,8 @@ __all__ = [
     "ResponseInput",
     "ResponseItem",
     "IncludeParameter",
+    "InputTool",
+    "InputToolMCP",
     "ResponsesApiParams",
     "ResponsesContext",
     "ResponsesConversationContext",

--- a/src/models/common/responses/responses_api_params.py
+++ b/src/models/common/responses/responses_api_params.py
@@ -4,9 +4,6 @@ from collections.abc import Mapping
 from typing import Any, Final, Optional
 
 from llama_stack_api.openai_responses import (
-    OpenAIResponseInputTool as InputTool,
-)
-from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolChoice as ToolChoice,
 )
 from llama_stack_api.openai_responses import (
@@ -23,7 +20,7 @@ from llama_stack_api.openai_responses import (
 )
 from pydantic import BaseModel, Field
 
-from models.common.responses.types import IncludeParameter, ResponseInput
+from models.common.responses.types import IncludeParameter, InputTool, ResponseInput
 from utils.tool_formatter import translate_vector_store_ids_to_user_facing
 
 # Attribute names that are echoed back in the response.
@@ -126,28 +123,16 @@ class ResponsesApiParams(BaseModel):
     )
 
     def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Serialize params, re-injecting MCP authorization stripped by exclude=True.
+        """Serialize to a request body dict.
 
-        llama-stack-api marks ``InputToolMCP.authorization`` with
-        ``Field(exclude=True)`` to prevent token leakage in API responses.
-        The base ``model_dump()`` therefore strips the field, but we need it
-        in the request payload so llama-stack server can authenticate with
-        MCP servers.  See LCORE-1414 / GitHub issue #1269.
+        Omits conversation when previous_response_id is set.
+
+        Returns:
+            Serializable dict for the Responses API request body.
         """
         result = super().model_dump(*args, **kwargs)
-        # Only one context option is allowed, previous_response_id has priority
-        # Turn is added to conversation manually if previous_response_id is used
         if self.previous_response_id:
             result.pop("conversation", None)
-        dumped_tools = result.get("tools")
-        if not self.tools or not isinstance(dumped_tools, list):
-            return result
-        if len(dumped_tools) != len(self.tools):
-            return result
-        for tool, dumped_tool in zip(self.tools, dumped_tools):
-            authorization = getattr(tool, "authorization", None)
-            if authorization is not None and isinstance(dumped_tool, dict):
-                dumped_tool["authorization"] = authorization
         return result
 
     def echoed_params(self, rag_id_mapping: Mapping[str, str]) -> dict[str, Any]:

--- a/src/models/common/responses/types.py
+++ b/src/models/common/responses/types.py
@@ -1,9 +1,19 @@
 """Type aliases for OpenAI-compatible Responses API input shapes."""
 
-from typing import Literal
+from typing import Annotated, Literal
 
 from llama_stack_api.openai_responses import (
     OpenAIResponseInputFunctionToolCallOutput as FunctionToolCallOutput,
+)
+from llama_stack_api.openai_responses import (
+    OpenAIResponseInputToolFileSearch as InputToolFileSearch,
+)
+from llama_stack_api.openai_responses import (
+    OpenAIResponseInputToolFunction as InputToolFunction,
+)
+from llama_stack_api.openai_responses import OpenAIResponseInputToolMCP
+from llama_stack_api.openai_responses import (
+    OpenAIResponseInputToolWebSearch as InputToolWebSearch,
 )
 from llama_stack_api.openai_responses import (
     OpenAIResponseMCPApprovalRequest as McpApprovalRequest,
@@ -29,6 +39,19 @@ from llama_stack_api.openai_responses import (
 from llama_stack_api.openai_responses import (
     OpenAIResponseOutputMessageWebSearchToolCall as WebSearchToolCall,
 )
+from pydantic import Field
+
+
+class InputToolMCP(OpenAIResponseInputToolMCP):
+    """MCP input tool with authorization included when serializing request bodies."""
+
+    authorization: str | None = None
+
+
+InputTool = Annotated[
+    InputToolWebSearch | InputToolFileSearch | InputToolFunction | InputToolMCP,
+    Field(discriminator="type"),
+]
 
 type IncludeParameter = Literal[
     "web_search_call.action.sources",

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -21,9 +21,6 @@ from llama_stack_api.openai_responses import (
     OpenAIResponseInputMessageContentText as InputTextPart,
 )
 from llama_stack_api.openai_responses import (
-    OpenAIResponseInputTool as InputTool,
-)
-from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolChoice as ToolChoice,
 )
 from llama_stack_api.openai_responses import (
@@ -34,9 +31,6 @@ from llama_stack_api.openai_responses import (
 )
 from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolFileSearch as InputToolFileSearch,
-)
-from llama_stack_api.openai_responses import (
-    OpenAIResponseInputToolMCP as InputToolMCP,
 )
 from llama_stack_api.openai_responses import (
     OpenAIResponseMCPApprovalRequest as MCPApprovalRequest,
@@ -99,7 +93,12 @@ from models.api.responses.error import (
     ServiceUnavailableResponse,
 )
 from models.common.responses.responses_api_params import ResponsesApiParams
-from models.common.responses.types import ResponseInput, ResponseItem
+from models.common.responses.types import (
+    InputTool,
+    InputToolMCP,
+    ResponseInput,
+    ResponseItem,
+)
 from models.common.turn_summary import (
     RAGChunk,
     ReferencedDocument,

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -13,7 +13,9 @@ from llama_stack_api import OpenAIResponseObject
 from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolChoiceMode as ToolChoiceMode,
 )
-from llama_stack_api.openai_responses import OpenAIResponseMessage
+from llama_stack_api.openai_responses import (
+    OpenAIResponseMessage,
+)
 from llama_stack_client import APIConnectionError, APIStatusError, AsyncLlamaStackClient
 from pytest_mock import MockerFixture
 
@@ -37,6 +39,7 @@ from models.common.responses.responses_context import ResponsesContext
 from models.common.responses.responses_conversation_context import (
     ResponsesConversationContext,
 )
+from models.common.responses.types import InputToolMCP
 from models.common.turn_summary import RAGContext, TurnSummary
 from models.config import Action, ModelContextProtocolServer
 from models.database.conversations import UserConversation
@@ -73,12 +76,7 @@ def build_api_params_and_context(  # pylint: disable=too-many-arguments
     user_agent: Optional[str] = None,
 ) -> tuple[ResponsesApiParams, ResponsesContext]:
     """Build api_params/context for direct helper invocation tests."""
-    api_params = ResponsesApiParams.model_validate(
-        {
-            **updated_request.model_dump(exclude={"tools"}),
-            "tools": updated_request.tools,
-        }
-    )
+    api_params = ResponsesApiParams.model_validate(updated_request.model_dump())
     context = ResponsesContext.model_construct(
         client=client,
         auth=auth,
@@ -94,6 +92,26 @@ def build_api_params_and_context(  # pylint: disable=too-many-arguments
         user_agent=user_agent,
     )
     return api_params, context
+
+
+def test_responses_api_params_preserves_mcp_authorization() -> None:
+    """After model_validate, MCP tool authorization from model_dump is kept on api_params.tools."""
+    token = "secret-token"
+    req = ResponsesRequest(
+        input="x",
+        model=MODEL,
+        conversation=VALID_CONV_ID,
+        tools=[
+            InputToolMCP(
+                server_label="alpha",
+                server_url="http://alpha",
+                require_approval="never",
+                authorization=token,
+            )
+        ],
+    )
+    api = ResponsesApiParams.model_validate(req.model_dump())
+    assert api.tools is not None and api.tools[0].authorization == token
 
 
 def _patch_base(mocker: MockerFixture, config: AppConfig) -> None:

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -13,9 +13,6 @@ from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolChoiceAllowedTools,
 )
 from llama_stack_api.openai_responses import (
-    OpenAIResponseInputTool as InputTool,
-)
-from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolChoiceFileSearch as ToolChoiceFileSearch,
 )
 from llama_stack_api.openai_responses import (
@@ -26,9 +23,6 @@ from llama_stack_api.openai_responses import (
 )
 from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolFunction as InputToolFunction,
-)
-from llama_stack_api.openai_responses import (
-    OpenAIResponseInputToolMCP as InputToolMCP,
 )
 from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolWebSearch as InputToolWebSearch,
@@ -60,6 +54,7 @@ from pytest_mock import MockerFixture
 
 import constants
 from models.api.requests import QueryRequest
+from models.common.responses.types import InputTool, InputToolMCP
 from models.config import ByokRag, ModelContextProtocolServer
 from utils.responses import (
     _build_chunk_attributes,

--- a/tests/unit/utils/test_types.py
+++ b/tests/unit/utils/test_types.py
@@ -2,15 +2,10 @@
 
 import pytest
 from llama_stack_api import URL, ImageContentItem, TextContentItem, _URLOrData
-from llama_stack_api.openai_responses import (
-    OpenAIResponseInputToolFileSearch as InputToolFileSearch,
-)
-from llama_stack_api.openai_responses import (
-    OpenAIResponseInputToolMCP as InputToolMCP,
-)
 from pydantic import AnyUrl, ValidationError
 
 from models.common.responses.responses_api_params import ResponsesApiParams
+from models.common.responses.types import InputToolFileSearch, InputToolMCP
 from models.common.turn_summary import (
     ReferencedDocument,
     ToolCallSummary,
@@ -148,11 +143,10 @@ class TestReferencedDocument:
 
 
 class TestResponsesApiParamsModelDump:
-    """Tests for ResponsesApiParams.model_dump() MCP authorization fix.
+    """Tests for ResponsesApiParams.model_dump() MCP authorization serialization.
 
-    Regression tests for LCORE-1414 / GitHub issue #1269: llama-stack-api's
-    InputToolMCP.authorization has Field(exclude=True), causing the base
-    model_dump() to silently strip authorization tokens.
+    Regression tests for LCORE-1414 / GitHub issue #1269: MCP authorization must
+    survive model_dump() when forwarding tools to Llama Stack.
     """
 
     def _make_params(self, tools: list) -> ResponsesApiParams:
@@ -175,7 +169,7 @@ class TestResponsesApiParamsModelDump:
             authorization="my-secret-token",
         )
         assert tool.authorization == "my-secret-token"
-        assert "authorization" not in tool.model_dump()
+        assert tool.model_dump()["authorization"] == "my-secret-token"
 
         params = self._make_params([tool])
         dumped = params.model_dump(exclude_none=True)
@@ -240,8 +234,8 @@ class TestResponsesApiParamsModelDump:
         assert dumped["tools"][0]["authorization"] == "token-a"
         assert dumped["tools"][1]["authorization"] == "token-b"
 
-    def test_exclude_changing_tool_list_shape_skips_reinjection(self) -> None:
-        """Test that exclude removing tool indices does not mis-assign authorization."""
+    def test_partial_tool_dump_reinjects_auth_by_server_label(self) -> None:
+        """When exclude drops some tools, remaining MCP rows still get auth by label."""
         tool_a = InputToolMCP(
             server_label="server-a",
             server_url="http://a:3000",
@@ -258,7 +252,7 @@ class TestResponsesApiParamsModelDump:
         dumped = params.model_dump(exclude={"tools": {0}})
         assert len(dumped["tools"]) == 1
         assert dumped["tools"][0]["server_label"] == "server-b"
-        assert "authorization" not in dumped["tools"][0]
+        assert dumped["tools"][0]["authorization"] == "token-b"
 
     def test_no_tools_does_not_error(self) -> None:
         """Test that model_dump() works when tools is None."""


### PR DESCRIPTION
## Description

Removes temporary workaround for preservation of MCP tool authorization attribute. 
Redefines the InputMCPTool type with overridden authorization attribute.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # [LCORE-1880](https://redhat.atlassian.net/browse/LCORE-1880)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MCP tool authorization to ensure authorization tokens are properly preserved during API request validation and processing.

* **Documentation**
  * Updated OpenAPI schema with new `InputToolMCP` input tool configuration for MCP tools.

* **Tests**
  * Added regression test to verify MCP authorization preservation in validated API parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->