### PR TITLE
LCORE-1858: degraded mode support

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -9,7 +9,7 @@ import sentry_sdk  # pyright: ignore[reportMissingImports]
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from llama_stack_client import APIConnectionError
+from llama_stack_client import APIConnectionError, AsyncLlamaStackClient
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -88,11 +88,19 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     llama_stack_config = configuration.configuration.llama_stack
     await AsyncLlamaStackClientHolder().load(llama_stack_config)
-    client = AsyncLlamaStackClientHolder().get_client()
+    client: AsyncLlamaStackClient = AsyncLlamaStackClientHolder().get_client()
+    logger.debug("Llama Stack client initialized, trying to connect to Llama Stack")
     # check if the Llama Stack version is supported by the service
     try:
-        await check_llama_stack_version(client)
+        llama_stack_version = await check_llama_stack_version(
+            client, llama_stack_config.max_retries, llama_stack_config.retry_delay
+        )
+        if llama_stack_version is None:
+            logger.error("Cannot retrieve Llama Stack version, check connection")
+        else:
+            logger.debug("Llama Stack version: %s", llama_stack_version)
     except APIConnectionError as e:
+        # if degraded mode is allowed, simply ignore the exception
         llama_stack_url = llama_stack_config.url
         logger.error(
             "Failed to connect to Llama Stack at '%s'. "
@@ -102,7 +110,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             llama_stack_url,
             e,
         )
-        raise
+        if llama_stack_config.allow_degraded_mode:
+            logger.info("Entering degraded mode: LCORE running w/o Llama Stack")
+        else:
+            raise
 
     logger.info("Registering MCP servers")
     await register_mcp_servers_async(logger, configuration.configuration)

--- a/src/utils/llama_stack_version.py
+++ b/src/utils/llama_stack_version.py
@@ -2,24 +2,20 @@
 
 import asyncio
 import re
+from typing import Optional
 
 from llama_stack_client import APIConnectionError, AsyncLlamaStackClient
 from semver import Version
 
 from constants import (
+    DEFAULT_MAX_RETRIES,
+    DEFAULT_RETRY_DELAY,
     MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION,
     MINIMAL_SUPPORTED_LLAMA_STACK_VERSION,
 )
 from log import get_logger
 
 logger = get_logger(__name__)
-
-# Retry settings for waiting on Llama Stack readiness during startup.
-# When LCS runs as a sidecar alongside Llama Stack, both containers start
-# concurrently and Llama Stack may not be ready when LCS attempts its
-# first version check.
-_DEFAULT_MAX_RETRIES = 5
-_DEFAULT_RETRY_DELAY = 2
 
 
 class InvalidLlamaStackVersionException(Exception):
@@ -28,9 +24,9 @@ class InvalidLlamaStackVersionException(Exception):
 
 async def check_llama_stack_version(
     client: AsyncLlamaStackClient,
-    max_retries: int = _DEFAULT_MAX_RETRIES,
-    retry_delay: int = _DEFAULT_RETRY_DELAY,
-) -> None:
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    retry_delay: int = DEFAULT_RETRY_DELAY,
+) -> Optional[str]:
     """
     Verify the connected Llama Stack's version is within the supported range.
 
@@ -61,7 +57,7 @@ async def check_llama_stack_version(
                 MINIMAL_SUPPORTED_LLAMA_STACK_VERSION,
                 MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION,
             )
-            return
+            return version_info.version
         except APIConnectionError:
             if attempt == max_retries - 1:
                 raise
@@ -72,6 +68,8 @@ async def check_llama_stack_version(
                 retry_delay,
             )
             await asyncio.sleep(retry_delay)
+    # version can not be retrieved
+    return None
 
 
 def compare_versions(version_info: str, minimal: str, maximal: str) -> None:
@@ -129,4 +127,4 @@ def compare_versions(version_info: str, minimal: str, maximal: str) -> None:
         raise InvalidLlamaStackVersionException(
             f"Llama Stack version <= {maximal_version} is required, but {current_version} is used"
         )
-    logger.info("Correct Llama Stack version : %s", current_version)
+    logger.info("Correct Llama Stack version: %s", current_version)


### PR DESCRIPTION
## Description

LCORE-1858: degraded mode support

## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-1858


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable retry mechanism for improved Llama Stack version checks during application initialization.
  * Enhanced graceful degradation support allowing the application to continue operation when Llama Stack connection fails during startup.

* **Bug Fixes**
  * Improved version detection to accurately report detected Llama Stack version information.
  * Corrected logging message formatting in version validation output messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->