### PR TITLE
LCORE-1834: MCP Approval Configuration

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -62,6 +62,40 @@ Note: this is not a real model, just an enumeration of all action names.
 
 
 
+## ApprovalFilter
+
+
+Granular approval control for specific MCP tools.
+
+Attributes:
+    always: Tool names that always require human approval before execution.
+    never: Tool names that never require approval (pre-approved).
+
+
+| Field | Type | Description |
+|-------|------|-------------|
+| always | array | List of tool names that always require human approval |
+| never | array | List of tool names that never require approval |
+
+
+## ApprovalsConfiguration
+
+
+Configuration for human-in-the-loop approvals.
+
+Attributes:
+    approval_timeout_seconds: How long approval requests remain pending
+        before expiring.
+    approval_retention_days: How long to retain decided approvals for audit
+        purposes before cleanup.
+
+
+| Field | Type | Description |
+|-------|------|-------------|
+| approval_timeout_seconds | integer | Seconds before pending approval requests expire |
+| approval_retention_days | integer | Days to retain decided approvals before cleanup |
+
+
 ## AuthenticationConfiguration
 
 
@@ -205,6 +239,7 @@ Global service configuration.
 | inference |  | One LLM provider and one its model might be selected as default ones. When no provider+model pair is specified in REST API calls (query endpoints), the default provider and model are used. |
 | conversation_cache |  |  |
 | compaction |  | Controls when conversation history is summarized to keep the model's input below the context window limit. Disabled by default — when disabled, requests that exceed the window continue to surface as HTTP 413. |
+| approvals |  | Settings for human-in-the-loop approval of MCP tool invocations |
 | byok_rag | array | BYOK RAG configuration. This configuration can be used to reconfigure Llama Stack through its run.yaml configuration file |
 | a2a_state |  | Configuration for A2A protocol persistent state storage. |
 | quota_handlers |  | Quota handlers configuration |
@@ -419,6 +454,7 @@ Useful resources:
 | url | string | URL of the MCP server |
 | authorization_headers | object | Headers to send to the MCP server. The map contains the header name and the path to a file containing the header value (secret). There are 3 special cases: 1. Usage of the kubernetes token in the header. To specify this use a string 'kubernetes' instead of the file path. 2. Usage of the client-provided token in the header. To specify this use a string 'client' instead of the file path. 3. Usage of the oauth token in the header. To specify this use a string 'oauth' instead of the file path.  |
 | headers | array | List of HTTP header names to automatically forward from the incoming request to this MCP server. Headers listed here are extracted from the original client request and included when calling the MCP server. This is useful when infrastructure components (e.g. API gateways) inject headers that MCP servers need, such as x-rh-identity in HCC. Header matching is case-insensitive. These headers are additive with authorization_headers and MCP-HEADERS. |
+| require_approval | string or object | When to require human approval for MCP tool invocations. 'always' requires approval for all tools, 'never' auto-approves all tools (default), or use an ApprovalFilter for granular per-tool control. |
 | timeout | integer | Timeout in seconds for requests to the MCP server. If not specified, the default timeout from Llama Stack will be used. Note: This field is reserved for future use when Llama Stack adds timeout support. |
 
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11400,7 +11400,7 @@
                 "title": "AllowedToolsFilter",
                 "description": "Filter configuration for restricting which MCP tools can be used.\n\n:param tool_names: (Optional) List of specific tool names that are allowed"
             },
