### PR TITLE
LCORE-1838: Wire MCP require approval

### DIFF
--- a/src/app/endpoints/responses_telemetry.py
+++ b/src/app/endpoints/responses_telemetry.py
@@ -10,8 +10,8 @@ from typing import Optional
 from fastapi import BackgroundTasks
 
 from log import get_logger
+from models.common.responses.contexts import ResponsesContext
 from models.common.responses.responses_api_params import ResponsesApiParams
-from models.common.responses.responses_context import ResponsesContext
 from models.common.turn_summary import TurnSummary
 from observability import ResponsesEventData, build_responses_event
 from observability.splunk import dispatch_splunk_event

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -8,6 +8,7 @@ from typing import Any, Optional, cast
 
 from fastapi import HTTPException
 from llama_stack_api import OpenAIResponseObject
+from llama_stack_api.openai_responses import ApprovalFilter
 from llama_stack_api.openai_responses import (
     OpenAIResponseContentPartRefusal as ContentPartRefusal,
 )
@@ -731,12 +732,20 @@ async def get_mcp_tools(
             continue
 
         authorization = headers.pop("Authorization", None)
+
+        require_approval = (
+            mcp_server.require_approval
+            if isinstance(mcp_server.require_approval, str)
+            else ApprovalFilter(
+                always=mcp_server.require_approval.always or None,
+                never=mcp_server.require_approval.never or None,
+            )
+        )
         tools.append(
             InputToolMCP(
-                type="mcp",
                 server_label=mcp_server.name,
                 server_url=mcp_server.url,
-                require_approval="never",
+                require_approval=require_approval,
                 headers=headers or None,
                 authorization=authorization,
             )

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -12,6 +12,7 @@ from llama_stack_api.openai_responses import (
     AllowedToolsFilter,
     OpenAIResponseInputToolChoiceAllowedTools,
 )
+from llama_stack_api.openai_responses import ApprovalFilter as LlamaStackApprovalFilter
 from llama_stack_api.openai_responses import (
     OpenAIResponseInputToolChoiceFileSearch as ToolChoiceFileSearch,
 )
@@ -55,7 +56,7 @@ from pytest_mock import MockerFixture
 import constants
 from models.api.requests import QueryRequest
 from models.common.responses.types import InputTool, InputToolMCP
-from models.config import ByokRag, ModelContextProtocolServer
+from models.config import ApprovalFilter, ByokRag, ModelContextProtocolServer
 from utils.responses import (
     _build_chunk_attributes,
     _merge_tools,
@@ -400,6 +401,50 @@ class TestGetMCPTools:
         assert tools_no_auth[0].server_label == "fs"
         assert tools_no_auth[0].server_url == "http://localhost:3000"
         assert tools_no_auth[0].headers is None
+        assert all(tool.require_approval == "never" for tool in tools_no_auth)
+
+    @pytest.mark.asyncio
+    async def test_get_mcp_tools_require_approval_always(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test get_mcp_tools passes require_approval='always' from config."""
+        server = ModelContextProtocolServer(
+            name="strict",
+            url="http://localhost:3000",
+            provider_id="mcp",
+            require_approval="always",
+        )
+        mock_config = mocker.Mock()
+        mock_config.mcp_servers = [server]
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        tools = await get_mcp_tools(token=None)
+        assert len(tools) == 1
+        assert tools[0].require_approval == "always"
+
+    @pytest.mark.asyncio
+    async def test_get_mcp_tools_require_approval_filter(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test get_mcp_tools translates ApprovalFilter to Llama Stack format."""
+        server = ModelContextProtocolServer(
+            name="github",
+            url="http://localhost:3000",
+            provider_id="mcp",
+            require_approval=ApprovalFilter(
+                always=["create_issue"],
+                never=["list_repos"],
+            ),
+        )
+        mock_config = mocker.Mock()
+        mock_config.mcp_servers = [server]
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        tools = await get_mcp_tools(token=None)
+        assert len(tools) == 1
+        assert isinstance(tools[0].require_approval, LlamaStackApprovalFilter)
+        assert tools[0].require_approval.always == ["create_issue"]
+        assert tools[0].require_approval.never == ["list_repos"]
 
     @pytest.mark.asyncio
     async def test_get_mcp_tools_with_kubernetes_auth(


### PR DESCRIPTION
## Description

Wires configured MCP approval policy to MCP creation process. Distinguishes between simple (string) and complex policies.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-1838](https://redhat.atlassian.net/browse/LCORE-1838)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed approval-filter handling so generated tools respect server approval settings (supports legacy and structured approval configs), ensuring correct require_approval behavior.

* **Tests**
  * Added unit tests validating default and configured approval behaviors and structured approval translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->