### PR TITLE
LCORE-1571: Extend conversation cache for compaction summaries

### DIFF
--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -215,6 +215,32 @@ class Cache(ABC):
         """
 
     @abstractmethod
+    def replace_summaries(
+        self,
+        user_id: str,
+        conversation_id: str,
+        folded_summary: ConversationSummary,
+        skip_user_id_check: bool,
+    ) -> None:
+        """Replace all stored summary chunks for a conversation with one fold.
+
+        Recursive re-summarization (R3, LCORE-1572) collapses the accumulated
+        summary chunks into a single folded summary when the chunks themselves
+        grow large. This atomically removes the conversation's existing chunks
+        and stores ``folded_summary`` in their place, so a subsequent
+        :meth:`get_summaries` returns the fold first (oldest), followed by any
+        chunks appended afterwards.
+
+        Parameters:
+        ----------
+            user_id (str): User identifier, part of the compound cache key.
+            conversation_id (str): Conversation identifier, part of the compound key.
+            folded_summary (ConversationSummary): The folded summary that
+                supersedes the conversation's existing chunks.
+            skip_user_id_check (bool): If True, skip validation of `user_id`.
+        """
+
+    @abstractmethod
     def ready(self) -> bool:
         """Check if the cache is ready.
 

--- a/src/cache/cache.py
+++ b/src/cache/cache.py
@@ -1,9 +1,11 @@
 """Abstract class that is parent for all cache implementations."""
 
+import builtins
 from abc import ABC, abstractmethod
 
 from cache.cache_entry import CacheEntry
 from models.common import ConversationData
+from models.compaction import ConversationSummary
 from utils.suid import check_suid
 
 
@@ -168,6 +170,48 @@ class Cache(ABC):
             conversation_id (str): Conversation identifier used as part of the compound cache key.
             topic_summary (str): Text summary of the conversation topic to store.
             skip_user_id_check (bool): If True, skip validation of `user_id` before storing.
+        """
+
+    @abstractmethod
+    def store_summary(
+        self,
+        user_id: str,
+        conversation_id: str,
+        summary: ConversationSummary,
+        skip_user_id_check: bool,
+    ) -> None:
+        """Append a conversation-compaction summary chunk to the cache.
+
+        Compaction (LCORE-1572) produces one ``ConversationSummary`` each time
+        it triggers. The additive design keeps every chunk: this method appends
+        a new chunk rather than replacing previous ones. Chunks are scoped to
+        the ``(user_id, conversation_id)`` compound key and ordered by their
+        ``created_at`` timestamp on retrieval.
+
+        Parameters:
+        ----------
+            user_id (str): User identifier, part of the compound cache key.
+            conversation_id (str): Conversation identifier, part of the compound key.
+            summary (ConversationSummary): The summary chunk to persist.
+            skip_user_id_check (bool): If True, skip validation of `user_id`.
+        """
+
+    @abstractmethod
+    def get_summaries(
+        self, user_id: str, conversation_id: str, skip_user_id_check: bool
+    ) -> builtins.list[ConversationSummary]:  # this class shadows the list builtin
+        """Retrieve all compaction summary chunks for a conversation.
+
+        Parameters:
+        ----------
+            user_id (str): User identifier, part of the compound cache key.
+            conversation_id (str): Conversation identifier, part of the compound key.
+            skip_user_id_check (bool): If True, skip validation of `user_id`.
+
+        Returns:
+        -------
+            list[ConversationSummary]: Summary chunks for the conversation,
+            oldest first (ordered by ``created_at``); empty list if none exist.
         """
 
     @abstractmethod

--- a/src/cache/in_memory_cache.py
+++ b/src/cache/in_memory_cache.py
@@ -1,9 +1,12 @@
 """In-memory cache implementation."""
 
+import builtins
+
 from cache.cache import Cache
 from cache.cache_entry import CacheEntry
 from log import get_logger
 from models.common import ConversationData
+from models.compaction import ConversationSummary
 from models.config import InMemoryCacheConfig
 from utils.connection_decorator import connection
 
@@ -162,6 +165,49 @@ class InMemoryCache(Cache):
         """
         # just check if user_id and conversation_id are UUIDs
         super().construct_key(user_id, conversation_id, skip_user_id_check)
