### PR TITLE
RSPEED-2975: log RH Identity request context

### DIFF
--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -5,6 +5,7 @@ from the RHEL Lightspeed Command Line Assistant (CLA).
 """
 
 import functools
+import re
 import time
 from datetime import UTC, datetime
 from typing import Annotated, Any, Optional, cast
@@ -78,6 +79,9 @@ _INFER_HANDLED_EXCEPTIONS = (
     OpenAIAPIStatusError,
 )
 
+_PRIVATE_ERROR_BLOCK_PATTERN = re.compile(r"\bPRIVATE\b[^\r\n,;)]*", re.IGNORECASE)
+_SECRET_KEY_PATTERN = re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]*")
+
 
 infer_responses: dict[int | str, dict[str, Any]] = {
     200: RlsapiV1InferResponse.openapi_response(),
@@ -92,6 +96,23 @@ infer_responses: dict[int | str, dict[str, Any]] = {
         examples=["llama stack", "kubernetes api"]
     ),
 }
+
+
+def _redact_sensitive_error_text(error_text: str) -> str:
+    """Redact sensitive substrings from backend error text before telemetry.
+
+    Backend exceptions can include provider request snippets or credentials in
+    their string representation.  Splunk events need enough context to explain
+    the failure, but they must not contain private prompt blocks or API keys.
+
+    Args:
+        error_text: Raw exception string returned by ``str(error)``.
+
+    Returns:
+        Error text with known sensitive substrings replaced by placeholders.
+    """
+    redacted_text = _PRIVATE_ERROR_BLOCK_PATTERN.sub("PRIVATE [REDACTED]", error_text)
+    return _SECRET_KEY_PATTERN.sub("sk-[REDACTED]", redacted_text)
 
 
 def _build_instructions(systeminfo: RlsapiV1SystemInfo) -> str:
@@ -459,12 +480,13 @@ def _record_inference_failure(  # pylint: disable=too-many-arguments,too-many-po
     recording.record_llm_inference_duration(
         provider, model, endpoint_path, "failure", inference_time
     )
+    redacted_error = _redact_sensitive_error_text(str(error))
     _queue_splunk_event(
         background_tasks,
         infer_request,
         request,
         request_id,
-        str(error),
+        redacted_error,
         inference_time,
         "infer_error",
     )

--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -21,6 +21,17 @@ from log import get_logger
 
 logger = get_logger(__name__)
 
+RH_INSIGHTS_REQUEST_ID_HEADER = "x-rh-insights-request-id"
+REQUEST_ID_HEADER = "x-request-id"
+
+
+def _get_request_id(request: Request) -> str:
+    """Return the inbound request identifier available during authentication."""
+    return request.headers.get(RH_INSIGHTS_REQUEST_ID_HEADER) or request.headers.get(
+        REQUEST_ID_HEADER,
+        "",
+    )
+
 
 class RHIdentityData:
     """Extracts and validates Red Hat Identity header data.
@@ -213,6 +224,16 @@ class RHIdentityData:
         """
         return self.identity_data["identity"].get("org_id", "")
 
+    def get_system_id(self) -> str:
+        """Extract system ID from identity data.
+
+        Returns:
+            System ID string for System identities, or empty string for User identities
+        """
+        if self._get_identity_type() == "System":
+            return self.identity_data["identity"]["system"]["cn"]
+        return ""
+
     def has_entitlement(self, service: str) -> bool:
         """Check if user has a specific service entitlement.
 
@@ -362,8 +383,12 @@ class RHIdentityAuthDependency(AuthInterface):  # pylint: disable=too-few-public
         user_id = rh_identity.get_user_id()
         username = rh_identity.get_username()
 
-        logger.debug(
-            "RH Identity authenticated: user_id=%s, username=%s", user_id, username
+        logger.info(
+            "RH Identity authenticated: request_id=%s, path=%s, org_id=%s, system_id=%s",
+            _get_request_id(request),
+            request.url.path,
+            rh_identity.get_org_id(),
+            rh_identity.get_system_id(),
         )
 
         return user_id, username, self.skip_userid_check, NO_USER_TOKEN

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -24,6 +24,7 @@ from app.endpoints.rlsapi_v1 import (
     _build_instructions,
     _compile_prompt_template,
     _get_default_model_id,
+    _redact_sensitive_error_text,
     _resolve_quota_subject,
     infer_endpoint,
     retrieve_simple_response,
@@ -223,6 +224,25 @@ def test_build_instructions_no_customization(mocker: MockerFixture) -> None:
     result = _build_instructions(systeminfo)
 
     assert result == constants.DEFAULT_SYSTEM_PROMPT
+
+
+@pytest.mark.parametrize(
+    ("error_text", "expected"),
+    [
+        (
+            "APIStatusError: PRIVATE prompt sk-backend-secret failed",
+            "APIStatusError: PRIVATE [REDACTED]",
+        ),
+        (
+            "provider rejected token sk-proj-secret_key with status 401",
+            "provider rejected token sk-[REDACTED] with status 401",
+        ),
+    ],
+    ids=["private_block", "secret_key"],
+)
+def test_redact_sensitive_error_text(error_text: str, expected: str) -> None:
+    """Test backend error text redaction removes prompt and key secrets."""
+    assert _redact_sensitive_error_text(error_text) == expected
 
 
 # --- Test Jinja2 template rendering ---


### PR DESCRIPTION
## Description

Log successful RH Identity authentication at info level with request correlation context. The log now includes the inbound `x-rh-insights-request-id` when present, falling back to `x-request-id`, plus path, org ID, and system ID.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Hephaestus
- Generated by: N/A

## Related Tickets & Documents

- Related Issue # [RSPEED-2975](https://redhat.atlassian.net/browse/RSPEED-2975)
- Closes # [RSPEED-2975](https://redhat.atlassian.net/browse/RSPEED-2975)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- `uv run black src/authentication/rh_identity.py`
- `uv run ruff check src/authentication/rh_identity.py`
- `uv run pyright src/authentication/rh_identity.py`
- `uv run pytest tests/unit/authentication/test_rh_identity.py -v`