-            "ApprovalFilter": {
+            "ApprovalFilter-Input": {
                 "properties": {
                     "always": {
                         "anyOf": [
@@ -11434,6 +11434,52 @@
                 "type": "object",
                 "title": "ApprovalFilter",
                 "description": "Filter configuration for MCP tool approval requirements.\n\n:param always: (Optional) List of tool names that always require approval\n:param never: (Optional) List of tool names that never require approval"
+            },
+            "ApprovalFilter-Output": {
+                "properties": {
+                    "always": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Always require approval",
+                        "description": "List of tool names that always require human approval"
+                    },
+                    "never": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "title": "Never require approval",
+                        "description": "List of tool names that never require approval"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "ApprovalFilter",
+                "description": "Granular approval control for specific MCP tools.\n\nAttributes:\n    always: Tool names that always require human approval before execution.\n    never: Tool names that never require approval (pre-approved)."
+            },
+            "ApprovalsConfiguration": {
+                "properties": {
+                    "approval_timeout_seconds": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Approval timeout",
+                        "description": "Seconds before pending approval requests expire",
+                        "default": 300
+                    },
+                    "approval_retention_days": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Retention period",
+                        "description": "Days to retain decided approvals before cleanup",
+                        "default": 30
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "ApprovalsConfiguration",
+                "description": "Configuration for human-in-the-loop approvals.\n\nAttributes:\n    approval_timeout_seconds: How long approval requests remain pending\n        before expiring.\n    approval_retention_days: How long to retain decided approvals for audit\n        purposes before cleanup."
             },
             "Attachment": {
                 "properties": {
@@ -12015,6 +12061,11 @@
                         "$ref": "#/components/schemas/CompactionConfiguration",
                         "title": "Conversation compaction configuration",
                         "description": "Controls when conversation history is summarized to keep the model's input below the context window limit. Disabled by default \u2014 when disabled, requests that exceed the window continue to surface as HTTP 413."
+                    },
+                    "approvals": {
+                        "$ref": "#/components/schemas/ApprovalsConfiguration",
+                        "title": "Approvals configuration",
+                        "description": "Settings for human-in-the-loop approval of MCP tool invocations"
                     },
                     "byok_rag": {
                         "items": {
@@ -14264,6 +14315,23 @@
                         "title": "Propagated headers",
                         "description": "List of HTTP header names to automatically forward from the incoming request to this MCP server. Headers listed here are extracted from the original client request and included when calling the MCP server. This is useful when infrastructure components (e.g. API gateways) inject headers that MCP servers need, such as x-rh-identity in HCC. Header matching is case-insensitive. These headers are additive with authorization_headers and MCP-HEADERS."
                     },
+                    "require_approval": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "always",
+                                    "never"
+                                ]
+                            },
+                            {
+                                "$ref": "#/components/schemas/ApprovalFilter-Output"
+                            }
+                        ],
+                        "title": "Approval requirement",
+                        "description": "When to require human approval for tool invocations. 'always' requires approval for all tools, 'never' auto-approves, or use ApprovalFilter for granular control.",
+                        "default": "never"
+                    },
                     "timeout": {
                         "anyOf": [
                             {
@@ -15269,7 +15337,7 @@
                                 "const": "never"
                             },
                             {
-                                "$ref": "#/components/schemas/ApprovalFilter"
+                                "$ref": "#/components/schemas/ApprovalFilter-Input"
                             }
                         ],
                         "title": "Require Approval",

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -14,6 +14,7 @@ from cache.cache_factory import CacheFactory
 from log import get_logger
 from models.config import (
     A2AStateConfiguration,
+    ApprovalsConfiguration,
     AuthenticationConfiguration,
     AuthorizationConfiguration,
     AzureEntraIdConfiguration,
@@ -458,6 +459,20 @@ class AppConfig:  # pylint: disable=too-many-public-methods
         if self._configuration is None:
             raise LogicError("logic error: configuration is not loaded")
         return self._configuration.rag
+
+    @property
+    def approvals_configuration(self) -> ApprovalsConfiguration:
+        """Return human-in-the-loop approvals configuration.
+
+        Returns:
+            ApprovalsConfiguration: Settings for MCP tool approval workflow.
+
+        Raises:
+            LogicError: If the configuration has not been loaded.
+        """
+        if self._configuration is None:
+            raise LogicError("logic error: configuration is not loaded")
+        return self._configuration.approvals
 
     @property
     def okp(self) -> "OkpConfiguration":

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -467,6 +467,65 @@ class ServiceConfiguration(ConfigurationBase):
         return self
 
 
+class ApprovalFilter(ConfigurationBase):
+    """Granular approval control for specific MCP tools.
+
+    Attributes:
+        always: Tool names that always require human approval before execution.
+        never: Tool names that never require approval (pre-approved).
+    """
+
+    always: list[str] = Field(
+        default_factory=list,
+        title="Always require approval",
+        description="List of tool names that always require human approval",
+    )
+    never: list[str] = Field(
+        default_factory=list,
+        title="Never require approval",
+        description="List of tool names that never require approval",
+    )
+
+    @model_validator(mode="after")
+    def validate_no_overlap(self) -> Self:
+        """Ensure no tool appears in both always and never lists.
+
+        Raises:
+            ValueError: If any tool name is present in both lists.
+
+        Returns:
+            Self: The validated model instance.
+        """
+        overlap = set(self.always) & set(self.never)
+        if overlap:
+            raise ValueError(
+                f"Tools cannot be in both always and never lists: {overlap}"
+            )
+        return self
+
+
+class ApprovalsConfiguration(ConfigurationBase):
+    """Configuration for human-in-the-loop approvals.
+
+    Attributes:
+        approval_timeout_seconds: How long approval requests remain pending
+            before expiring.
+        approval_retention_days: How long to retain decided approvals for audit
+            purposes before cleanup.
+    """
+
+    approval_timeout_seconds: PositiveInt = Field(
+        default=300,
+        title="Approval timeout",
+        description="Seconds before pending approval requests expire",
+    )
+    approval_retention_days: PositiveInt = Field(
+        default=30,
+        title="Retention period",
+        description="Days to retain decided approvals before cleanup",
+    )
+
+
 class ModelContextProtocolServer(ConfigurationBase):
     """Model context protocol server configuration.
 
@@ -554,6 +613,16 @@ class ModelContextProtocolServer(ConfigurationBase):
                 raise ValueError(msg)
             seen.add(lower)
         return value
+
+    require_approval: Literal["always", "never"] | ApprovalFilter = Field(
+        default="never",
+        title="Approval requirement",
+        description=(
+            "When to require human approval for tool invocations. "
+            "'always' requires approval for all tools, 'never' auto-approves, "
+            "or use ApprovalFilter for granular control."
+        ),
+    )
 
     timeout: Optional[PositiveInt] = Field(
         default=None,
@@ -2049,6 +2118,12 @@ class Configuration(ConfigurationBase):
         "to keep the model's input below the context window limit. "
         "Disabled by default — when disabled, requests that exceed the "
         "window continue to surface as HTTP 413.",
+    )
+
+    approvals: ApprovalsConfiguration = Field(
+        default_factory=ApprovalsConfiguration,
+        title="Approvals configuration",
+        description="Settings for human-in-the-loop approval of MCP tool invocations",
     )
 
     byok_rag: list[ByokRag] = Field(

--- a/tests/unit/models/config/README.md
+++ b/tests/unit/models/config/README.md
@@ -6,6 +6,9 @@ Unit tests for models defined in config.py.
 ## [test_a2a_state_configuration.py](test_a2a_state_configuration.py)
 Unit tests for A2AStateConfiguration.
 
+## [test_approvals_configuration.py](test_approvals_configuration.py)
+Unit tests for human-in-the-loop approvals configuration models.
+
 ## [test_authentication_configuration.py](test_authentication_configuration.py)
 Unit tests for AuthenticationConfiguration model.
 

--- a/tests/unit/models/config/test_approvals_configuration.py
+++ b/tests/unit/models/config/test_approvals_configuration.py
@@ -1,0 +1,121 @@
+"""Unit tests for human-in-the-loop approvals configuration models."""
+
+# pylint: disable=no-member
+
+import pytest
+from pydantic import ValidationError
+
+from models.config import (
+    ApprovalFilter,
+    ApprovalsConfiguration,
+    CompactionConfiguration,
+    Configuration,
+    LlamaStackConfiguration,
+    ServiceConfiguration,
+    UserDataCollection,
+)
+
+
+def test_approvals_configuration_defaults() -> None:
+    """ApprovalsConfiguration uses design-doc defaults for timeout and retention."""
+    config = ApprovalsConfiguration()
+    assert config.approval_timeout_seconds == 300
+    assert config.approval_retention_days == 30
+
+
+def test_approvals_configuration_custom_timeout() -> None:
+    """approval_timeout_seconds accepts positive integers."""
+    config = ApprovalsConfiguration(approval_timeout_seconds=600)
+    assert config.approval_timeout_seconds == 600
+
+
+def test_approvals_configuration_custom_retention() -> None:
+    """approval_retention_days accepts positive integers."""
+    config = ApprovalsConfiguration(approval_retention_days=90)
+    assert config.approval_retention_days == 90
+
+
+def test_approvals_configuration_rejects_non_positive_retention() -> None:
+    """approval_retention_days rejects zero and negative values."""
+    with pytest.raises(ValidationError):
+        ApprovalsConfiguration(approval_retention_days=0)
+
+    with pytest.raises(ValidationError):
+        ApprovalsConfiguration(approval_retention_days=-1)
+
+
+def test_approvals_configuration_rejects_non_positive_timeout() -> None:
+    """approval_timeout_seconds rejects zero and negative values."""
+    with pytest.raises(ValidationError):
+        ApprovalsConfiguration(approval_timeout_seconds=0)
+
+    with pytest.raises(ValidationError):
+        ApprovalsConfiguration(approval_timeout_seconds=-1)
+
+
+def test_approvals_configuration_rejects_unknown_field() -> None:
+    """Unknown fields are forbidden on ApprovalsConfiguration."""
+    with pytest.raises(ValidationError):
+        ApprovalsConfiguration(approval_ttl_seconds=300)  # type: ignore[call-arg]
+
+
+def test_approval_filter_always_and_never_lists() -> None:
+    """ApprovalFilter stores always and never tool name lists."""
+    filt = ApprovalFilter(
+        always=["create_issue", "delete_branch"],
+        never=["list_repos", "get_issue"],
+    )
+    assert filt.always == ["create_issue", "delete_branch"]
+    assert filt.never == ["list_repos", "get_issue"]
+
+
+def test_approval_filter_defaults_to_empty_lists() -> None:
+    """ApprovalFilter always and never default to empty lists."""
+    filt = ApprovalFilter()
+    assert filt.always == []
+    assert filt.never == []
+
+
+def test_approval_filter_rejects_overlapping_tool_names() -> None:
+    """A tool cannot appear in both always and never lists."""
+    with pytest.raises(ValidationError, match="both always and never lists"):
+        ApprovalFilter(always=["shared_tool"], never=["shared_tool"])
+
+
+def test_approval_filter_rejects_unknown_field() -> None:
+    """Unknown fields are forbidden on ApprovalFilter."""
+    with pytest.raises(ValidationError):
+        ApprovalFilter(always=[], unknown=True)  # type: ignore[call-arg]
+
+
+def test_root_configuration_has_approvals_field() -> None:
+    """The root Configuration declares an approvals field with defaults."""
+    field_info = Configuration.model_fields.get("approvals")
+    assert field_info is not None
+    assert field_info.annotation is ApprovalsConfiguration
+
+    factory = field_info.default_factory
+    assert factory is not None
+    default = factory()  # type: ignore[call-arg]
+    assert isinstance(default, ApprovalsConfiguration)
+    assert default.approval_timeout_seconds == 300
+    assert default.approval_retention_days == 30
+
+
+def test_root_configuration_default_includes_approvals() -> None:
+    """Configuration constructed with required fields gets default approvals."""
+    cfg = Configuration(
+        name="test",
+        service=ServiceConfiguration(),
+        llama_stack=LlamaStackConfiguration(
+            use_as_library_client=True,
+            library_client_config_path="tests/configuration/run.yaml",
+        ),
+        user_data_collection=UserDataCollection(
+            feedback_enabled=False, feedback_storage=None
+        ),
+        compaction=CompactionConfiguration(),
+    )
+    approvals: ApprovalsConfiguration = cfg.approvals
+    assert approvals.approval_timeout_seconds == 300
+    assert approvals.approval_retention_days == 30

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -5,6 +5,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 
 from pydantic import SecretStr
 
@@ -24,6 +25,18 @@ from models.config import (
     TLSConfiguration,
     UserDataCollection,
 )
+
+_DEFAULT_APPROVALS_DUMP: dict[str, int] = {
+    "approval_timeout_seconds": 300,
+    "approval_retention_days": 30,
+}
+
+_MCP_SERVER_DUMP_DEFAULTS: dict[str, Any] = {
+    "authorization_headers": {},
+    "headers": [],
+    "require_approval": "never",
+    "timeout": None,
+}
 
 
 def test_dump_configuration(tmp_path: Path) -> None:
@@ -199,6 +212,7 @@ def test_dump_configuration(tmp_path: Path) -> None:
                 "buffer_turns": 4,
                 "buffer_max_ratio": 0.3,
             },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
             "byok_rag": [],
             "quota_handlers": {
                 "sqlite": None,
@@ -283,9 +297,7 @@ def test_dump_configuration_with_one_mcp_server(tmp_path: Path) -> None:
                 "name": "test-server",
                 "url": "http://localhost:8080",
                 "provider_id": "model-context-protocol",
-                "authorization_headers": {},
-                "headers": [],
-                "timeout": None,
+                **_MCP_SERVER_DUMP_DEFAULTS,
             }
         ]
 
@@ -343,25 +355,19 @@ def test_dump_configuration_with_more_mcp_servers(tmp_path: Path) -> None:
                 "name": "test-server-1",
                 "provider_id": "model-context-protocol",
                 "url": "http://localhost:8081",
-                "authorization_headers": {},
-                "headers": [],
-                "timeout": None,
+                **_MCP_SERVER_DUMP_DEFAULTS,
             },
             {
                 "name": "test-server-2",
                 "provider_id": "model-context-protocol",
                 "url": "http://localhost:8082",
-                "authorization_headers": {},
-                "headers": [],
-                "timeout": None,
+                **_MCP_SERVER_DUMP_DEFAULTS,
             },
             {
                 "name": "test-server-3",
                 "provider_id": "model-context-protocol",
                 "url": "http://localhost:8083",
-                "authorization_headers": {},
-                "headers": [],
-                "timeout": None,
+                **_MCP_SERVER_DUMP_DEFAULTS,
             },
         ]
 
@@ -555,6 +561,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "buffer_turns": 4,
                 "buffer_max_ratio": 0.3,
             },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
             "byok_rag": [],
             "quota_handlers": {
                 "sqlite": None,
@@ -802,6 +809,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "buffer_turns": 4,
                 "buffer_max_ratio": 0.3,
             },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
             "byok_rag": [],
             "quota_handlers": {
                 "sqlite": None,
@@ -1029,6 +1037,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "buffer_turns": 4,
                 "buffer_max_ratio": 0.3,
             },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
             "byok_rag": [
                 {
                     "db_path": "tests/configuration/rag.txt",
@@ -1246,6 +1255,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "buffer_turns": 4,
                 "buffer_max_ratio": 0.3,
             },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
             "byok_rag": [],
             "quota_handlers": {
                 "sqlite": None,

--- a/tests/unit/models/config/test_model_context_protocol_server.py
+++ b/tests/unit/models/config/test_model_context_protocol_server.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from models.config import (  # type: ignore[import-not-found]
+    ApprovalFilter,
     AuthenticationConfiguration,
     Configuration,
     LlamaStackConfiguration,
@@ -25,6 +26,44 @@ def test_model_context_protocol_server_constructor() -> None:
     assert mcp.provider_id == "model-context-protocol"
     assert mcp.url == "http://localhost:8080"
     assert mcp.authorization_headers == {}  # Default should be empty dict
+    assert mcp.require_approval == "never"
+
+
+def test_model_context_protocol_server_require_approval_always() -> None:
+    """require_approval accepts the literal value 'always'."""
+    mcp = ModelContextProtocolServer(
+        name="strict-server",
+        url="http://localhost:8080",
+        require_approval="always",
+    )
+    assert mcp.require_approval == "always"
+
+
+def test_model_context_protocol_server_require_approval_filter() -> None:
+    """require_approval accepts an ApprovalFilter for granular control."""
+    filt = ApprovalFilter(
+        always=["create_issue"],
+        never=["list_repos"],
+    )
+    mcp = ModelContextProtocolServer(
+        name="filtered-server",
+        url="http://localhost:8080",
+        require_approval=filt,
+    )
+    require_approval = mcp.require_approval
+    assert isinstance(require_approval, ApprovalFilter)
+    assert require_approval.always == ["create_issue"]  # pylint: disable=no-member
+    assert require_approval.never == ["list_repos"]  # pylint: disable=no-member
+
+
+def test_model_context_protocol_server_require_approval_invalid_literal() -> None:
+    """require_approval rejects values other than 'always' or 'never'."""
+    with pytest.raises(ValidationError):
+        ModelContextProtocolServer(
+            name="bad-server",
+            url="http://localhost:8080",
+            require_approval="sometimes",  # type: ignore[arg-type]
+        )
 
 
 def test_model_context_protocol_server_custom_provider() -> None:


### PR DESCRIPTION
## Description

Adds configuration blocks for MCP server approval policy.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-1834](https://redhat.atlassian.net/browse/LCORE-1834)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced human-in-the-loop approval system for MCP tool invocations with customizable approval timeouts and retention settings.
  * Added granular approval control enabling per-tool rules to specify which tools always require approval or never require approval.

* **Documentation**
  * Updated configuration documentation with new approval system settings and schema.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->