+
+    @connection
+    def store_summary(
+        self,
+        user_id: str,
+        conversation_id: str,
+        summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Store a compaction summary chunk (no-op for the in-memory cache).
+
+        This implementation does not persist data; it only validates the
+        compound key, mirroring the other in-memory operations.
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            summary: The ConversationSummary chunk (not persisted).
+            skip_user_id_check: Skip user_id suid check.
+        """
+        # just check if user_id and conversation_id are UUIDs
+        super().construct_key(user_id, conversation_id, skip_user_id_check)
+
+    @connection
+    def get_summaries(
+        self, user_id: str, conversation_id: str, skip_user_id_check: bool = False
+    ) -> builtins.list[ConversationSummary]:  # this class shadows the list builtin
+        """Return compaction summaries (always empty for the in-memory cache).
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            skip_user_id_check: Skip user_id suid check.
+
+        Returns:
+        -------
+            An empty list.
+        """
+        # just check if user_id and conversation_id are UUIDs
+        super().construct_key(user_id, conversation_id, skip_user_id_check)
+        return []
 
     def ready(self) -> bool:
         """Check if the cache is ready.

--- a/src/cache/in_memory_cache.py
+++ b/src/cache/in_memory_cache.py
@@ -209,6 +209,29 @@ class InMemoryCache(Cache):
         super().construct_key(user_id, conversation_id, skip_user_id_check)
         return []
 
+    @connection
+    def replace_summaries(
+        self,
+        user_id: str,
+        conversation_id: str,
+        folded_summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Replace stored summary chunks with a fold (no-op for the in-memory cache).
+
+        This implementation does not persist data; it only validates the
+        compound key, mirroring the other in-memory summary operations.
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            folded_summary: The folded summary (not persisted).
+            skip_user_id_check: Skip user_id suid check.
+        """
+        # just check if user_id and conversation_id are UUIDs
+        super().construct_key(user_id, conversation_id, skip_user_id_check)
+
     def ready(self) -> bool:
         """Check if the cache is ready.
 

--- a/src/cache/noop_cache.py
+++ b/src/cache/noop_cache.py
@@ -185,6 +185,26 @@ class NoopCache(Cache):
         super().construct_key(user_id, conversation_id, skip_user_id_check)
         return []
 
+    @connection
+    def replace_summaries(
+        self,
+        user_id: str,
+        conversation_id: str,
+        folded_summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Replace stored summary chunks with a fold (no-op for the no-op cache).
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            folded_summary: The folded summary (not persisted).
+            skip_user_id_check: Skip user_id suid check.
+        """
+        # just check if user_id and conversation_id are UUIDs
+        super().construct_key(user_id, conversation_id, skip_user_id_check)
+
     def ready(self) -> bool:
         """Check if the cache is ready.
 

--- a/src/cache/noop_cache.py
+++ b/src/cache/noop_cache.py
@@ -1,9 +1,12 @@
 """No-operation cache implementation."""
 
+import builtins
+
 from cache.cache import Cache
 from cache.cache_entry import CacheEntry
 from log import get_logger
 from models.common import ConversationData
+from models.compaction import ConversationSummary
 from utils.connection_decorator import connection
 
 logger = get_logger(__name__)
@@ -141,6 +144,46 @@ class NoopCache(Cache):
         """
         # just check if user_id and conversation_id are UUIDs
         super().construct_key(user_id, conversation_id, skip_user_id_check)
+
+    @connection
+    def store_summary(
+        self,
+        user_id: str,
+        conversation_id: str,
+        summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Store a compaction summary chunk (no-op for the no-op cache).
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            summary: The ConversationSummary chunk (not persisted).
+            skip_user_id_check: Skip user_id suid check.
+        """
+        # just check if user_id and conversation_id are UUIDs
+        super().construct_key(user_id, conversation_id, skip_user_id_check)
+
+    @connection
+    def get_summaries(
+        self, user_id: str, conversation_id: str, skip_user_id_check: bool = False
+    ) -> builtins.list[ConversationSummary]:  # this class shadows the list builtin
+        """Return compaction summaries (always empty for the no-op cache).
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            skip_user_id_check: Skip user_id suid check.
+
+        Returns:
+        -------
+            An empty list.
+        """
+        # just check if user_id and conversation_id are UUIDs
+        super().construct_key(user_id, conversation_id, skip_user_id_check)
+        return []
 
     def ready(self) -> bool:
         """Check if the cache is ready.

--- a/src/cache/postgres_cache.py
+++ b/src/cache/postgres_cache.py
@@ -686,6 +686,58 @@ class PostgresCache(Cache):
             for row in rows
         ]
 
+    @connection
+    def replace_summaries(
+        self,
+        user_id: str,
+        conversation_id: str,
+        folded_summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Replace all stored summary chunks for a conversation with one fold.
+
+        Deletes the conversation's existing chunks and inserts ``folded_summary``
+        within one transaction, so a subsequent :meth:`get_summaries` returns the
+        fold first, followed by any chunks appended afterwards. Used by recursive
+        re-summarization (R3, LCORE-1572).
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            folded_summary: The folded summary that supersedes existing chunks.
+            skip_user_id_check: Skip user_id suid check.
+
+        Raises:
+        ------
+            CacheError: If the cache is disconnected or a database error occurs.
+        """
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("replace_summaries: cache is disconnected")
+
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(
+                    PostgresCache.DELETE_SUMMARIES_STATEMENT,
+                    (user_id, conversation_id),
+                )
+                cursor.execute(
+                    PostgresCache.INSERT_SUMMARY_STATEMENT,
+                    (
+                        user_id,
+                        conversation_id,
+                        folded_summary.created_at,
+                        folded_summary.summarized_through_turn,
+                        folded_summary.token_count,
+                        folded_summary.model_used,
+                        folded_summary.summary_text,
+                    ),
+                )
+        except psycopg2.DatabaseError as e:
+            logger.error("PostgresCache.replace_summaries: %s", e)
+            raise CacheError("PostgresCache.replace_summaries", e) from e
+
     def ready(self) -> bool:
         """Check if the cache is ready.
 

--- a/src/cache/postgres_cache.py
+++ b/src/cache/postgres_cache.py
@@ -1,5 +1,6 @@
 """PostgreSQL cache implementation."""
 
+import builtins
 import json
 
 import psycopg2
@@ -15,6 +16,7 @@ from models.common.turn_summary import (
     ToolCallSummary,
     ToolResultSummary,
 )
+from models.compaction import ConversationSummary
 from models.config import PostgreSQLDatabaseConfiguration
 from utils.connection_decorator import connection
 
@@ -79,6 +81,19 @@ class PostgresCache(Cache):
         );
         """
 
+    CREATE_CONVERSATION_SUMMARIES_TABLE = """
+        CREATE TABLE IF NOT EXISTS conversation_summaries (
+            user_id                 text NOT NULL,
+            conversation_id         text NOT NULL,
+            created_at              text NOT NULL,
+            summarized_through_turn integer NOT NULL,
+            token_count             integer NOT NULL,
+            model_used              text NOT NULL,
+            summary_text            text NOT NULL,
+            PRIMARY KEY(user_id, conversation_id, created_at)
+        );
+        """
+
     CREATE_INDEX = """
         CREATE INDEX IF NOT EXISTS timestamps
             ON cache (created_at)
@@ -132,6 +147,24 @@ class PostgresCache(Cache):
         VALUES (%s, %s, %s, CURRENT_TIMESTAMP)
         ON CONFLICT (user_id, conversation_id)
         DO UPDATE SET last_message_timestamp = EXCLUDED.last_message_timestamp
+        """
+
+    INSERT_SUMMARY_STATEMENT = """
+        INSERT INTO conversation_summaries(user_id, conversation_id, created_at,
+                          summarized_through_turn, token_count, model_used, summary_text)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        """
+
+    SELECT_SUMMARIES_STATEMENT = """
+        SELECT summary_text, summarized_through_turn, token_count, created_at, model_used
+          FROM conversation_summaries
+         WHERE user_id=%s AND conversation_id=%s
+         ORDER BY created_at
+        """
+
+    DELETE_SUMMARIES_STATEMENT = """
+        DELETE FROM conversation_summaries
+         WHERE user_id=%s AND conversation_id=%s
         """
 
     def __init__(self, config: PostgreSQLDatabaseConfiguration) -> None:
@@ -243,6 +276,9 @@ class PostgresCache(Cache):
 
         logger.info("Initializing table for conversations")
         cursor.execute(PostgresCache.CREATE_CONVERSATIONS_TABLE)
+
+        logger.info("Initializing table for conversation summaries")
+        cursor.execute(PostgresCache.CREATE_CONVERSATION_SUMMARIES_TABLE)
 
         logger.info("Initializing index for cache")
         cursor.execute(PostgresCache.CREATE_INDEX)
@@ -483,6 +519,12 @@ class PostgresCache(Cache):
                     (user_id, conversation_id),
                 )
 
+                # Also delete any compaction summaries for this conversation
+                cursor.execute(
+                    PostgresCache.DELETE_SUMMARIES_STATEMENT,
+                    (user_id, conversation_id),
+                )
+
                 return deleted > 0
         except psycopg2.DatabaseError as e:
             logger.error("PostgresCache.delete: %s", e)
@@ -554,6 +596,95 @@ class PostgresCache(Cache):
         except psycopg2.DatabaseError as e:
             logger.error("PostgresCache.set_topic_summary: %s", e)
             raise CacheError("PostgresCache.set_topic_summary", e) from e
+
+    @connection
+    def store_summary(
+        self,
+        user_id: str,
+        conversation_id: str,
+        summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Append a compaction summary chunk for the given conversation.
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            summary: The ConversationSummary chunk to persist.
+            skip_user_id_check: Skip user_id suid check.
+
+        Raises:
+        ------
+            CacheError: If the cache is disconnected or a database error occurs.
+        """
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("store_summary: cache is disconnected")
+
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(
+                    self.INSERT_SUMMARY_STATEMENT,
+                    (
+                        user_id,
+                        conversation_id,
+                        summary.created_at,
+                        summary.summarized_through_turn,
+                        summary.token_count,
+                        summary.model_used,
+                        summary.summary_text,
+                    ),
+                )
+        except psycopg2.DatabaseError as e:
+            logger.error("PostgresCache.store_summary: %s", e)
+            raise CacheError("PostgresCache.store_summary", e) from e
+
+    @connection
+    def get_summaries(
+        self, user_id: str, conversation_id: str, skip_user_id_check: bool = False
+    ) -> builtins.list[ConversationSummary]:  # this class shadows the list builtin
+        """Retrieve all compaction summary chunks for a conversation.
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            skip_user_id_check: Skip user_id suid check.
+
+        Returns:
+        -------
+            Summary chunks for the conversation, oldest first (ordered by
+            ``created_at``); empty list if none exist.
+
+        Raises:
+        ------
+            CacheError: If the cache is disconnected or a database error occurs.
+        """
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("get_summaries: cache is disconnected")
+
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(
+                    self.SELECT_SUMMARIES_STATEMENT, (user_id, conversation_id)
+                )
+                rows = cursor.fetchall()
+        except psycopg2.DatabaseError as e:
+            logger.error("PostgresCache.get_summaries: %s", e)
+            raise CacheError("PostgresCache.get_summaries", e) from e
+
+        return [
+            ConversationSummary(
+                summary_text=row[0],
+                summarized_through_turn=row[1],
+                token_count=row[2],
+                created_at=row[3],
+                model_used=row[4],
+            )
+            for row in rows
+        ]
 
     def ready(self) -> bool:
         """Check if the cache is ready.

--- a/src/cache/sqlite_cache.py
+++ b/src/cache/sqlite_cache.py
@@ -656,6 +656,53 @@ class SQLiteCache(Cache):
             for row in rows
         ]
 
+    @connection
+    def replace_summaries(
+        self,
+        user_id: str,
+        conversation_id: str,
+        folded_summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Replace all stored summary chunks for a conversation with one fold.
+
+        Deletes the conversation's existing chunks and inserts ``folded_summary``
+        in a single transaction, so a subsequent :meth:`get_summaries` returns the
+        fold first, followed by any chunks appended afterwards. Used by recursive
+        re-summarization (R3, LCORE-1572).
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            folded_summary: The folded summary that supersedes existing chunks.
+            skip_user_id_check: Skip user_id suid check.
+
+        Raises:
+        ------
+            CacheError: If the cache connection is not available.
+        """
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("replace_summaries: cache is disconnected")
+
+        cursor = self.connection.cursor()
+        cursor.execute(self.DELETE_SUMMARIES_STATEMENT, (user_id, conversation_id))
+        cursor.execute(
+            self.INSERT_SUMMARY_STATEMENT,
+            (
+                user_id,
+                conversation_id,
+                folded_summary.created_at,
+                folded_summary.summarized_through_turn,
+                folded_summary.token_count,
+                folded_summary.model_used,
+                folded_summary.summary_text,
+            ),
+        )
+        cursor.close()
+        self.connection.commit()
+
     def ready(self) -> bool:
         """Check if the cache is ready.
 

--- a/src/cache/sqlite_cache.py
+++ b/src/cache/sqlite_cache.py
@@ -1,5 +1,6 @@
 """Cache that uses SQLite to store cached values."""
 
+import builtins
 import json
 import sqlite3
 from time import time
@@ -14,6 +15,7 @@ from models.common.turn_summary import (
     ToolCallSummary,
     ToolResultSummary,
 )
+from models.compaction import ConversationSummary
 from models.config import SQLiteDatabaseConfiguration
 from utils.connection_decorator import connection
 
@@ -76,6 +78,19 @@ class SQLiteCache(Cache):
         );
         """
 
+    CREATE_CONVERSATION_SUMMARIES_TABLE = """
+        CREATE TABLE IF NOT EXISTS conversation_summaries (
+            user_id                 text NOT NULL,
+            conversation_id         text NOT NULL,
+            created_at              text NOT NULL,
+            summarized_through_turn int  NOT NULL,
+            token_count             int  NOT NULL,
+            model_used              text NOT NULL,
+            summary_text            text NOT NULL,
+            PRIMARY KEY(user_id, conversation_id, created_at)
+        );
+        """
+
     CREATE_INDEX = """
         CREATE INDEX IF NOT EXISTS timestamps
             ON cache (created_at)
@@ -127,6 +142,24 @@ class SQLiteCache(Cache):
         VALUES (?, ?, ?, ?)
         ON CONFLICT (user_id, conversation_id)
         DO UPDATE SET last_message_timestamp = excluded.last_message_timestamp
+        """
+
+    INSERT_SUMMARY_STATEMENT = """
+        INSERT INTO conversation_summaries(user_id, conversation_id, created_at,
+                          summarized_through_turn, token_count, model_used, summary_text)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """
+
+    SELECT_SUMMARIES_STATEMENT = """
+        SELECT summary_text, summarized_through_turn, token_count, created_at, model_used
+          FROM conversation_summaries
+         WHERE user_id=? AND conversation_id=?
+         ORDER BY created_at
+        """
+
+    DELETE_SUMMARIES_STATEMENT = """
+        DELETE FROM conversation_summaries
+         WHERE user_id=? AND conversation_id=?
         """
 
     def __init__(self, config: SQLiteDatabaseConfiguration) -> None:
@@ -203,8 +236,12 @@ class SQLiteCache(Cache):
     def initialize_cache(self) -> None:
         """Initialize cache - clean it up etc.
 
-        Creates the cache table, conversations table, and index if they do not
-        already exist, and commits the changes.
+        Creates the cache table, conversations table, conversation_summaries
+        table, and index if they do not already exist, and commits the changes.
+        Because every table is created with ``CREATE TABLE IF NOT EXISTS``, this
+        doubles as the forward-only schema migration: running it against an
+        existing database adds only the missing ``conversation_summaries`` table
+        and leaves existing data untouched.
 
         Raises:
             CacheError: if the database connection is not established.
@@ -220,6 +257,9 @@ class SQLiteCache(Cache):
 
         logger.info("Initializing table for conversations")
         cursor.execute(SQLiteCache.CREATE_CONVERSATIONS_TABLE)
+
+        logger.info("Initializing table for conversation summaries")
+        cursor.execute(SQLiteCache.CREATE_CONVERSATION_SUMMARIES_TABLE)
 
         logger.info("Initializing index for cache")
         cursor.execute(SQLiteCache.CREATE_INDEX)
@@ -458,6 +498,12 @@ class SQLiteCache(Cache):
             (user_id, conversation_id),
         )
 
+        # Also delete any compaction summaries for this conversation
+        cursor.execute(
+            self.DELETE_SUMMARIES_STATEMENT,
+            (user_id, conversation_id),
+        )
+
         cursor.close()
         self.connection.commit()
         return deleted
@@ -527,6 +573,88 @@ class SQLiteCache(Cache):
         )
         cursor.close()
         self.connection.commit()
