### PR TITLE
LCORE-2318: Options to wait for Llama Stack

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -1116,6 +1116,23 @@ mode</td>
 180 seconds (3 minutes) to accommodate long-running RAG queries.</td>
         </tr>
         <tr class="even">
+          <td>max_retries</td>
+          <td>integer</td>
+          <td>Maximum number of connection attempts before giving up. Used on
+startup to connect to Llama Stack and retrieve its version. Connection
+attempts are retried with a fixed delay to handle the case where Llama
+Stack is still starting up (e.g., when running as a sidecar in the same
+pod).</td>
+        </tr>
+        <tr class="odd">
+          <td>retry_delay</td>
+          <td>integer</td>
+          <td>Delay in seconds between retry attempts. Used on startup to connect
+to Llama Stack and retrieve its version. Connection attempts are retried
+with a fixed delay to handle the case where Llama Stack is still
+starting up (e.g., when running as a sidecar in the same pod).</td>
+        </tr>
+        <tr class="even">
           <td>allow_degraded_mode</td>
           <td>boolean</td>
           <td>If enabled, Lightspeed Core can be started even when Llama Stack is

--- a/docs/config.json
+++ b/docs/config.json
@@ -920,6 +920,20 @@
             "title": "Request timeout",
             "type": "integer"
           },
+          "max_retries": {
+            "default": 5,
+            "description": "Maximum number of connection attempts before giving up. Used on startup to connect to Llama Stack and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where Llama Stack is still starting up (e.g., when running as a sidecar in the same pod).",
+            "minimum": 0,
+            "title": "Maximum number of connection attempts before giving up",
+            "type": "integer"
+          },
+          "retry_delay": {
+            "default": 2,
+            "description": "Delay in seconds between retry attempts. Used on startup to connect to Llama Stack and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where Llama Stack is still starting up (e.g., when running as a sidecar in the same pod).",
+            "minimum": 0,
+            "title": "Delay in seconds between retry attempts",
+            "type": "integer"
+          },
           "allow_degraded_mode": {
             "type": "boolean",
             "nullable": true,

--- a/docs/config.md
+++ b/docs/config.md
@@ -427,6 +427,8 @@ Useful resources:
 | use_as_library_client | boolean | When set to true Llama Stack will be used in library mode, not in server mode (default) |
 | library_client_config_path | string | Path to configuration file used when Llama Stack is run in library mode |
 | timeout | integer | Timeout in seconds for requests to Llama Stack service. Default is 180 seconds (3 minutes) to accommodate long-running RAG queries. |
+| max_retries | integer | Maximum number of connection attempts before giving up. Used on startup to connect to Llama Stack and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where Llama Stack is still starting up (e.g., when running as a sidecar in the same pod). |
+| retry_delay | integer | Delay in seconds between retry attempts. Used on startup to connect to Llama Stack and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where Llama Stack is still starting up (e.g., when running as a sidecar in the same pod). |
 | allow_degraded_mode | boolean | If enabled, Lightspeed Core can be started even when Llama Stack is not accessible (valid for server mode only) |
 
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13850,6 +13850,20 @@
                         "description": "Timeout in seconds for requests to Llama Stack service. Default is 180 seconds (3 minutes) to accommodate long-running RAG queries.",
                         "default": 180
                     },
