### PR TITLE
LCORE-1569 LCORE-1570: token estimation + compaction core modules

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11898,6 +11898,46 @@
                 "title": "ClientCredentialsOAuthFlow",
                 "description": "Defines configuration details for the OAuth 2.0 Client Credentials flow."
             },
+            "CompactionConfiguration": {
+                "properties": {
+                    "enabled": {
+                        "type": "boolean",
+                        "title": "Enable compaction",
+                        "description": "When true, older conversation turns are summarized when estimated tokens approach the context window limit.",
+                        "default": false
+                    },
+                    "threshold_ratio": {
+                        "type": "number",
+                        "title": "Threshold ratio",
+                        "description": "Trigger compaction when estimated tokens exceed this fraction of the model's context window (0.0-1.0).",
+                        "default": 0.7
+                    },
+                    "token_floor": {
+                        "type": "integer",
+                        "minimum": 0.0,
+                        "title": "Token floor",
+                        "description": "Minimum token count before compaction can trigger. Prevents triggering on very small context windows.",
+                        "default": 4096
+                    },
+                    "buffer_turns": {
+                        "type": "integer",
+                        "minimum": 0.0,
+                        "title": "Buffer turns",
+                        "description": "Number of recent turns to keep verbatim.",
+                        "default": 4
+                    },
+                    "buffer_max_ratio": {
+                        "type": "number",
+                        "title": "Buffer max ratio",
+                        "description": "Maximum fraction of context window the buffer zone can occupy, regardless of buffer_turns.",
+                        "default": 0.3
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "CompactionConfiguration",
+                "description": "Configuration for conversation history compaction.\n\nCompaction summarizes older conversation turns when their estimated\ntoken count approaches the context window limit, keeping the\nconversation usable instead of failing with HTTP 413. The\nconfiguration here controls when compaction triggers and how much\nrecent context is preserved verbatim.\n\nAttributes:\n    enabled: Master switch. When False, compaction never triggers\n        and other fields are inert.\n    threshold_ratio: Trigger compaction when estimated input tokens\n        exceed this fraction of the model's context window\n        (clamped to 0.0..1.0).\n    token_floor: Minimum estimated token count before compaction\n        can trigger, regardless of threshold_ratio. Prevents\n        triggering on very small context windows.\n    buffer_turns: Initial number of recent turns to keep verbatim.\n        The runtime applies a degrading guard \u2014 if these turns\n        exceed the available budget, it reduces buffer_turns by\n        one repeatedly until the budget fits, down to zero.\n    buffer_max_ratio: Hard cap on the fraction of the context\n        window the buffer zone may occupy, regardless of\n        buffer_turns."
+            },
             "Configuration": {
                 "properties": {
                     "name": {
@@ -11970,6 +12010,11 @@
                     "conversation_cache": {
                         "$ref": "#/components/schemas/ConversationHistoryConfiguration",
                         "title": "Conversation history configuration"
+                    },
+                    "compaction": {
+                        "$ref": "#/components/schemas/CompactionConfiguration",
+                        "title": "Conversation compaction configuration",
+                        "description": "Controls when conversation history is summarized to keep the model's input below the context window limit. Disabled by default \u2014 when disabled, requests that exceed the window continue to surface as HTTP 413."
                     },
                     "byok_rag": {
                         "items": {
@@ -13391,6 +13436,15 @@
                         ],
                         "title": "Default provider",
                         "description": "Identification of default provider used when no other model is specified."
+                    },
+                    "context_windows": {
+                        "additionalProperties": {
+                            "type": "integer",
+                            "exclusiveMinimum": 0.0
+                        },
+                        "type": "object",
+                        "title": "Per-model context window sizes (tokens)",
+                        "description": "Map of fully-qualified model identifier (e.g., \"openai/gpt-4o-mini\") to context window size in tokens. Used by the conversation compaction trigger to decide when older turns must be summarized before the input exceeds the window. Models absent from this map have no registered window \u2014 callers fall back to their own default or skip the token-based trigger."
                     }
                 },
                 "additionalProperties": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ dependencies = [
     # Used for error tracking and monitoring
     "sentry-sdk[fastapi]>=2.58.0",
     "python-dotenv>=1.2.2",
+    # Used for token estimation before LLM calls (LCORE-1569 / conversation compaction)
+    "tiktoken>=0.8.0",
 ]
 
 

--- a/src/models/compaction.py
+++ b/src/models/compaction.py
@@ -1,0 +1,70 @@
+"""Pydantic models for conversation compaction.
+
+Defines ``ConversationSummary`` — one chunk produced each time
+compaction triggers. The compaction module (``src/utils/compaction.py``)
+creates instances of this model from raw Llama Stack conversation
+items; the conversation cache (LCORE-1571) is responsible for
+persisting them.
+
+Each compaction run produces exactly one ``ConversationSummary``. The
+additive design (decision 2 of the spike) keeps every chunk's summary
+as a separate record — they are only re-summarized into a single
+record by the recursive fallback when the total summary token count
+itself approaches the context window.
+"""
+
+from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt
+
+
+class ConversationSummary(BaseModel):
+    """A single compaction-produced summary chunk.
+
+    Attributes:
+        summary_text: The natural-language summary produced by the
+            summarization LLM call. Used directly as context for
+            subsequent requests (alongside any later summary chunks
+            and the buffer of recent turns kept verbatim).
+        summarized_through_turn: Running total of conversation items
+            consumed by this and all preceding summaries. Used by the
+            caller to advance the partition boundary on the next
+            compaction so the new summary only covers items that
+            have not yet been summarized.
+        token_count: Number of tokens in ``summary_text``. Tracked so
+            the recursive-resummarize fallback can decide when the
+            cumulative summary size itself approaches the context
+            limit without re-tokenizing.
+        created_at: ISO 8601 timestamp recording when this summary was
+            produced. Kept as a string (not datetime) to match the
+            cache schema convention used elsewhere in the codebase.
+        model_used: Fully-qualified model identifier used for the
+            summarization LLM call (e.g., ``"openai/gpt-4o-mini"``).
+            Preserved for audit and for diagnostics when summary
+            quality varies between models.
+    """
+
+    summary_text: str = Field(
+        ...,
+        title="Summary text",
+        description="Natural-language summary produced by the summarization LLM call.",
+    )
+    summarized_through_turn: NonNegativeInt = Field(
+        ...,
+        title="Summarized through turn",
+        description="Running total of conversation items consumed by "
+        "this and all preceding summaries.",
+    )
+    token_count: PositiveInt = Field(
+        ...,
+        title="Token count",
+        description="Number of tokens in summary_text.",
+    )
+    created_at: str = Field(
+        ...,
+        title="Created at",
+        description="ISO 8601 timestamp recording when this summary was produced.",
+    )
+    model_used: str = Field(
+        ...,
+        title="Model used",
+        description="Fully-qualified model identifier used for the summarization call.",
+    )

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1522,9 +1522,7 @@ class CompactionConfiguration(ConfigurationBase):
     def _validate_threshold_ratio(cls, value: float) -> float:
         """Reject threshold ratios outside the inclusive 0..1 range."""
         if not 0.0 <= value <= 1.0:
-            raise ValueError(
-                "threshold_ratio must be between 0.0 and 1.0 (inclusive)"
-            )
+            raise ValueError("threshold_ratio must be between 0.0 and 1.0 (inclusive)")
         return value
 
     @field_validator("buffer_max_ratio")
@@ -1532,9 +1530,7 @@ class CompactionConfiguration(ConfigurationBase):
     def _validate_buffer_max_ratio(cls, value: float) -> float:
         """Reject buffer-max ratios outside the inclusive 0..1 range."""
         if not 0.0 <= value <= 1.0:
-            raise ValueError(
-                "buffer_max_ratio must be between 0.0 and 1.0 (inclusive)"
-            )
+            raise ValueError("buffer_max_ratio must be between 0.0 and 1.0 (inclusive)")
         return value
 
 

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2007,7 +2007,13 @@ class Configuration(ConfigurationBase):
     )
 
     compaction: CompactionConfiguration = Field(
-        default_factory=CompactionConfiguration,
+        default_factory=lambda: CompactionConfiguration(
+            enabled=False,
+            threshold_ratio=0.7,
+            token_floor=4096,
+            buffer_turns=4,
+            buffer_max_ratio=0.3,
+        ),
         title="Conversation compaction configuration",
         description="Controls when conversation history is summarized "
         "to keep the model's input below the context window limit. "

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1460,6 +1460,84 @@ class InferenceConfiguration(ConfigurationBase):
         return self
 
 
+class CompactionConfiguration(ConfigurationBase):
+    """Configuration for conversation history compaction.
+
+    Compaction summarizes older conversation turns when their estimated
+    token count approaches the context window limit, keeping the
+    conversation usable instead of failing with HTTP 413. The
+    configuration here controls when compaction triggers and how much
+    recent context is preserved verbatim.
+
+    Attributes:
+        enabled: Master switch. When False, compaction never triggers
+            and other fields are inert.
+        threshold_ratio: Trigger compaction when estimated input tokens
+            exceed this fraction of the model's context window
+            (clamped to 0.0..1.0).
+        token_floor: Minimum estimated token count before compaction
+            can trigger, regardless of threshold_ratio. Prevents
+            triggering on very small context windows.
+        buffer_turns: Initial number of recent turns to keep verbatim.
+            The runtime applies a degrading guard — if these turns
+            exceed the available budget, it reduces buffer_turns by
+            one repeatedly until the budget fits, down to zero.
+        buffer_max_ratio: Hard cap on the fraction of the context
+            window the buffer zone may occupy, regardless of
+            buffer_turns.
+    """
+
+    enabled: bool = Field(
+        False,
+        title="Enable compaction",
+        description="When true, older conversation turns are summarized "
+        "when estimated tokens approach the context window limit.",
+    )
+    threshold_ratio: float = Field(
+        0.7,
+        title="Threshold ratio",
+        description="Trigger compaction when estimated tokens exceed "
+        "this fraction of the model's context window (0.0-1.0).",
+    )
+    token_floor: NonNegativeInt = Field(
+        4096,
+        title="Token floor",
+        description="Minimum token count before compaction can trigger. "
+        "Prevents triggering on very small context windows.",
+    )
+    buffer_turns: NonNegativeInt = Field(
+        4,
+        title="Buffer turns",
+        description="Number of recent turns to keep verbatim.",
+    )
+    buffer_max_ratio: float = Field(
+        0.3,
+        title="Buffer max ratio",
+        description="Maximum fraction of context window the buffer zone "
+        "can occupy, regardless of buffer_turns.",
+    )
+
+    @field_validator("threshold_ratio")
+    @classmethod
+    def _validate_threshold_ratio(cls, value: float) -> float:
+        """Reject threshold ratios outside the inclusive 0..1 range."""
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                "threshold_ratio must be between 0.0 and 1.0 (inclusive)"
+            )
+        return value
+
+    @field_validator("buffer_max_ratio")
+    @classmethod
+    def _validate_buffer_max_ratio(cls, value: float) -> float:
+        """Reject buffer-max ratios outside the inclusive 0..1 range."""
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                "buffer_max_ratio must be between 0.0 and 1.0 (inclusive)"
+            )
+        return value
+
+
 class ConversationHistoryConfiguration(ConfigurationBase):
     """Conversation history configuration."""
 
@@ -1930,6 +2008,15 @@ class Configuration(ConfigurationBase):
         ),
         title="Conversation history configuration",
         description="Conversation history configuration.",
+    )
+
+    compaction: CompactionConfiguration = Field(
+        default_factory=CompactionConfiguration,
+        title="Conversation compaction configuration",
+        description="Controls when conversation history is summarized "
+        "to keep the model's input below the context window limit. "
+        "Disabled by default — when disabled, requests that exceed the "
+        "window continue to surface as HTTP 413.",
     )
 
     byok_rag: list[ByokRag] = Field(

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1427,6 +1427,17 @@ class InferenceConfiguration(ConfigurationBase):
         description="Identification of default provider used when no other model is specified.",
     )
 
+    context_windows: dict[str, PositiveInt] = Field(
+        default_factory=dict,
+        title="Per-model context window sizes (tokens)",
+        description="Map of fully-qualified model identifier (e.g., "
+        '"openai/gpt-4o-mini") to context window size in tokens. Used by '
+        "the conversation compaction trigger to decide when older turns "
+        "must be summarized before the input exceeds the window. Models "
+        "absent from this map have no registered window — callers fall "
+        "back to their own default or skip the token-based trigger.",
+    )
+
     @model_validator(mode="after")
     def check_default_model_and_provider(self) -> Self:
         """

--- a/src/utils/compaction.py
+++ b/src/utils/compaction.py
@@ -34,7 +34,12 @@ from llama_stack_client import AsyncLlamaStackClient
 
 from log import get_logger
 from models.compaction import ConversationSummary
-from utils.token_estimator import estimate_conversation_tokens, estimate_tokens
+from utils.token_estimator import (
+    estimate_conversation_tokens,
+    estimate_tokens,
+    extract_message_text,
+    is_message_item,
+)
 
 logger = get_logger(__name__)
 
@@ -58,63 +63,6 @@ Includes the five preservation directives required by the spec doc and
 the JIRA acceptance criteria. Exposed as a module constant so tests can
 assert directive presence and so future tuning is visible in one place.
 """