+
+    @connection
+    def store_summary(
+        self,
+        user_id: str,
+        conversation_id: str,
+        summary: ConversationSummary,
+        skip_user_id_check: bool = False,
+    ) -> None:
+        """Append a compaction summary chunk for the given conversation.
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            summary: The ConversationSummary chunk to persist.
+            skip_user_id_check: Skip user_id suid check.
+
+        Raises:
+        ------
+            CacheError: If the cache connection is not available.
+        """
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("store_summary: cache is disconnected")
+
+        cursor = self.connection.cursor()
+        cursor.execute(
+            self.INSERT_SUMMARY_STATEMENT,
+            (
+                user_id,
+                conversation_id,
+                summary.created_at,
+                summary.summarized_through_turn,
+                summary.token_count,
+                summary.model_used,
+                summary.summary_text,
+            ),
+        )
+        cursor.close()
+        self.connection.commit()
+
+    @connection
+    def get_summaries(
+        self, user_id: str, conversation_id: str, skip_user_id_check: bool = False
+    ) -> builtins.list[ConversationSummary]:  # this class shadows the list builtin
+        """Retrieve all compaction summary chunks for a conversation.
+
+        Parameters:
+        ----------
+            user_id: User identification.
+            conversation_id: Conversation ID unique for given user.
+            skip_user_id_check: Skip user_id suid check.
+
+        Returns:
+        -------
+            Summary chunks for the conversation, oldest first (ordered by
+            ``created_at``); empty list if none exist.
+
+        Raises:
+        ------
+            CacheError: If the cache connection is not available.
+        """
+        if self.connection is None:
+            logger.error("Cache is disconnected")
+            raise CacheError("get_summaries: cache is disconnected")
+
+        cursor = self.connection.cursor()
+        cursor.execute(self.SELECT_SUMMARIES_STATEMENT, (user_id, conversation_id))
+        rows = cursor.fetchall()
+        cursor.close()
+
+        return [
+            ConversationSummary(
+                summary_text=row[0],
+                summarized_through_turn=row[1],
+                token_count=row[2],
+                created_at=row[3],
+                model_used=row[4],
+            )
+            for row in rows
+        ]
 
     def ready(self) -> bool:
         """Check if the cache is ready.

--- a/tests/unit/cache/test_in_memory_cache.py
+++ b/tests/unit/cache/test_in_memory_cache.py
@@ -1,0 +1,56 @@
+"""Unit tests for InMemoryCache class — conversation compaction summaries (LCORE-1571).
+
+The in-memory cache is a non-persisting implementation (its ``get`` returns an
+empty list and ``insert_or_append`` is a no-op). The summary operations follow
+the same contract: ``store_summary`` validates the key but does not persist, and
+``get_summaries`` always returns an empty list.
+"""
+
+import pytest
+
+from cache.in_memory_cache import InMemoryCache
+from models.compaction import ConversationSummary
+from models.config import InMemoryCacheConfig
+from utils import suid
+
+USER_ID = suid.get_suid()
+CONVERSATION_ID = suid.get_suid()
+
+summary_1 = ConversationSummary(
+    summary_text="Summary chunk for the in-memory cache test.",
+    summarized_through_turn=8,
+    token_count=9,
+    created_at="2025-10-03T09:31:29Z",
+    model_used="openai/gpt-4o-mini",
+)
+
+
+@pytest.fixture(name="cache_fixture")
+def cache() -> InMemoryCache:
+    """Construct an initialized in-memory cache for tests."""
+    c = InMemoryCache(InMemoryCacheConfig(max_entries=100))
+    c.initialize_cache()
+    return c
+
+
+def test_store_summary_is_noop(cache_fixture: InMemoryCache) -> None:
+    """store_summary accepts a summary without persisting (in-memory cache)."""
+    cache_fixture.store_summary(USER_ID, CONVERSATION_ID, summary_1)
+
+
+def test_get_summaries_returns_empty(cache_fixture: InMemoryCache) -> None:
+    """get_summaries always returns an empty list for the in-memory cache."""
+    cache_fixture.store_summary(USER_ID, CONVERSATION_ID, summary_1)
+    assert cache_fixture.get_summaries(USER_ID, CONVERSATION_ID) == []
+
+
+def test_store_summary_validates_conversation_id(cache_fixture: InMemoryCache) -> None:
+    """store_summary validates the conversation ID like the other operations."""
+    with pytest.raises(ValueError, match="Invalid conversation ID"):
+        cache_fixture.store_summary(USER_ID, "not-a-valid-uuid", summary_1)
+
+
+def test_get_summaries_validates_conversation_id(cache_fixture: InMemoryCache) -> None:
+    """get_summaries validates the conversation ID like the other operations."""
+    with pytest.raises(ValueError, match="Invalid conversation ID"):
+        cache_fixture.get_summaries(USER_ID, "not-a-valid-uuid")

--- a/tests/unit/cache/test_in_memory_cache.py
+++ b/tests/unit/cache/test_in_memory_cache.py
@@ -54,3 +54,17 @@ def test_get_summaries_validates_conversation_id(cache_fixture: InMemoryCache) -
     """get_summaries validates the conversation ID like the other operations."""
     with pytest.raises(ValueError, match="Invalid conversation ID"):
         cache_fixture.get_summaries(USER_ID, "not-a-valid-uuid")
+
+
+def test_replace_summaries_is_noop(cache_fixture: InMemoryCache) -> None:
+    """replace_summaries accepts a fold without persisting (in-memory cache)."""
+    cache_fixture.replace_summaries(USER_ID, CONVERSATION_ID, summary_1)
+    assert cache_fixture.get_summaries(USER_ID, CONVERSATION_ID) == []
+
+
+def test_replace_summaries_validates_conversation_id(
+    cache_fixture: InMemoryCache,
+) -> None:
+    """replace_summaries validates the conversation ID like the other operations."""
+    with pytest.raises(ValueError, match="Invalid conversation ID"):
+        cache_fixture.replace_summaries(USER_ID, "not-a-valid-uuid", summary_1)

--- a/tests/unit/cache/test_noop_cache.py
+++ b/tests/unit/cache/test_noop_cache.py
@@ -278,3 +278,15 @@ def test_get_summaries_validates_conversation_id(cache_fixture: NoopCache) -> No
     """get_summaries validates the conversation ID like the other operations."""
     with pytest.raises(ValueError, match="Invalid conversation ID"):
         cache_fixture.get_summaries(USER_ID, "this-is-not-valid-uuid")
+
+
+def test_replace_summaries_is_noop(cache_fixture: NoopCache) -> None:
+    """replace_summaries accepts a fold without persisting (no-op cache)."""
+    cache_fixture.replace_summaries(USER_ID, CONVERSATION_ID, summary_1)
+    assert cache_fixture.get_summaries(USER_ID, CONVERSATION_ID) == []
+
+
+def test_replace_summaries_validates_conversation_id(cache_fixture: NoopCache) -> None:
+    """replace_summaries validates the conversation ID like the other operations."""
+    with pytest.raises(ValueError, match="Invalid conversation ID"):
+        cache_fixture.replace_summaries(USER_ID, "this-is-not-valid-uuid", summary_1)

--- a/tests/unit/cache/test_noop_cache.py
+++ b/tests/unit/cache/test_noop_cache.py
@@ -6,6 +6,7 @@ import pytest
 
 from cache.cache_entry import CacheEntry
 from cache.noop_cache import NoopCache
+from models.compaction import ConversationSummary
 from utils import suid
 
 USER_ID = suid.get_suid()
@@ -250,3 +251,30 @@ def test_get_improper_conversation_id(cache_fixture: NoopCache) -> None:
     """
     with pytest.raises(ValueError, match="Invalid conversation ID"):
         cache_fixture.get(USER_ID, "this-is-not-valid-uuid")
