### PR TITLE
RSPEED-3017: use custom buckets for response duration histogram

### DIFF
--- a/src/metrics/__init__.py
+++ b/src/metrics/__init__.py
@@ -32,7 +32,10 @@ rest_api_calls_total = Counter(
 # Histogram to measure response durations
 # This will be used to track how long it takes to handle requests
 response_duration_seconds = Histogram(
-    "ls_response_duration_seconds", "Response durations", ["path"]
+    "ls_response_duration_seconds",
+    "Response durations",
+    ["path"],
+    buckets=LLM_INFERENCE_DURATION_BUCKETS,
 )
 
 # Metric that indicates what provider + model customers are using so we can


### PR DESCRIPTION
## Description

Add custom bucket boundaries to the `response_duration_seconds` Prometheus histogram. The default `prometheus_client` buckets max out at 10s, which caps Grafana `histogram_quantile` calculations for requests that take longer. This reuses the existing `LLM_INFERENCE_DURATION_BUCKETS` tuple (0.1-120s) already used by `llm_inference_duration_seconds`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude (opencode)
- Generated by: N/A

## Related Tickets & Documents

- [RSPEED-3017](https://redhat.atlassian.net/browse/RSPEED-3017)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- All 16 existing metrics unit tests pass (`uv run make test-unit`).
- Verified `response_duration_seconds` histogram now uses the custom buckets (0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0, 30.0, 60.0, 120.0, +Inf) matching the `llm_inference_duration_seconds` histogram.
- `uv run make verify` passes cleanly.