-
-
-def is_message_item(item: Any) -> bool:
-    """Return True when *item* is a chat-message-shaped conversation item.
-
-    Accepts the Llama Stack duck-typed shape (``.type == "message"``)
-    and the OpenAI-style ``{"role", "content"}`` dict.
-
-    Parameters:
-        item: Conversation item to classify.
-
-    Returns:
-        True when the item is a message; False otherwise (function
-        calls, tool results, structured outputs, etc.).
-    """
-    if isinstance(item, dict):
-        return "role" in item
-    return getattr(item, "type", None) == "message"
-
-
-def extract_message_text(item: Any) -> str:
-    """Return the plain text of a chat-message item.
-
-    Accepts both the Llama Stack object shape (``.content`` may be a
-    string, a list of content-part objects with ``.text``, or a list
-    of dicts with ``"text"`` keys) and the OpenAI-style dict shape
-    (``content`` is a string or list of dicts).
-
-    Parameters:
-        item: A chat-message item.
-
-    Returns:
-        The textual content joined by spaces, or the empty string when
-        no text can be extracted.
-    """
-    content: Any
-    if isinstance(item, dict):
-        content = item.get("content")
-    else:
-        content = getattr(item, "content", None)
-
-    if content is None:
-        return ""
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for part in content:
-            text = None
-            if hasattr(part, "text"):
-                text = getattr(part, "text", None)
-            elif isinstance(part, dict) and "text" in part:
-                text = part["text"]
-            if text:
-                parts.append(text)
-        return " ".join(parts)
-    return str(content)
 
 
 def format_conversation_for_summary(items: list[Any]) -> str:
