### PR TITLE
LCORE-2478: improved docstring in schema_dumper

### DIFF
--- a/src/utils/schema_dumper.py
+++ b/src/utils/schema_dumper.py
@@ -12,15 +12,23 @@ from models.config import Configuration
 def recursive_update(
     original: dict[str, Any],
 ) -> dict[str, Any]:
-    """Recursively update the schema to be 100% OpenAPI-compatible.
+    """Transform a JSON Schema-like dictionary into an OpenAPI-compatible schema.
+
+    Recursively walks the input mapping and applies compatibility fixes:
+    - converts patterns like `anyOf: [{ "type": X }, { "type": "null" }]` into
+      a single `"type": X` with `"nullable": True` (optional types)
+    - rewrites `"exclusiveMinimum"` to `"minimum"`
+    - otherwise preserves entries
 
     Parameters:
     ----------
-        original (dict): The original schema dictionary to transform.
+        original (dict[str, Any]): Input schema dictionary that is produced by
+        Pydantic.
 
     Returns:
     -------
-        dict: A new dictionary with OpenAPI-compatible transformations applied.
+        dict[str, Any]: A new schema dictionary with all OpenAPI-compatible
+        transformations applied.
     """
     new: dict[str, Any] = {}
     for key, value in original.items():


### PR DESCRIPTION
## Description

LCORE-2478: improved docstring in `schema_dumper`

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation for the schema transformation utility to clarify how JSON schemas are converted to OpenAPI-compatible formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->