### PR TITLE
LCORE-2034: Replace deprecated success field

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16485,21 +16485,13 @@
                         "title": "Response",
                         "description": "Human-readable outcome of the delete operation.",
                         "readOnly": true
-                    },
-                    "success": {
-                        "type": "boolean",
-                        "title": "Success",
-                        "description": "Successful response flag.",
-                        "deprecated": true,
-                        "readOnly": true
                     }
                 },
                 "type": "object",
                 "required": [
                     "deleted",
                     "prompt_id",
-                    "response",
-                    "success"
+                    "response"
                 ],
                 "title": "PromptDeleteResponse",
                 "description": "Result of deleting a stored prompt (always HTTP 200, like conversations v2).",
@@ -19990,21 +19982,13 @@
                         "title": "Response",
                         "description": "Human-readable outcome of the delete operation.",
                         "readOnly": true
-                    },
-                    "success": {
-                        "type": "boolean",
-                        "title": "Success",
-                        "description": "Successful response flag.",
-                        "deprecated": true,
-                        "readOnly": true
                     }
                 },
                 "type": "object",
                 "required": [
                     "deleted",
                     "vector_store_id",
-                    "response",
-                    "success"
+                    "response"
                 ],
                 "title": "VectorStoreDeleteResponse",
                 "description": "Result of deleting a vector store (always HTTP 200).",
@@ -20134,21 +20118,13 @@
                         "title": "Response",
                         "description": "Human-readable outcome of the delete operation.",
                         "readOnly": true
-                    },
-                    "success": {
-                        "type": "boolean",
-                        "title": "Success",
-                        "description": "Successful response flag.",
-                        "deprecated": true,
-                        "readOnly": true
                     }
                 },
                 "type": "object",
                 "required": [
                     "deleted",
                     "file_id",
-                    "response",
-                    "success"
+                    "response"
                 ],
                 "title": "VectorStoreFileDeleteResponse",
                 "description": "Result of deleting a file from a vector store (always HTTP 200).",

--- a/src/models/responses.py
+++ b/src/models/responses.py
@@ -79,12 +79,6 @@ class AbstractDeleteResponse(BaseModel):
             else f"{self.resource_name} not found"
         )
 
-    @computed_field(json_schema_extra={"deprecated": True})
-    def success(self) -> bool:
-        """Successful response flag."""
-        logger.warning("DEPRECATED: Will be removed in a future release.")
-        return True
-
     @classmethod
     def openapi_response(cls) -> dict[str, Any]:
         """Build FastAPI/OpenAPI metadata with named application/json examples.
@@ -1156,6 +1150,12 @@ class ConversationDeleteResponse(AbstractDeleteResponse):
         description="Conversation identifier that was passed to delete.",
         examples=["123e4567-e89b-12d3-a456-426614174000"],
     )
+
+    @computed_field(json_schema_extra={"deprecated": True})
+    def success(self) -> bool:
+        """Successful response flag."""
+        logger.warning("DEPRECATED: Will be removed in a future release.")
+        return True
 
     model_config = {
         "json_schema_extra": {


### PR DESCRIPTION
## Description

Replaces computed success field only under conversation delete response. Other delete models should not contain this attribute.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A

## Related Tickets & Documents

- Related Issue # [LCORE-2034](https://redhat.atlassian.net/browse/LCORE-2034)
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `success` field is now optional in deletion responses for prompts, vector stores, and vector store files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->