### PR TITLE
LCORE-2139: Fixed CVE in LiteLLM

### DIFF
--- a/.konflux/requirements-build.txt
+++ b/.konflux/requirements-build.txt
@@ -104,6 +104,8 @@ tomlkit==0.14.0
     # via uv-dynamic-versioning
 trove-classifiers==2026.1.14.14
     # via hatchling
+uv-build==0.11.8
+    # via litellm
 uv-dynamic-versioning==0.14.0
     # via
     #   a2a-sdk

--- a/.konflux/requirements.hashes.source.txt
+++ b/.konflux/requirements.hashes.source.txt
@@ -509,9 +509,9 @@ jsonschema==4.23.0 \
 langdetect==1.0.9 \
     --hash=sha256:7cbc0746252f19e76f77c0b1690aadf01963be835ef0cd4b56dddf2a8f1dfc2a \
     --hash=sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
-litellm==1.83.7 \
-    --hash=sha256:5784a1d9a9a4a8acd6ca1e347003a5e2e1b3c749b4d41e7da4904577adade111 \
-    --hash=sha256:e2f2cb99df2e2b2eab63f1354faa45c88dd7c8d40c18eb648afb1b349c689633
+litellm==1.85.0 \
+    --hash=sha256:2bb449153610691faffd76f5b94a8c29e4b66fc5394156ebf54fd4fe92759b1a \
+    --hash=sha256:babdd569809af913d08a08a7eb55df1ed3e6a3960ee365c6cef4ad031c9bc72a
 llama-stack==0.6.0 \
     --hash=sha256:b804830664dc91e54c7225a7a081cb1874c48fc18573569c19fac4a9397e8076 \
     --hash=sha256:d92711791633f5505a4473ffba3f3e26acb700716fddab5aec419d99e614c802


### PR DESCRIPTION
## Description

LCORE-2139: Fixed CVE in LiteLLM

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2139