+
+
+# --- conversation compaction summaries (LCORE-1571) ---
+
+summary_1 = ConversationSummary(
+    summary_text="Summary chunk for the no-op cache test.",
+    summarized_through_turn=8,
+    token_count=9,
+    created_at="2025-10-03T09:31:29Z",
+    model_used="openai/gpt-4o-mini",
+)
+
+
+def test_store_summary_is_noop(cache_fixture: NoopCache) -> None:
+    """store_summary accepts a summary without persisting (no-op cache)."""
+    cache_fixture.store_summary(USER_ID, CONVERSATION_ID, summary_1)
+
+
+def test_get_summaries_returns_empty(cache_fixture: NoopCache) -> None:
+    """get_summaries always returns an empty list for the no-op cache."""
+    assert cache_fixture.get_summaries(USER_ID, CONVERSATION_ID) == []
+
+
+def test_get_summaries_validates_conversation_id(cache_fixture: NoopCache) -> None:
+    """get_summaries validates the conversation ID like the other operations."""
+    with pytest.raises(ValueError, match="Invalid conversation ID"):
+        cache_fixture.get_summaries(USER_ID, "this-is-not-valid-uuid")

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -1,5 +1,7 @@
 """Unit tests for PostgreSQL cache implementation."""
 
+# pylint: disable=too-many-lines
+
 import json
 from typing import Any
 
