### PR TITLE
LCORE-694: add skip_for_health_probes support to jwk-token and api-key-token auth modules

### DIFF
--- a/src/authentication/api_key_token.py
+++ b/src/authentication/api_key_token.py
@@ -10,8 +10,9 @@ import secrets
 
 from fastapi import HTTPException, Request, status
 
-from authentication.interface import AuthInterface, AuthTuple
+from authentication.interface import NO_AUTH_TUPLE, AuthInterface, AuthTuple
 from authentication.utils import extract_user_token
+from configuration import configuration
 from constants import (
     DEFAULT_USER_NAME,
     DEFAULT_USER_UID,
@@ -21,6 +22,19 @@ from log import get_logger
 from models.config import APIKeyTokenConfiguration
 
 logger = get_logger(__name__)
+
+
+def _should_skip_auth(request: Request) -> bool:
+    """Check if auth should be skipped for health probe or metrics endpoints."""
+    auth_config = configuration.authentication_configuration
+    if auth_config.skip_for_health_probes and request.url.path in (
+        "/readiness",
+        "/liveness",
+    ):
+        return True
+    if auth_config.skip_for_metrics and request.url.path in ("/metrics",):
+        return True
+    return False
 
 
 class APIKeyTokenAuthDependency(
@@ -59,6 +73,10 @@ class APIKeyTokenAuthDependency(
             HTTPException: If the bearer token is missing or
             doesn't match the configured API key (HTTP 401).
         """
+        if not request.headers.get("Authorization"):
+            if _should_skip_auth(request):
+                return NO_AUTH_TUPLE
+
         # try to extract user token from request
         user_token = extract_user_token(request.headers)
 

--- a/src/authentication/jwk_token.py
+++ b/src/authentication/jwk_token.py
@@ -16,8 +16,9 @@ from authlib.jose.errors import (
 from cachetools import TTLCache
 from fastapi import HTTPException, Request
 
-from authentication.interface import AuthInterface, AuthTuple
+from authentication.interface import NO_AUTH_TUPLE, AuthInterface, AuthTuple
 from authentication.utils import extract_user_token
+from configuration import configuration
 from constants import (
     DEFAULT_VIRTUAL_PATH,
 )
@@ -141,6 +142,19 @@ def key_resolver_func(
     return _internal
 
 
+def _should_skip_auth(request: Request) -> bool:
+    """Check if auth should be skipped for health probe or metrics endpoints."""
+    auth_config = configuration.authentication_configuration
+    if auth_config.skip_for_health_probes and request.url.path in (
+        "/readiness",
+        "/liveness",
+    ):
+        return True
+    if auth_config.skip_for_metrics and request.url.path in ("/metrics",):
+        return True
+    return False
+
+
 class JwkTokenAuthDependency(AuthInterface):  # pylint: disable=too-few-public-methods
     """JWK AuthDependency class for JWK-based JWT authentication."""
 
@@ -166,7 +180,9 @@ class JwkTokenAuthDependency(AuthInterface):  # pylint: disable=too-few-public-m
         self.config: JwkConfiguration = config
         self.skip_userid_check = False
 
-    async def __call__(self, request: Request) -> AuthTuple:
+    async def __call__(  # pylint: disable=too-many-statements
+        self, request: Request
+    ) -> AuthTuple:
         """Authenticate the JWT in the headers against the keys from the JWK url.
 
         When the Authorization header is missing, this method raises
@@ -190,6 +206,8 @@ class JwkTokenAuthDependency(AuthInterface):  # pylint: disable=too-few-public-m
             authentication; all error paths raise HTTPException.
         """
         if not request.headers.get("Authorization"):
+            if _should_skip_auth(request):
+                return NO_AUTH_TUPLE
             response = UnauthorizedResponse(cause="No Authorization header found")
             raise HTTPException(**response.model_dump())
 


### PR DESCRIPTION
## Summary

The `skip_for_health_probes` and `skip_for_metrics` config options were only implemented in the `k8s` and `rh_identity` auth modules. The `jwk_token` and `api_key_token` modules immediately rejected unauthenticated requests without checking whether the request was for a health probe endpoint, forcing deployments to use TCP probes instead of HTTP health probes.

## Changes

- **`src/authentication/jwk_token.py`**: Add health probe and metrics endpoint checks before raising 401 for missing Authorization header
- **`src/authentication/api_key_token.py`**: Same guard pattern added before token extraction

Both follow the existing pattern from `src/authentication/k8s.py` (lines 440-447).

## Testing

- Deploy with `authentication.module: jwk-token` and `skip_for_health_probes: true`
- `GET /liveness` without Authorization header → should return 200 (currently returns 401)
- `GET /readiness` without Authorization header → should return 200 (currently returns 401)
- `POST /v1/query` without Authorization header → should still return 401

Fixes #1787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authentication now optionally skips validation for operational endpoints (readiness, liveness, metrics) when configured, returning a permissive response for those probes if enabled; all other endpoints continue to require credentials and retain existing unauthorized responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->