### PR TITLE
LCORE-2395: remove read-only mount for llama-stack config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ LLAMA_STACK_IMAGE ?= lightspeed-llama-stack:local
 LLAMA_STACK_PORT ?= 8321
 CONTAINER_RUNTIME ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 
-.PHONY: run build-llama-stack-image remove-llama-stack-container start-llama-stack-container wait-for-llama-stack-health clean-llama-stack
+.PHONY: run run-local build-llama-stack-image remove-llama-stack-container start-llama-stack-container wait-for-llama-stack-health clean-llama-stack
 
 run: start-llama-stack-container ## Run the service locally with llama-stack container
 	@echo "Starting Lightspeed Core Stack..."
@@ -108,6 +108,9 @@ clean-llama-stack: remove-llama-stack-container ## Remove container and image
 		echo "Removing llama-stack image..."; \
 		$(CONTAINER_RUNTIME) rmi $(LLAMA_STACK_IMAGE); \
 	fi
+run-local: ## Run the service locally, assuming llama-stack is already running externally
+	uv run src/lightspeed_stack.py -c $(CONFIG)
+
 run-llama-stack: ## Start Llama Stack with enriched config (for local service mode)
 	uv run src/llama_stack_configuration.py -c $(CONFIG) -i $(LLAMA_STACK_CONFIG) -o $(LLAMA_STACK_CONFIG) && \
 	uv run llama stack run $(LLAMA_STACK_CONFIG)

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,14 @@ LLAMA_STACK_IMAGE ?= lightspeed-llama-stack:local
 LLAMA_STACK_PORT ?= 8321
 CONTAINER_RUNTIME ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 
-.PHONY: run run-local build-llama-stack-image remove-llama-stack-container start-llama-stack-container wait-for-llama-stack-health clean-llama-stack
+.PHONY: run run-stack build-llama-stack-image remove-llama-stack-container start-llama-stack-container wait-for-llama-stack-health clean-llama-stack
 
-run: start-llama-stack-container ## Run the service locally with llama-stack container
-	@echo "Starting Lightspeed Core Stack..."
+run-stack: ## Run lightspeed-stack directly, without building dependent service/s
 	uv run src/lightspeed_stack.py -c $(CONFIG)
+
+run: start-llama-stack-container ## Run the service locally with dependent services
+	@echo "Starting Lightspeed Core Stack..."
+	$(MAKE) run-stack
 
 build-llama-stack-image: remove-llama-stack-container ## Build llama-stack container image
 	@echo "Building llama-stack container image..."
@@ -108,8 +111,6 @@ clean-llama-stack: remove-llama-stack-container ## Remove container and image
 		echo "Removing llama-stack image..."; \
 		$(CONTAINER_RUNTIME) rmi $(LLAMA_STACK_IMAGE); \
 	fi
-run-local: ## Run the service locally, assuming llama-stack is already running externally
-	uv run src/lightspeed_stack.py -c $(CONFIG)
 
 run-llama-stack: ## Start Llama Stack with enriched config (for local service mode)
 	uv run src/llama_stack_configuration.py -c $(CONFIG) -i $(LLAMA_STACK_CONFIG) -o $(LLAMA_STACK_CONFIG) && \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ start-llama-stack-container: build-llama-stack-image ## Start llama-stack contai
 		--health-timeout 5s \
 		--health-retries 3 \
 		--health-start-period 15s \
-		-v $(PWD)/$(LLAMA_STACK_CONFIG):/opt/app-root/run.yaml:ro,z \
+		-v $(PWD)/$(LLAMA_STACK_CONFIG):/opt/app-root/run.yaml:z \
 		-v $(PWD)/$(CONFIG):/opt/app-root/lightspeed-stack.yaml:ro,z \
 		-v $(PWD)/scripts/llama-stack-entrypoint.sh:/opt/app-root/enrich-entrypoint.sh:ro,z \
 		-v $(PWD)/src/llama_stack_configuration.py:/opt/app-root/llama_stack_configuration.py:ro,z \


### PR DESCRIPTION
## Description

Two Makefile fixes for `make run`:

1. **Remove `ro` from `run.yaml` mount** — the enrichment script writes the enriched config back to `run.yaml` at startup, so the volume mount must be writable. The `ro` flag was causing enrichment to fail with a read-only filesystem error.

2. **Add `make run-local` target** — restores the pre-LCORE-1872 behaviour as a dedicated target: starts only the lightspeed-stack service, assuming llama-stack is already running externally (e.g. via `docker compose` or a separate process). Useful for local development iteration without rebuilding the container image.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude
- Generated by: Claude Sonnet 4.6 (1M context)

## Related Tickets & Documents

- Related Issue: [LCORE-2395](https://redhat.atlassian.net/browse/LCORE-2395)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

1. Run `make run` — verify enrichment completes without read-only filesystem errors and llama-stack starts correctly.
2. With llama-stack already running separately, run `make run-local` — verify lightspeed-stack starts without attempting to build/start any container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored application launch process to automatically initialize and start required containers before execution, reducing manual setup steps and improving user experience.
  * Modified container configuration to enable write access to system directories, enhancing application state management and runtime flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->