### PR TITLE
LCORE-1983: Added e2e scenario for OpenTelemetry

### DIFF
--- a/tests/e2e/features/opentelemetry.feature
+++ b/tests/e2e/features/opentelemetry.feature
@@ -1,0 +1,29 @@
+@e2e_group_1 @OTel @skip
+Feature: OpenTelemetry observability tests
+
+  Background:
+    Given The service is started locally
+      And The system is in default state
+      And An OpenTelemetry service is running and listening for OTLP data
+      And The service is configured to export data to the OpenTelemetry service
+      And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+      And REST API service prefix is /v1
+      And the Lightspeed stack configuration directory is "tests/e2e/configuration"
+      And The service uses the lightspeed-stack-auth-noop-token.yaml configuration
+      And The service is restarted
+
+
+  Scenario: Successful responses request processing is visible in delivered telemetry
+    Given The system is in default state
+    When I use "responses" to ask question with authorization header
+      """
+      {
+        "input": "Say hello in one short sentence.",
+        "model": "{PROVIDER}/{MODEL}",
+        "stream": false,
+        "safety_identifier": "e2e-otel-delivery-marker"
+      }
+      """
+    Then The status code of the response is 200
+     And The service exported an OpenTelemetry event containing e2e-otel-delivery-marker
+     And The OpenTelemetry service received data containing e2e-otel-delivery-marker

--- a/tests/e2e/test_list.txt
+++ b/tests/e2e/test_list.txt
@@ -26,3 +26,4 @@ features/mcp_servers_api_auth.feature
 features/mcp_servers_api_no_config.feature
 features/proxy.feature
 features/tls.feature
+features/opentelemetry.feature


### PR DESCRIPTION
## Description

Adds an e2e test scenario for OpenTelemetry. The scenario tests whether Otel events are exported and successfully received by configured Otel service. The remaining functionality will be tested by integration tests.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-1983](https://redhat.atlassian.net/browse/LCORE-1983)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end Gherkin test validating OpenTelemetry observability: it exercises an authorized responses request, verifies HTTP 200, and confirms the OpenTelemetry pipeline exports and receives a delivery marker while ensuring the service is started and configured for OTLP. The new feature is included in the E2E test list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->