### PR TITLE
LCORE-623: proper gss_encmode config type in PostgreSQL configuration

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -19255,12 +19255,39 @@
                             }
                         ],
                         "title": "Filters",
-                        "description": "Solr provider filter payload passed through as params['solr'].",
+                        "description": "Solr provider filter payload passed through as params['solr']. Supports structured metadata filters (eq, ne, in, nin comparison operators). Legacy filter-only objects (e.g. fq) are still accepted.",
                         "examples": [
                             {
+                                "filters": {
+                                    "key": "product",
+                                    "type": "eq",
+                                    "value": "openshift_container_platform"
+                                }
+                            },
+                            {
+                                "filters": {
+                                    "filters": [
+                                        {
+                                            "key": "product",
+                                            "type": "eq",
+                                            "value": "openshift_container_platform"
+                                        },
+                                        {
+                                            "key": "version",
+                                            "type": "in",
+                                            "value": [
+                                                "4.14",
+                                                "4.15",
+                                                "4.16"
+                                            ]
+                                        }
+                                    ],
+                                    "type": "and"
+                                }
+                            },
+                            {
                                 "fq": [
-                                    "product:*openshift*",
-                                    "product_version:*4.16*"
+                                    "product:*openshift*"
                                 ]
                             }
                         ]

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -16325,6 +16325,11 @@
                     },
                     "gss_encmode": {
                         "type": "string",
+                        "enum": [
+                            "disable",
+                            "prefer",
+                            "require"
+                        ],
                         "title": "GSS encmode",
                         "description": "This option determines whether or with what priority a secure GSS TCP/IP connection will be negotiated with the server.",
                         "default": "prefer"
@@ -19250,39 +19255,12 @@
                             }
                         ],
                         "title": "Filters",
-                        "description": "Solr provider filter payload passed through as params['solr']. Supports structured metadata filters (eq, ne, in, nin comparison operators). Legacy filter-only objects (e.g. fq) are still accepted.",
+                        "description": "Solr provider filter payload passed through as params['solr'].",
                         "examples": [
                             {
-                                "filters": {
-                                    "key": "product",
-                                    "type": "eq",
-                                    "value": "openshift_container_platform"
-                                }
-                            },
-                            {
-                                "filters": {
-                                    "filters": [
-                                        {
-                                            "key": "product",
-                                            "type": "eq",
-                                            "value": "openshift_container_platform"
-                                        },
-                                        {
-                                            "key": "version",
-                                            "type": "in",
-                                            "value": [
-                                                "4.14",
-                                                "4.15",
-                                                "4.16"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "and"
-                                }
-                            },
-                            {
                                 "fq": [
-                                    "product:*openshift*"
+                                    "product:*openshift*",
+                                    "product_version:*4.16*"
                                 ]
                             }
                         ]

--- a/src/constants.py
+++ b/src/constants.py
@@ -160,7 +160,7 @@ LLM_TURN_COMPLETE_EVENT: Final[str] = "turn_complete"
 # See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-SSLMODE
 POSTGRES_DEFAULT_SSL_MODE: Final[Literal["prefer"]] = "prefer"
 # See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
-POSTGRES_DEFAULT_GSS_ENCMODE: Final[str] = "prefer"
+POSTGRES_DEFAULT_GSS_ENCMODE: Final[Literal["prefer"]] = "prefer"
 
 # cache constants
 CACHE_TYPE_MEMORY: Final[str] = "memory"

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -236,7 +236,7 @@ class PostgreSQLDatabaseConfiguration(ConfigurationBase):
         description="SSL mode",
     )
 
-    gss_encmode: str = Field(
+    gss_encmode: Literal["disable", "prefer", "require"] = Field(
         constants.POSTGRES_DEFAULT_GSS_ENCMODE,
         title="GSS encmode",
         description="This option determines whether or with what priority a secure GSS "

--- a/tests/unit/models/config/test_postgresql_database_configuration.py
+++ b/tests/unit/models/config/test_postgresql_database_configuration.py
@@ -264,3 +264,48 @@ def test_postgresql_database_configuration_improper_ssl_mode(
                     password="password",
                     ssl_mode=ssl_mode,
                 )  # pyright: ignore[reportCallIssue]
+
+
+def test_postgresql_database_configuration_gss_encmode(subtests: SubTests) -> None:
+    """Test the PostgreSQLDatabaseConfiguration model."""
+    gss_encmodes = ("disable", "prefer", "require")
+
+    for gss_encmode in gss_encmodes:
+        with subtests.test(msg=f"GSS encmode {gss_encmode}"):
+            # pylint: disable=no-member
+            c = PostgreSQLDatabaseConfiguration(
+                db="db",
+                user="user",
+                password="password",
+                gss_encmode=gss_encmode,
+            )  # pyright: ignore[reportCallIssue]
+
+            # most attributes are set to default values
+            assert c is not None
+            assert c.host == "localhost"
+            assert c.port == 5432
+            assert c.db == "db"
+            assert c.user == "user"
+            assert c.password.get_secret_value() == "password"
+            assert c.ssl_mode == POSTGRES_DEFAULT_SSL_MODE
+            assert c.gss_encmode == gss_encmode
+            assert c.namespace == "public"
+            assert c.ca_cert_path is None
+
+
+def test_postgresql_database_configuration_improper_gss_encmode(
+    subtests: SubTests,
+) -> None:
+    """Test the PostgreSQLDatabaseConfiguration model."""
+    gss_encmodes = ("foo", "bar", "baz", "")
+
+    for gss_encmode in gss_encmodes:
+        with subtests.test(msg=f"GSS encmode {gss_encmode}"):
+            with pytest.raises(ValueError, match="Input should be 'disable'"):
+                # pylint: disable=no-member
+                PostgreSQLDatabaseConfiguration(
+                    db="db",
+                    user="user",
+                    password="password",
+                    gss_encmode=gss_encmode,
+                )  # pyright: ignore[reportCallIssue]


### PR DESCRIPTION
## Description

LCORE-623: proper `gss_encmode` config type in PostgreSQL configuration

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation with OpenAPI schema changes for configuration parameters.

* **Bug Fixes**
  * Improved PostgreSQL configuration validation to restrict GSS encryption mode to only valid options (`disable`, `prefer`, `require`), preventing invalid configurations from being accepted.

* **Tests**
  * Added unit test coverage for PostgreSQL configuration parameter validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->