### PR TITLE
LCORE-2231: use Lightspeed Core Stack name consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lightspeed-stack
+# Lightspeed Core Stack (LCS)
 
 ## About The Project
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
-title: Lightspeed core service
-description: Lightspeed core service
+title: Lightspeed Core Stack
+description: Lightspeed Core Stack
 baseurl: "/lightspeed-stack"
 url: "https://lightspeed-core.github.io/lightspeed-stack/"
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,9 +1,9 @@
 {
     "openapi": "3.1.0",
     "info": {
-        "title": "Lightspeed Core Service (LCS) service - OpenAPI",
-        "summary": "Lightspeed Core Service (LCS) service API specification.",
-        "description": "Lightspeed Core Service (LCS) service API specification.",
+        "title": "Lightspeed Core Stack (LCS) service - OpenAPI",
+        "summary": "Lightspeed Core Stack (LCS) service API specification.",
+        "description": "Lightspeed Core Stack (LCS) service API specification.",
         "contact": {
             "name": "Pavel Tisnovsky",
             "url": "https://github.com/tisnik/",

--- a/lightspeed-stack.yaml
+++ b/lightspeed-stack.yaml
@@ -1,4 +1,4 @@
-name: Lightspeed Core Service (LCS)
+name: Lightspeed Core Stack (LCS)
 service:
   host: 0.0.0.0
   port: 8080

--- a/src/app/endpoints/root.py
+++ b/src/app/endpoints/root.py
@@ -24,10 +24,10 @@ router = APIRouter(tags=["root"])
 INDEX_PAGE = """
 <html>
     <head>
-        <title>Lightspeed core service</title>
+        <title>Lightspeed Core Stack</title>
     </head>
     <body style='font-family: sans-serif;text-align:center;'>
-        <h1>Lightspeed core service</h1>
+        <h1>Lightspeed Core Stack</h1>
         <img src="data:image/jpeg;base64,
 /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAUDBAQEAwUEBAQFBQUGBwwIBwcHBw8LCwkMEQ8SEhEP
 ERETFhwXExQaFRERGCEYGh0dHx8fExciJCIeJBweHx7/2wBDAQUFBQcGBw4ICA4eFBEUHh4eHh4e

--- a/tests/configuration/lightspeed-stack-proper-name.yaml
+++ b/tests/configuration/lightspeed-stack-proper-name.yaml
@@ -1,4 +1,4 @@
-name: Lightspeed Core Service (LCS)
+name: Lightspeed Core Stack (LCS)
 service:
   host: localhost
   port: 8080

--- a/tests/integration/endpoints/test_root_endpoint.py
+++ b/tests/integration/endpoints/test_root_endpoint.py
@@ -71,5 +71,5 @@ async def test_root_endpoint(
     assert response.status_code == status.HTTP_200_OK
     # retrieve response body as a string
     body = response.body.decode("utf-8")
-    assert "<title>Lightspeed core service</title>" in body
-    assert "<h1>Lightspeed core service</h1>" in body
+    assert "<title>Lightspeed Core Stack</title>" in body
+    assert "<h1>Lightspeed Core Stack</h1>" in body

--- a/tests/integration/test_openapi_json.py
+++ b/tests/integration/test_openapi_json.py
@@ -115,7 +115,7 @@ def _check_openapi_top_level_info(spec: dict[str, Any]) -> None:
     assert spec.get("openapi") == "3.1.0"
 
     info = spec.get("info") or {}
-    assert info.get("title") == "Lightspeed Core Service (LCS) service - OpenAPI"
+    assert info.get("title") == "Lightspeed Core Stack (LCS) service - OpenAPI"
     assert "version" in info
 
     contact = info.get("contact") or {}


### PR DESCRIPTION
## Description

LCORE-2231: use Lightspeed Core Stack name consistently

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2231
