### PR TITLE
RSPEED-3082: add build-nudge-files annotation for cross-repo nudging

### DIFF
--- a/.tekton/lightspeed-stack-push.yaml
+++ b/.tekton/lightspeed-stack-push.yaml
@@ -2,6 +2,10 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    # Cross-repo nudge: after each push build, the Konflux nudge controller
+    # opens an MR in lscore-deploy (gitlab.cee.redhat.com/rhel-lightspeed/lscore-deploy)
+    # to bump the image digest in openshift/lightspeed-stack.yml. See RSPEED-3082.
+    build.appstudio.openshift.io/build-nudge-files: "openshift/lightspeed-stack.yml"
     build.appstudio.openshift.io/repo: https://github.com/lightspeed-core/lightspeed-stack?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
## What

Add `build.appstudio.openshift.io/build-nudge-files` annotation to the push PipelineRun, targeting `openshift/lightspeed-stack.yml` in lscore-deploy.

## Why

The Konflux nudge controller's default file pattern (`.*Dockerfile.*, .*.yaml, .*Containerfile.*`) only matches `.yaml` files. Since lscore-deploy uses `openshift/lightspeed-stack.yml` (note: `.yml`), the nudge controller silently skips it — no MR is opened to bump the image digest.

This annotation explicitly tells the nudge controller which file to scan, bypassing the default pattern entirely.

## Tickets

- [RSPEED-3082](https://redhat.atlassian.net/browse/RSPEED-3082)

## Testing

Once merged, the push pipeline triggered by this merge will include the annotation. The nudge controller should then open an MR in lscore-deploy updating the image digest in `openshift/lightspeed-stack.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new metadata annotation to the build pipeline configuration.
  * Updated pipeline metadata to include a reference to a stack configuration file.
  * Minor metadata-only change; no functional behavior changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->