### PR TITLE
LCORE- Update `make` target to only format src and test directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ security-check: ## Check the project for security issues
 	uv run bandit -c pyproject.toml -r src tests
 
 format: ## Format the code into unified format
-	uv run black  --line-length 88 .
+	uv run black --line-length 88 src tests
 	uv run ruff check src tests --fix
 
 schema:	## Generate OpenAPI schema file


### PR DESCRIPTION
## Description

Trying to format the examples directory results in a failure from `black` which prevents the `ruff` check from running.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Generated by: Me

## Related Tickets & Documents

None

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
Run `make format`. Without this change:

```
uv run black --line-length 88 .
error: cannot format /Users/sdoran/Developer/lightspeed-stack/docs/demos/lcore/weak_points_for_ai/ex1.py: Cannot parse for target version Python 3.13: 3:0:     for key, value in entry.items():
reformatted /Users/sdoran/Developer/lightspeed-stack/docs/demos/lcore/weak_points_for_ai/ex9.py
error: cannot format /Users/sdoran/Developer/lightspeed-stack/docs/demos/lcore/weak_points_for_ai/ex5.py: Cannot parse for target version Python 3.13: 146:8:         )
reformatted /Users/sdoran/Developer/lightspeed-stack/docs/demos/lcore/weak_points_for_ai/ex3.py
reformatted /Users/sdoran/Developer/lightspeed-stack/docs/demos/lcore/weak_points_for_ai/exA.py
reformatted /Users/sdoran/Developer/lightspeed-stack/docs/demos/lcore/weak_points_for_ai/exB.py

Oh no! 💥 💔 💥
4 files reformatted, 401 files left unchanged, 2 files failed to reformat.
make: *** [format] Error 123
```

With this change:

```
> make format
uv run black --line-length 88 src tests
All done! ✨ 🍰 ✨
392 files left unchanged.
uv run ruff check src tests --fix
All checks passed!
```
