### PR TITLE
LCORE-1861: config toggle for degraded mode

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -1115,6 +1115,12 @@ mode</td>
           <td>Timeout in seconds for requests to Llama Stack service. Default is
 180 seconds (3 minutes) to accommodate long-running RAG queries.</td>
         </tr>
+        <tr class="even">
+          <td>allow_degraded_mode</td>
+          <td>boolean</td>
+          <td>If enabled, Lightspeed Core can be started even when Llama Stack is
+not accessible (valid for server mode only)</td>
+        </tr>
       </tbody>
     </table>
     <h2 id="modelcontextprotocolserver">ModelContextProtocolServer</h2>

--- a/docs/config.json
+++ b/docs/config.json
@@ -919,6 +919,13 @@
             "minimum": 0,
             "title": "Request timeout",
             "type": "integer"
+          },
+          "allow_degraded_mode": {
+            "type": "boolean",
+            "nullable": true,
+            "default": false,
+            "description": "If enabled, Lightspeed Core can be started even when Llama Stack is not accessible (valid for server mode only)",
+            "title": "Allow degraded mode"
           }
         },
         "title": "LlamaStackConfiguration",

--- a/docs/config.md
+++ b/docs/config.md
@@ -427,6 +427,7 @@ Useful resources:
 | use_as_library_client | boolean | When set to true Llama Stack will be used in library mode, not in server mode (default) |
 | library_client_config_path | string | Path to configuration file used when Llama Stack is run in library mode |
 | timeout | integer | Timeout in seconds for requests to Llama Stack service. Default is 180 seconds (3 minutes) to accommodate long-running RAG queries. |
+| allow_degraded_mode | boolean | If enabled, Lightspeed Core can be started even when Llama Stack is not accessible (valid for server mode only) |
 
 
 ## ModelContextProtocolServer

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13849,6 +13849,19 @@
                         "title": "Request timeout",
                         "description": "Timeout in seconds for requests to Llama Stack service. Default is 180 seconds (3 minutes) to accommodate long-running RAG queries.",
                         "default": 180
+                    },
+                    "allow_degraded_mode": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Allow degraded mode",
+                        "description": "If enabled, Lightspeed Core can be started even when Llama Stack is not accessible (valid for server mode only)",
+                        "default": false
                     }
                 },
                 "additionalProperties": false,

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -701,6 +701,13 @@ class LlamaStackConfiguration(ConfigurationBase):
         "Default is 180 seconds (3 minutes) to accommodate long-running RAG queries.",
     )
 