@@ -17,6 +19,7 @@ from models.common.turn_summary import (
     ToolCallSummary,
     ToolResultSummary,
 )
+from models.compaction import ConversationSummary
 from models.config import PostgreSQLDatabaseConfiguration
 from utils import suid
 
@@ -914,3 +917,147 @@ def test_insert_and_get_with_tool_calls_and_results(
     assert retrieved_entries[0].tool_results is not None
     assert len(retrieved_entries[0].tool_results) == 1
     assert retrieved_entries[0].tool_results[0].status == "success"
+
+
+# --- conversation compaction summaries (LCORE-1571) ---
+
+summary_1 = ConversationSummary(
+    summary_text="User asked about Kubernetes pods; assistant explained kubectl.",
+    summarized_through_turn=8,
+    token_count=14,
+    created_at="2025-10-03T09:31:29Z",
+    model_used="openai/gpt-4o-mini",
+)
+summary_2 = ConversationSummary(
+    summary_text="User then moved on to Helm charts and Istio routing.",
+    summarized_through_turn=18,
+    token_count=12,
+    created_at="2025-10-03T10:05:01Z",
+    model_used="openai/gpt-4o-mini",
+)
+
+
+def test_store_summary_when_disconnected(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """store_summary raises CacheError when the cache is disconnected."""
+    mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    cache.connection = None
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+
+
+def test_store_summary_when_connected(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """store_summary issues the insert without failing when connected."""
+    mock_connect = mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+
+    mock_cursor = mock_connect.return_value.cursor.return_value.__enter__.return_value
+    # The most recent execute() is the INSERT (an earlier "SELECT 1" comes from
+    # the @connection decorator's connected() probe sharing this mock cursor).
+    statement, params = mock_cursor.execute.call_args[0]
+    assert "INSERT INTO conversation_summaries" in statement
+    # the values tuple carries the summary fields in column order
+    assert params == (
+        USER_ID_1,
+        CONVERSATION_ID_1,
+        summary_1.created_at,
+        summary_1.summarized_through_turn,
+        summary_1.token_count,
+        summary_1.model_used,
+        summary_1.summary_text,
+    )
+
+
+def test_store_summary_database_error(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """store_summary wraps a psycopg2 DatabaseError in CacheError."""
+    mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    cache.connect = lambda: None
+    cache.connection = ConnectionMock()  # pyright: ignore
+
+    with pytest.raises(CacheError, match="store_summary"):
+        cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+
+
+def test_get_summaries_when_disconnected(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """get_summaries raises CacheError when the cache is disconnected."""
+    mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    cache.connection = None
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+
+
+def test_get_summaries_empty(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """get_summaries returns an empty list when the table has no rows."""
+    mock_connect = mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    mock_cursor = mock_connect.return_value.cursor.return_value.__enter__.return_value
+    mock_cursor.fetchall.return_value = []
+
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == []
+
+
+def test_get_summaries_returns_rows(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """get_summaries reconstructs ConversationSummary objects from DB rows."""
+    mock_connect = mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    mock_cursor = mock_connect.return_value.cursor.return_value.__enter__.return_value
+    # SELECT order: summary_text, summarized_through_turn, token_count, created_at, model_used
+    mock_cursor.fetchall.return_value = [
+        (
+            summary_1.summary_text,
+            summary_1.summarized_through_turn,
+            summary_1.token_count,
+            summary_1.created_at,
+            summary_1.model_used,
+        ),
+        (
+            summary_2.summary_text,
+            summary_2.summarized_through_turn,
+            summary_2.token_count,
+            summary_2.created_at,
+            summary_2.model_used,
+        ),
+    ]
+
+    summaries = cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+    assert summaries == [summary_1, summary_2]
+
+
+def test_get_summaries_database_error(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """get_summaries wraps a psycopg2 DatabaseError in CacheError."""
+    mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    cache.connect = lambda: None
+    cache.connection = ConnectionMock()  # pyright: ignore
+
+    with pytest.raises(CacheError, match="get_summaries"):
+        cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)

--- a/tests/unit/cache/test_postgres_cache.py
+++ b/tests/unit/cache/test_postgres_cache.py
@@ -935,6 +935,14 @@ summary_2 = ConversationSummary(
     created_at="2025-10-03T10:05:01Z",
     model_used="openai/gpt-4o-mini",
 )
+# A fold collapsing the accumulated chunks (R3, LCORE-1572).
+folded_summary = ConversationSummary(
+    summary_text="Folded: pods/kubectl, then Helm charts and Istio routing.",
+    summarized_through_turn=18,
+    token_count=11,
+    created_at="2025-10-03T11:00:00Z",
+    model_used="openai/gpt-4o-mini",
+)
 
 
 def test_store_summary_when_disconnected(
@@ -1061,3 +1069,61 @@ def test_get_summaries_database_error(
 
     with pytest.raises(CacheError, match="get_summaries"):
         cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+
+
+def test_replace_summaries_when_disconnected(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """replace_summaries raises CacheError when the cache is disconnected."""
+    mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    cache.connection = None
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)
+
+
+def test_replace_summaries_when_connected(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """replace_summaries deletes existing chunks then inserts the fold."""
+    mock_connect = mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+
+    cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)
+
+    mock_cursor = mock_connect.return_value.cursor.return_value.__enter__.return_value
+    statements = [call.args[0] for call in mock_cursor.execute.call_args_list]
+    assert any("DELETE FROM conversation_summaries" in s for s in statements)
+    insert_calls = [
+        call
+        for call in mock_cursor.execute.call_args_list
+        if "INSERT INTO conversation_summaries" in call.args[0]
+    ]
+    assert len(insert_calls) == 1
+    assert insert_calls[0].args[1] == (
+        USER_ID_1,
+        CONVERSATION_ID_1,
+        folded_summary.created_at,
+        folded_summary.summarized_through_turn,
+        folded_summary.token_count,
+        folded_summary.model_used,
+        folded_summary.summary_text,
+    )
+
+
+def test_replace_summaries_database_error(
+    postgres_cache_config_fixture: PostgreSQLDatabaseConfiguration,
+    mocker: MockerFixture,
+) -> None:
+    """replace_summaries wraps a psycopg2 DatabaseError in CacheError."""
+    mocker.patch("psycopg2.connect")
+    cache = PostgresCache(postgres_cache_config_fixture)
+    cache.connect = lambda: None
+    cache.connection = ConnectionMock()  # pyright: ignore
+
+    with pytest.raises(CacheError, match="replace_summaries"):
+        cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)

--- a/tests/unit/cache/test_sqlite_cache.py
+++ b/tests/unit/cache/test_sqlite_cache.py
@@ -16,6 +16,7 @@ from models.common.turn_summary import (
     ToolCallSummary,
     ToolResultSummary,
 )
+from models.compaction import ConversationSummary
 from models.config import SQLiteDatabaseConfiguration
 from utils import suid
 
@@ -616,3 +617,134 @@ def test_insert_and_get_with_all_fields(tmpdir: Path) -> None:
     assert retrieved_entries[0].tool_calls[0].name == "test_tool"
     assert retrieved_entries[0].tool_results is not None
     assert retrieved_entries[0].tool_results[0].status == "success"
+
+
+# --- conversation compaction summaries (LCORE-1571) ---
+
+summary_1 = ConversationSummary(
+    summary_text="User asked about Kubernetes pods; assistant explained kubectl.",
+    summarized_through_turn=8,
+    token_count=14,
+    created_at="2025-10-03T09:31:29Z",
+    model_used="openai/gpt-4o-mini",
+)
+summary_2 = ConversationSummary(
+    summary_text="User then moved on to Helm charts and Istio routing.",
+    summarized_through_turn=18,
+    token_count=12,
+    created_at="2025-10-03T10:05:01Z",
+    model_used="openai/gpt-4o-mini",
+)
+
+
+def test_get_summaries_empty(tmpdir: Path) -> None:
+    """get_summaries returns an empty list for a conversation with no summaries."""
+    cache = create_cache(tmpdir)
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == []
+
+
+def test_store_and_get_single_summary(tmpdir: Path) -> None:
+    """A stored summary can be retrieved by conversation_id (AC1)."""
+    cache = create_cache(tmpdir)
+
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+
+    summaries = cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+    assert len(summaries) == 1
+    assert summaries[0] == summary_1
+
+
+def test_store_multiple_summary_chunks_additive(tmpdir: Path) -> None:
+    """Multiple chunks per conversation are supported and returned oldest-first (AC2)."""
+    cache = create_cache(tmpdir)
+
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_2, False)
+
+    summaries = cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+    assert len(summaries) == 2
+    # ordered by created_at: summary_1 (09:31) before summary_2 (10:05)
+    assert summaries[0] == summary_1
+    assert summaries[1] == summary_2
+    # the first chunk is preserved verbatim, not re-summarized
+    assert summaries[0].summarized_through_turn == 8
+
+
+def test_summaries_isolated_per_conversation_and_user(tmpdir: Path) -> None:
+    """Summaries are scoped to the (user_id, conversation_id) compound key."""
+    cache = create_cache(tmpdir)
+
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_2, summary_2, False)
+
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == [summary_1]
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_2, False) == [summary_2]
+    assert cache.get_summaries(USER_ID_2, CONVERSATION_ID_1, False) == []
+
+
+def test_summaries_persist_across_reconnect(tmpdir: Path) -> None:
+    """Summaries survive a fresh cache instance over the same db file (restart)."""
+    db_path = str(tmpdir / "test.sqlite")
+    cache = SQLiteCache(SQLiteDatabaseConfiguration(db_path=db_path))
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+
+    # New instance on the same file simulates a service restart.
+    reopened = SQLiteCache(SQLiteDatabaseConfiguration(db_path=db_path))
+    summaries = reopened.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+    assert summaries == [summary_1]
+
+
+def test_summaries_deleted_with_conversation(tmpdir: Path) -> None:
+    """Deleting a conversation cascades to its summaries."""
+    cache = create_cache(tmpdir)
+
+    cache.insert_or_append(USER_ID_1, CONVERSATION_ID_1, cache_entry_1, False)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+    assert len(cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)) == 1
+
+    cache.delete(USER_ID_1, CONVERSATION_ID_1, False)
+
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == []
+
+
+def test_store_summary_when_disconnected(tmpdir: Path) -> None:
+    """store_summary raises CacheError when the cache is disconnected."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+
+
+def test_get_summaries_when_disconnected(tmpdir: Path) -> None:
+    """get_summaries raises CacheError when the cache is disconnected."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+
+
+def test_migration_adds_summaries_table_to_existing_db(tmpdir: Path) -> None:
+    """initialize_cache adds the summaries table to a pre-existing cache db (AC3).
+
+    Simulates an older database that has the cache/conversations tables but not
+    conversation_summaries, then verifies a fresh SQLiteCache initializes the
+    new table without error and can store/retrieve summaries.
+    """
+    db_path = str(tmpdir / "legacy.sqlite")
+
+    # Build a "legacy" db with only the pre-1571 tables.
+    legacy = sqlite3.connect(db_path)
+    legacy.execute(SQLiteCache.CREATE_CACHE_TABLE)
+    legacy.execute(SQLiteCache.CREATE_CONVERSATIONS_TABLE)
+    legacy.commit()
+    legacy.close()
+
+    # Opening with the current code must migrate (create the missing table)
+    # without error and be immediately usable.
+    cache = SQLiteCache(SQLiteDatabaseConfiguration(db_path=db_path))
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == [summary_1]

--- a/tests/unit/cache/test_sqlite_cache.py
+++ b/tests/unit/cache/test_sqlite_cache.py
@@ -635,6 +635,22 @@ summary_2 = ConversationSummary(
     created_at="2025-10-03T10:05:01Z",
     model_used="openai/gpt-4o-mini",
 )
+# A fold collapsing summary_1 + summary_2; created after both (R3, LCORE-1572).
+folded_summary = ConversationSummary(
+    summary_text="Folded: pods/kubectl, then Helm charts and Istio routing.",
+    summarized_through_turn=18,
+    token_count=11,
+    created_at="2025-10-03T11:00:00Z",
+    model_used="openai/gpt-4o-mini",
+)
+# A chunk produced after a fold; created later still, so it sorts after the fold.
+summary_after_fold = ConversationSummary(
+    summary_text="Later: user asked about ArgoCD sync waves.",
+    summarized_through_turn=26,
+    token_count=10,
+    created_at="2025-10-03T11:42:00Z",
+    model_used="openai/gpt-4o-mini",
+)
 
 
 def test_get_summaries_empty(tmpdir: Path) -> None:
@@ -725,6 +741,61 @@ def test_get_summaries_when_disconnected(tmpdir: Path) -> None:
 
     with pytest.raises(CacheError, match="cache is disconnected"):
         cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False)
+
+
+def test_replace_summaries_collapses_chunks(tmpdir: Path) -> None:
+    """replace_summaries removes all existing chunks and stores the fold (R3)."""
+    cache = create_cache(tmpdir)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_2, False)
+
+    cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)
+
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == [folded_summary]
+
+
+def test_replace_summaries_on_empty_conversation(tmpdir: Path) -> None:
+    """replace_summaries with no existing chunks simply stores the fold."""
+    cache = create_cache(tmpdir)
+
+    cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)
+
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == [folded_summary]
+
+
+def test_replace_summaries_then_append_keeps_fold_first(tmpdir: Path) -> None:
+    """After a fold, a later chunk appends after it (ordered by created_at)."""
+    cache = create_cache(tmpdir)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+    cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_after_fold, False)
+
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == [
+        folded_summary,
+        summary_after_fold,
+    ]
+
+
+def test_replace_summaries_isolated_per_conversation(tmpdir: Path) -> None:
+    """replace_summaries only affects its own (user_id, conversation_id)."""
+    cache = create_cache(tmpdir)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_1, summary_1, False)
+    cache.store_summary(USER_ID_1, CONVERSATION_ID_2, summary_2, False)
+
+    cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)
+
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_1, False) == [folded_summary]
+    assert cache.get_summaries(USER_ID_1, CONVERSATION_ID_2, False) == [summary_2]
+
+
+def test_replace_summaries_when_disconnected(tmpdir: Path) -> None:
+    """replace_summaries raises CacheError when the cache is disconnected."""
+    cache = create_cache(tmpdir)
+    cache.connection = None
+    cache.connect = lambda: None
+
+    with pytest.raises(CacheError, match="cache is disconnected"):
+        cache.replace_summaries(USER_ID_1, CONVERSATION_ID_1, folded_summary, False)
 
 
 def test_migration_adds_summaries_table_to_existing_db(tmpdir: Path) -> None:


### PR DESCRIPTION
## Description

Extends the conversation cache with persistent storage for conversation-compaction summaries (part of the Conversation Compaction epic, LCORE-1631).

When compaction summarizes older conversation turns (LCORE-1570), each run produces a `ConversationSummary` chunk. This PR lets those chunks be persisted and retrieved per conversation so they survive across requests and service restarts.

- **Cache ABC** (`src/cache/cache.py`): new `store_summary()`, `get_summaries()`, and `replace_summaries()` abstract methods.
- **SQLite & PostgreSQL**: new `conversation_summaries` table keyed by `(user_id, conversation_id, created_at)`, supporting multiple additive summary chunks per conversation and returned oldest-first. The table is created with `CREATE TABLE IF NOT EXISTS` in `initialize_cache()`, which doubles as a forward-only schema migration for existing databases. `delete()` cascades to the summaries table.
- **Recursive-fold persistence** (`replace_summaries()`): atomically replaces a conversation's accumulated summary chunks with a single folded summary (delete + insert in one transaction). This is the persistence layer for recursive re-summarization (R3, LCORE-1572) — a fold is computed once and reused rather than recomputed per request. Ordering by `created_at` means a later `get_summaries()` returns the fold first, followed by any chunks appended after it (the active set).
- **In-memory & no-op backends**: interface-satisfying no-op stubs, mirroring the existing `set_topic_summary` contract.

