### PR TITLE
RSPEED-3116: explicitly set type='mcp' on InputToolMCP constructions

### DIFF
--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -743,6 +743,13 @@ async def get_mcp_tools(
         )
         tools.append(
             InputToolMCP(
+                # Pass type explicitly: the llama-stack client serializes pydantic
+                # instances with model_dump(exclude_unset=True), which strips fields
+                # filled from defaults. Without an explicit value here, the 'type'
+                # discriminator is dropped before reaching CreateResponseRequest,
+                # causing a union_tag_not_found validation error in library-client
+                # mode. See RSPEED-3116.
+                type="mcp",
                 server_label=mcp_server.name,
                 server_url=mcp_server.url,
                 require_approval=require_approval,
@@ -807,6 +814,10 @@ def apply_mcp_headers_to_explicit_tools(
         out.append(
             mcp_tool.model_copy(
                 update={
+                    # Force 'type' to be explicitly set on the copy so it survives
+                    # model_dump(exclude_unset=True) in the llama-stack client.
+                    # See RSPEED-3116.
+                    "type": "mcp",
                     "headers": headers or None,
                     "authorization": authorization,
                 }

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -834,6 +834,86 @@ class TestGetMCPTools:
         assert len(tools[0].headers) == 1
 
 
+class TestInputToolMCPTypeDiscriminator:
+    """Regression tests for RSPEED-3116.
+
+    The llama-stack client SDK serializes pydantic instances with
+    ``model_dump(exclude_unset=True)`` before sending them to the server.
+    Because Pydantic v2 treats defaulted fields as "unset", the
+    ``type: Literal['mcp'] = 'mcp'`` discriminator on the parent class is
+    stripped from the wire payload unless we pass ``type='mcp'`` explicitly
+    at every construction site. In library-client mode the resulting dict
+    is revalidated against a discriminated union and raises
+    ``union_tag_not_found``.
+    """
+
+    def test_input_tool_mcp_dump_excludes_unset_includes_type(self) -> None:
+        """InputToolMCP must serialize 'type' under exclude_unset=True."""
+        tool = InputToolMCP(
+            type="mcp",
+            server_label="okp",
+            server_url="http://example.com",
+        )
+
+        dumped = tool.model_dump(exclude_unset=True)
+
+        assert dumped.get("type") == "mcp"
+
+    @pytest.mark.asyncio
+    async def test_get_mcp_tools_sets_type_explicitly(
+        self, mocker: MockerFixture
+    ) -> None:
+        """get_mcp_tools must produce instances whose dump retains 'type'."""
+        servers = [
+            ModelContextProtocolServer(
+                name="okp", url="http://okp.example.com", provider_id="mcp"
+            ),
+        ]
+        mock_config = mocker.Mock()
+        mock_config.mcp_servers = servers
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        tools = await get_mcp_tools(token=None)
+
+        assert len(tools) == 1
+        dumped = tools[0].model_dump(exclude_unset=True)
+        assert dumped.get("type") == "mcp"
+
+    @pytest.mark.asyncio
+    async def test_apply_mcp_headers_preserves_type(
+        self, mocker: MockerFixture
+    ) -> None:
+        """apply_mcp_headers_to_explicit_tools must keep 'type' explicitly set."""
+        from utils.responses import (  # pylint: disable=import-outside-toplevel
+            apply_mcp_headers_to_explicit_tools,
+        )
+
+        servers = [
+            ModelContextProtocolServer(
+                name="okp", url="http://okp.example.com", provider_id="mcp"
+            ),
+        ]
+        mock_config = mocker.Mock()
+        mock_config.mcp_servers = servers
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        # Simulate an explicit tool that came in over the wire. Construct it
+        # via the parent path (no explicit type=) so model_copy is the only
+        # place 'type' could become set.
+        explicit = InputToolMCP(
+            server_label="okp",
+            server_url="http://okp.example.com",
+        )
+
+        out = apply_mcp_headers_to_explicit_tools(
+            [explicit], token=None, mcp_headers=None, request_headers=None
+        )
+
+        assert len(out) == 1
+        dumped = out[0].model_dump(exclude_unset=True)
+        assert dumped.get("type") == "mcp"
+
+
 class TestGetTopicSummary:
     """Tests for get_topic_summary function."""
 


### PR DESCRIPTION
## Description

MCP-enabled requests in library-client mode fail with `union_tag_not_found` on `CreateResponseRequest.tools.0`. The input dict is missing the `type` key.

- `InputToolMCP(...)` is built without passing `type='mcp'`, so Pydantic fills it from the parent class default.
- The llama-stack client SDK serializes via `model_dump(exclude_unset=True)`, which drops defaulted fields, so `type` never leaves our process.
- In library-client mode, `library_client._convert_body` revalidates the dict against the discriminated union and blows up.

Fix: pass `type="mcp"` at both `InputToolMCP` construction sites in `src/utils/responses.py` so the field is set and survives `exclude_unset`.

Note: redeclaring `type: Literal['mcp'] = 'mcp'` on the subclass does not fix it. Defaulted is still unset under Pydantic v2.

## Type of change

- [x] Bug fix
- [x] Unit tests improvement

## Tools used to create PR

- Assisted-by: Claude (opencode), CodeRabbit (local, 0 findings)
- Generated by: N/A

## Related Tickets & Documents

- Refs: RSPEED-3116

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- `uv run make format` and `uv run make verify` clean.
- New `TestInputToolMCPTypeDiscriminator` covers both call sites plus the underlying `model_dump(exclude_unset=True)` behavior.
- Sanity check: with the source fix reverted, the two call-site tests fail with `assert None == 'mcp'`. With the fix in place, all three pass.