### PR TITLE
LCORE-2334: use specific rule codes in type ignore comments

### DIFF
--- a/tests/unit/app/endpoints/test_authorized.py
+++ b/tests/unit/app/endpoints/test_authorized.py
@@ -67,10 +67,10 @@ async def test_authorized_dependency_unauthorized() -> None:
     with pytest.raises(HTTPException) as exc_info:
         extract_user_token(headers_no_auth)
     assert exc_info.value.status_code == 401
-    assert exc_info.value.detail["response"] == (  # type: ignore
+    assert exc_info.value.detail["response"] == (  # type: ignore[index]
         "Missing or invalid credentials provided by client"
     )
-    assert exc_info.value.detail["cause"] == (  # type: ignore
+    assert exc_info.value.detail["cause"] == (  # type: ignore[index]
         "No Authorization header found"
     )
 
@@ -78,9 +78,9 @@ async def test_authorized_dependency_unauthorized() -> None:
     with pytest.raises(HTTPException) as exc_info:
         extract_user_token(headers_invalid_auth)
     assert exc_info.value.status_code == 401
-    assert exc_info.value.detail["response"] == (  # type: ignore
+    assert exc_info.value.detail["response"] == (  # type: ignore[index]
         "Missing or invalid credentials provided by client"
     )
-    assert exc_info.value.detail["cause"] == (  # type: ignore
+    assert exc_info.value.detail["cause"] == (  # type: ignore[index]
         "No token found in Authorization header"
     )

--- a/tests/unit/app/endpoints/test_config.py
+++ b/tests/unit/app/endpoints/test_config.py
@@ -40,8 +40,8 @@ async def test_config_endpoint_handler_configuration_not_loaded(
 
     detail = exc_info.value.detail
     assert isinstance(detail, dict)
-    assert detail["response"] == "Configuration is not loaded"  # type: ignore
-    assert detail["cause"] == (  # type: ignore
+    assert detail["response"] == "Configuration is not loaded"  # type: ignore[index]
+    assert detail["cause"] == (  # type: ignore[index]
         "Lightspeed Stack configuration has not been initialized."
     )
 

--- a/tests/unit/utils/test_shields.py
+++ b/tests/unit/utils/test_shields.py
@@ -296,7 +296,7 @@ class TestRunShieldModeration:
             await run_shield_moderation(mock_client, "test input", "/test-endpoint")
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-        assert "missing-model" in exc_info.value.detail["cause"]  # type: ignore
+        assert "missing-model" in exc_info.value.detail["cause"]  # type: ignore[index]
 
     @pytest.mark.asyncio
     async def test_raises_http_exception_when_shield_has_no_provider_resource_id(
@@ -352,8 +352,8 @@ class TestRunShieldModeration:
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-        assert "Shield" in exc_info.value.detail["response"]  # type: ignore
-        assert "typo-shield" in exc_info.value.detail["cause"]  # type: ignore
+        assert "Shield" in exc_info.value.detail["response"]  # type: ignore[index]
+        assert "typo-shield" in exc_info.value.detail["cause"]  # type: ignore[index]
 
     @pytest.mark.asyncio
     async def test_shield_ids_filters_to_specific_shield(
@@ -577,8 +577,8 @@ class TestGetShieldsForRequest:
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-        assert "Shield" in exc_info.value.detail["response"]  # type: ignore
-        assert "missing-shield" in exc_info.value.detail["cause"]  # type: ignore
+        assert "Shield" in exc_info.value.detail["response"]  # type: ignore[index]
+        assert "missing-shield" in exc_info.value.detail["cause"]  # type: ignore[index]
 
     @pytest.mark.asyncio
     async def test_raises_404_when_multiple_requested_shields_not_configured(
@@ -594,8 +594,8 @@ class TestGetShieldsForRequest:
             )
 
         assert exc_info.value.status_code == status.HTTP_404_NOT_FOUND
-        assert "Shields" in exc_info.value.detail["response"]  # type: ignore
-        cause = exc_info.value.detail["cause"]  # type: ignore
+        assert "Shields" in exc_info.value.detail["response"]  # type: ignore[index]
+        cause = exc_info.value.detail["cause"]  # type: ignore[index]
         assert "missing-1" in cause
         assert "missing-2" in cause
 


### PR DESCRIPTION
## Description

LCORE-2334: use specific rule codes in type ignore comments

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2334


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated type annotations in unit tests for authorization, configuration, and shield endpoints to improve type safety and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->