### PR TITLE
RHOKP-1361: enable deep-linking using correct online and offline…

### DIFF
--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -518,6 +518,8 @@ def enrich_solr(  # pylint: disable=too-many-locals
                         "chunk_content_field": "chunk_field",
                         "chunk_index_field": "chunk_index",
                         "chunk_token_count_field": "num_tokens",
+                        "chunk_online_source_url_field": "online_source_url",
+                        "chunk_source_path_field": "source_path",
                         "parent_total_chunks_field": "total_chunks",
                         "parent_total_tokens_field": "total_tokens",
                         "chunk_filter_query": chunk_filter_query,

--- a/src/utils/vector_search.py
+++ b/src/utils/vector_search.py
@@ -281,13 +281,14 @@ async def _query_store_for_byok_rag(
 
 def _extract_solr_document_metadata(
     chunk: Any,
-) -> tuple[Optional[str], Optional[str], Optional[str]]:
-    """Extract document ID, title, and reference URL from chunk metadata."""
+) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """Extract document ID, title, reference URL, and source path from chunk metadata."""
     # 1) dict metadata
     metadata = getattr(chunk, "metadata", None) or {}
     doc_id = metadata.get("doc_id") or metadata.get("document_id")
     title = metadata.get("title")
     reference_url = metadata.get("reference_url")
+    source_path = metadata.get("source_path")
 
     # 2) typed chunk_metadata
     if not doc_id:
@@ -296,15 +297,19 @@ def _extract_solr_document_metadata(
             if isinstance(chunk_meta, dict):
                 doc_id = chunk_meta.get("doc_id") or chunk_meta.get("document_id")
                 title = title or chunk_meta.get("title")
-                reference_url = chunk_meta.get("reference_url")
+                reference_url = reference_url or chunk_meta.get("reference_url")
+                source_path = source_path or chunk_meta.get("source_path")
             else:
                 doc_id = getattr(chunk_meta, "doc_id", None) or getattr(
                     chunk_meta, "document_id", None
                 )
                 title = title or getattr(chunk_meta, "title", None)
-                reference_url = getattr(chunk_meta, "reference_url", None)
+                reference_url = reference_url or getattr(
+                    chunk_meta, "reference_url", None
+                )
+                source_path = source_path or getattr(chunk_meta, "source_path", None)
 
-    return doc_id, title, reference_url
+    return doc_id, title, reference_url, source_path
 
 
 def _process_byok_rag_chunks_for_documents(
@@ -396,13 +401,17 @@ def _process_solr_chunks_for_documents(
             "Extracting doc ids from chunk id: %s", getattr(chunk, "chunk_id", None)
         )
 
-        doc_id, title, reference_url = _extract_solr_document_metadata(chunk)
+        doc_id, title, reference_url, source_path = _extract_solr_document_metadata(
+            chunk
+        )
 
-        if not doc_id and not reference_url:
+        if not doc_id and not reference_url and not source_path:
             continue
 
         # Build URL based on offline flag
-        doc_url, reference_doc = _build_document_url(offline, doc_id, reference_url)
+        doc_url, reference_doc = _build_document_url(
+            offline, doc_id, reference_url, source_path
+        )
 
         if reference_doc and reference_doc not in metadata_doc_ids:
             metadata_doc_ids.add(reference_doc)
@@ -718,16 +727,18 @@ def _join_okp_doc_url(base_url: AnyUrl, reference: Optional[str]) -> str:
 
 
 def _build_document_url(
-    offline: bool, doc_id: Optional[str], reference_url: Optional[str]
+    offline: bool,
+    doc_id: Optional[str],
+    reference_url: Optional[str],
+    source_path: Optional[str] = None,
 ) -> tuple[str, Optional[str]]:
-    """
-    Build document URL based on offline flag and available metadata.
+    """Build document URL based on offline flag and available metadata.
 
     Args:
-        offline: Whether to use offline
-        (parent_id) or online mode (reference_url)
+        offline: Whether to use offline mode (source_path) or online mode (reference_url)
         doc_id: Document ID from chunk metadata
-        reference_url: Reference URL from chunk metadata
+        reference_url: Reference URL from chunk metadata (online deep-link)
+        source_path: Relative path from chunk metadata (offline deep-link)
 
     Returns:
         Tuple of (doc_url, reference_doc) where:
@@ -735,7 +746,10 @@ def _build_document_url(
         - reference_doc: The document reference used for deduplication
     """
     base_url = _get_okp_base_url()
-    reference_doc = doc_id if offline else (reference_url or doc_id)
+    if offline:
+        reference_doc = source_path or doc_id
+    else:
+        reference_doc = reference_url or doc_id
     doc_url = _join_okp_doc_url(base_url, reference_doc)
     return doc_url, reference_doc
 
@@ -765,10 +779,10 @@ def _convert_solr_chunks_to_rag_format(
         # Legacy logic: extract doc_url from chunk metadata based on offline flag
         if chunk.metadata:
             if offline:
-                parent_id = chunk.metadata.get("parent_id")
-                if parent_id:
+                source_path = chunk.metadata.get("source_path")
+                if source_path:
                     attributes["doc_url"] = _join_okp_doc_url(
-                        _get_okp_base_url(), parent_id
+                        _get_okp_base_url(), source_path
                     )
             else:
                 reference_url = chunk.metadata.get("reference_url")

--- a/tests/unit/utils/test_vector_search.py
+++ b/tests/unit/utils/test_vector_search.py
@@ -309,13 +309,17 @@ class TestExtractSolrDocumentMetadata:
             "doc_id": "doc_123",
             "title": "Test Document",
             "reference_url": "https://example.com/doc",
+            "source_path": "/docs/page.html#section",
         }
 
-        doc_id, title, reference_url = _extract_solr_document_metadata(chunk)
+        doc_id, title, reference_url, source_path = _extract_solr_document_metadata(
+            chunk
+        )
 
         assert doc_id == "doc_123"
         assert title == "Test Document"
         assert reference_url == "https://example.com/doc"
+        assert source_path == "/docs/page.html#section"
 
     def test_extract_from_chunk_metadata_object(self, mocker: MockerFixture) -> None:
         """Test extraction from typed chunk_metadata object."""
@@ -323,27 +327,34 @@ class TestExtractSolrDocumentMetadata:
         chunk_meta.doc_id = "doc_456"
         chunk_meta.title = "Another Document"
         chunk_meta.reference_url = "https://example.com/another"
+        chunk_meta.source_path = "/docs/another.html"
 
         chunk = mocker.Mock()
         chunk.metadata = {}
         chunk.chunk_metadata = chunk_meta
 
-        doc_id, title, reference_url = _extract_solr_document_metadata(chunk)
+        doc_id, title, reference_url, source_path = _extract_solr_document_metadata(
+            chunk
+        )
 
         assert doc_id == "doc_456"
         assert title == "Another Document"
         assert reference_url == "https://example.com/another"
+        assert source_path == "/docs/another.html"
 
     def test_extract_with_missing_fields(self, mocker: MockerFixture) -> None:
         """Test extraction when some fields are missing."""
         chunk = mocker.Mock()
         chunk.metadata = {"doc_id": "doc_789"}
 
-        doc_id, title, reference_url = _extract_solr_document_metadata(chunk)
+        doc_id, title, reference_url, source_path = _extract_solr_document_metadata(
+            chunk
+        )
 
         assert doc_id == "doc_789"
         assert title is None
         assert reference_url is None
+        assert source_path is None
 
 
 class TestGetOkpBaseUrl:
@@ -371,8 +382,22 @@ class TestGetOkpBaseUrl:
 class TestBuildDocumentUrl:
     """Tests for _build_document_url function."""
 
-    def test_offline_mode_with_doc_id(self, mocker: MockerFixture) -> None:
-        """Test URL building in offline mode with doc_id."""
+    def test_offline_mode_with_source_path(self, mocker: MockerFixture) -> None:
+        """Test URL building in offline mode with source_path."""
+        config_mock = mocker.Mock()
+        config_mock.okp.rhokp_url = "https://mimir.test"
+        mocker.patch("utils.vector_search.configuration", config_mock)
+        doc_url, reference_doc = _build_document_url(
+            offline=True,
+            doc_id="doc_123",
+            reference_url=None,
+            source_path="/docs/install.html#step-3",
+        )
+        assert doc_url == "https://mimir.test/docs/install.html#step-3"
+        assert reference_doc == "/docs/install.html#step-3"
+
+    def test_offline_mode_falls_back_to_doc_id(self, mocker: MockerFixture) -> None:
+        """Test offline mode falls back to doc_id when source_path is None."""
         config_mock = mocker.Mock()
         config_mock.okp.rhokp_url = "https://mimir.test"
         mocker.patch("utils.vector_search.configuration", config_mock)
@@ -387,11 +412,11 @@ class TestBuildDocumentUrl:
         doc_url, reference_doc = _build_document_url(
             offline=False,
             doc_id="doc_123",
-            reference_url="https://docs.example.com/page",
+            reference_url="https://docs.example.com/page#chunk1",
         )
 
-        assert doc_url == "https://docs.example.com/page"
-        assert reference_doc == "https://docs.example.com/page"
+        assert doc_url == "https://docs.example.com/page#chunk1"
+        assert reference_doc == "https://docs.example.com/page#chunk1"
 
     def test_online_mode_without_http(self, mocker: MockerFixture) -> None:
         """Test online mode when reference_url doesn't start with http."""
@@ -404,8 +429,8 @@ class TestBuildDocumentUrl:
         assert doc_url == "https://mimir.test/relative/path"
         assert reference_doc == "relative/path"
 
-    def test_offline_mode_without_doc_id(self) -> None:
-        """Test offline mode when doc_id is None."""
+    def test_offline_mode_without_doc_id_or_source_path(self) -> None:
+        """Test offline mode when both doc_id and source_path are None."""
         doc_url, reference_doc = _build_document_url(
             offline=True, doc_id=None, reference_url="https://example.com"
         )
@@ -418,10 +443,10 @@ class TestConvertSolrChunksToRagFormat:
     """Tests for _convert_solr_chunks_to_rag_format function."""
 
     def test_convert_with_metadata_offline(self, mocker: MockerFixture) -> None:
-        """Test conversion with metadata in offline mode."""
+        """Test conversion with metadata in offline mode uses source_path."""
         chunk = mocker.Mock()
         chunk.content = "Test content"
-        chunk.metadata = {"parent_id": "parent_123"}
+        chunk.metadata = {"source_path": "/docs/install.html#step-3"}
         chunk.chunk_metadata = None
 
         result = _convert_solr_chunks_to_rag_format([chunk], [0.85], offline=True)
@@ -432,7 +457,7 @@ class TestConvertSolrChunksToRagFormat:
         assert result[0].score == 0.85
         assert result[0].attributes is not None
         assert "doc_url" in result[0].attributes
-        assert "parent_123" in result[0].attributes["doc_url"]
+        assert "/docs/install.html#step-3" in result[0].attributes["doc_url"]
 
     def test_convert_with_metadata_online(self, mocker: MockerFixture) -> None:
         """Test conversion with metadata in online mode."""
@@ -467,12 +492,12 @@ class TestConvertSolrChunksToRagFormat:
         """Test conversion of multiple chunks."""
         chunk1 = mocker.Mock()
         chunk1.content = "Content 1"
-        chunk1.metadata = {"parent_id": "parent_1"}
+        chunk1.metadata = {"source_path": "/docs/page1.html"}
         chunk1.chunk_metadata = None
 
         chunk2 = mocker.Mock()
         chunk2.content = "Content 2"
-        chunk2.metadata = {"parent_id": "parent_2"}
+        chunk2.metadata = {"source_path": "/docs/page2.html"}
         chunk2.chunk_metadata = None
 
         result = _convert_solr_chunks_to_rag_format(


### PR DESCRIPTION
… solr meta-data fields for urls

This updates the Solr reference URL mappings to use the correct solr url fields for both online and offline modes.  Previously `doc_id` was used as the offline reference url. That was not correct, the correct offline url field is called `source_path`

## Type of change

- [ x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR



- Assisted-by: Claude


## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/RHOKP-1361

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Test OKP rag reference urls in both online and offline mode