+                    "max_retries": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Maximum number of connection attempts before giving up",
+                        "description": "Maximum number of connection attempts before giving up. Used on startup to connect to Llama Stack and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where Llama Stack is still starting up (e.g., when running as a sidecar in the same pod).",
+                        "default": 5
+                    },
+                    "retry_delay": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Delay in seconds between retry attempts",
+                        "description": "Delay in seconds between retry attempts. Used on startup to connect to Llama Stack and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where Llama Stack is still starting up (e.g., when running as a sidecar in the same pod).",
+                        "default": 2
+                    },
                     "allow_degraded_mode": {
                         "anyOf": [
                             {

--- a/src/constants.py
+++ b/src/constants.py
@@ -285,3 +285,10 @@ SENTRY_EXCLUDED_ROUTES: Final[tuple[str, ...]] = (
 # Set this to a file path (e.g. /etc/pki/tls/certs/ca-bundle.crt) when
 # connecting to a Sentry instance that uses a private or internal CA.
 SENTRY_CA_CERTS_ENV_VAR: Final[str] = "SENTRY_CA_CERTS"
+
+# Retry settings for waiting on Llama Stack readiness during startup.
+# When LCS runs as a sidecar alongside Llama Stack, both containers start
+# concurrently and Llama Stack may not be ready when LCS attempts its
+# first version check.
+DEFAULT_MAX_RETRIES: Final[int] = 5
+DEFAULT_RETRY_DELAY: Final[int] = 2

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -701,6 +701,24 @@ class LlamaStackConfiguration(ConfigurationBase):
         "Default is 180 seconds (3 minutes) to accommodate long-running RAG queries.",
     )
 
+    max_retries: PositiveInt = Field(
+        constants.DEFAULT_MAX_RETRIES,
+        title="Maximum number of connection attempts before giving up",
+        description="Maximum number of connection attempts before giving up. "
+        "Used on startup to connect to Llama Stack and retrieve its version. Connection attempts "
+        "are retried with a fixed delay to handle the case where Llama Stack is still starting "
+        "up (e.g., when running as a sidecar in the same pod).",
+    )
+
+    retry_delay: PositiveInt = Field(
+        constants.DEFAULT_RETRY_DELAY,
+        title="Delay in seconds between retry attempts",
+        description="Delay in seconds between retry attempts. Used on startup to connect to Llama "
+        "Stack and retrieve its version. Connection attempts are retried with a fixed delay to "
+        "handle the case where Llama Stack is still starting up (e.g., when running as a sidecar "
+        "in the same pod).",
+    )
+
     allow_degraded_mode: Optional[bool] = Field(
         False,
         title="Allow degraded mode",

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from pydantic import SecretStr
 
+import constants
 from models.config import (
     ByokRag,
     Configuration,
@@ -161,6 +162,8 @@ def test_dump_configuration(tmp_path: Path) -> None:
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
                 "allow_degraded_mode": False,
+                "max_retries": constants.DEFAULT_MAX_RETRIES,
+                "retry_delay": constants.DEFAULT_RETRY_DELAY,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -512,6 +515,8 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
                 "allow_degraded_mode": False,
+                "max_retries": constants.DEFAULT_MAX_RETRIES,
+                "retry_delay": constants.DEFAULT_RETRY_DELAY,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -762,6 +767,8 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
                 "allow_degraded_mode": False,
+                "max_retries": constants.DEFAULT_MAX_RETRIES,
+                "retry_delay": constants.DEFAULT_RETRY_DELAY,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -992,6 +999,8 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
                 "allow_degraded_mode": False,
+                "max_retries": constants.DEFAULT_MAX_RETRIES,
+                "retry_delay": constants.DEFAULT_RETRY_DELAY,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -1212,6 +1221,8 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "library_client_config_path": "tests/configuration/run.yaml",
                 "timeout": 180,
                 "allow_degraded_mode": False,
+                "max_retries": constants.DEFAULT_MAX_RETRIES,
+                "retry_delay": constants.DEFAULT_RETRY_DELAY,
             },
             "user_data_collection": {
                 "feedback_enabled": False,
@@ -1507,6 +1518,444 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
                 "library_client_config_path": None,
                 "timeout": 180,
                 "allow_degraded_mode": True,
+                "max_retries": constants.DEFAULT_MAX_RETRIES,
+                "retry_delay": constants.DEFAULT_RETRY_DELAY,
+            },
+            "user_data_collection": {
+                "feedback_enabled": False,
+                "feedback_storage": None,
+                "transcripts_enabled": False,
+                "transcripts_storage": None,
+            },
+            "mcp_servers": [],
+            "authentication": {
+                "module": "noop",
+                "skip_tls_verification": False,
+                "skip_for_health_probes": False,
+                "skip_for_metrics": False,
+                "k8s_ca_cert_path": None,
+                "k8s_cluster_api": None,
+                "jwk_config": None,
+                "api_key_config": None,
+                "rh_identity_config": None,
+            },
+            "customization": None,
+            "inference": {
+                "default_provider": "default_provider",
+                "default_model": "default_model",
+                "context_windows": {},
+            },
+            "database": {
+                "sqlite": None,
+                "postgres": {
+                    "host": "localhost",
+                    "port": 5432,
+                    "db": "lightspeed_stack",
+                    "user": "ls_user",
+                    "password": "**********",
+                    "ssl_mode": "require",
+                    "gss_encmode": "disable",
+                    "namespace": "public",
+                    "ca_cert_path": None,
+                },
+            },
+            "authorization": None,
+            "conversation_cache": {
+                "memory": None,
+                "postgres": None,
+                "sqlite": None,
+                "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
+            },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
+            "byok_rag": [],
+            "quota_handlers": {
+                "sqlite": None,
+                "postgres": None,
+                "limiters": [],
+                "scheduler": {
+                    "period": 1,
+                    "database_reconnection_count": 10,
+                    "database_reconnection_delay": 1,
+                },
+                "enable_token_history": False,
+            },
+            "a2a_state": {
+                "sqlite": None,
+                "postgres": None,
+            },
+            "azure_entra_id": None,
+            "rag": {
+                "inline": [],
+                "tool": [],
+            },
+            "okp": {
+                "rhokp_url": None,
+                "offline": True,
+                "chunk_filter_query": None,
+            },
+            "rlsapi_v1": {
+                "allow_verbose_infer": False,
+                "quota_subject": None,
+            },
+            "splunk": None,
+            "deployment_environment": "development",
+            "reranker": {
+                "enabled": False,
+                "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
+            },
+            "skills": None,
+        }
+
+
+def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
+    """
+    Test that the Configuration object can be serialized to a JSON file and
+    that the resulting file contains all expected sections and values.
+
+    Please note that redaction process is not in place.
+
+    Parameters:
+    ----------
+        tmp_path (Path): Directory where the test JSON file will be written.
+    """
+    cfg = Configuration(
+        name="test_name",
+        service=ServiceConfiguration(
+            tls_config=TLSConfiguration(
+                tls_certificate_path=Path("tests/configuration/server.crt"),
+                tls_key_path=Path("tests/configuration/server.key"),
+                tls_key_password=Path("tests/configuration/password"),
+            ),
+            cors=CORSConfiguration(
+                allow_origins=["foo_origin", "bar_origin", "baz_origin"],
+                allow_credentials=False,
+                allow_methods=["foo_method", "bar_method", "baz_method"],
+                allow_headers=["foo_header", "bar_header", "baz_header"],
+            ),
+        ),
+        llama_stack=LlamaStackConfiguration(
+            use_as_library_client=True,
+            library_client_config_path="tests/configuration/run.yaml",
+            api_key=SecretStr("whatever"),
+            max_retries=42,
+        ),
+        user_data_collection=UserDataCollection(
+            feedback_enabled=False, feedback_storage=None
+        ),
+        database=DatabaseConfiguration(
+            sqlite=None,
+            postgres=PostgreSQLDatabaseConfiguration(
+                db="lightspeed_stack",
+                user="ls_user",
+                password=SecretStr("ls_password"),
+                port=5432,
+                ca_cert_path=None,
+                ssl_mode="require",
+                gss_encmode="disable",
+            ),
+        ),
+        mcp_servers=[],
+        customization=None,
+        inference=InferenceConfiguration(
+            default_provider="default_provider",
+            default_model="default_model",
+        ),
+    )
+    assert cfg is not None
+    dump_file = tmp_path / "test.json"
+    cfg.dump(dump_file)
+
+    with open(dump_file, "r", encoding="utf-8") as fin:
+        content = json.load(fin)
+        # content should be loaded
+        assert content is not None
+
+        # all sections must exists
+        assert "name" in content
+        assert "service" in content
+        assert "llama_stack" in content
+        assert "user_data_collection" in content
+        assert "mcp_servers" in content
+        assert "authentication" in content
+        assert "authorization" in content
+        assert "customization" in content
+        assert "inference" in content
+        assert "database" in content
+        assert "byok_rag" in content
+        assert "quota_handlers" in content
+        assert "azure_entra_id" in content
+        assert "reranker" in content
+
+        # check the whole deserialized JSON file content
+        assert content == {
+            "name": "test_name",
+            "service": {
+                "host": "localhost",
+                "port": 8080,
+                "base_url": None,
+                "auth_enabled": False,
+                "workers": 1,
+                "color_log": True,
+                "access_log": True,
+                "tls_config": {
+                    "tls_certificate_path": "tests/configuration/server.crt",
+                    "tls_key_password": "tests/configuration/password",
+                    "tls_key_path": "tests/configuration/server.key",
+                },
+                "root_path": "",
+                "cors": {
+                    "allow_credentials": False,
+                    "allow_headers": [
+                        "foo_header",
+                        "bar_header",
+                        "baz_header",
+                    ],
+                    "allow_methods": [
+                        "foo_method",
+                        "bar_method",
+                        "baz_method",
+                    ],
+                    "allow_origins": [
+                        "foo_origin",
+                        "bar_origin",
+                        "baz_origin",
+                    ],
+                },
+            },
+            "llama_stack": {
+                "url": None,
+                "use_as_library_client": True,
+                "api_key": "**********",
+                "library_client_config_path": "tests/configuration/run.yaml",
+                "timeout": 180,
+                "allow_degraded_mode": False,
+                "max_retries": 42,
+                "retry_delay": constants.DEFAULT_RETRY_DELAY,
+            },
+            "user_data_collection": {
+                "feedback_enabled": False,
+                "feedback_storage": None,
+                "transcripts_enabled": False,
+                "transcripts_storage": None,
+            },
+            "mcp_servers": [],
+            "authentication": {
+                "module": "noop",
+                "skip_tls_verification": False,
+                "skip_for_health_probes": False,
+                "skip_for_metrics": False,
+                "k8s_ca_cert_path": None,
+                "k8s_cluster_api": None,
+                "jwk_config": None,
+                "api_key_config": None,
+                "rh_identity_config": None,
+            },
+            "customization": None,
+            "inference": {
+                "default_provider": "default_provider",
+                "default_model": "default_model",
+                "context_windows": {},
+            },
+            "database": {
+                "sqlite": None,
+                "postgres": {
+                    "host": "localhost",
+                    "port": 5432,
+                    "db": "lightspeed_stack",
+                    "user": "ls_user",
+                    "password": "**********",
+                    "ssl_mode": "require",
+                    "gss_encmode": "disable",
+                    "namespace": "public",
+                    "ca_cert_path": None,
+                },
+            },
+            "authorization": None,
+            "conversation_cache": {
+                "memory": None,
+                "postgres": None,
+                "sqlite": None,
+                "type": None,
+            },
+            "compaction": {
+                "enabled": False,
+                "threshold_ratio": 0.7,
+                "token_floor": 4096,
+                "buffer_turns": 4,
+                "buffer_max_ratio": 0.3,
+            },
+            "approvals": _DEFAULT_APPROVALS_DUMP,
+            "byok_rag": [],
+            "quota_handlers": {
+                "sqlite": None,
+                "postgres": None,
+                "limiters": [],
+                "scheduler": {
+                    "period": 1,
+                    "database_reconnection_count": 10,
+                    "database_reconnection_delay": 1,
+                },
+                "enable_token_history": False,
+            },
+            "a2a_state": {
+                "sqlite": None,
+                "postgres": None,
+            },
+            "azure_entra_id": None,
+            "rag": {
+                "inline": [],
+                "tool": [],
+            },
+            "okp": {
+                "rhokp_url": None,
+                "offline": True,
+                "chunk_filter_query": None,
+            },
+            "rlsapi_v1": {
+                "allow_verbose_infer": False,
+                "quota_subject": None,
+            },
+            "splunk": None,
+            "deployment_environment": "development",
+            "reranker": {
+                "enabled": False,
+                "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
+            },
+            "skills": None,
+        }
+
+
+def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
+    """
+    Test that the Configuration object can be serialized to a JSON file and
+    that the resulting file contains all expected sections and values.
+
+    Please note that redaction process is not in place.
+
+    Parameters:
+    ----------
+        tmp_path (Path): Directory where the test JSON file will be written.
+    """
+    cfg = Configuration(
+        name="test_name",
+        service=ServiceConfiguration(
+            tls_config=TLSConfiguration(
+                tls_certificate_path=Path("tests/configuration/server.crt"),
+                tls_key_path=Path("tests/configuration/server.key"),
+                tls_key_password=Path("tests/configuration/password"),
+            ),
+            cors=CORSConfiguration(
+                allow_origins=["foo_origin", "bar_origin", "baz_origin"],
+                allow_credentials=False,
+                allow_methods=["foo_method", "bar_method", "baz_method"],
+                allow_headers=["foo_header", "bar_header", "baz_header"],
+            ),
+        ),
+        llama_stack=LlamaStackConfiguration(
+            use_as_library_client=True,
+            library_client_config_path="tests/configuration/run.yaml",
+            api_key=SecretStr("whatever"),
+            retry_delay=42,
+        ),
+        user_data_collection=UserDataCollection(
+            feedback_enabled=False, feedback_storage=None
+        ),
+        database=DatabaseConfiguration(
+            sqlite=None,
+            postgres=PostgreSQLDatabaseConfiguration(
+                db="lightspeed_stack",
+                user="ls_user",
+                password=SecretStr("ls_password"),
+                port=5432,
+                ca_cert_path=None,
+                ssl_mode="require",
+                gss_encmode="disable",
+            ),
+        ),
+        mcp_servers=[],
+        customization=None,
+        inference=InferenceConfiguration(
+            default_provider="default_provider",
+            default_model="default_model",
+        ),
+    )
+    assert cfg is not None
+    dump_file = tmp_path / "test.json"
+    cfg.dump(dump_file)
+
+    with open(dump_file, "r", encoding="utf-8") as fin:
+        content = json.load(fin)
+        # content should be loaded
+        assert content is not None
+
+        # all sections must exists
+        assert "name" in content
+        assert "service" in content
+        assert "llama_stack" in content
+        assert "user_data_collection" in content
+        assert "mcp_servers" in content
+        assert "authentication" in content
+        assert "authorization" in content
+        assert "customization" in content
+        assert "inference" in content
+        assert "database" in content
+        assert "byok_rag" in content
+        assert "quota_handlers" in content
+        assert "azure_entra_id" in content
+        assert "reranker" in content
+
+        # check the whole deserialized JSON file content
+        assert content == {
+            "name": "test_name",
+            "service": {
+                "host": "localhost",
+                "port": 8080,
+                "base_url": None,
+                "auth_enabled": False,
+                "workers": 1,
+                "color_log": True,
+                "access_log": True,
+                "tls_config": {
+                    "tls_certificate_path": "tests/configuration/server.crt",
+                    "tls_key_password": "tests/configuration/password",
+                    "tls_key_path": "tests/configuration/server.key",
+                },
+                "root_path": "",
+                "cors": {
+                    "allow_credentials": False,
+                    "allow_headers": [
+                        "foo_header",
+                        "bar_header",
+                        "baz_header",
+                    ],
+                    "allow_methods": [
+                        "foo_method",
+                        "bar_method",
+                        "baz_method",
+                    ],
+                    "allow_origins": [
+                        "foo_origin",
+                        "bar_origin",
+                        "baz_origin",
+                    ],
+                },
+            },
+            "llama_stack": {
+                "url": None,
+                "use_as_library_client": True,
+                "api_key": "**********",
+                "library_client_config_path": "tests/configuration/run.yaml",
+                "timeout": 180,
+                "allow_degraded_mode": False,
+                "max_retries": constants.DEFAULT_MAX_RETRIES,
+                "retry_delay": 42,
             },
             "user_data_collection": {
                 "feedback_enabled": False,

--- a/tests/unit/models/config/test_llama_stack_configuration.py
+++ b/tests/unit/models/config/test_llama_stack_configuration.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import AnyHttpUrl, ValidationError
 from pytest_subtests import SubTests
 
+import constants
 from models.config import LlamaStackConfiguration
 from utils.checks import InvalidConfigurationError
 
@@ -24,6 +25,8 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         )
         assert llama_stack_configuration is not None
         assert llama_stack_configuration.allow_degraded_mode is False
+        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Configuration for server mode"):
         llama_stack_configuration = LlamaStackConfiguration(
@@ -35,6 +38,8 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         )
         assert llama_stack_configuration is not None
         assert llama_stack_configuration.allow_degraded_mode is False
+        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Minimal configuration for server mode"):
         llama_stack_configuration = LlamaStackConfiguration(
@@ -42,6 +47,8 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         )  # pyright: ignore[reportCallIssue]
         assert llama_stack_configuration is not None
         assert llama_stack_configuration.allow_degraded_mode is False
+        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Full configuration for server mode"):
         llama_stack_configuration = LlamaStackConfiguration(
@@ -49,6 +56,8 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         )  # pyright: ignore[reportCallIssue]
         assert llama_stack_configuration is not None
         assert llama_stack_configuration.allow_degraded_mode is False
+        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Degraded mode enabled"):
         llama_stack_configuration = LlamaStackConfiguration(
@@ -57,6 +66,8 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         )  # pyright: ignore[reportCallIssue]
         assert llama_stack_configuration is not None
         assert llama_stack_configuration.allow_degraded_mode is True
+        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
 
 def test_llama_stack_configuration_no_run_yaml() -> None:
@@ -149,3 +160,35 @@ def test_llama_stack_configuration_invalid_scheme_rejected() -> None:
         LlamaStackConfiguration(
             url="ftp://localhost:8321"
         )  # pyright: ignore[reportCallIssue]
+
+
+def test_llama_stack_configuration_wrong_max_retries_count(subtests: SubTests) -> None:
+    """Test that malformed URLs are rejected with a ValidationError."""
+    with subtests.test(msg="Configuration with zero max_retries count"):
+        with pytest.raises(ValidationError, match="Input should be greater than 0"):
+            LlamaStackConfiguration(
+                url="https://llama-stack.example.com:8321",
+                max_retries=0,
+            )  # pyright: ignore[reportCallIssue]
+    with subtests.test(msg="Configuration with negative max_retries count"):
+        with pytest.raises(ValidationError, match="Input should be greater than 0"):
+            LlamaStackConfiguration(
+                url="https://llama-stack.example.com:8321",
+                max_retries=-1,
+            )  # pyright: ignore[reportCallIssue]
+
+
+def test_llama_stack_configuration_wrong_retry_delay_value(subtests: SubTests) -> None:
+    """Test that malformed URLs are rejected with a ValidationError."""
+    with subtests.test(msg="Configuration with zero retry_delay value"):
+        with pytest.raises(ValidationError, match="Input should be greater than 0"):
+            LlamaStackConfiguration(
+                url="https://llama-stack.example.com:8321",
+                retry_delay=0,
+            )  # pyright: ignore[reportCallIssue]
+    with subtests.test(msg="Configuration with negative retry_delay value"):
+        with pytest.raises(ValidationError, match="Input should be greater than 0"):
+            LlamaStackConfiguration(
+                url="https://llama-stack.example.com:8321",
+                retry_delay=-1,
+            )  # pyright: ignore[reportCallIssue]


### PR DESCRIPTION
## Description

LCORE-2318: Options to wait for Llama Stack

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2318


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable startup retry settings to support flexible deployment scenarios. Users can now specify the maximum number of retry attempts (default: 5) and the delay between consecutive retries in seconds (default: 2). These configuration options provide greater control over system behavior during initialization across various operational environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->