@@ -221,22 +169,6 @@ def partition_conversation(
     return items, []
 
 
-def _build_summarization_prompt_body(items: list[Any]) -> str:
-    """Render the full prompt body sent to the summarization LLM call.
-
-    Concatenates the system-style summarization prompt with a
-    ``role: text``-formatted transcript of the items being summarized.
-
-    Parameters:
-        items: The chunk to summarize.
-
-    Returns:
-        Full prompt body string.
-    """
-    transcript = format_conversation_for_summary(items)
-    return f"{SUMMARIZATION_PROMPT}\nConversation:\n{transcript}"
-
-
 def _extract_response_text(response: Any) -> str:
     """Pull the human-readable text out of a Responses-API result.
 
@@ -322,15 +254,21 @@ async def summarize_chunk(
             cannot be persisted (PositiveInt) and is also useless as
             context, so propagating an error is the honest behavior.
     """
-    prompt = _build_summarization_prompt_body(old_items)
+    transcript = format_conversation_for_summary(old_items)
     logger.info(
         "Summarizing %d conversation items (%d messages) for model %s.",
         len(old_items),
         sum(1 for item in old_items if is_message_item(item)),
         model,
     )
+    # Pass directives via `instructions` (system channel) and the transcript
+    # via `input` (user channel). This matches the codebase convention used
+    # by utils.responses.get_topic_summary and protects the directives from
+    # prompt-injection via user message content that ends up in the
+    # transcript.
     response = await client.responses.create(
-        input=prompt,
+        input=f"Conversation:\n{transcript}",
+        instructions=SUMMARIZATION_PROMPT,
         model=model,
         stream=False,
         store=False,
@@ -429,15 +367,16 @@ async def recursively_resummarize(
         f"{s.summary_text}"
         for i, s in enumerate(summaries)
     )
-    prompt = f"{RECURSIVE_RESUMMARIZATION_PROMPT}\n{transcript}"
 
     logger.info(
         "Recursively re-summarizing %d existing summary chunks for model %s.",
         len(summaries),
         model,
     )
+    # Same instructions/input split as summarize_chunk — see comment there.
     response = await client.responses.create(
-        input=prompt,
+        input=transcript,
+        instructions=RECURSIVE_RESUMMARIZATION_PROMPT,
         model=model,
         stream=False,
         store=False,

--- a/src/utils/compaction.py
+++ b/src/utils/compaction.py
@@ -1,0 +1,196 @@
+"""Conversation compaction — partitioning, summarization, additive fold-up.
+
+Pure-logic core of the conversation-compaction feature. The module
+exposes three units of work:
+
+* ``partition_conversation`` — split an ordered list of conversation
+  items into the older chunk that will be summarized and the buffer of
+  recent turns kept verbatim. Applies the *degrading guard*: it starts
+  with ``buffer_turns`` turn pairs and shrinks the buffer one turn at a
+  time until the buffer fits inside ``available_budget_tokens``. This
+  is decision 9 of the spike.
+
+* ``summarize_chunk`` — call the LLM once to summarize a chunk of items
+  and return a :class:`ConversationSummary`. This is the *additive*
+  primitive of decision 2: each chunk is summarized once and kept.
+  Lives in a later commit.
+
+* ``recursively_resummarize`` — fall back to a single-summary collapse
+  when the cumulative size of existing summaries itself approaches the
+  context window. Lives in a later commit.
+
+This module deliberately does **not** touch conversation state. It does
+not create new Llama Stack conversations, inject marker items, write
+to the cache, or acquire locks. Those side-effecting concerns belong
+to LCORE-1572 (request-flow integration) and LCORE-1571 (cache
+extension). Keeping this layer pure makes it unit-testable without
+mocking the whole stack and lets LCORE-1572 wire it in without having
+to disentangle a tangle of side effects.
+"""
+
+from typing import Any
+
+
+def is_message_item(item: Any) -> bool:
+    """Return True when *item* is a chat-message-shaped conversation item.
+
+    Accepts the Llama Stack duck-typed shape (``.type == "message"``)
+    and the OpenAI-style ``{"role", "content"}`` dict.
+
+    Parameters:
+        item: Conversation item to classify.
+
+    Returns:
+        True when the item is a message; False otherwise (function
+        calls, tool results, structured outputs, etc.).
+    """
+    if isinstance(item, dict):
+        return "role" in item
+    return getattr(item, "type", None) == "message"
+
+
+def extract_message_text(item: Any) -> str:
+    """Return the plain text of a chat-message item.
+
+    Accepts both the Llama Stack object shape (``.content`` may be a
+    string, a list of content-part objects with ``.text``, or a list
+    of dicts with ``"text"`` keys) and the OpenAI-style dict shape
+    (``content`` is a string or list of dicts).
+
+    Parameters:
+        item: A chat-message item.
+
+    Returns:
+        The textual content joined by spaces, or the empty string when
+        no text can be extracted.
+    """
+    content: Any
+    if isinstance(item, dict):
+        content = item.get("content")
+    else:
+        content = getattr(item, "content", None)
+
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            text = None
+            if hasattr(part, "text"):
+                text = getattr(part, "text", None)
+            elif isinstance(part, dict) and "text" in part:
+                text = part["text"]
+            if text:
+                parts.append(text)
+        return " ".join(parts)
+    return str(content)
+
+
+def format_conversation_for_summary(items: list[Any]) -> str:
+    """Render conversation items as ``role: text`` lines for a summarization prompt.
+
+    Non-message items are skipped — the summarization prompt is meant
+    for the human-language transcript, not the tool-call control flow.
+
+    Parameters:
+        items: Ordered list of conversation items.
+
+    Returns:
+        Multi-line string. One line per message in the form
+        ``"<role>: <text>"``. Empty when no message items contain text.
+    """
+    lines: list[str] = []
+    for item in items:
+        if not is_message_item(item):
+            continue
+        if isinstance(item, dict):
+            role = item.get("role", "unknown")
+        else:
+            role = getattr(item, "role", "unknown")
+        text = extract_message_text(item)
+        if text:
+            lines.append(f"{role}: {text}")
+    return "\n".join(lines)
+
+
+def _message_indices(items: list[Any]) -> list[int]:
+    """Return positions in *items* that correspond to message items."""
+    return [i for i, item in enumerate(items) if is_message_item(item)]
+
+
+def partition_conversation(
+    items: list[Any],
+    available_budget_tokens: int,
+    buffer_turns: int,
+    encoding_name: str,
+) -> tuple[list[Any], list[Any]]:
+    """Split *items* into ``(old, recent)`` honoring the degrading guard.
+
+    "Old" is the chunk that will be summarized; "recent" is the buffer
+    of trailing turns kept verbatim. The buffer is sized in *turn
+    pairs* (one user message + one assistant message). The function
+    starts from ``buffer_turns`` pairs and shrinks one pair at a time
+    until the recent chunk fits inside ``available_budget_tokens``.
+
+    The shrink continues all the way down to zero — at which point all
+    items are placed in the old chunk and the recent chunk is empty.
+    This handles the pathological case described in the spec (a few
+    very large tool-result turns that would themselves overflow the
+    context window even after summarizing everything else).
+
+    Non-message items (function calls, tool results) are kept attached
+    to whichever chunk their bracketing messages land in. The split
+    boundary is always the position of a user message — the leading
+    boundary of a turn pair.
+
+    Parameters:
+        items: Ordered list of conversation items, oldest first.
+        available_budget_tokens: How many tokens the buffer chunk is
+            allowed to consume. The compaction runtime computes this
+            as ``context_window - summary_token_budget - new_query_tokens``.
+        buffer_turns: Initial buffer size in turn pairs. The degrading
+            guard reduces this until the buffer fits.
+        encoding_name: Tiktoken encoding name passed through to the
+            token estimator so the budget computation matches whatever
+            encoding the production caller already chose for the
+            request.
+
+    Returns:
+        ``(old_items, recent_items)``. ``old_items`` may be empty (no
+        compaction needed); ``recent_items`` may be empty (everything
+        had to be summarized).
+    """
+    # Import locally to avoid a top-level circular import once the
+    # request-flow integration in LCORE-1572 imports both modules.
+    from utils.token_estimator import estimate_conversation_tokens
+
+    msg_indices = _message_indices(items)
+    if not msg_indices:
+        return [], items
+
+    # Try each candidate buffer size from buffer_turns down to 0. The
+    # boundary is always the start of a user/assistant pair: we keep
+    # the last `n * 2` message items in the buffer.
+    for candidate_turns in range(buffer_turns, -1, -1):
+        recent_msg_count = candidate_turns * 2
+        if recent_msg_count == 0:
+            # Buffer fully degraded — everything goes to old.
+            return items, []
+        if recent_msg_count > len(msg_indices):
+            # Not enough messages to satisfy this candidate buffer
+            # size; smaller candidates will be tried next iteration.
+            continue
+        split_at = msg_indices[-recent_msg_count]
+        recent_items = items[split_at:]
+        recent_tokens = estimate_conversation_tokens(
+            recent_items, encoding_name=encoding_name
+        )
+        if recent_tokens <= available_budget_tokens:
+            return items[:split_at], recent_items
+
+    # Defensive fallback — the loop above always returns. Mirror
+    # the buffer-fully-degraded branch so the function has a single
+    # well-defined behavior in every reachable state.
+    return items, []

--- a/src/utils/compaction.py
+++ b/src/utils/compaction.py
@@ -27,13 +27,14 @@ mocking the whole stack and lets LCORE-1572 wire it in without having
 to disentangle a tangle of side effects.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from llama_stack_client import AsyncLlamaStackClient
 
 from log import get_logger
 from models.compaction import ConversationSummary
+from utils.token_estimator import estimate_conversation_tokens, estimate_tokens
 
 logger = get_logger(__name__)
 
@@ -190,10 +191,6 @@ def partition_conversation(
         compaction needed); ``recent_items`` may be empty (everything
         had to be summarized).
     """
-    # Import locally to avoid a top-level circular import once the
-    # request-flow integration in LCORE-1572 imports both modules.
-    from utils.token_estimator import estimate_conversation_tokens
-
     msg_indices = _message_indices(items)
     if not msg_indices:
         return [], items
@@ -325,8 +322,6 @@ async def summarize_chunk(
             cannot be persisted (PositiveInt) and is also useless as
             context, so propagating an error is the honest behavior.
     """
-    from utils.token_estimator import estimate_tokens
-
     prompt = _build_summarization_prompt_body(old_items)
     logger.info(
         "Summarizing %d conversation items (%d messages) for model %s.",
@@ -351,7 +346,7 @@ async def summarize_chunk(
         summary_text=summary_text,
         summarized_through_turn=summarized_through_turn,
         token_count=token_count,
-        created_at=datetime.now(timezone.utc).isoformat(),
+        created_at=datetime.now(UTC).isoformat(),
         model_used=model,
     )
 
@@ -423,8 +418,6 @@ async def recursively_resummarize(
             fold is needed) or when the LLM call yields no
             extractable text.
     """
-    from utils.token_estimator import estimate_tokens
-
     if len(summaries) < 2:
         raise ValueError(
             "recursively_resummarize requires at least 2 summary chunks "
@@ -459,6 +452,6 @@ async def recursively_resummarize(
         summary_text=folded_text,
         summarized_through_turn=summaries[-1].summarized_through_turn,
         token_count=estimate_tokens(folded_text, encoding_name=encoding_name),
-        created_at=datetime.now(timezone.utc).isoformat(),
+        created_at=datetime.now(UTC).isoformat(),
         model_used=model,
     )

--- a/src/utils/compaction.py
+++ b/src/utils/compaction.py
@@ -354,3 +354,111 @@ async def summarize_chunk(
         created_at=datetime.now(timezone.utc).isoformat(),
         model_used=model,
     )
+
+
+RECURSIVE_RESUMMARIZATION_PROMPT = (
+    "The following are summaries of older portions of a conversation"
+    " between a user and an AI assistant helping with Red Hat product"
+    " support. Combine them into a single summary that preserves the"
+    " same five categories of detail (original question and"
+    " environment, error messages and outcomes, decisions and"
+    " rationale, what was resolved versus what is open, and clear"
+    " attribution between user and assistant). Resolve repetition;"
+    " keep all distinct facts.\n"
+)
+"""Prompt used when collapsing multiple summaries into one.
+
+Separate from SUMMARIZATION_PROMPT because the input is qualitatively
+different (already-summarized text, not raw conversation), but the
+preservation directives are the same.
+"""
+
+
+async def recursively_resummarize(
+    client: AsyncLlamaStackClient,
+    model: str,
+    summaries: list[ConversationSummary],
+    encoding_name: str,
+) -> ConversationSummary:
+    """Collapse multiple ``ConversationSummary`` records into one.
+
+    This is the fallback for the additive design (spike decision 2).
+    Each compaction normally produces a new summary chunk that is kept
+    alongside the previous ones, but the spec mandates a recursive
+    fold-up when the cumulative size of the summaries themselves
+    approaches the context limit:
+
+        When total summary token count itself approaches the context
+        limit, fall back to recursive re-summarization of the oldest
+        summary chunks.
+        — docs/design/conversation-compaction/conversation-compaction.md
+
+    The caller decides *when* to invoke this (typically after measuring
+    that the total summary tokens cross some configured fraction of
+    the model's context window). This function carries out the fold:
+    it builds a prompt that lists each existing summary in order, asks
+    the LLM to produce a single combined summary preserving the same
+    five directives, and returns a fresh ``ConversationSummary``.
+
+    The returned summary inherits ``summarized_through_turn`` from the
+    most recent input summary (the running total has not advanced —
+    we have re-folded, not summarized anything new).
+
+    Parameters:
+        client: Llama Stack client to call.
+        model: Fully-qualified model identifier used for the LLM call.
+        summaries: Existing summary chunks to fold, in chronological
+            order (oldest first). Must contain at least two entries —
+            folding a single summary is a no-op the caller should
+            short-circuit before invoking this function.
+        encoding_name: Tiktoken encoding name used to count tokens in
+            the produced fold.
+
+    Returns:
+        A single ConversationSummary representing the union of
+        ``summaries``.
+
+    Raises:
+        ValueError: When *summaries* has fewer than two entries (no
+            fold is needed) or when the LLM call yields no
+            extractable text.
+    """
+    from utils.token_estimator import estimate_tokens
+
+    if len(summaries) < 2:
+        raise ValueError(
+            "recursively_resummarize requires at least 2 summary chunks "
+            "to fold; caller must short-circuit when fewer are present."
+        )
+
+    transcript = "\n\n".join(
+        f"Summary {i + 1} (through turn {s.summarized_through_turn}):\n"
+        f"{s.summary_text}"
+        for i, s in enumerate(summaries)
+    )
+    prompt = f"{RECURSIVE_RESUMMARIZATION_PROMPT}\n{transcript}"
+
+    logger.info(
+        "Recursively re-summarizing %d existing summary chunks for model %s.",
+        len(summaries),
+        model,
+    )
+    response = await client.responses.create(
+        input=prompt,
+        model=model,
+        stream=False,
+        store=False,
+    )
+    folded_text = _extract_response_text(response).strip()
+    if not folded_text:
+        raise ValueError(
+            "Recursive re-summarization LLM call returned no extractable "
+            "text; cannot fold the existing ConversationSummary records."
+        )
+    return ConversationSummary(
+        summary_text=folded_text,
+        summarized_through_turn=summaries[-1].summarized_through_turn,
+        token_count=estimate_tokens(folded_text, encoding_name=encoding_name),
+        created_at=datetime.now(timezone.utc).isoformat(),
+        model_used=model,
+    )

--- a/src/utils/compaction.py
+++ b/src/utils/compaction.py
@@ -13,7 +13,6 @@ exposes three units of work:
 * ``summarize_chunk`` — call the LLM once to summarize a chunk of items
   and return a :class:`ConversationSummary`. This is the *additive*
   primitive of decision 2: each chunk is summarized once and kept.
-  Lives in a later commit.
 
 * ``recursively_resummarize`` — fall back to a single-summary collapse
   when the cumulative size of existing summaries itself approaches the
@@ -28,7 +27,36 @@ mocking the whole stack and lets LCORE-1572 wire it in without having
 to disentangle a tangle of side effects.
 """
 
+from datetime import datetime, timezone
 from typing import Any
+
+from llama_stack_client import AsyncLlamaStackClient
+
+from log import get_logger
+from models.compaction import ConversationSummary
+
+logger = get_logger(__name__)
+
+
+SUMMARIZATION_PROMPT = (
+    "Summarize this conversation history for an AI assistant that helps with\n"
+    "Red Hat product support. Preserve:\n"
+    "1. The user's original question and environment details.\n"
+    "2. All error messages, commands run, and their outcomes.\n"
+    "3. Key decisions and their rationale.\n"
+    "4. What was resolved and what remains open.\n"
+    "5. Clear attribution (what the user reported vs what the assistant"
+    " suggested).\n"
+    "\n"
+    "Be concise but complete. The assistant will use this summary as its only\n"
+    "memory of older conversation turns.\n"
+)
+"""Domain-specific summarization prompt.
+
+Includes the five preservation directives required by the spec doc and
+the JIRA acceptance criteria. Exposed as a module constant so tests can
+assert directive presence and so future tuning is visible in one place.
+"""
 
 
 def is_message_item(item: Any) -> bool:
@@ -194,3 +222,135 @@ def partition_conversation(
     # the buffer-fully-degraded branch so the function has a single
     # well-defined behavior in every reachable state.
     return items, []
+
+
+def _build_summarization_prompt_body(items: list[Any]) -> str:
+    """Render the full prompt body sent to the summarization LLM call.
+
+    Concatenates the system-style summarization prompt with a
+    ``role: text``-formatted transcript of the items being summarized.
+
+    Parameters:
+        items: The chunk to summarize.
+
+    Returns:
+        Full prompt body string.
+    """
+    transcript = format_conversation_for_summary(items)
+    return f"{SUMMARIZATION_PROMPT}\nConversation:\n{transcript}"
+
+
+def _extract_response_text(response: Any) -> str:
+    """Pull the human-readable text out of a Responses-API result.
+
+    Walks ``response.output`` and concatenates the ``.text`` field of
+    every content part that has one. Mirrors the shape-handling done
+    by :func:`utils.responses.extract_text_from_response_items` but is
+    kept local here so the compaction module does not depend on the
+    response-handling utility module that LCORE-1572 will eventually
+    integrate with.
+
+    Parameters:
+        response: The result of ``client.responses.create``.
+
+    Returns:
+        Concatenated response text, or the empty string when nothing
+        could be extracted.
+    """
+    parts: list[str] = []
+    output = getattr(response, "output", None) or []
+    for output_item in output:
+        content = getattr(output_item, "content", None)
+        if not content:
+            continue
+        for content_part in content:
+            text = getattr(content_part, "text", None)
+            if text:
+                parts.append(text)
+    return "".join(parts)
+
+
+async def summarize_chunk(
+    client: AsyncLlamaStackClient,
+    model: str,
+    old_items: list[Any],
+    summarized_through_turn: int,
+    encoding_name: str,
+) -> ConversationSummary:
+    """Summarize *old_items* via one LLM call and return a ConversationSummary.
+
+    This is the additive primitive of compaction decision 2. The
+    function:
+
+    1. Renders the summarization prompt against the transcript of
+       *old_items*.
+    2. Calls ``client.responses.create`` once with ``store=False`` (the
+       summarization call is a one-shot — its output is not stored as
+       a conversation item by Llama Stack; the caller in LCORE-1572 is
+       responsible for injecting the summary into the conversation
+       under whatever marker scheme it chooses).
+    3. Wraps the resulting text in a :class:`ConversationSummary` with
+       a freshly-computed token count and a UTC ISO 8601 timestamp.
+
+    The function does **not** mutate the caller's conversation, does
+    not write to the cache, does not acquire any lock. Concurrency
+    control and persistence belong to LCORE-1572 / LCORE-1571.
+
+    Parameters:
+        client: Llama Stack client to call.
+        model: Fully-qualified model identifier (e.g.,
+            ``"openai/gpt-4o-mini"``). The spec mandates the same
+            model as the user's query (spike decision 3); the choice
+            is the caller's, this function only records it.
+        old_items: Conversation items to summarize. Non-message items
+            are filtered out by the transcript renderer.
+        summarized_through_turn: Running total of items the caller has
+            already summarized at the moment this chunk completes —
+            this value is stored on the returned ConversationSummary
+            so the caller can advance the partition boundary on the
+            next compaction. Caller-tracked; not derived from
+            ``old_items`` alone because additive compaction can span
+            multiple invocations whose chunk boundaries do not start
+            at zero.
+        encoding_name: Tiktoken encoding name used to count tokens in
+            the produced summary. Should match the encoding used to
+            decide the compaction trigger.
+
+    Returns:
+        A populated ConversationSummary.
+
+    Raises:
+        ValueError: When the LLM call returns no extractable text and
+            the resulting summary would be empty. A zero-token summary
+            cannot be persisted (PositiveInt) and is also useless as
+            context, so propagating an error is the honest behavior.
+    """
+    from utils.token_estimator import estimate_tokens
+
+    prompt = _build_summarization_prompt_body(old_items)
+    logger.info(
+        "Summarizing %d conversation items (%d messages) for model %s.",
+        len(old_items),
+        sum(1 for item in old_items if is_message_item(item)),
+        model,
+    )
+    response = await client.responses.create(
+        input=prompt,
+        model=model,
+        stream=False,
+        store=False,
+    )
+    summary_text = _extract_response_text(response).strip()
+    if not summary_text:
+        raise ValueError(
+            "Summarization LLM call returned no extractable text; "
+            "cannot construct ConversationSummary."
+        )
+    token_count = estimate_tokens(summary_text, encoding_name=encoding_name)
+    return ConversationSummary(
+        summary_text=summary_text,
+        summarized_through_turn=summarized_through_turn,
+        token_count=token_count,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        model_used=model,
+    )

--- a/src/utils/token_estimator.py
+++ b/src/utils/token_estimator.py
@@ -76,7 +76,7 @@ def estimate_tokens(text: str, encoding_name: str = DEFAULT_ENCODING_NAME) -> in
     return len(_get_encoding(encoding_name).encode(text))
 
 
-def _extract_message_text(message: Any) -> str:
+def extract_message_text(message: Any) -> str:
     """Pull the textual content out of a chat-message-shaped value.
 
     Accepts the duck-typed Llama Stack conversation-item shape
@@ -119,7 +119,7 @@ def _extract_message_text(message: Any) -> str:
     return str(content)
 
 
-def _is_message(value: Any) -> bool:
+def is_message_item(value: Any) -> bool:
     """Return True when *value* looks like a chat message.
 
     Either an OpenAI-style dict with a ``"role"`` key, or a Llama Stack
@@ -140,7 +140,7 @@ def estimate_conversation_tokens(
     Sums tokens across the optional system prompt and every message in
     *messages*. Non-message items in the list (tool calls, function
     results, etc.) are ignored — only items recognized by
-    ``_is_message`` contribute. Both Llama Stack conversation-item
+    ``is_message_item`` contribute. Both Llama Stack conversation-item
     objects and plain ``{"role", "content"}`` dicts are accepted in the
     same list.
 
@@ -159,9 +159,9 @@ def estimate_conversation_tokens(
     if system_prompt:
         total += len(encoding.encode(system_prompt))
     for message in messages:
-        if not _is_message(message):
+        if not is_message_item(message):
             continue
-        text = _extract_message_text(message)
+        text = extract_message_text(message)
         if text:
             total += len(encoding.encode(text))
     return total

--- a/src/utils/token_estimator.py
+++ b/src/utils/token_estimator.py
@@ -1,0 +1,188 @@
+"""Pre-LLM-call token estimation.
+
+This module estimates the number of tokens a prompt will consume *before*
+the request is sent to the LLM. The conversation compaction trigger uses
+the estimate to decide when older conversation turns must be summarized
+to keep the request inside the model's context window.
+
+Estimation is performed with the ``tiktoken`` library against an
+OpenAI-compatible encoding (``cl100k_base`` by default — the family used
+by GPT-3.5, GPT-4, and GPT-4o). Encodings are cached at module level so
+the wheel-bundled BPE tables are only loaded once per process.
+
+The function ``estimate_conversation_tokens`` understands two shapes of
+chat-message: Llama Stack conversation-item objects (with ``.type``,
+``.role``, ``.content`` attributes) and plain ``{"role", "content"}``
+dictionaries. The duck-typed shape lets the caller pass whatever the
+local code path produces without an adapter.
+"""
+
+from functools import lru_cache
+from typing import Any, Optional
+
+import tiktoken
+
+from log import get_logger
+from models.config import InferenceConfiguration
+
+logger = get_logger(__name__)
+
+DEFAULT_ENCODING_NAME = "cl100k_base"
+"""Default tiktoken encoding name used when the caller does not pick one."""
+
+
+@lru_cache(maxsize=8)
+def _get_encoding(encoding_name: str) -> tiktoken.Encoding:
+    """Return a cached tiktoken Encoding for *encoding_name*.
+
+    The result is memoized so the BPE merge tables are loaded once per
+    encoding per process. ``maxsize=8`` covers every encoding tiktoken
+    ships with comfortable headroom.
+
+    Parameters:
+        encoding_name: Name accepted by ``tiktoken.get_encoding`` (e.g.,
+            ``"cl100k_base"``, ``"o200k_base"``).
+
+    Returns:
+        The encoding object.
+
+    Raises:
+        ValueError: Propagated from tiktoken when the encoding name is
+            unknown.
+    """
+    return tiktoken.get_encoding(encoding_name)
+
+
+def estimate_tokens(text: str, encoding_name: str = DEFAULT_ENCODING_NAME) -> int:
+    """Estimate the number of tokens *text* will consume.
+
+    Tokenization is performed with ``tiktoken`` against *encoding_name*.
+    The function returns 0 for the empty string and a positive integer
+    for any non-empty text containing recognizable characters.
+
+    Parameters:
+        text: Text whose token count should be estimated.
+        encoding_name: Name of the tiktoken encoding to use. Defaults to
+            ``"cl100k_base"`` (the GPT-3.5 / GPT-4 / GPT-4o family).
+
+    Returns:
+        The token count.
+
+    Raises:
+        ValueError: When *encoding_name* is not recognized by tiktoken.
+    """
+    if not text:
+        return 0
+    return len(_get_encoding(encoding_name).encode(text))
+
+
+def _extract_message_text(message: Any) -> str:
+    """Pull the textual content out of a chat-message-shaped value.
+
+    Accepts the duck-typed Llama Stack conversation-item shape
+    (``.type == "message"`` with ``.role`` and ``.content`` attributes)
+    and the OpenAI-style ``{"role", "content"}`` dictionary.
+
+    ``content`` can be a plain string, a list of content-part objects
+    each with a ``.text`` attribute, or a list of dicts each with a
+    ``"text"`` key. Anything unrecognized is coerced via ``str(...)``.
+
+    Parameters:
+        message: Chat-message-shaped value.
+
+    Returns:
+        The textual content joined by spaces, or the empty string when
+        no text can be located.
+    """
+    content: Any
+    if isinstance(message, dict):
+        content = message.get("content")
+    else:
+        content = getattr(message, "content", None)
+
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if hasattr(part, "text"):
+                text = getattr(part, "text", None)
+                if text:
+                    parts.append(text)
+            elif isinstance(part, dict) and "text" in part:
+                text = part["text"]
+                if text:
+                    parts.append(text)
+        return " ".join(parts)
+    return str(content)
+
+
+def _is_message(value: Any) -> bool:
+    """Return True when *value* looks like a chat message.
+
+    Either an OpenAI-style dict with a ``"role"`` key, or a Llama Stack
+    conversation-item object whose ``.type`` attribute is ``"message"``.
+    """
+    if isinstance(value, dict):
+        return "role" in value
+    return getattr(value, "type", None) == "message"
+
+
+def estimate_conversation_tokens(
+    messages: list[Any],
+    system_prompt: Optional[str] = None,
+    encoding_name: str = DEFAULT_ENCODING_NAME,
+) -> int:
+    """Estimate the token count of a chat conversation.
+
+    Sums tokens across the optional system prompt and every message in
+    *messages*. Non-message items in the list (tool calls, function
+    results, etc.) are ignored — only items recognized by
+    ``_is_message`` contribute. Both Llama Stack conversation-item
+    objects and plain ``{"role", "content"}`` dicts are accepted in the
+    same list.
+
+    Parameters:
+        messages: Chat history. Each element may be a Llama Stack
+            conversation item or a plain dict.
+        system_prompt: Optional system prompt prepended to the
+            estimate.
+        encoding_name: Name of the tiktoken encoding to use.
+
+    Returns:
+        The total token count.
+    """
+    encoding = _get_encoding(encoding_name)
+    total = 0
+    if system_prompt:
+        total += len(encoding.encode(system_prompt))
+    for message in messages:
+        if not _is_message(message):
+            continue
+        text = _extract_message_text(message)
+        if text:
+            total += len(encoding.encode(text))
+    return total
+
+
+def get_context_window(
+    model: str, inference_config: InferenceConfiguration
+) -> Optional[int]:
+    """Return the configured context window size for *model* in tokens.
+
+    Looks up *model* in ``inference_config.context_windows``. Returns
+    ``None`` when the model is absent from the map. The caller decides
+    how to handle the absence — typically, skipping the token-based
+    compaction trigger.
+
+    Parameters:
+        model: Fully-qualified model identifier (e.g.,
+            ``"openai/gpt-4o-mini"``).
+        inference_config: The application's inference configuration.
+
+    Returns:
+        The context window size in tokens, or ``None`` when unset.
+    """
+    return inference_config.context_windows.get(model)

--- a/tests/unit/models/config/test_compaction_configuration.py
+++ b/tests/unit/models/config/test_compaction_configuration.py
@@ -1,0 +1,116 @@
+"""Unit tests for CompactionConfiguration and its placement on Configuration."""
+
+import pytest
+
+from models.config import CompactionConfiguration, Configuration
+
+
+def test_default_values() -> None:
+    """Default-construct CompactionConfiguration matches the spec defaults.
+
+    Defaults come from the conversation-compaction spec doc — disabled,
+    70% trigger, 4096 token floor, 4 buffer turns, 30% max buffer.
+    """
+    config = CompactionConfiguration()
+    assert config.enabled is False
+    assert config.threshold_ratio == 0.7
+    assert config.token_floor == 4096
+    assert config.buffer_turns == 4
+    assert config.buffer_max_ratio == 0.3
+
+
+def test_enabled_can_be_turned_on() -> None:
+    """The enabled master switch is configurable."""
+    config = CompactionConfiguration(enabled=True)
+    assert config.enabled is True
+
+
+def test_threshold_ratio_accepts_boundary_values() -> None:
+    """threshold_ratio accepts 0.0 and 1.0 inclusively."""
+    assert CompactionConfiguration(threshold_ratio=0.0).threshold_ratio == 0.0
+    assert CompactionConfiguration(threshold_ratio=1.0).threshold_ratio == 1.0
+
+
+def test_threshold_ratio_rejects_negative() -> None:
+    """threshold_ratio below 0 is rejected."""
+    with pytest.raises(
+        ValueError, match="threshold_ratio must be between 0.0 and 1.0"
+    ):
+        CompactionConfiguration(threshold_ratio=-0.1)
+
+
+def test_threshold_ratio_rejects_above_one() -> None:
+    """threshold_ratio above 1 is rejected."""
+    with pytest.raises(
+        ValueError, match="threshold_ratio must be between 0.0 and 1.0"
+    ):
+        CompactionConfiguration(threshold_ratio=1.1)
+
+
+def test_buffer_max_ratio_boundary_values() -> None:
+    """buffer_max_ratio accepts 0.0 and 1.0 inclusively."""
+    assert CompactionConfiguration(buffer_max_ratio=0.0).buffer_max_ratio == 0.0
+    assert CompactionConfiguration(buffer_max_ratio=1.0).buffer_max_ratio == 1.0
+
+
+def test_buffer_max_ratio_rejects_negative() -> None:
+    """buffer_max_ratio below 0 is rejected."""
+    with pytest.raises(
+        ValueError, match="buffer_max_ratio must be between 0.0 and 1.0"
+    ):
+        CompactionConfiguration(buffer_max_ratio=-0.05)
+
+
+def test_buffer_max_ratio_rejects_above_one() -> None:
+    """buffer_max_ratio above 1 is rejected."""
+    with pytest.raises(
+        ValueError, match="buffer_max_ratio must be between 0.0 and 1.0"
+    ):
+        CompactionConfiguration(buffer_max_ratio=1.5)
+
+
+def test_token_floor_rejects_negative() -> None:
+    """token_floor is NonNegativeInt and rejects negatives."""
+    with pytest.raises(ValueError):
+        CompactionConfiguration(token_floor=-1)
+
+
+def test_buffer_turns_rejects_negative() -> None:
+    """buffer_turns is NonNegativeInt and rejects negatives."""
+    with pytest.raises(ValueError):
+        CompactionConfiguration(buffer_turns=-1)
+
+
+def test_token_floor_zero_is_allowed() -> None:
+    """A zero token floor is allowed — caller may want pure ratio trigger."""
+    assert CompactionConfiguration(token_floor=0).token_floor == 0
+
+
+def test_buffer_turns_zero_is_allowed() -> None:
+    """Zero buffer turns are allowed — caller may want full summarization."""
+    assert CompactionConfiguration(buffer_turns=0).buffer_turns == 0
+
+
+def test_rejects_unknown_field() -> None:
+    """Unknown fields are forbidden via ConfigurationBase's extra='forbid'."""
+    with pytest.raises(ValueError):
+        CompactionConfiguration(unknown_field=True)  # type: ignore[call-arg]
+
+
+def test_root_configuration_has_compaction_field() -> None:
+    """The root Configuration declares a `compaction` field typed as
+    CompactionConfiguration with a default-factory that produces a
+    fresh CompactionConfiguration with the spec defaults."""
+    fields = Configuration.model_fields
+    assert "compaction" in fields, "Configuration must declare a compaction field"
+    field_info = fields["compaction"]
+    assert field_info.annotation is CompactionConfiguration
+
+    # default_factory must produce a CompactionConfiguration with disabled
+    # state — sanity check that the wiring isn't accidentally swapping in
+    # an enabled-by-default instance.
+    factory = field_info.default_factory
+    assert factory is not None
+    default = factory()  # type: ignore[call-arg]
+    assert isinstance(default, CompactionConfiguration)
+    assert default.enabled is False

--- a/tests/unit/models/config/test_compaction_configuration.py
+++ b/tests/unit/models/config/test_compaction_configuration.py
@@ -97,9 +97,8 @@ def test_root_configuration_has_compaction_field() -> None:
     """The root Configuration declares a `compaction` field typed as
     CompactionConfiguration with a default-factory that produces a
     fresh CompactionConfiguration with the spec defaults."""
-    fields = Configuration.model_fields
-    assert "compaction" in fields, "Configuration must declare a compaction field"
-    field_info = fields["compaction"]
+    field_info = Configuration.model_fields.get("compaction")
+    assert field_info is not None, "Configuration must declare a compaction field"
     assert field_info.annotation is CompactionConfiguration
 
     # default_factory must produce a CompactionConfiguration with disabled

--- a/tests/unit/models/config/test_compaction_configuration.py
+++ b/tests/unit/models/config/test_compaction_configuration.py
@@ -33,17 +33,13 @@ def test_threshold_ratio_accepts_boundary_values() -> None:
 
 def test_threshold_ratio_rejects_negative() -> None:
     """threshold_ratio below 0 is rejected."""
-    with pytest.raises(
-        ValueError, match="threshold_ratio must be between 0.0 and 1.0"
-    ):
+    with pytest.raises(ValueError, match="threshold_ratio must be between 0.0 and 1.0"):
         CompactionConfiguration(threshold_ratio=-0.1)
 
 
 def test_threshold_ratio_rejects_above_one() -> None:
     """threshold_ratio above 1 is rejected."""
-    with pytest.raises(
-        ValueError, match="threshold_ratio must be between 0.0 and 1.0"
-    ):
+    with pytest.raises(ValueError, match="threshold_ratio must be between 0.0 and 1.0"):
         CompactionConfiguration(threshold_ratio=1.1)
 
 

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -168,6 +168,7 @@ def test_dump_configuration(tmp_path: Path) -> None:
             "inference": {
                 "default_provider": "default_provider",
                 "default_model": "default_model",
+                "context_windows": {},
             },
             "database": {
                 "sqlite": None,
@@ -189,6 +190,13 @@ def test_dump_configuration(tmp_path: Path) -> None:
                 "postgres": None,
                 "sqlite": None,
                 "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
             },
             "byok_rag": [],
             "quota_handlers": {
@@ -511,6 +519,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
             "inference": {
                 "default_provider": "default_provider",
                 "default_model": "default_model",
+                "context_windows": {},
             },
             "database": {
                 "sqlite": None,
@@ -532,6 +541,13 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "postgres": None,
                 "sqlite": None,
                 "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
             },
             "byok_rag": [],
             "quota_handlers": {
@@ -746,6 +762,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
             "inference": {
                 "default_provider": "default_provider",
                 "default_model": "default_model",
+                "context_windows": {},
             },
             "database": {
                 "sqlite": None,
@@ -767,6 +784,13 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "postgres": None,
                 "sqlite": None,
                 "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
             },
             "byok_rag": [],
             "quota_handlers": {
@@ -961,6 +985,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
             "inference": {
                 "default_provider": "default_provider",
                 "default_model": "default_model",
+                "context_windows": {},
             },
             "database": {
                 "sqlite": None,
@@ -982,6 +1007,13 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "postgres": None,
                 "sqlite": None,
                 "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
             },
             "byok_rag": [
                 {
@@ -1166,6 +1198,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
             "inference": {
                 "default_provider": "default_provider",
                 "default_model": "default_model",
+                "context_windows": {},
             },
             "database": {
                 "sqlite": None,
@@ -1187,6 +1220,13 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "postgres": None,
                 "sqlite": None,
                 "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
             },
             "byok_rag": [],
             "quota_handlers": {

--- a/tests/unit/models/config/test_inference_configuration.py
+++ b/tests/unit/models/config/test_inference_configuration.py
@@ -56,3 +56,37 @@ def test_inference_default_provider_missing() -> None:
         InferenceConfiguration(
             default_model="default_model",
         )  # pyright: ignore[reportCallIssue]
+
+
+def test_context_windows_default_empty() -> None:
+    """Test the context_windows field defaults to an empty dict."""
+    inference_config = InferenceConfiguration()  # pyright: ignore[reportCallIssue]
+    assert inference_config.context_windows == {}
+
+
+def test_context_windows_accepts_model_to_size_map() -> None:
+    """Test context_windows accepts a populated model-to-window map."""
+    inference_config = InferenceConfiguration(
+        context_windows={
+            "openai/gpt-4o-mini": 128000,
+            "openai/gpt-4o": 128000,
+        },
+    )  # pyright: ignore[reportCallIssue]
+    assert inference_config.context_windows["openai/gpt-4o-mini"] == 128000
+    assert inference_config.context_windows["openai/gpt-4o"] == 128000
+
+
+def test_context_windows_rejects_non_positive_size() -> None:
+    """Test that a non-positive window size is rejected by Pydantic."""
+    with pytest.raises(ValueError):
+        InferenceConfiguration(
+            context_windows={"openai/gpt-4o-mini": 0},
+        )  # pyright: ignore[reportCallIssue]
+
+
+def test_context_windows_rejects_negative_size() -> None:
+    """Test that a negative window size is rejected by Pydantic."""
+    with pytest.raises(ValueError):
+        InferenceConfiguration(
+            context_windows={"openai/gpt-4o-mini": -1},
+        )  # pyright: ignore[reportCallIssue]

--- a/tests/unit/models/test_compaction.py
+++ b/tests/unit/models/test_compaction.py
@@ -1,0 +1,76 @@
+"""Unit tests for the ConversationSummary model."""
+
+import pytest
+
+from models.compaction import ConversationSummary
+
+
+def _valid_kwargs() -> dict:
+    """Return a kwargs dict with valid values for every required field."""
+    return {
+        "summary_text": "Summary of the conversation.",
+        "summarized_through_turn": 8,
+        "token_count": 42,
+        "created_at": "2026-05-11T00:00:00Z",
+        "model_used": "openai/gpt-4o-mini",
+    }
+
+
+def test_constructor_with_valid_values() -> None:
+    """All required fields populated; instance round-trips through Pydantic."""
+    summary = ConversationSummary(**_valid_kwargs())
+    assert summary.summary_text == "Summary of the conversation."
+    assert summary.summarized_through_turn == 8
+    assert summary.token_count == 42
+    assert summary.created_at == "2026-05-11T00:00:00Z"
+    assert summary.model_used == "openai/gpt-4o-mini"
+
+
+def test_summarized_through_turn_accepts_zero() -> None:
+    """A zero turn count is allowed (NonNegativeInt) — represents an empty
+    conversation entry point even though compaction itself does not produce
+    one in this state."""
+    kwargs = _valid_kwargs()
+    kwargs["summarized_through_turn"] = 0
+    summary = ConversationSummary(**kwargs)
+    assert summary.summarized_through_turn == 0
+
+
+def test_summarized_through_turn_rejects_negative() -> None:
+    """Negative turn counts are rejected."""
+    kwargs = _valid_kwargs()
+    kwargs["summarized_through_turn"] = -1
+    with pytest.raises(ValueError):
+        ConversationSummary(**kwargs)
+
+
+def test_token_count_rejects_zero() -> None:
+    """Token count of zero is rejected (PositiveInt); a summary with no
+    tokens would not be a meaningful record."""
+    kwargs = _valid_kwargs()
+    kwargs["token_count"] = 0
+    with pytest.raises(ValueError):
+        ConversationSummary(**kwargs)
+
+
+def test_token_count_rejects_negative() -> None:
+    """Negative token count is rejected."""
+    kwargs = _valid_kwargs()
+    kwargs["token_count"] = -1
+    with pytest.raises(ValueError):
+        ConversationSummary(**kwargs)
+
+
+def test_required_fields_are_required() -> None:
+    """Omitting any required field raises a Pydantic validation error."""
+    for field in (
+        "summary_text",
+        "summarized_through_turn",
+        "token_count",
+        "created_at",
+        "model_used",
+    ):
+        kwargs = _valid_kwargs()
+        del kwargs[field]
+        with pytest.raises(ValueError):
+            ConversationSummary(**kwargs)

--- a/tests/unit/utils/test_compaction.py
+++ b/tests/unit/utils/test_compaction.py
@@ -1,5 +1,7 @@
 """Unit tests for utils/compaction — partitioning, prompt, summarization."""
 
+# pylint: disable=too-few-public-methods
+
 from typing import Any
 
 import pytest

--- a/tests/unit/utils/test_compaction.py
+++ b/tests/unit/utils/test_compaction.py
@@ -5,7 +5,9 @@ from typing import Any
 import pytest
 from pytest_mock import MockerFixture
 
+from models.compaction import ConversationSummary
 from utils.compaction import (
+    RECURSIVE_RESUMMARIZATION_PROMPT,
     SUMMARIZATION_PROMPT,
     _build_summarization_prompt_body,
     _extract_response_text,
@@ -13,6 +15,7 @@ from utils.compaction import (
     format_conversation_for_summary,
     is_message_item,
     partition_conversation,
+    recursively_resummarize,
     summarize_chunk,
 )
 from utils.token_estimator import (
@@ -499,3 +502,145 @@ class TestSummarizeChunk:
         assert first.summary_text == "First summary."
         assert second.summary_text == "Second summary."
         assert second.summarized_through_turn > first.summarized_through_turn
+
+
+# ---------------------------------------------------------------------------
+# recursively_resummarize
+# ---------------------------------------------------------------------------
+
+
+def _make_summary(text: str, through: int, tokens: int = 5) -> ConversationSummary:
+    """Build a ConversationSummary value for tests."""
+    return ConversationSummary(
+        summary_text=text,
+        summarized_through_turn=through,
+        token_count=tokens,
+        created_at="2026-05-11T00:00:00Z",
+        model_used="openai/gpt-4o-mini",
+    )
+
+
+class TestRecursivelyResummarize:
+    """Tests for the recursive-fold fallback."""
+
+    @pytest.mark.asyncio
+    async def test_collapses_n_summaries_into_one(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Multiple summaries fold into one ConversationSummary."""
+        client = mocker.AsyncMock()
+        client.responses.create.return_value = _make_summary_response(
+            mocker, "Combined summary covering all prior chunks."
+        )
+        summaries = [
+            _make_summary("First chunk summary.", through=5),
+            _make_summary("Second chunk summary.", through=10),
+            _make_summary("Third chunk summary.", through=15),
+        ]
+        folded = await recursively_resummarize(
+            client=client,
+            model="openai/gpt-4o-mini",
+            summaries=summaries,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert (
+            folded.summary_text
+            == "Combined summary covering all prior chunks."
+        )
+        # The fold inherits the most recent input's running total — no
+        # new turns were summarized by this call.
+        assert folded.summarized_through_turn == 15
+        assert folded.token_count > 0
+        assert folded.model_used == "openai/gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_prompt_lists_each_summary(
+        self, mocker: MockerFixture
+    ) -> None:
+        """All input summary texts and the fallback prompt appear in the call."""
+        client = mocker.AsyncMock()
+        client.responses.create.return_value = _make_summary_response(
+            mocker, "Folded summary."
+        )
+        summaries = [
+            _make_summary("Alpha facts.", through=5),
+            _make_summary("Beta facts.", through=10),
+        ]
+        await recursively_resummarize(
+            client=client,
+            model="openai/gpt-4o-mini",
+            summaries=summaries,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        prompt_input = client.responses.create.call_args.kwargs["input"]
+        assert RECURSIVE_RESUMMARIZATION_PROMPT in prompt_input
+        assert "Alpha facts." in prompt_input
+        assert "Beta facts." in prompt_input
+        assert "Summary 1" in prompt_input
+        assert "Summary 2" in prompt_input
+
+    @pytest.mark.asyncio
+    async def test_uses_store_false(self, mocker: MockerFixture) -> None:
+        """The recursive call also uses store=False — like the additive one."""
+        client = mocker.AsyncMock()
+        client.responses.create.return_value = _make_summary_response(
+            mocker, "Folded."
+        )
+        summaries = [
+            _make_summary("a", through=1),
+            _make_summary("b", through=2),
+        ]
+        await recursively_resummarize(
+            client=client,
+            model="openai/gpt-4o-mini",
+            summaries=summaries,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs["store"] is False
+        assert kwargs["stream"] is False
+
+    @pytest.mark.asyncio
+    async def test_raises_for_single_summary(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Folding a single summary is a no-op the caller must avoid."""
+        client = mocker.AsyncMock()
+        with pytest.raises(ValueError, match="at least 2 summary chunks"):
+            await recursively_resummarize(
+                client=client,
+                model="openai/gpt-4o-mini",
+                summaries=[_make_summary("only one", through=5)],
+                encoding_name=DEFAULT_ENCODING_NAME,
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_for_empty_list(self, mocker: MockerFixture) -> None:
+        """Folding an empty list is a no-op the caller must avoid."""
+        client = mocker.AsyncMock()
+        with pytest.raises(ValueError, match="at least 2 summary chunks"):
+            await recursively_resummarize(
+                client=client,
+                model="openai/gpt-4o-mini",
+                summaries=[],
+                encoding_name=DEFAULT_ENCODING_NAME,
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_when_llm_returns_empty(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Empty LLM response surfaces ValueError, not an empty fold."""
+        client = mocker.AsyncMock()
+        client.responses.create.return_value = _make_summary_response(mocker, "")
+        summaries = [
+            _make_summary("a", through=1),
+            _make_summary("b", through=2),
+        ]
+        with pytest.raises(ValueError, match="no extractable text"):
+            await recursively_resummarize(
+                client=client,
+                model="openai/gpt-4o-mini",
+                summaries=summaries,
+                encoding_name=DEFAULT_ENCODING_NAME,
+            )

--- a/tests/unit/utils/test_compaction.py
+++ b/tests/unit/utils/test_compaction.py
@@ -23,7 +23,6 @@ from utils.token_estimator import (
     estimate_conversation_tokens,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -62,9 +61,7 @@ def _make_history(num_pairs: int, words_per_message: int = 1) -> list[Any]:
     snippet = "alpha "
     for i in range(num_pairs):
         items.append(_MessageItem("user", (snippet * words_per_message) + str(i)))
-        items.append(
-            _MessageItem("assistant", (snippet * words_per_message) + f"A{i}")
-        )
+        items.append(_MessageItem("assistant", (snippet * words_per_message) + f"A{i}"))
     return items
 
 
@@ -442,9 +439,7 @@ class TestSummarizeChunk:
         assert "user: hi" in kwargs["input"]
 
     @pytest.mark.asyncio
-    async def test_raises_when_llm_returns_empty(
-        self, mocker: MockerFixture
-    ) -> None:
+    async def test_raises_when_llm_returns_empty(self, mocker: MockerFixture) -> None:
         """An empty LLM response surfaces ValueError, not a silent empty summary."""
         client = mocker.AsyncMock()
         client.responses.create.return_value = _make_summary_response(mocker, "")
@@ -524,9 +519,7 @@ class TestRecursivelyResummarize:
     """Tests for the recursive-fold fallback."""
 
     @pytest.mark.asyncio
-    async def test_collapses_n_summaries_into_one(
-        self, mocker: MockerFixture
-    ) -> None:
+    async def test_collapses_n_summaries_into_one(self, mocker: MockerFixture) -> None:
         """Multiple summaries fold into one ConversationSummary."""
         client = mocker.AsyncMock()
         client.responses.create.return_value = _make_summary_response(
@@ -543,10 +536,7 @@ class TestRecursivelyResummarize:
             summaries=summaries,
             encoding_name=DEFAULT_ENCODING_NAME,
         )
-        assert (
-            folded.summary_text
-            == "Combined summary covering all prior chunks."
-        )
+        assert folded.summary_text == "Combined summary covering all prior chunks."
         # The fold inherits the most recent input's running total — no
         # new turns were summarized by this call.
         assert folded.summarized_through_turn == 15
@@ -554,9 +544,7 @@ class TestRecursivelyResummarize:
         assert folded.model_used == "openai/gpt-4o-mini"
 
     @pytest.mark.asyncio
-    async def test_prompt_lists_each_summary(
-        self, mocker: MockerFixture
-    ) -> None:
+    async def test_prompt_lists_each_summary(self, mocker: MockerFixture) -> None:
         """All input summary texts and the fallback prompt appear in the call."""
         client = mocker.AsyncMock()
         client.responses.create.return_value = _make_summary_response(
@@ -583,9 +571,7 @@ class TestRecursivelyResummarize:
     async def test_uses_store_false(self, mocker: MockerFixture) -> None:
         """The recursive call also uses store=False — like the additive one."""
         client = mocker.AsyncMock()
-        client.responses.create.return_value = _make_summary_response(
-            mocker, "Folded."
-        )
+        client.responses.create.return_value = _make_summary_response(mocker, "Folded.")
         summaries = [
             _make_summary("a", through=1),
             _make_summary("b", through=2),
@@ -601,9 +587,7 @@ class TestRecursivelyResummarize:
         assert kwargs["stream"] is False
 
     @pytest.mark.asyncio
-    async def test_raises_for_single_summary(
-        self, mocker: MockerFixture
-    ) -> None:
+    async def test_raises_for_single_summary(self, mocker: MockerFixture) -> None:
         """Folding a single summary is a no-op the caller must avoid."""
         client = mocker.AsyncMock()
         with pytest.raises(ValueError, match="at least 2 summary chunks"):
@@ -627,9 +611,7 @@ class TestRecursivelyResummarize:
             )
 
     @pytest.mark.asyncio
-    async def test_raises_when_llm_returns_empty(
-        self, mocker: MockerFixture
-    ) -> None:
+    async def test_raises_when_llm_returns_empty(self, mocker: MockerFixture) -> None:
         """Empty LLM response surfaces ValueError, not an empty fold."""
         client = mocker.AsyncMock()
         client.responses.create.return_value = _make_summary_response(mocker, "")

--- a/tests/unit/utils/test_compaction.py
+++ b/tests/unit/utils/test_compaction.py
@@ -1,0 +1,274 @@
+"""Unit tests for utils/compaction — partitioning + duck-type helpers."""
+
+from typing import Any
+
+from utils.compaction import (
+    extract_message_text,
+    format_conversation_for_summary,
+    is_message_item,
+    partition_conversation,
+)
+from utils.token_estimator import (
+    DEFAULT_ENCODING_NAME,
+    estimate_conversation_tokens,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MessageItem:
+    """Minimal stand-in for a Llama Stack conversation message item."""
+
+    def __init__(self, role: str, text: str) -> None:
+        self.type = "message"
+        self.role = role
+        self.content = text
+
+
+class _ToolCallItem:
+    """Minimal stand-in for a non-message conversation item."""
+
+    def __init__(self) -> None:
+        self.type = "function_call"
+
+
+class _TextPart:
+    """Content part with a .text attribute."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+def _make_history(num_pairs: int, words_per_message: int = 1) -> list[Any]:
+    """Build a Llama-Stack-shaped conversation with *num_pairs* user/assistant pairs.
+
+    Each message text is ``words_per_message`` repetitions of a short
+    sentence so callers can dial the per-message token cost.
+    """
+    items: list[Any] = []
+    snippet = "alpha "
+    for i in range(num_pairs):
+        items.append(_MessageItem("user", (snippet * words_per_message) + str(i)))
+        items.append(
+            _MessageItem("assistant", (snippet * words_per_message) + f"A{i}")
+        )
+    return items
+
+
+# ---------------------------------------------------------------------------
+# is_message_item
+# ---------------------------------------------------------------------------
+
+
+class TestIsMessageItem:
+    """Tests for is_message_item."""
+
+    def test_llama_stack_message(self) -> None:
+        """Llama-stack message item is recognised."""
+        assert is_message_item(_MessageItem("user", "hi")) is True
+
+    def test_llama_stack_tool_call(self) -> None:
+        """Tool-call item is not a message."""
+        assert is_message_item(_ToolCallItem()) is False
+
+    def test_openai_dict_with_role(self) -> None:
+        """OpenAI-style dict with role key is a message."""
+        assert is_message_item({"role": "user", "content": "hi"}) is True
+
+    def test_dict_without_role(self) -> None:
+        """Dict without role key is not a message."""
+        assert is_message_item({"content": "hi"}) is False
+
+
+# ---------------------------------------------------------------------------
+# extract_message_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMessageText:
+    """Tests for extract_message_text."""
+
+    def test_string_content_object(self) -> None:
+        """Plain string content on an object is returned as-is."""
+        assert extract_message_text(_MessageItem("user", "hello")) == "hello"
+
+    def test_string_content_dict(self) -> None:
+        """Plain string content in a dict is returned as-is."""
+        assert extract_message_text({"role": "user", "content": "hi"}) == "hi"
+
+    def test_list_content_with_text_attr(self) -> None:
+        """List of content-parts with .text is joined."""
+        item: Any = _MessageItem("user", "ignored")
+        item.content = [_TextPart("one"), _TextPart("two")]
+        assert extract_message_text(item) == "one two"
+
+    def test_list_content_with_text_dict(self) -> None:
+        """List of dicts with 'text' key is joined."""
+        item = {
+            "role": "user",
+            "content": [{"text": "alpha"}, {"text": "beta"}],
+        }
+        assert extract_message_text(item) == "alpha beta"
+
+    def test_none_content(self) -> None:
+        """None content yields the empty string."""
+        item: Any = _MessageItem("user", "ignored")
+        item.content = None
+        assert extract_message_text(item) == ""
+
+
+# ---------------------------------------------------------------------------
+# format_conversation_for_summary
+# ---------------------------------------------------------------------------
+
+
+class TestFormatConversationForSummary:
+    """Tests for format_conversation_for_summary."""
+
+    def test_formats_role_and_text(self) -> None:
+        """Each message becomes one 'role: text' line."""
+        items: list[Any] = [
+            _MessageItem("user", "What is Kubernetes?"),
+            _MessageItem("assistant", "A container orchestrator."),
+        ]
+        out = format_conversation_for_summary(items)
+        assert "user: What is Kubernetes?" in out
+        assert "assistant: A container orchestrator." in out
+
+    def test_skips_non_message_items(self) -> None:
+        """Tool-call items are not rendered into the prompt body."""
+        items: list[Any] = [
+            _MessageItem("user", "hello"),
+            _ToolCallItem(),
+            _MessageItem("assistant", "world"),
+        ]
+        out = format_conversation_for_summary(items)
+        assert "function_call" not in out
+        assert "user: hello" in out and "assistant: world" in out
+
+    def test_handles_dict_shape(self) -> None:
+        """OpenAI-style dicts are rendered alongside Llama-Stack items."""
+        items: list[Any] = [
+            {"role": "user", "content": "from dict"},
+            _MessageItem("assistant", "from object"),
+        ]
+        out = format_conversation_for_summary(items)
+        assert "user: from dict" in out
+        assert "assistant: from object" in out
+
+
+# ---------------------------------------------------------------------------
+# partition_conversation — degrading guard
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionConversation:
+    """Tests for partition_conversation (decision 9 — degrading guard)."""
+
+    def test_twenty_turn_conversation_produces_non_empty_partitions(self) -> None:
+        """JIRA AC: 20+ turn conversation produces non-empty old AND recent."""
+        items = _make_history(num_pairs=20)
+        old, recent = partition_conversation(
+            items,
+            available_budget_tokens=10_000,
+            buffer_turns=4,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert len(old) > 0
+        assert len(recent) > 0
+
+    def test_buffer_keeps_n_turn_pairs_when_budget_is_generous(self) -> None:
+        """With ample budget, the buffer is exactly buffer_turns pairs."""
+        items = _make_history(num_pairs=10)
+        old, recent = partition_conversation(
+            items,
+            available_budget_tokens=1_000_000,
+            buffer_turns=4,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        # 4 pairs = 8 messages.
+        assert len(recent) == 8
+        assert len(old) == len(items) - 8
+
+    def test_buffer_degrades_when_budget_is_tight(self) -> None:
+        """Recent chunk shrinks turn-by-turn until it fits the budget."""
+        # 20 pairs, each turn pair carrying enough text that all 4
+        # pairs together exceed a small budget but a single pair fits.
+        items = _make_history(num_pairs=20, words_per_message=8)
+        # Compute the per-pair token count so we can size the budget.
+        single_pair = items[-2:]
+        single_pair_tokens = estimate_conversation_tokens(
+            single_pair, encoding_name=DEFAULT_ENCODING_NAME
+        )
+        # Allow strictly less than 2 pairs.
+        tight_budget = int(single_pair_tokens * 1.5)
+        old, recent = partition_conversation(
+            items,
+            available_budget_tokens=tight_budget,
+            buffer_turns=4,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        # Buffer degraded to one pair (two messages).
+        assert len(recent) == 2
+        assert len(old) == len(items) - 2
+
+    def test_buffer_degrades_to_zero_when_no_pair_fits(self) -> None:
+        """When even one turn pair exceeds the budget, the buffer is empty."""
+        items = _make_history(num_pairs=5, words_per_message=8)
+        old, recent = partition_conversation(
+            items,
+            available_budget_tokens=1,
+            buffer_turns=4,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert recent == []
+        assert old == items
+
+    def test_buffer_turns_zero_treats_everything_as_old(self) -> None:
+        """A buffer_turns of zero short-circuits to fully old."""
+        items = _make_history(num_pairs=4)
+        old, recent = partition_conversation(
+            items,
+            available_budget_tokens=1_000_000,
+            buffer_turns=0,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert recent == []
+        assert old == items
+
+    def test_no_messages_short_circuits(self) -> None:
+        """Empty conversation returns empty partitions."""
+        old, recent = partition_conversation(
+            [],
+            available_budget_tokens=1_000_000,
+            buffer_turns=4,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert old == []
+        assert recent == []
+
+    def test_fewer_messages_than_buffer_takes_smaller_buffer(self) -> None:
+        """If conversation has fewer turns than buffer_turns, all fit in buffer."""
+        items = _make_history(num_pairs=2)
+        old, recent = partition_conversation(
+            items,
+            available_budget_tokens=1_000_000,
+            buffer_turns=4,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert old == []
+        assert recent == items
+
+    def test_partitions_are_disjoint_and_cover_input(self) -> None:
+        """old + recent = items for every successful partition."""
+        items = _make_history(num_pairs=8)
+        old, recent = partition_conversation(
+            items,
+            available_budget_tokens=1_000_000,
+            buffer_turns=3,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert old + recent == items

--- a/tests/unit/utils/test_compaction.py
+++ b/tests/unit/utils/test_compaction.py
@@ -11,7 +11,6 @@ from models.compaction import ConversationSummary
 from utils.compaction import (
     RECURSIVE_RESUMMARIZATION_PROMPT,
     SUMMARIZATION_PROMPT,
-    _build_summarization_prompt_body,
     _extract_response_text,
     extract_message_text,
     format_conversation_for_summary,
@@ -327,31 +326,6 @@ class TestSummarizationPrompt:
 
 
 # ---------------------------------------------------------------------------
-# _build_summarization_prompt_body
-# ---------------------------------------------------------------------------
-
-
-class TestBuildSummarizationPromptBody:
-    """Tests for _build_summarization_prompt_body."""
-
-    def test_includes_prompt_and_transcript(self) -> None:
-        """The body begins with the prompt and embeds the transcript."""
-        items: list[Any] = [
-            _MessageItem("user", "What is Kubernetes?"),
-            _MessageItem("assistant", "An orchestrator."),
-        ]
-        body = _build_summarization_prompt_body(items)
-        assert body.startswith(SUMMARIZATION_PROMPT)
-        assert "user: What is Kubernetes?" in body
-        assert "assistant: An orchestrator." in body
-
-    def test_empty_items_still_yields_prompt(self) -> None:
-        """An empty chunk yields the prompt followed by an empty transcript."""
-        body = _build_summarization_prompt_body([])
-        assert body.startswith(SUMMARIZATION_PROMPT)
-
-
-# ---------------------------------------------------------------------------
 # _extract_response_text
 # ---------------------------------------------------------------------------
 
@@ -421,7 +395,8 @@ class TestSummarizeChunk:
     async def test_invokes_responses_create_with_store_false(
         self, mocker: MockerFixture
     ) -> None:
-        """The summarization call uses store=False and stream=False."""
+        """The summarization call uses store=False and stream=False, and
+        passes the system prompt via `instructions` (not bundled into `input`)."""
         client = mocker.AsyncMock()
         client.responses.create.return_value = _make_summary_response(
             mocker, "Summary."
@@ -437,7 +412,12 @@ class TestSummarizeChunk:
         assert kwargs["store"] is False
         assert kwargs["stream"] is False
         assert kwargs["model"] == "openai/gpt-4o-mini"
-        assert SUMMARIZATION_PROMPT in kwargs["input"]
+        # System directives travel as `instructions`, transcript as `input`.
+        # This keeps the directives in their own channel (resilient to
+        # prompt-injection from user content) and matches the convention used
+        # by utils.responses.get_topic_summary.
+        assert kwargs["instructions"] == SUMMARIZATION_PROMPT
+        assert SUMMARIZATION_PROMPT not in kwargs["input"]
         assert "user: hi" in kwargs["input"]
 
     @pytest.mark.asyncio
@@ -547,7 +527,8 @@ class TestRecursivelyResummarize:
 
     @pytest.mark.asyncio
     async def test_prompt_lists_each_summary(self, mocker: MockerFixture) -> None:
-        """All input summary texts and the fallback prompt appear in the call."""
+        """All input summary texts appear in `input`; the fallback prompt
+        is passed via `instructions`."""
         client = mocker.AsyncMock()
         client.responses.create.return_value = _make_summary_response(
             mocker, "Folded summary."
@@ -562,12 +543,13 @@ class TestRecursivelyResummarize:
             summaries=summaries,
             encoding_name=DEFAULT_ENCODING_NAME,
         )
-        prompt_input = client.responses.create.call_args.kwargs["input"]
-        assert RECURSIVE_RESUMMARIZATION_PROMPT in prompt_input
-        assert "Alpha facts." in prompt_input
-        assert "Beta facts." in prompt_input
-        assert "Summary 1" in prompt_input
-        assert "Summary 2" in prompt_input
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs["instructions"] == RECURSIVE_RESUMMARIZATION_PROMPT
+        assert RECURSIVE_RESUMMARIZATION_PROMPT not in kwargs["input"]
+        assert "Alpha facts." in kwargs["input"]
+        assert "Beta facts." in kwargs["input"]
+        assert "Summary 1" in kwargs["input"]
+        assert "Summary 2" in kwargs["input"]
 
     @pytest.mark.asyncio
     async def test_uses_store_false(self, mocker: MockerFixture) -> None:

--- a/tests/unit/utils/test_compaction.py
+++ b/tests/unit/utils/test_compaction.py
@@ -1,12 +1,19 @@
-"""Unit tests for utils/compaction — partitioning + duck-type helpers."""
+"""Unit tests for utils/compaction — partitioning, prompt, summarization."""
 
 from typing import Any
 
+import pytest
+from pytest_mock import MockerFixture
+
 from utils.compaction import (
+    SUMMARIZATION_PROMPT,
+    _build_summarization_prompt_body,
+    _extract_response_text,
     extract_message_text,
     format_conversation_for_summary,
     is_message_item,
     partition_conversation,
+    summarize_chunk,
 )
 from utils.token_estimator import (
     DEFAULT_ENCODING_NAME,
@@ -272,3 +279,223 @@ class TestPartitionConversation:
             encoding_name=DEFAULT_ENCODING_NAME,
         )
         assert old + recent == items
+
+
+# ---------------------------------------------------------------------------
+# SUMMARIZATION_PROMPT
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizationPrompt:
+    """Tests for the SUMMARIZATION_PROMPT constant.
+
+    JIRA AC: "Summarization prompt includes all 5 preservation directives".
+    """
+
+    def test_includes_red_hat_domain(self) -> None:
+        """Prompt is domain-scoped to Red Hat product support."""
+        assert "Red Hat product support" in SUMMARIZATION_PROMPT
+
+    def test_includes_user_question_and_environment_directive(self) -> None:
+        """Directive 1: user's original question and environment details."""
+        assert "original question" in SUMMARIZATION_PROMPT
+        assert "environment" in SUMMARIZATION_PROMPT
+
+    def test_includes_error_messages_and_commands_directive(self) -> None:
+        """Directive 2: error messages, commands run, and their outcomes."""
+        assert "error messages" in SUMMARIZATION_PROMPT
+        assert "commands" in SUMMARIZATION_PROMPT
+        assert "outcomes" in SUMMARIZATION_PROMPT
+
+    def test_includes_decisions_and_rationale_directive(self) -> None:
+        """Directive 3: key decisions and their rationale."""
+        assert "decisions" in SUMMARIZATION_PROMPT
+        assert "rationale" in SUMMARIZATION_PROMPT
+
+    def test_includes_resolved_versus_open_directive(self) -> None:
+        """Directive 4: what was resolved and what remains open."""
+        assert "resolved" in SUMMARIZATION_PROMPT
+        assert "open" in SUMMARIZATION_PROMPT
+
+    def test_includes_attribution_directive(self) -> None:
+        """Directive 5: attribution (user vs assistant)."""
+        assert "attribution" in SUMMARIZATION_PROMPT
+        assert "user reported" in SUMMARIZATION_PROMPT
+        assert "assistant suggested" in SUMMARIZATION_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# _build_summarization_prompt_body
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSummarizationPromptBody:
+    """Tests for _build_summarization_prompt_body."""
+
+    def test_includes_prompt_and_transcript(self) -> None:
+        """The body begins with the prompt and embeds the transcript."""
+        items: list[Any] = [
+            _MessageItem("user", "What is Kubernetes?"),
+            _MessageItem("assistant", "An orchestrator."),
+        ]
+        body = _build_summarization_prompt_body(items)
+        assert body.startswith(SUMMARIZATION_PROMPT)
+        assert "user: What is Kubernetes?" in body
+        assert "assistant: An orchestrator." in body
+
+    def test_empty_items_still_yields_prompt(self) -> None:
+        """An empty chunk yields the prompt followed by an empty transcript."""
+        body = _build_summarization_prompt_body([])
+        assert body.startswith(SUMMARIZATION_PROMPT)
+
+
+# ---------------------------------------------------------------------------
+# _extract_response_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResponseText:
+    """Tests for the private response-text extractor."""
+
+    def test_concatenates_text_parts(self, mocker: MockerFixture) -> None:
+        """Text fragments across output items are concatenated."""
+        part1 = mocker.Mock(text="Hello, ")
+        part2 = mocker.Mock(text="world.")
+        item = mocker.Mock(content=[part1, part2])
+        response = mocker.Mock(output=[item])
+        assert _extract_response_text(response) == "Hello, world."
+
+    def test_no_output_yields_empty(self, mocker: MockerFixture) -> None:
+        """An empty .output attribute yields the empty string."""
+        response = mocker.Mock(output=[])
+        assert _extract_response_text(response) == ""
+
+
+# ---------------------------------------------------------------------------
+# summarize_chunk
+# ---------------------------------------------------------------------------
+
+
+def _make_summary_response(mocker: MockerFixture, text: str) -> Any:
+    """Build a Responses-API-shaped mock that yields *text*."""
+    part = mocker.Mock(text=text)
+    item = mocker.Mock(content=[part])
+    return mocker.Mock(output=[item])
+
+
+class TestSummarizeChunk:
+    """Tests for summarize_chunk (the additive primitive)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_conversation_summary_with_populated_fields(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Happy path: LLM returns text; we get a populated ConversationSummary."""
+        client = mocker.AsyncMock()
+        client.responses.create.return_value = _make_summary_response(
+            mocker, "User asked about Kubernetes. Assistant gave overview."
+        )
+        items: list[Any] = [
+            _MessageItem("user", "What is Kubernetes?"),
+            _MessageItem("assistant", "An orchestrator."),
+        ]
+        summary = await summarize_chunk(
+            client=client,
+            model="openai/gpt-4o-mini",
+            old_items=items,
+            summarized_through_turn=2,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        assert (
+            summary.summary_text
+            == "User asked about Kubernetes. Assistant gave overview."
+        )
+        assert summary.summarized_through_turn == 2
+        assert summary.token_count > 0
+        assert summary.model_used == "openai/gpt-4o-mini"
+        assert summary.created_at  # non-empty ISO 8601
+
+    @pytest.mark.asyncio
+    async def test_invokes_responses_create_with_store_false(
+        self, mocker: MockerFixture
+    ) -> None:
+        """The summarization call uses store=False and stream=False."""
+        client = mocker.AsyncMock()
+        client.responses.create.return_value = _make_summary_response(
+            mocker, "Summary."
+        )
+        await summarize_chunk(
+            client=client,
+            model="openai/gpt-4o-mini",
+            old_items=[_MessageItem("user", "hi")],
+            summarized_through_turn=1,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs["store"] is False
+        assert kwargs["stream"] is False
+        assert kwargs["model"] == "openai/gpt-4o-mini"
+        assert SUMMARIZATION_PROMPT in kwargs["input"]
+        assert "user: hi" in kwargs["input"]
+
+    @pytest.mark.asyncio
+    async def test_raises_when_llm_returns_empty(
+        self, mocker: MockerFixture
+    ) -> None:
+        """An empty LLM response surfaces ValueError, not a silent empty summary."""
+        client = mocker.AsyncMock()
+        client.responses.create.return_value = _make_summary_response(mocker, "")
+        with pytest.raises(ValueError, match="no extractable text"):
+            await summarize_chunk(
+                client=client,
+                model="openai/gpt-4o-mini",
+                old_items=[_MessageItem("user", "hi")],
+                summarized_through_turn=1,
+                encoding_name=DEFAULT_ENCODING_NAME,
+            )
+
+    @pytest.mark.asyncio
+    async def test_additive_second_call_does_not_resummarize_first(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Two sequential calls produce two independent summaries (additive).
+
+        JIRA AC: "Additive mode: second compaction appends a new summary
+        chunk, does not re-summarize the first."
+        """
+        client = mocker.AsyncMock()
+        client.responses.create.side_effect = [
+            _make_summary_response(mocker, "First summary."),
+            _make_summary_response(mocker, "Second summary."),
+        ]
+
+        first_chunk: list[Any] = [_MessageItem("user", "First topic.")]
+        second_chunk: list[Any] = [_MessageItem("user", "Second topic.")]
+
+        first = await summarize_chunk(
+            client=client,
+            model="openai/gpt-4o-mini",
+            old_items=first_chunk,
+            summarized_through_turn=1,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+        second = await summarize_chunk(
+            client=client,
+            model="openai/gpt-4o-mini",
+            old_items=second_chunk,
+            summarized_through_turn=2,
+            encoding_name=DEFAULT_ENCODING_NAME,
+        )
+
+        # Each call summarized exactly its own chunk — the second call's
+        # prompt body does not include first_chunk's content.
+        first_input = client.responses.create.call_args_list[0].kwargs["input"]
+        second_input = client.responses.create.call_args_list[1].kwargs["input"]
+        assert "First topic." in first_input
+        assert "First topic." not in second_input
+        assert "Second topic." in second_input
+
+        # The two summaries are distinct records — additive, not rolled up.
+        assert first.summary_text == "First summary."
+        assert second.summary_text == "Second summary."
+        assert second.summarized_through_turn > first.summarized_through_turn

--- a/tests/unit/utils/test_token_estimator.py
+++ b/tests/unit/utils/test_token_estimator.py
@@ -1,8 +1,11 @@
 """Unit tests for utils/token_estimator."""
 
+# pylint: disable=too-few-public-methods
+
 from typing import Any
 
 import pytest
+import tiktoken
 
 from models.config import InferenceConfiguration
 from utils.token_estimator import (
@@ -93,8 +96,6 @@ class TestEstimateTokens:
         is at most 5% — establishing that the estimator does not
         introduce its own off-by-some error.
         """
-        import tiktoken
-
         encoding = tiktoken.get_encoding(DEFAULT_ENCODING_NAME)
         text = (
             "The quick brown fox jumps over the lazy dog. "

--- a/tests/unit/utils/test_token_estimator.py
+++ b/tests/unit/utils/test_token_estimator.py
@@ -14,7 +14,6 @@ from utils.token_estimator import (
     get_context_window,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
@@ -65,9 +64,7 @@ class TestEstimateTokens:
 
     def test_pangram(self) -> None:
         """The pangram tokenizes to the known cl100k_base count."""
-        assert (
-            estimate_tokens("The quick brown fox jumps over the lazy dog.") == 10
-        )
+        assert estimate_tokens("The quick brown fox jumps over the lazy dog.") == 10
 
     def test_known_phrase(self) -> None:
         """A second reference phrase agrees with the published count."""
@@ -214,9 +211,9 @@ class TestEstimateConversationTokens:
             _MessageItem("user", "hello world"),
             _MessageItem("assistant", "hi"),
         ]
-        assert estimate_conversation_tokens(
-            dicts
-        ) == estimate_conversation_tokens(items)
+        assert estimate_conversation_tokens(dicts) == estimate_conversation_tokens(
+            items
+        )
 
     def test_accepts_mixed_shapes(self) -> None:
         """A mixed list of dicts and Llama Stack items is supported."""

--- a/tests/unit/utils/test_token_estimator.py
+++ b/tests/unit/utils/test_token_estimator.py
@@ -10,11 +10,11 @@ import tiktoken
 from models.config import InferenceConfiguration
 from utils.token_estimator import (
     DEFAULT_ENCODING_NAME,
-    _extract_message_text,
-    _is_message,
     estimate_conversation_tokens,
     estimate_tokens,
+    extract_message_text,
     get_context_window,
+    is_message_item,
 )
 
 # ---------------------------------------------------------------------------
@@ -108,62 +108,62 @@ class TestEstimateTokens:
 
 
 # ---------------------------------------------------------------------------
-# _is_message
+# is_message_item
 # ---------------------------------------------------------------------------
 
 
 class TestIsMessage:
-    """Tests for the private _is_message duck-type check."""
+    """Tests for the is_message_item duck-type check."""
 
     def test_llama_stack_message_item(self) -> None:
         """A Llama-Stack-shaped object with type == 'message' is a message."""
-        assert _is_message(_MessageItem("user", "hi")) is True
+        assert is_message_item(_MessageItem("user", "hi")) is True
 
     def test_llama_stack_tool_call_item(self) -> None:
         """A tool-call-shaped object is not a message."""
-        assert _is_message(_ToolCallItem()) is False
+        assert is_message_item(_ToolCallItem()) is False
 
     def test_openai_dict_with_role(self) -> None:
         """An OpenAI-style dict with a 'role' key is a message."""
-        assert _is_message({"role": "user", "content": "hi"}) is True
+        assert is_message_item({"role": "user", "content": "hi"}) is True
 
     def test_dict_without_role(self) -> None:
         """A dict without a 'role' key is not a message."""
-        assert _is_message({"content": "hi"}) is False
+        assert is_message_item({"content": "hi"}) is False
 
 
 # ---------------------------------------------------------------------------
-# _extract_message_text
+# extract_message_text
 # ---------------------------------------------------------------------------
 
 
 class TestExtractMessageText:
-    """Tests for the private _extract_message_text duck-type extractor."""
+    """Tests for the extract_message_text duck-type extractor."""
 
     def test_llama_stack_string_content(self) -> None:
         """Plain string content is returned as-is."""
-        assert _extract_message_text(_MessageItem("user", "hello")) == "hello"
+        assert extract_message_text(_MessageItem("user", "hello")) == "hello"
 
     def test_openai_dict_string_content(self) -> None:
         """OpenAI-style dict with string content is supported."""
-        assert _extract_message_text({"role": "user", "content": "hi"}) == "hi"
+        assert extract_message_text({"role": "user", "content": "hi"}) == "hi"
 
     def test_list_content_with_text_attr(self) -> None:
         """A list of content parts with .text attribute is joined."""
         item: Any = _MessageItem("user", "placeholder")
         item.content = [_TextPart("first"), _TextPart("second")]
-        assert _extract_message_text(item) == "first second"
+        assert extract_message_text(item) == "first second"
 
     def test_list_content_with_text_dict(self) -> None:
         """A list of content dicts each with a 'text' key is joined."""
         item = {"role": "user", "content": [{"text": "alpha"}, {"text": "beta"}]}
-        assert _extract_message_text(item) == "alpha beta"
+        assert extract_message_text(item) == "alpha beta"
 
     def test_none_content(self) -> None:
         """None content yields an empty string."""
         item: Any = _MessageItem("user", "placeholder")
         item.content = None
-        assert _extract_message_text(item) == ""
+        assert extract_message_text(item) == ""
 
     def test_missing_content_on_object(self) -> None:
         """Object without content attribute yields empty string."""
@@ -172,7 +172,7 @@ class TestExtractMessageText:
             type = "message"
             role = "user"
 
-        assert _extract_message_text(_Empty()) == ""
+        assert extract_message_text(_Empty()) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_token_estimator.py
+++ b/tests/unit/utils/test_token_estimator.py
@@ -1,0 +1,275 @@
+"""Unit tests for utils/token_estimator."""
+
+from typing import Any
+
+import pytest
+
+from models.config import InferenceConfiguration
+from utils.token_estimator import (
+    DEFAULT_ENCODING_NAME,
+    _extract_message_text,
+    _is_message,
+    estimate_conversation_tokens,
+    estimate_tokens,
+    get_context_window,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+class _MessageItem:
+    """Minimal stand-in for a Llama Stack conversation message item."""
+
+    def __init__(self, role: str, text: str) -> None:
+        self.type = "message"
+        self.role = role
+        self.content = text
+
+
+class _ToolCallItem:
+    """Minimal stand-in for a non-message conversation item."""
+
+    def __init__(self) -> None:
+        self.type = "function_call"
+
+
+class _TextPart:
+    """Minimal stand-in for a content-part object with a .text attribute."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+# ---------------------------------------------------------------------------
+# estimate_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateTokens:
+    """Tests for estimate_tokens."""
+
+    def test_empty_string_is_zero(self) -> None:
+        """An empty string contributes zero tokens."""
+        assert estimate_tokens("") == 0
+
+    def test_returns_positive_integer_for_text(self) -> None:
+        """A non-empty string yields a positive integer (JIRA AC)."""
+        assert estimate_tokens("hello world") == 2
+
+    def test_single_word(self) -> None:
+        """'hello' is a single cl100k_base token."""
+        assert estimate_tokens("hello") == 1
+
+    def test_pangram(self) -> None:
+        """The pangram tokenizes to the known cl100k_base count."""
+        assert (
+            estimate_tokens("The quick brown fox jumps over the lazy dog.") == 10
+        )
+
+    def test_known_phrase(self) -> None:
+        """A second reference phrase agrees with the published count."""
+        assert estimate_tokens("tiktoken is great!") == 6
+
+    def test_default_encoding_used(self) -> None:
+        """Omitting encoding_name uses cl100k_base (per module default)."""
+        text = "Compaction summarizes older conversation turns."
+        assert estimate_tokens(text) == estimate_tokens(
+            text, encoding_name=DEFAULT_ENCODING_NAME
+        )
+
+    def test_unknown_encoding_raises(self) -> None:
+        """An unknown encoding name surfaces a ValueError from tiktoken."""
+        with pytest.raises(ValueError):
+            estimate_tokens("hello", encoding_name="not_a_real_encoding")
+
+    def test_within_5pct_of_explicit_tiktoken_call(self) -> None:
+        """Estimate is within 5% of a direct tiktoken call (JIRA AC).
+
+        The JIRA AC requires accuracy "within 5% of actual token count".
+        For OpenAI-family models, the "actual" token count is whatever
+        tiktoken produces for the same encoding. This test routes
+        through the public estimator and compares to a direct, known
+        tiktoken invocation on the same text, asserting the deviation
+        is at most 5% — establishing that the estimator does not
+        introduce its own off-by-some error.
+        """
+        import tiktoken
+
+        encoding = tiktoken.get_encoding(DEFAULT_ENCODING_NAME)
+        text = (
+            "The quick brown fox jumps over the lazy dog. "
+            "Pack my box with five dozen liquor jugs."
+        )
+        reference = len(encoding.encode(text))
+        estimate = estimate_tokens(text)
+        delta_ratio = abs(estimate - reference) / reference
+        assert delta_ratio <= 0.05
+
+
+# ---------------------------------------------------------------------------
+# _is_message
+# ---------------------------------------------------------------------------
+
+
+class TestIsMessage:
+    """Tests for the private _is_message duck-type check."""
+
+    def test_llama_stack_message_item(self) -> None:
+        """A Llama-Stack-shaped object with type == 'message' is a message."""
+        assert _is_message(_MessageItem("user", "hi")) is True
+
+    def test_llama_stack_tool_call_item(self) -> None:
+        """A tool-call-shaped object is not a message."""
+        assert _is_message(_ToolCallItem()) is False
+
+    def test_openai_dict_with_role(self) -> None:
+        """An OpenAI-style dict with a 'role' key is a message."""
+        assert _is_message({"role": "user", "content": "hi"}) is True
+
+    def test_dict_without_role(self) -> None:
+        """A dict without a 'role' key is not a message."""
+        assert _is_message({"content": "hi"}) is False
+
+
+# ---------------------------------------------------------------------------
+# _extract_message_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMessageText:
+    """Tests for the private _extract_message_text duck-type extractor."""
+
+    def test_llama_stack_string_content(self) -> None:
+        """Plain string content is returned as-is."""
+        assert _extract_message_text(_MessageItem("user", "hello")) == "hello"
+
+    def test_openai_dict_string_content(self) -> None:
+        """OpenAI-style dict with string content is supported."""
+        assert _extract_message_text({"role": "user", "content": "hi"}) == "hi"
+
+    def test_list_content_with_text_attr(self) -> None:
+        """A list of content parts with .text attribute is joined."""
+        item: Any = _MessageItem("user", "placeholder")
+        item.content = [_TextPart("first"), _TextPart("second")]
+        assert _extract_message_text(item) == "first second"
+
+    def test_list_content_with_text_dict(self) -> None:
+        """A list of content dicts each with a 'text' key is joined."""
+        item = {"role": "user", "content": [{"text": "alpha"}, {"text": "beta"}]}
+        assert _extract_message_text(item) == "alpha beta"
+
+    def test_none_content(self) -> None:
+        """None content yields an empty string."""
+        item: Any = _MessageItem("user", "placeholder")
+        item.content = None
+        assert _extract_message_text(item) == ""
+
+    def test_missing_content_on_object(self) -> None:
+        """Object without content attribute yields empty string."""
+
+        class _Empty:
+            type = "message"
+            role = "user"
+
+        assert _extract_message_text(_Empty()) == ""
+
+
+# ---------------------------------------------------------------------------
+# estimate_conversation_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateConversationTokens:
+    """Tests for estimate_conversation_tokens."""
+
+    def test_empty_conversation_no_prompt(self) -> None:
+        """No messages and no system prompt is zero tokens."""
+        assert estimate_conversation_tokens([]) == 0
+
+    def test_system_prompt_only(self) -> None:
+        """System prompt alone contributes its own token count."""
+        prompt = "You are a helpful assistant."
+        total = estimate_conversation_tokens([], system_prompt=prompt)
+        assert total == estimate_tokens(prompt)
+
+    def test_sums_messages(self) -> None:
+        """Total is the sum of per-message token counts."""
+        messages: list[Any] = [
+            _MessageItem("user", "hello world"),
+            _MessageItem("assistant", "hi"),
+        ]
+        total = estimate_conversation_tokens(messages)
+        assert total == estimate_tokens("hello world") + estimate_tokens("hi")
+
+    def test_accepts_openai_dict_shape(self) -> None:
+        """OpenAI-style dicts are counted equivalently to Llama Stack items."""
+        dicts = [
+            {"role": "user", "content": "hello world"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        items: list[Any] = [
+            _MessageItem("user", "hello world"),
+            _MessageItem("assistant", "hi"),
+        ]
+        assert estimate_conversation_tokens(
+            dicts
+        ) == estimate_conversation_tokens(items)
+
+    def test_accepts_mixed_shapes(self) -> None:
+        """A mixed list of dicts and Llama Stack items is supported."""
+        mixed: list[Any] = [
+            _MessageItem("user", "hello world"),
+            {"role": "assistant", "content": "hi"},
+        ]
+        assert estimate_conversation_tokens(mixed) == estimate_tokens(
+            "hello world"
+        ) + estimate_tokens("hi")
+
+    def test_skips_non_message_items(self) -> None:
+        """Tool-call-shaped items in the list are ignored."""
+        messages: list[Any] = [
+            _MessageItem("user", "hello"),
+            _ToolCallItem(),
+            _MessageItem("assistant", "world"),
+        ]
+        assert estimate_conversation_tokens(messages) == estimate_tokens(
+            "hello"
+        ) + estimate_tokens("world")
+
+    def test_system_prompt_and_messages(self) -> None:
+        """System prompt is added on top of message totals."""
+        prompt = "You are a helpful assistant."
+        messages: list[Any] = [_MessageItem("user", "hello world")]
+        total = estimate_conversation_tokens(messages, system_prompt=prompt)
+        assert total == estimate_tokens(prompt) + estimate_tokens("hello world")
+
+
+# ---------------------------------------------------------------------------
+# get_context_window
+# ---------------------------------------------------------------------------
+
+
+class TestGetContextWindow:
+    """Tests for get_context_window."""
+
+    def test_returns_size_for_known_model(self) -> None:
+        """A configured model returns its window size."""
+        config = InferenceConfiguration(
+            context_windows={"openai/gpt-4o-mini": 128000},
+        )  # pyright: ignore[reportCallIssue]
+        assert get_context_window("openai/gpt-4o-mini", config) == 128000
+
+    def test_returns_none_for_unknown_model(self) -> None:
+        """An unconfigured model returns None — caller decides fallback."""
+        config = InferenceConfiguration(
+            context_windows={"openai/gpt-4o-mini": 128000},
+        )  # pyright: ignore[reportCallIssue]
+        assert get_context_window("anthropic/claude-3", config) is None
+
+    def test_returns_none_when_map_empty(self) -> None:
+        """An empty context_windows dict returns None for any model."""
+        config = InferenceConfiguration()  # pyright: ignore[reportCallIssue]
+        assert get_context_window("openai/gpt-4o-mini", config) is None

--- a/uv.lock
+++ b/uv.lock
@@ -1584,6 +1584,7 @@ dependencies = [
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette" },
+    { name = "tiktoken" },
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
@@ -1688,6 +1689,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.58.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.42" },
     { name = "starlette", specifier = ">=0.47.1" },
+    { name = "tiktoken", specifier = ">=0.8.0" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "uvicorn", specifier = ">=0.34.3" },
 ]


### PR DESCRIPTION
LCORE-1569,LCORE-1570: token estimation + compaction core modules

## Description

First two tickets of the conversation-compaction epic (LCORE-1631). Lands the two foundation modules that the rest of the epic builds on: pre-LLM-call token estimation (LCORE-1569) and the conversation-summarization core (LCORE-1570).

Both modules are isolated — they do **not** wire into the request flow, the conversation cache, or the response model. Those concerns belong to LCORE-1571 / LCORE-1572 / LCORE-1573 and are deliberately untouched.

**LCORE-1569 — Add token estimation**

- New `tiktoken>=0.8.0` dependency in `pyproject.toml`.
- New `src/utils/token_estimator.py`: `estimate_tokens()`, `estimate_conversation_tokens()`, `get_context_window()`. Encoding is memoized at module level (`lru_cache`) so BPE tables load once per process. `estimate_conversation_tokens` accepts both Llama Stack-shaped items (`.type`/`.role`/`.content`) and OpenAI-style `{"role", "content"}` dicts in the same list — the duck-typed shape avoids forcing callers to adapt whatever their local code path already produces.
- New `context_windows: dict[str, PositiveInt]` field on `InferenceConfiguration` — per-model context-window registry the compaction trigger reads. Defaults to `{}`. `PositiveInt` rejects zero / negative window sizes at parse time.

**LCORE-1570 — Implement conversation summarization module**

- New `src/models/compaction.py`: `ConversationSummary` Pydantic model (summary_text, summarized_through_turn, token_count, created_at, model_used).
- New `CompactionConfiguration` Pydantic model on `models/config.py`, wired onto the root `Configuration` as the `compaction` field with a default-factory. Defaults match the spec (disabled, 0.7 threshold ratio, 4096 token floor, 4 buffer turns, 0.3 max buffer ratio). `threshold_ratio` and `buffer_max_ratio` are clamped to `[0, 1]` at parse time.
- New `src/utils/compaction.py`:
  - `partition_conversation(...)` — splits conversation items into `(old, recent)` with the *degrading guard* of spike decision 9: starts at `buffer_turns` turn pairs and shrinks to zero until the buffer fits the budget.
  - `summarize_chunk(...)` — the *additive primitive* of spike decision 2. One LLM call → one `ConversationSummary`. Uses `store=False`. Caller tracks the running `summarized_through_turn` total across additive invocations.
  - `recursively_resummarize(...)` — fallback that folds multiple existing summaries into one when their cumulative size approaches the context window.
  - `SUMMARIZATION_PROMPT` and `RECURSIVE_RESUMMARIZATION_PROMPT` exposed as module constants. The former carries all five spec-mandated Red Hat support preservation directives (original question + environment; errors + commands + outcomes; decisions + rationale; resolved vs open; user/assistant attribution).

Backwards-compatible: existing YAML configs without a `compaction:` block continue to parse — the default-factory supplies the disabled-by-default `CompactionConfiguration`.

Spec doc this PR implements against: `docs/design/conversation-compaction/conversation-compaction.md` (LCORE-1314 spike).

## Type of change

- [x] New feature
- [x] Unit tests improvement
- [x] Configuration Update

## Tools used to create PR

- Assisted-by: Claude Opus 4.7 (1M context)
- Generated by: Claude Opus 4.7 (1M context)

## Related Tickets & Documents

- Related Issue # LCORE-1631 (parent epic), LCORE-1311 (parent feature), LCORE-1314 (spike)
- Closes # LCORE-1569
- Closes # LCORE-1570

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

### How to test

1. Check out the branch and sync the environment:

   ```
   git checkout lcore-1569-1570-token-estimation-and-compaction-module
   uv sync --group dev --group llslibdev
   ```

2. Run the new unit tests on their own:

   ```
   uv run pytest tests/unit/utils/test_token_estimator.py \
                 tests/unit/utils/test_compaction.py \
                 tests/unit/models/test_compaction.py \
                 tests/unit/models/config/test_compaction_configuration.py \
                 tests/unit/models/config/test_inference_configuration.py
   ```

   Expected: 95 passed.

3. Run the full unit-test suite to confirm no regressions in unrelated tests (the dump-configuration snapshot tests required updating because the dump shape grew two fields):

   ```
   uv run pytest tests/unit/
   ```

   Expected: 2251 passed, 1 skipped, 0 failed.

4. Run the full linter / type-checker chain:

   ```
   uv run make verify
   ```

   Expected: exit 0. pylint 10.00/10.

5. Smoke-test token estimation:

   ```
   uv run python -c "from utils.token_estimator import estimate_tokens; print(estimate_tokens('hello world'))"
   ```

   Expected: `2`.

6. Smoke-test backwards-compatible YAML loading (no `compaction:` block in `lightspeed-stack.yaml`):

   ```
   uv run lightspeed-stack --dump-configuration --config lightspeed-stack.yaml
   ```

   Expected: starts, logs `compaction=CompactionConfiguration(enabled=False, threshold_ratio=0.7, token_floor=4096, buffer_turns=4, buffer_max_ratio=0.3)` and `inference=InferenceConfiguration(... context_windows={})` in the resolved configuration, writes `configuration.json`, exits 0.

### Evidence captured during PR preparation

```
$ uv run pytest tests/unit/
================ 2251 passed, 1 skipped, 94 warnings in 11.20s =================

$ uv run make verify
[... black/pylint/pyright/ruff/pydocstyle/mypy/lint-openapi ...]
Your code has been rated at 10.00/10
Success: no issues found in 178 source files
Success: no issues found in 203 source files
EXIT=0

$ uv run python -c "from utils.token_estimator import estimate_tokens; print(estimate_tokens('hello world'))"
2

$ uv run lightspeed-stack --dump-configuration
... INFO lightspeed_stack:129 Configuration: ... inference=InferenceConfiguration(default_model=None, default_provider=None, context_windows={}) conversation_cache=ConversationHistoryConfiguration(...) compaction=CompactionConfiguration(enabled=False, threshold_ratio=0.7, token_floor=4096, buffer_turns=4, buffer_max_ratio=0.3) ...
... INFO lightspeed_stack:139 Configuration dumped to configuration.json
```

### Real-shape verification of `_extract_response_text`

The summarization functions parse `client.responses.create(...).output[].content[].text`. Verified against the real Llama Stack types (no mock):

```
>>> from llama_stack_client.types.response_object import OutputOpenAIResponseMessageOutput as Msg, ...TextOutput as TextPart
>>> msg = Msg(id='msg_1', role='assistant', status='completed', type='message',
...           content=[TextPart(text='Hello, ', type='output_text'),
...                    TextPart(text='world.', type='output_text')])
>>> class _Resp: output = [msg]
>>> from utils.compaction import _extract_response_text
>>> _extract_response_text(_Resp())
'Hello, world.'
```

### Out of scope for this PR (tracked elsewhere in LCORE-1631)

- Integration tests (LCORE-1574).
- Real LLM roundtrip for `summarize_chunk` / `recursively_resummarize` — meaningful only once the runtime wiring lands (LCORE-1572).
- Conversation-cache extension to persist `ConversationSummary` (LCORE-1571).
- `context_status` response field (LCORE-1573).
- Per-conversation blocking lock + streaming compaction event (LCORE-1572).
- E2E feature files / step definitions (LCORE-1673 + its sibling).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation compaction to summarize chat history and manage context before LLM calls.
  * Token estimation utilities and per-model context windows to preview and limit token usage.
  * Configurable compaction controls (enable/disable, thresholds, token/buffer settings).

* **Documentation**
  * OpenAPI schema updated to document compaction settings and context window semantics.

* **Tests**
  * Added unit tests covering compaction, token estimation, and related configuration behavior.

* **Chores**
  * Added tiktoken dependency for token counting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1718)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->