+    allow_degraded_mode: Optional[bool] = Field(
+        False,
+        title="Allow degraded mode",
+        description="If enabled, Lightspeed Core can be started even when Llama Stack "
+        "is not accessible (valid for server mode only)",
+    )
+
     @model_validator(mode="after")
     def check_llama_stack_model(self) -> Self:
         """

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -160,6 +160,7 @@ def test_dump_configuration(tmp_path: Path) -> None:
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
+                "allow_degraded_mode": False,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -510,6 +511,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
+                "allow_degraded_mode": False,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -759,6 +761,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
+                "allow_degraded_mode": False,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -988,6 +991,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
+                "allow_degraded_mode": False,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -1207,6 +1211,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "api_key": "**********",
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
+                "allow_degraded_mode": False,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -1377,4 +1382,220 @@ def test_dump_configuration_with_skills(tmp_path: Path) -> None:
                 "/var/skills/code-review",
                 "/opt/custom-skills",
             ]
+        }
+
+
+def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
+    """
+    Test that the Configuration object can be serialized to a JSON file and
+    that the resulting file contains all expected sections and values.
+
+    Please note that redaction process is not in place.
+
+    Parameters:
+    ----------
+        tmp_path (Path): Directory where the test JSON file will be written.
+    """
+    cfg = Configuration(
+        name="test_name",
+        service=ServiceConfiguration(
+            tls_config=TLSConfiguration(
+                tls_certificate_path=Path("tests/configuration/server.crt"),
+                tls_key_path=Path("tests/configuration/server.key"),
+                tls_key_password=Path("tests/configuration/password"),
+            ),
+            cors=CORSConfiguration(
+                allow_origins=["foo_origin", "bar_origin", "baz_origin"],
+                allow_credentials=False,
+                allow_methods=["foo_method", "bar_method", "baz_method"],
+                allow_headers=["foo_header", "bar_header", "baz_header"],
+            ),
+        ),
+        llama_stack=LlamaStackConfiguration(
+            use_as_library_client=False,
+            url="http://localhost",
+            api_key=SecretStr("whatever"),
+            allow_degraded_mode=True,
+        ),
+        user_data_collection=UserDataCollection(
+            feedback_enabled=False, feedback_storage=None
+        ),
+        database=DatabaseConfiguration(
+            sqlite=None,
+            postgres=PostgreSQLDatabaseConfiguration(
+                db="lightspeed_stack",
+                user="ls_user",
+                password=SecretStr("ls_password"),
+                port=5432,
+                ca_cert_path=None,
+                ssl_mode="require",
+                gss_encmode="disable",
+            ),
+        ),
+        mcp_servers=[],
+        customization=None,
+        inference=InferenceConfiguration(
+            default_provider="default_provider",
+            default_model="default_model",
+        ),
+    )
+    assert cfg is not None
+    dump_file = tmp_path / "test.json"
+    cfg.dump(dump_file)
+
+    with open(dump_file, "r", encoding="utf-8") as fin:
+        content = json.load(fin)
+        # content should be loaded
+        assert content is not None
+
+        # all sections must exists
+        assert "name" in content
+        assert "service" in content
+        assert "llama_stack" in content
+        assert "user_data_collection" in content
+        assert "mcp_servers" in content
+        assert "authentication" in content
+        assert "authorization" in content
+        assert "customization" in content
+        assert "inference" in content
+        assert "database" in content
+        assert "byok_rag" in content
+        assert "quota_handlers" in content
+        assert "azure_entra_id" in content
+        assert "reranker" in content
+
+        # check the whole deserialized JSON file content
+        assert content == {
+            "name": "test_name",
+            "service": {
+                "host": "localhost",
+                "port": 8080,
+                "base_url": None,
+                "auth_enabled": False,
+                "workers": 1,
+                "color_log": True,
+                "access_log": True,
+                "tls_config": {
+                    "tls_certificate_path": "tests/configuration/server.crt",
+                    "tls_key_password": "tests/configuration/password",
+                    "tls_key_path": "tests/configuration/server.key",
+                },
+                "root_path": "",
+                "cors": {
+                    "allow_credentials": False,
+                    "allow_headers": [
+                        "foo_header",
+                        "bar_header",
+                        "baz_header",
+                    ],
+                    "allow_methods": [
+                        "foo_method",
+                        "bar_method",
+                        "baz_method",
+                    ],
+                    "allow_origins": [
+                        "foo_origin",
+                        "bar_origin",
+                        "baz_origin",
+                    ],
+                },
+            },
+            "llama_stack": {
+                "url": "http://localhost/",
+                "use_as_library_client": False,
+                "api_key": "**********",
+                "library_client_config_path": None,
+                "timeout": 180,
+                "allow_degraded_mode": True,
+            },
+            "user_data_collection": {
+                "feedback_enabled": False,
+                "feedback_storage": None,
+                "transcripts_enabled": False,
+                "transcripts_storage": None,
+            },
+            "mcp_servers": [],
+            "authentication": {
+                "module": "noop",
+                "skip_tls_verification": False,
+                "skip_for_health_probes": False,
+                "skip_for_metrics": False,
+                "k8s_ca_cert_path": None,
+                "k8s_cluster_api": None,
+                "jwk_config": None,
+                "api_key_config": None,
+                "rh_identity_config": None,
+            },
+            "customization": None,
+            "inference": {
+                "default_provider": "default_provider",
+                "default_model": "default_model",
+                "context_windows": {},
+            },
+            "database": {
+                "sqlite": None,
+                "postgres": {
+                    "host": "localhost",
+                    "port": 5432,
+                    "db": "lightspeed_stack",
+                    "user": "ls_user",
+                    "password": "**********",
+                    "ssl_mode": "require",
+                    "gss_encmode": "disable",
+                    "namespace": "public",
+                    "ca_cert_path": None,
+                },
+            },
+            "authorization": None,
+            "conversation_cache": {
+                "memory": None,
+                "postgres": None,
+                "sqlite": None,
+                "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
+            },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
+            "byok_rag": [],
+            "quota_handlers": {
+                "sqlite": None,
+                "postgres": None,
+                "limiters": [],
+                "scheduler": {
+                    "period": 1,
+                    "database_reconnection_count": 10,
+                    "database_reconnection_delay": 1,
+                },
+                "enable_token_history": False,
+            },
+            "a2a_state": {
+                "sqlite": None,
+                "postgres": None,
+            },
+            "azure_entra_id": None,
+            "rag": {
+                "inline": [],
+                "tool": [],
+            },
+            "okp": {
+                "rhokp_url": None,
+                "offline": True,
+                "chunk_filter_query": None,
+            },
+            "rlsapi_v1": {
+                "allow_verbose_infer": False,
+                "quota_subject": None,
+            },
+            "splunk": None,
+            "deployment_environment": "development",
+            "reranker": {
+                "enabled": False,
+                "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
+            },
+            "skills": None,
         }

--- a/tests/unit/models/config/test_llama_stack_configuration.py
+++ b/tests/unit/models/config/test_llama_stack_configuration.py
@@ -2,44 +2,61 @@
 
 import pytest
 from pydantic import AnyHttpUrl, ValidationError
+from pytest_subtests import SubTests
 
 from models.config import LlamaStackConfiguration
 from utils.checks import InvalidConfigurationError
 
 
-def test_llama_stack_configuration_constructor() -> None:
+def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
     """
     Verify that the LlamaStackConfiguration constructor accepts
     valid combinations of parameters and creates instances
     successfully.
     """
-    llama_stack_configuration = LlamaStackConfiguration(
-        use_as_library_client=True,
-        library_client_config_path="tests/configuration/run.yaml",
-        url=None,
-        api_key=None,
-        timeout=60,
-    )
-    assert llama_stack_configuration is not None
+    with subtests.test(msg="Configuration for library mode"):
+        llama_stack_configuration = LlamaStackConfiguration(
+            use_as_library_client=True,
+            library_client_config_path="tests/configuration/run.yaml",
+            url=None,
+            api_key=None,
+            timeout=60,
+        )
+        assert llama_stack_configuration is not None
+        assert llama_stack_configuration.allow_degraded_mode is False
 
-    llama_stack_configuration = LlamaStackConfiguration(
-        use_as_library_client=False,
-        url=AnyHttpUrl("http://localhost"),
-        library_client_config_path=None,
-        api_key=None,
-        timeout=60,
-    )
-    assert llama_stack_configuration is not None
+    with subtests.test(msg="Configuration for server mode"):
+        llama_stack_configuration = LlamaStackConfiguration(
+            use_as_library_client=False,
+            url=AnyHttpUrl("http://localhost"),
+            library_client_config_path=None,
+            api_key=None,
+            timeout=60,
+        )
+        assert llama_stack_configuration is not None
+        assert llama_stack_configuration.allow_degraded_mode is False
 
-    llama_stack_configuration = LlamaStackConfiguration(
-        url="http://localhost"
-    )  # pyright: ignore[reportCallIssue]
-    assert llama_stack_configuration is not None
+    with subtests.test(msg="Minimal configuration for server mode"):
+        llama_stack_configuration = LlamaStackConfiguration(
+            url="http://localhost"
+        )  # pyright: ignore[reportCallIssue]
+        assert llama_stack_configuration is not None
+        assert llama_stack_configuration.allow_degraded_mode is False
 
-    llama_stack_configuration = LlamaStackConfiguration(
-        use_as_library_client=False, url="http://localhost", api_key="foo"
-    )  # pyright: ignore[reportCallIssue]
-    assert llama_stack_configuration is not None
+    with subtests.test(msg="Full configuration for server mode"):
+        llama_stack_configuration = LlamaStackConfiguration(
+            use_as_library_client=False, url="http://localhost", api_key="foo"
+        )  # pyright: ignore[reportCallIssue]
+        assert llama_stack_configuration is not None
+        assert llama_stack_configuration.allow_degraded_mode is False
+
+    with subtests.test(msg="Degraded mode enabled"):
+        llama_stack_configuration = LlamaStackConfiguration(
+            url="http://localhost",
+            allow_degraded_mode=True,
+        )  # pyright: ignore[reportCallIssue]
+        assert llama_stack_configuration is not None
+        assert llama_stack_configuration.allow_degraded_mode is True
 
 
 def test_llama_stack_configuration_no_run_yaml() -> None:


### PR DESCRIPTION
## Description

LCORE-1861: config toggle for degraded mode

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1861


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `allow_degraded_mode` configuration option to enable Lightspeed Core startup even when Llama Stack is unavailable (server mode only).

* **Documentation**
  * Updated configuration schema documentation to reflect the new option.

* **Tests**
  * Added unit tests to validate the new configuration field behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->