### PR TITLE
LCORE-2079: added agent skills e2e feature file

### DIFF
--- a/tests/e2e/features/skills.feature
+++ b/tests/e2e/features/skills.feature
@@ -1,0 +1,377 @@
+@e2e_group_2
+Feature: Agent skills tests
+
+  Background:
+    Given The service is started locally
+      And The system is in default state
+      And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+      And REST API service prefix is /v1
+      And the Lightspeed stack configuration directory is "tests/e2e/configuration"
+
+  # --- Configuration & startup ---
+
+  @SkillsConfig
+  Scenario: Service starts successfully with skills configured
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills.yaml configuration
+      And The service is restarted
+    When I access endpoint "readiness" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response contains true
+
+  @SkillsConfig
+  Scenario: Service fails to start when skill path does not exist
+    Given The service uses the lightspeed-stack-skills-invalid-path.yaml configuration
+      And The service is restarted
+    When I access endpoint "readiness" using HTTP GET method
+    Then The status code of the response is not 200
+
+  @SkillsConfig
+  Scenario: Service fails to start when SKILL.md is missing from skill directory
+    Given The e2e-missing-skillmd-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-missing-skillmd.yaml configuration
+      And The service is restarted
+    When I access endpoint "readiness" using HTTP GET method
+    Then The status code of the response is not 200
+
+  @SkillsConfig
+  Scenario: Service fails to start when SKILL.md has invalid frontmatter
+    Given The service uses the lightspeed-stack-skills-invalid-frontmatter.yaml configuration
+      And The service is restarted
+    When I access endpoint "readiness" using HTTP GET method
+    Then The status code of the response is not 200
+
+  @SkillsConfig
+  Scenario: Service fails to start when duplicate skill names are configured
+    Given The service uses the lightspeed-stack-skills-duplicate-names.yaml configuration
+      And The service is restarted
+    When I access endpoint "readiness" using HTTP GET method
+    Then The status code of the response is not 200
+
+
+  # --- Skill tools registration ---
+
+  @SkillsConfig
+  Scenario: Skill tools are registered when skills are configured
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills.yaml configuration
+      And The service is restarted
+    When I access REST API endpoint "tools" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response contains list_skills
+      And The body of the response contains activate_skill
+      And The body of the response contains load_skill_resource
+
+  Scenario: Skill tools are not registered when no skills are configured
+    Given The service uses the lightspeed-stack.yaml configuration
+      And The service is restarted
+    When I access REST API endpoint "tools" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response does not contain list_skills
+      And The body of the response does not contain activate_skill
+      And The body of the response does not contain load_skill_resource
+
+
+  # --- Skill discovery ---
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: LLM can discover skills via list_skills tool using query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "What skills are available? Use the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains e2e-test-skill
+      And The token metrics have increased
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: LLM can discover skills via list_skills tool using streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "What skills are available? Use the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | e2e-test-skill            |
+      And The token metrics have increased
+
+
+  # --- Skill activation ---
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: LLM can activate a skill and use its instructions via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "I need help with e2e testing. Use the activate_skill tool to load the e2e-test-skill.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains skill_content
+      And The token metrics have increased
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: LLM can activate a skill and use its instructions via streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "I need help with e2e testing. Use the activate_skill tool to load the e2e-test-skill.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | skill_content             |
+      And The token metrics have increased
+
+
+  # --- Skill resource loading ---
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: LLM can load a skill reference file via load_skill_resource tool using query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Load the reference file references/guide.md from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains skill_resource
+      And The token metrics have increased
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: LLM can load a skill reference file via load_skill_resource tool using streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "Load the reference file references/guide.md from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | skill_resource            |
+      And The token metrics have increased
+
+
+  # --- Security: path traversal ---
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: load_skill_resource rejects path traversal attempts via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Load the resource ../../etc/passwd from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains outside skill directory
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: load_skill_resource rejects path traversal attempts via streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "Load the resource ../../etc/passwd from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | outside skill directory   |
+
+
+  # --- Error handling: unknown skill ---
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: activate_skill returns error for unknown skill name via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Activate a skill called nonexistent-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains Unknown skill
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: activate_skill returns error for unknown skill name via streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "Activate a skill called nonexistent-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | Unknown skill             |
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: load_skill_resource returns error for unknown skill name via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Load references/guide.md from a skill called nonexistent-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains Unknown skill
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: load_skill_resource returns error for unknown skill name via streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "Load references/guide.md from a skill called nonexistent-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | Unknown skill             |
+
+
+  # --- Error handling: missing resource ---
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: load_skill_resource returns error for nonexistent resource file via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Load references/nonexistent.md from e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains Resource not found
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: load_skill_resource returns error for nonexistent resource file via streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "Load references/nonexistent.md from e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | Resource not found        |
+
+
+  # --- Context management: deduplication ---
+
+  @SkillsConfig @Authorized @flaky
+  Scenario: Duplicate skill activation in same conversation returns already-loaded note via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Activate e2e-test-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And I store conversation details
+    When I use "query" to ask question with same conversation_id
+    """
+    {"query": "Activate e2e-test-skill again using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains already loaded
+
+
+  # --- Multiple skills ---
+
+  @SkillsMultiConfig @Authorized @flaky
+  Scenario: Multiple skills can be discovered via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The e2e-second-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-multi.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains e2e-test-skill
+      And The body of the response contains e2e-second-skill
+
+  @SkillsMultiConfig @Authorized @flaky
+  Scenario: Multiple skills can be discovered via streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The e2e-second-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-multi.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | e2e-test-skill            |
+          | e2e-second-skill          |
+
+  @SkillsMultiConfig @Authorized @flaky
+  Scenario: Skills directory path discovers all skills in subdirectories via query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The e2e-second-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-directory.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains e2e-test-skill
+      And The body of the response contains e2e-second-skill
+
+  @SkillsMultiConfig @Authorized @flaky
+  Scenario: Skills directory path discovers all skills in subdirectories via streaming_query endpoint
+    Given The e2e-test-skill skill directory is present in the container
+      And The e2e-second-skill skill directory is present in the container
+      And The service uses the lightspeed-stack-skills-directory.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The streamed response contains following fragments
+          | Fragments in LLM response |
+          | e2e-test-skill            |
+          | e2e-second-skill          |

--- a/tests/e2e/features/skills.feature
+++ b/tests/e2e/features/skills.feature
@@ -1,53 +1,14 @@
-@e2e_group_2
+@e2e_group_2 @skip
 Feature: Agent skills tests
 
   Background:
     Given The service is started locally
       And The system is in default state
-      And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
       And REST API service prefix is /v1
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
 
-  # --- Configuration & startup ---
 
-  @SkillsConfig
-  Scenario: Service starts successfully with skills configured
-    Given The e2e-test-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills.yaml configuration
-      And The service is restarted
-    When I access endpoint "readiness" using HTTP GET method
-    Then The status code of the response is 200
-      And The body of the response contains true
-
-  @SkillsConfig
-  Scenario: Service fails to start when skill path does not exist
-    Given The service uses the lightspeed-stack-skills-invalid-path.yaml configuration
-      And The service is restarted
-    When I access endpoint "readiness" using HTTP GET method
-    Then The status code of the response is not 200
-
-  @SkillsConfig
-  Scenario: Service fails to start when SKILL.md is missing from skill directory
-    Given The e2e-missing-skillmd-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills-missing-skillmd.yaml configuration
-      And The service is restarted
-    When I access endpoint "readiness" using HTTP GET method
-    Then The status code of the response is not 200
-
-  @SkillsConfig
-  Scenario: Service fails to start when SKILL.md has invalid frontmatter
-    Given The service uses the lightspeed-stack-skills-invalid-frontmatter.yaml configuration
-      And The service is restarted
-    When I access endpoint "readiness" using HTTP GET method
-    Then The status code of the response is not 200
-
-  @SkillsConfig
-  Scenario: Service fails to start when duplicate skill names are configured
-    Given The service uses the lightspeed-stack-skills-duplicate-names.yaml configuration
-      And The service is restarted
-    When I access endpoint "readiness" using HTTP GET method
-    Then The status code of the response is not 200
-
+  #TODO: Remove "The e2e-test-skill skill directory is present in the container"
 
   # --- Skill tools registration ---
 
@@ -61,6 +22,7 @@ Feature: Agent skills tests
       And The body of the response contains list_skills
       And The body of the response contains activate_skill
       And The body of the response contains load_skill_resource
+      #TODO: list all the tools, check for number of tools (total)    (More comprehensive than just basic testing is +)
 
   Scenario: Skill tools are not registered when no skills are configured
     Given The service uses the lightspeed-stack.yaml configuration
@@ -70,31 +32,33 @@ Feature: Agent skills tests
       And The body of the response does not contain list_skills
       And The body of the response does not contain activate_skill
       And The body of the response does not contain load_skill_resource
+      #TODO: list all the tools, check for number of tools (total should be just non-skill tools)
 
 
   # --- Skill discovery ---
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: LLM can discover skills via list_skills tool using query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
-    When I use "query" to ask question with authorization header
+    When I use "query" to ask question 
     """
     {"query": "What skills are available? Use the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains e2e-test-skill
+      And The body of the response contains e2e-test-skill  #TODO: Make this more specific (instead of checking entire response check the skill content metadata (new step required))
+      #TODO: Instead of ^ Check tool results from list_skills tool (make it more decisive)
       And The token metrics have increased
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: LLM can discover skills via list_skills tool using streaming_query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
-    When I use "streaming_query" to ask question with authorization header
+    When I use "streaming_query" to ask question 
     """
     {"query": "What skills are available? Use the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -104,31 +68,32 @@ Feature: Agent skills tests
           | Fragments in LLM response |
           | e2e-test-skill            |
       And The token metrics have increased
+    #TODO: SEE ABOVE TEST
 
 
   # --- Skill activation ---
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: LLM can activate a skill and use its instructions via query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
-    When I use "query" to ask question with authorization header
+    When I use "query" to ask question 
     """
     {"query": "I need help with e2e testing. Use the activate_skill tool to load the e2e-test-skill.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains skill_content
+      And The body of the response contains skill_content #FIX: VERY GENERAL should check tool_results instead
       And The token metrics have increased
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: LLM can activate a skill and use its instructions via streaming_query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
-    When I use "streaming_query" to ask question with authorization header
+    When I use "streaming_query" to ask question 
     """
     {"query": "I need help with e2e testing. Use the activate_skill tool to load the e2e-test-skill.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -142,13 +107,13 @@ Feature: Agent skills tests
 
   # --- Skill resource loading ---
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: LLM can load a skill reference file via load_skill_resource tool using query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
-    When I use "query" to ask question with authorization header
+    When I use "query" to ask question 
     """
     {"query": "Load the reference file references/guide.md from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -156,13 +121,13 @@ Feature: Agent skills tests
       And The body of the response contains skill_resource
       And The token metrics have increased
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: LLM can load a skill reference file via load_skill_resource tool using streaming_query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
-    When I use "streaming_query" to ask question with authorization header
+    When I use "streaming_query" to ask question 
     """
     {"query": "Load the reference file references/guide.md from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -173,57 +138,26 @@ Feature: Agent skills tests
           | skill_resource            |
       And The token metrics have increased
 
-
-  # --- Security: path traversal ---
-
-  @SkillsConfig @Authorized @flaky
-  Scenario: load_skill_resource rejects path traversal attempts via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "Load the resource ../../etc/passwd from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains outside skill directory
-
-  @SkillsConfig @Authorized @flaky
-  Scenario: load_skill_resource rejects path traversal attempts via streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
-      And The service is restarted
-    When I use "streaming_query" to ask question with authorization header
-    """
-    {"query": "Load the resource ../../etc/passwd from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    When I wait for the response to be completed
-    Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | outside skill directory   |
-
-
   # --- Error handling: unknown skill ---
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: activate_skill returns error for unknown skill name via query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
-    When I use "query" to ask question with authorization header
+    When I use "query" to ask question 
     """
     {"query": "Activate a skill called nonexistent-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains Unknown skill
+      And The body of the response contains Unknown skill  #TODO: Make more descriptive
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: activate_skill returns error for unknown skill name via streaming_query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
-    When I use "streaming_query" to ask question with authorization header
+    When I use "streaming_query" to ask question 
     """
     {"query": "Activate a skill called nonexistent-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -231,56 +165,28 @@ Feature: Agent skills tests
     Then The status code of the response is 200
       And The streamed response contains following fragments
           | Fragments in LLM response |
-          | Unknown skill             |
-
-  @SkillsConfig @Authorized @flaky
-  Scenario: load_skill_resource returns error for unknown skill name via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "Load references/guide.md from a skill called nonexistent-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains Unknown skill
-
-  @SkillsConfig @Authorized @flaky
-  Scenario: load_skill_resource returns error for unknown skill name via streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
-      And The service is restarted
-    When I use "streaming_query" to ask question with authorization header
-    """
-    {"query": "Load references/guide.md from a skill called nonexistent-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    When I wait for the response to be completed
-    Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | Unknown skill             |
-
+          | Unknown skill             |  #TODO: Make descriptive
 
   # --- Error handling: missing resource ---
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: load_skill_resource returns error for nonexistent resource file via query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
-    When I use "query" to ask question with authorization header
+    When I use "query" to ask question 
     """
     {"query": "Load references/nonexistent.md from e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains Resource not found
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: load_skill_resource returns error for nonexistent resource file via streaming_query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
-    When I use "streaming_query" to ask question with authorization header
+    When I use "streaming_query" to ask question 
     """
     {"query": "Load references/nonexistent.md from e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -293,12 +199,12 @@ Feature: Agent skills tests
 
   # --- Context management: deduplication ---
 
-  @SkillsConfig @Authorized @flaky
+  @SkillsConfig
   Scenario: Duplicate skill activation in same conversation returns already-loaded note via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
-    When I use "query" to ask question with authorization header
+    When I use "query" to ask question 
     """
     {"query": "Activate e2e-test-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -309,49 +215,18 @@ Feature: Agent skills tests
     {"query": "Activate e2e-test-skill again using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains already loaded
+      And The body of the response contains already loaded   #FIX: This looks/feels wrong (make more descriptve)
 
 
   # --- Multiple skills ---
 
-  @SkillsMultiConfig @Authorized @flaky
-  Scenario: Multiple skills can be discovered via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
-      And The e2e-second-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills-multi.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains e2e-test-skill
-      And The body of the response contains e2e-second-skill
-
-  @SkillsMultiConfig @Authorized @flaky
-  Scenario: Multiple skills can be discovered via streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
-      And The e2e-second-skill skill directory is present in the container
-      And The service uses the lightspeed-stack-skills-multi.yaml configuration
-      And The service is restarted
-    When I use "streaming_query" to ask question with authorization header
-    """
-    {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    When I wait for the response to be completed
-    Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | e2e-test-skill            |
-          | e2e-second-skill          |
-
-  @SkillsMultiConfig @Authorized @flaky
+  @SkillsMultiConfig
   Scenario: Skills directory path discovers all skills in subdirectories via query endpoint
     Given The e2e-test-skill skill directory is present in the container
       And The e2e-second-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-directory.yaml configuration
       And The service is restarted
-    When I use "query" to ask question with authorization header
+    When I use "query" to ask question 
     """
     {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
@@ -359,13 +234,13 @@ Feature: Agent skills tests
       And The body of the response contains e2e-test-skill
       And The body of the response contains e2e-second-skill
 
-  @SkillsMultiConfig @Authorized @flaky
+  @SkillsMultiConfig
   Scenario: Skills directory path discovers all skills in subdirectories via streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "skills/e2e-test-skill"
       And The e2e-second-skill skill directory is present in the container
       And The service uses the lightspeed-stack-skills-directory.yaml configuration
       And The service is restarted
-    When I use "streaming_query" to ask question with authorization header
+    When I use "streaming_query" to ask question 
     """
     {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """

--- a/tests/e2e/features/skills.feature
+++ b/tests/e2e/features/skills.feature
@@ -7,39 +7,75 @@ Feature: Agent skills tests
       And REST API service prefix is /v1
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
 
-
-  #TODO: Remove "The e2e-test-skill skill directory is present in the container"
-
   # --- Skill tools registration ---
 
   @SkillsConfig
   Scenario: Skill tools are registered when skills are configured
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills.yaml configuration
       And The service is restarted
     When I access REST API endpoint "tools" using HTTP GET method
     Then The status code of the response is 200
-      And The body of the response contains list_skills
-      And The body of the response contains activate_skill
-      And The body of the response contains load_skill_resource
-      #TODO: list all the tools, check for number of tools (total)    (More comprehensive than just basic testing is +)
+     And The body of the response is the following    #TODO: Currently placeholder, should reflect actual tools (all tools not just skill tools)
+      """
+      {
+        "tools": [
+            {
+                "identifier": "filesystem_read",
+                "description": "Read contents of a file from the filesystem",
+                "parameters": [
+                    {
+                        "name": "path",
+                        "description": "Path to the file to read",
+                        "parameter_type": "string",
+                        "required": True,
+                        "default": None,
+                    }
+                ],
+                "provider_id": "model-context-protocol",
+                "toolgroup_id": "filesystem-tools",
+                "server_source": "http://localhost:3000",
+                "type": "tool",
+            }
+        ],
+      }
+      """
 
   Scenario: Skill tools are not registered when no skills are configured
     Given The service uses the lightspeed-stack.yaml configuration
       And The service is restarted
     When I access REST API endpoint "tools" using HTTP GET method
     Then The status code of the response is 200
-      And The body of the response does not contain list_skills
-      And The body of the response does not contain activate_skill
-      And The body of the response does not contain load_skill_resource
-      #TODO: list all the tools, check for number of tools (total should be just non-skill tools)
-
+     And The body of the response is the following    #TODO: Currently placeholder, should reflect actual tools (default tools, not skill tools)
+      """
+      {
+        "tools": [
+            {
+                "identifier": "filesystem_read",
+                "description": "Read contents of a file from the filesystem",
+                "parameters": [
+                    {
+                        "name": "path",
+                        "description": "Path to the file to read",
+                        "parameter_type": "string",
+                        "required": True,
+                        "default": None,
+                    }
+                ],
+                "provider_id": "model-context-protocol",
+                "toolgroup_id": "filesystem-tools",
+                "server_source": "http://localhost:3000",
+                "type": "tool",
+            }
+        ],
+      }
+      """
 
   # --- Skill discovery ---
 
   @SkillsConfig
   Scenario: LLM can discover skills via list_skills tool using query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
@@ -48,13 +84,23 @@ Feature: Agent skills tests
     {"query": "What skills are available? Use the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains e2e-test-skill  #TODO: Make this more specific (instead of checking entire response check the skill content metadata (new step required))
-      #TODO: Instead of ^ Check tool results from list_skills tool (make it more decisive)
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
       And The token metrics have increased
 
   @SkillsConfig
   Scenario: LLM can discover skills via list_skills tool using streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
@@ -64,18 +110,26 @@ Feature: Agent skills tests
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | e2e-test-skill            |
+      And The response is the last streamed fragment
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
       And The token metrics have increased
-    #TODO: SEE ABOVE TEST
-
 
   # --- Skill activation ---
 
   @SkillsConfig
   Scenario: LLM can activate a skill and use its instructions via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
@@ -84,12 +138,23 @@ Feature: Agent skills tests
     {"query": "I need help with e2e testing. Use the activate_skill tool to load the e2e-test-skill.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains skill_content #FIX: VERY GENERAL should check tool_results instead
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
       And The token metrics have increased
 
   @SkillsConfig
   Scenario: LLM can activate a skill and use its instructions via streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
@@ -99,9 +164,19 @@ Feature: Agent skills tests
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | skill_content             |
+      And The response is the last streamed fragment
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
       And The token metrics have increased
 
 
@@ -109,7 +184,7 @@ Feature: Agent skills tests
 
   @SkillsConfig
   Scenario: LLM can load a skill reference file via load_skill_resource tool using query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
@@ -118,12 +193,23 @@ Feature: Agent skills tests
     {"query": "Load the reference file references/guide.md from the e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains skill_resource
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
       And The token metrics have increased
 
   @SkillsConfig
   Scenario: LLM can load a skill reference file via load_skill_resource tool using streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
       And I capture the current token metrics
@@ -133,16 +219,26 @@ Feature: Agent skills tests
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | skill_resource            |
+      And The response is the last streamed fragment
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
       And The token metrics have increased
 
   # --- Error handling: unknown skill ---
 
   @SkillsConfig
   Scenario: activate_skill returns error for unknown skill name via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
     When I use "query" to ask question 
@@ -150,11 +246,22 @@ Feature: Agent skills tests
     {"query": "Activate a skill called nonexistent-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains Unknown skill  #TODO: Make more descriptive
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "failure",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
 
   @SkillsConfig
   Scenario: activate_skill returns error for unknown skill name via streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
     When I use "streaming_query" to ask question 
@@ -163,15 +270,24 @@ Feature: Agent skills tests
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | Unknown skill             |  #TODO: Make descriptive
-
+      And The response is the last streamed fragment
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "failure",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
   # --- Error handling: missing resource ---
 
   @SkillsConfig
   Scenario: load_skill_resource returns error for nonexistent resource file via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
     When I use "query" to ask question 
@@ -179,11 +295,22 @@ Feature: Agent skills tests
     {"query": "Load references/nonexistent.md from e2e-test-skill using load_skill_resource.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains Resource not found
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "failure",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
 
   @SkillsConfig
   Scenario: load_skill_resource returns error for nonexistent resource file via streaming_query endpoint
-    Given The e2e-test-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
       And The service is restarted
     When I use "streaming_query" to ask question 
@@ -192,9 +319,19 @@ Feature: Agent skills tests
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | Resource not found        |
+      And The response is the last streamed fragment
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "failure",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
 
 
   # --- Context management: deduplication ---
@@ -209,21 +346,45 @@ Feature: Agent skills tests
     {"query": "Activate e2e-test-skill using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And I store conversation details
+     And I store conversation details
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
+
     When I use "query" to ask question with same conversation_id
     """
     {"query": "Activate e2e-test-skill again using the activate_skill tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains already loaded   #FIX: This looks/feels wrong (make more descriptve)
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "failure",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
 
 
   # --- Multiple skills ---
 
   @SkillsMultiConfig
   Scenario: Skills directory path discovers all skills in subdirectories via query endpoint
-    Given The e2e-test-skill skill directory is present in the container
-      And The e2e-second-skill skill directory is present in the container
+    Given The e2e-test-skill skill directory path is "skills/e2e-test-skill"
+      And The e2e-second-skill skill directory path is "skills/e2e-second-skill"
       And The service uses the lightspeed-stack-skills-directory.yaml configuration
       And The service is restarted
     When I use "query" to ask question 
@@ -231,13 +392,23 @@ Feature: Agent skills tests
     {"query": "List all available skills using the list_skills tool.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
-      And The body of the response contains e2e-test-skill
-      And The body of the response contains e2e-second-skill
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
 
   @SkillsMultiConfig
   Scenario: Skills directory path discovers all skills in subdirectories via streaming_query endpoint
     Given The e2e-test-skill skill directory path is "skills/e2e-test-skill"
-      And The e2e-second-skill skill directory is present in the container
+      And The e2e-second-skill skill directory path is "skills/e2e-second-skill"
       And The service uses the lightspeed-stack-skills-directory.yaml configuration
       And The service is restarted
     When I use "streaming_query" to ask question 
@@ -246,7 +417,16 @@ Feature: Agent skills tests
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
-      And The streamed response contains following fragments
-          | Fragments in LLM response |
-          | e2e-test-skill            |
-          | e2e-second-skill          |
+      And The response is the last streamed fragment
+      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "1",
+          "status": "success",
+          "content": "bla",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """

--- a/tests/e2e/features/skills.feature
+++ b/tests/e2e/features/skills.feature
@@ -553,7 +553,7 @@ Feature: Agent skills tests
       And I capture the current token metrics
     When I use "query" to ask question
     """
-    {"query": "Use the agent skills tools in this exact order: (1) call list_skills to discover available skills, (2) call activate_skill with name \"e2e-test-skill\" to load its instructions, (3) call load_skill_resource with skill_name \"e2e-test-skill\" and path \"references/guide.md\" to read the reference guide. After all three tool calls complete, briefly summarize the guide.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the echo skill to echo this 'Hello World!'", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
      And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
@@ -587,7 +587,7 @@ Feature: Agent skills tests
       """
 
 
-  @SkillsConfig @flaky
+  @SkillsConfig
   Scenario: LLM completes list_skills then activate_skill then load_skill_resource via streaming_query endpoint
     Given The e2e-test-skill skill directory path is "e2e-test-skill"
       And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
@@ -595,7 +595,7 @@ Feature: Agent skills tests
       And I capture the current token metrics
     When I use "streaming_query" to ask question
     """
-    {"query": "Use the agent skills tools in this exact order: (1) call list_skills to discover available skills, (2) call activate_skill with name \"e2e-test-skill\" to load its instructions, (3) call load_skill_resource with skill_name \"e2e-test-skill\" and path \"references/guide.md\" to read the reference guide. After all three tool calls complete, briefly summarize the guide.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the echo skill to echo this 'Hello World!'", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     When I wait for the response to be completed
     Then The status code of the response is 200

--- a/tests/e2e/features/skills.feature
+++ b/tests/e2e/features/skills.feature
@@ -20,24 +20,114 @@ Feature: Agent skills tests
       """
       {
         "tools": [
-            {
-                "identifier": "filesystem_read",
-                "description": "Read contents of a file from the filesystem",
-                "parameters": [
-                    {
-                        "name": "path",
-                        "description": "Path to the file to read",
-                        "parameter_type": "string",
-                        "required": True,
-                        "default": None,
-                    }
-                ],
-                "provider_id": "model-context-protocol",
-                "toolgroup_id": "filesystem-tools",
-                "server_source": "http://localhost:3000",
-                "type": "tool",
-            }
-        ],
+          {
+            "identifier": "insert_into_memory",
+            "description": "Insert documents into memory",
+            "parameters": [],
+            "provider_id": "rag-runtime",
+            "toolgroup_id": "builtin::rag",
+            "server_source": "builtin",
+            "type": "tool_group"
+          },
+          {
+            "identifier": "knowledge_search",
+            "description": "Search for information in a database.",
+            "parameters": [
+              {
+                "name": "query",
+                "description": "The query to search for. Can be a natural language sentence or keywords.",
+                "parameter_type": "string",
+                "required": true,
+                "default": null
+              }
+            ],
+            "provider_id": "rag-runtime",
+            "toolgroup_id": "builtin::rag",
+            "server_source": "builtin",
+            "type": "tool_group"
+          },
+          {
+            "identifier": "list_skills",
+            "description": "List available skills with their names and descriptions. Call this to discover what skills are available.",
+            "parameters": [],
+            "provider_id": "agent-skills",
+            "toolgroup_id": "builtin::agent-skills",
+            "server_source": "builtin",
+            "type": "tool"
+          },
+          {
+            "identifier": "activate_skill",
+            "description": "Load full instructions for a skill. Call this when a task matches a skill's description.",
+            "parameters": [
+              {
+                "name": "name",
+                "description": "The name of the skill to load",
+                "parameter_type": "string",
+                "required": true,
+                "default": null
+              }
+            ],
+            "provider_id": "agent-skills",
+            "toolgroup_id": "builtin::agent-skills",
+            "server_source": "builtin",
+            "type": "tool"
+          },
+          {
+            "identifier": "load_skill_resource",
+            "description": "Load a file from a skill's references/ directory. Use this when skill instructions reference additional documentation.",
+            "parameters": [
+              {
+                "name": "skill_name",
+                "description": "The name of the skill containing the resource",
+                "parameter_type": "string",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "path",
+                "description": "Relative path to the resource file (e.g., 'references/guide.md')",
+                "parameter_type": "string",
+                "required": true,
+                "default": null
+              }
+            ],
+            "provider_id": "agent-skills",
+            "toolgroup_id": "builtin::agent-skills",
+            "server_source": "builtin",
+            "type": "tool"
+          },
+          {
+            "identifier": "run_skill_script",
+            "description": "Execute a skill script that performs actions or computations.",
+            "parameters": [
+              {
+                "name": "skill_name",
+                "description": "Name of the skill containing the script",
+                "parameter_type": "string",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "script_name",
+                "description": "Exact name of the script as listed in the skill",
+                "parameter_type": "string",
+                "required": true,
+                "default": null
+              },
+              {
+                "name": "args",
+                "description": "Arguments required by the script",
+                "parameter_type": "object",
+                "required": false,
+                "default": null
+              }
+            ],
+            "provider_id": "agent-skills",
+            "toolgroup_id": "builtin::agent-skills",
+            "server_source": "builtin",
+            "type": "tool"
+          }
+        ]
       }
       """
 
@@ -50,23 +140,32 @@ Feature: Agent skills tests
       """
       {
         "tools": [
-            {
-                "identifier": "filesystem_read",
-                "description": "Read contents of a file from the filesystem",
-                "parameters": [
-                    {
-                        "name": "path",
-                        "description": "Path to the file to read",
-                        "parameter_type": "string",
-                        "required": True,
-                        "default": None,
-                    }
-                ],
-                "provider_id": "model-context-protocol",
-                "toolgroup_id": "filesystem-tools",
-                "server_source": "http://localhost:3000",
-                "type": "tool",
-            }
+          {
+            "identifier": "insert_into_memory",
+            "description": "Insert documents into memory",
+            "parameters": [],
+            "provider_id": "rag-runtime",
+            "toolgroup_id": "builtin::rag",
+            "server_source": "builtin",
+            "type": "tool_group"
+          },
+          {
+            "identifier": "knowledge_search",
+            "description": "Search for information in a database.",
+            "parameters": [
+              {
+                "name": "query",
+                "description": "The query to search for. Can be a natural language sentence or keywords.",
+                "parameter_type": "string",
+                "required": true,
+                "default": null
+              }
+            ],
+            "provider_id": "rag-runtime",
+            "toolgroup_id": "builtin::rag",
+            "server_source": "builtin",
+            "type": "tool_group"
+          }
         ],
       }
       """
@@ -88,9 +187,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "list_skills"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -115,9 +215,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "list_skills"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -142,9 +243,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "activate_skill"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -169,9 +271,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "activate_skill"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -197,13 +300,13 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "load_skill_resource"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
-        }
-      ]
+        }      ]
       """
       And The token metrics have increased
 
@@ -224,9 +327,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "load_skill_resource"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -250,9 +354,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "activate_skill"
           "status": "failure",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -275,9 +380,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "activate_skill"
           "status": "failure",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -299,9 +405,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "load_skill_resource"
           "status": "failure",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -324,9 +431,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "load_skill_resource"
           "status": "failure",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -351,9 +459,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
-          "status": "success",
-          "content": "bla",
+          "id": "<call_id>",
+          "name": "activate_skill"
+          "status": "failure",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -369,9 +478,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "activate_skill"
           "status": "failure",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -396,9 +506,10 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "list_skills"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }
@@ -422,9 +533,97 @@ Feature: Agent skills tests
       """
       [
         {
-          "id": "1",
+          "id": "<call_id>",
+          "name": "list_skills"
           "status": "success",
-          "content": "bla",
+          "content": "<tool_call content>",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
+
+  # --- Full progressive disclosure flow ---
+
+  @SkillsConfig @flaky
+  Scenario: LLM completes list_skills then activate_skill then load_skill_resource via query endpoint
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "query" to ask question
+    """
+    {"query": "Use the agent skills tools in this exact order: (1) call list_skills to discover available skills, (2) call activate_skill with name \"e2e-test-skill\" to load its instructions, (3) call load_skill_resource with skill_name \"e2e-test-skill\" and path \"references/guide.md\" to read the reference guide. After all three tool calls complete, briefly summarize the guide.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "<call_id>",
+          "name": "list_skills"
+          "status": "success",
+          "content": "<tool_call content>",
+          "type": "tool_result",
+          "round": 1,
+        },
+        {
+          "id": "<call_id>",
+          "name": "activate_skill"
+          "status": "success",
+          "content": "<tool_call content>",
+          "type": "tool_result",
+          "round": 1,
+        },
+        {
+          "id": "<call_id>",
+          "name": "load_skill_resource"
+          "status": "success",
+          "content": "<tool_call content>",
+          "type": "tool_result",
+          "round": 1,
+        }
+      ]
+      """
+
+
+  @SkillsConfig @flaky
+  Scenario: LLM completes list_skills then activate_skill then load_skill_resource via streaming_query endpoint
+    Given The e2e-test-skill skill directory path is "e2e-test-skill"
+      And The service uses the lightspeed-stack-skills-auth-noop-token.yaml configuration
+      And The service is restarted
+      And I capture the current token metrics
+    When I use "streaming_query" to ask question
+    """
+    {"query": "Use the agent skills tools in this exact order: (1) call list_skills to discover available skills, (2) call activate_skill with name \"e2e-test-skill\" to load its instructions, (3) call load_skill_resource with skill_name \"e2e-test-skill\" and path \"references/guide.md\" to read the reference guide. After all three tool calls complete, briefly summarize the guide.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+     And The response is the last streamed fragment
+     And The body of the "tool_results" field is    #TODO: Currently placeholder, should reflect actual tool results
+      """
+      [
+        {
+          "id": "<call_id>",
+          "name": "list_skills"
+          "status": "success",
+          "content": "<tool_call content>",
+          "type": "tool_result",
+          "round": 1,
+        },
+        {
+          "id": "<call_id>",
+          "name": "activate_skill"
+          "status": "success",
+          "content": "<tool_call content>",
+          "type": "tool_result",
+          "round": 1,
+        },
+        {
+          "id": "<call_id>",
+          "name": "load_skill_resource"
+          "status": "success",
+          "content": "<tool_call content>",
           "type": "tool_result",
           "round": 1,
         }


### PR DESCRIPTION
## Description

Added E2E feature file for agent skills.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude
- Generated by: Claude

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive end-to-end Gherkin feature for agent skills: REST tool listing, LLM-driven skill discovery, skill activation, resource loading, error handling for unknown/missing skills, conversation-scoped deduplication, multi-skill discovery, and full progressive-disclosure flows. Scenarios exercise both query and streaming modes, include token-metric assertions, and contain placeholder/annotated expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->