Reuses the `ConversationSummary` model from LCORE-1570. No public API or OpenAPI changes.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude (Claude Code)
- Generated by: Claude Opus 4.7

## Related Tickets & Documents

- Related Issue # LCORE-1571
- Closes # LCORE-1571

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

Cache-layer change; verified with unit tests (no running stack required).

1. Cache backend tests: `uv run python -m pytest tests/unit/cache/ -q` -> 140 passed, 1 skipped. For SQLite (real on-disk DB): store/retrieve a summary, additive multi-chunk ordering, per-(user, conversation) isolation, persistence across a fresh cache instance (simulated restart), forward-only migration on a legacy DB that lacks the new table, cascade delete with the conversation, and disconnected error paths. `replace_summaries()` is covered for collapse, empty-conversation, fold-then-append ordering, per-conversation isolation, and disconnected/DB-error paths. PostgreSQL paths covered via mocked psycopg2 (store/replace params, row reconstruction, empty result, disconnected/DB-error). Memory and no-op backends: no-op behavior and conversation-id validation.

2. Full unit suite (confirms the new abstract methods broke no existing Cache users): `uv run python -m pytest tests/unit` -> 2373 passed, 1 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversation summary storage and retrieval capabilities across all cache backends (in-memory, SQLite, PostgreSQL).
  * Conversation deletion now cascades to remove associated summaries.

* **Tests**
  * Added comprehensive test coverage for summary operations across cache implementations, including edge cases and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lightspeed-core/lightspeed-stack/pull/1795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
