### PR TITLE
LCORE-2120: Refactoring - use AuthTuple where appropriate

### DIFF
--- a/src/authentication/api_key_token.py
+++ b/src/authentication/api_key_token.py
@@ -10,7 +10,7 @@ import secrets
 
 from fastapi import HTTPException, Request, status
 
-from authentication.interface import AuthInterface
+from authentication.interface import AuthInterface, AuthTuple
 from authentication.utils import extract_user_token
 from constants import (
     DEFAULT_USER_NAME,
@@ -45,7 +45,7 @@ class APIKeyTokenAuthDependency(
         self.config: APIKeyTokenConfiguration = config
         self.skip_userid_check = True
 
-    async def __call__(self, request: Request) -> tuple[str, str, bool, str]:
+    async def __call__(self, request: Request) -> AuthTuple:
         """Validate FastAPI Requests for authentication and authorization.
 
         Args:

--- a/src/authentication/k8s.py
+++ b/src/authentication/k8s.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, Request
 from kubernetes.client.rest import ApiException
 from kubernetes.config import ConfigException
 
-from authentication.interface import NO_AUTH_TUPLE, AuthInterface
+from authentication.interface import NO_AUTH_TUPLE, AuthInterface, AuthTuple
 from authentication.utils import extract_user_token
 from configuration import configuration
 from constants import DEFAULT_VIRTUAL_PATH
@@ -418,7 +418,7 @@ class K8SAuthDependency(AuthInterface):  # pylint: disable=too-few-public-method
         self.virtual_path = virtual_path
         self.skip_userid_check = False
 
-    async def __call__(self, request: Request) -> tuple[str, str, bool, str]:
+    async def __call__(self, request: Request) -> AuthTuple:
         """Validate FastAPI Requests for authentication and authorization.
 
         Parameters:

--- a/src/authentication/noop.py
+++ b/src/authentication/noop.py
@@ -2,7 +2,7 @@
 
 from fastapi import HTTPException, Request
 
-from authentication.interface import AuthInterface
+from authentication.interface import AuthInterface, AuthTuple
 from constants import (
     DEFAULT_USER_NAME,
     DEFAULT_USER_UID,
@@ -31,7 +31,7 @@ class NoopAuthDependency(AuthInterface):  # pylint: disable=too-few-public-metho
         self.virtual_path = virtual_path
         self.skip_userid_check = True
 
-    async def __call__(self, request: Request) -> tuple[str, str, bool, str]:
+    async def __call__(self, request: Request) -> AuthTuple:
         """Validate FastAPI Requests for authentication and authorization.
 
         Parameters:
@@ -40,7 +40,7 @@ class NoopAuthDependency(AuthInterface):  # pylint: disable=too-few-public-metho
 
         Returns:
         -------
-            tuple[str, str, bool, str]: A 4-tuple containing:
+            AuthTuple: A 4-tuple containing:
                 - user_id: the value of the "user_id" query parameter if
                            present, otherwise DEFAULT_USER_UID.
                 - username: DEFAULT_USER_NAME.

--- a/src/authentication/noop_with_token.py
+++ b/src/authentication/noop_with_token.py
@@ -11,7 +11,7 @@ Behavior:
 
 from fastapi import HTTPException, Request
 
-from authentication.interface import AuthInterface
+from authentication.interface import AuthInterface, AuthTuple
 from authentication.utils import extract_user_token
 from constants import (
     DEFAULT_USER_NAME,
@@ -43,7 +43,7 @@ class NoopWithTokenAuthDependency(
         self.virtual_path = virtual_path
         self.skip_userid_check = True
 
-    async def __call__(self, request: Request) -> tuple[str, str, bool, str]:
+    async def __call__(self, request: Request) -> AuthTuple:
         """Validate FastAPI Requests for authentication and authorization.
 
         Parameters:
@@ -52,7 +52,7 @@ class NoopWithTokenAuthDependency(
 
         Returns:
         -------
-            tuple[str, str, bool, str]: A 4-tuple containing:
+            AuthTuple: A 4-tuple containing:
                 - user_id: The value of the "user_id" query parameter or
                            DEFAULT_USER_UID if absent.
                 - username: DEFAULT_USER_NAME.

--- a/src/models/common/responses/responses_context.py
+++ b/src/models/common/responses/responses_context.py
@@ -11,6 +11,7 @@ from models.common.moderation import ShieldModerationResult
 from models.common.turn_summary import RAGContext
 
 
+# TODO: LCORE-2121: Use AuthTuple everywhere (type refactoring needed) pylint: disable=W0511
 class ResponsesContext(BaseModel):
     """Shared request-scoped context for the /responses endpoint pipeline."""
 

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -24,6 +24,7 @@ from app.endpoints.responses import (
     handle_streaming_response,
     responses_endpoint_handler,
 )
+from authentication.interface import AuthTuple
 from configuration import AppConfig
 from constants import DEFAULT_SYSTEM_PROMPT, SUBSTITUTED_INSTRUCTIONS_PLACEHOLDER
 from models.api.responses.successful import ResponsesResponse
@@ -57,7 +58,7 @@ def build_api_params_and_context(  # pylint: disable=too-many-arguments
     *,
     updated_request: ResponsesRequest,
     client: Any,
-    auth: tuple[str, str, bool, str],
+    auth: AuthTuple,
     input_text: str,
     started_at: datetime,
     moderation_result: Any,


### PR DESCRIPTION
## Description

LCORE-2120: Refactoring - use `AuthTuple` where appropriate

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2120


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal type annotations across authentication modules for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->