### PR TITLE
LCORE-2310: Adding explicit TLS output checks

### DIFF
--- a/tests/e2e/features/tls.feature
+++ b/tests/e2e/features/tls.feature
@@ -21,6 +21,7 @@ Feature: TLS configuration for remote inference providers
     {"query": "Say hello", "model": "mock-tls-model", "provider": "tls-openai"}
     """
      Then The status code of the response is 200
+      And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference succeeds with CA certificate verification
     Given Llama Stack is configured with CA certificate verification
@@ -31,6 +32,7 @@ Feature: TLS configuration for remote inference providers
     {"query": "Say hello", "model": "mock-tls-model", "provider": "tls-openai"}
     """
      Then The status code of the response is 200
+      And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference fails with an untrusted CA certificate
     Given Llama Stack is configured with CA certificate path "/certs/untrusted-ca.crt"
@@ -74,6 +76,7 @@ Feature: TLS configuration for remote inference providers
     {"query": "Say hello", "model": "mock-tls-model", "provider": "tls-openai"}
     """
      Then The status code of the response is 200
+      And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference fails when mTLS is required but no client certificate is provided
     Given Llama Stack is configured for mTLS without client certificate
@@ -150,6 +153,7 @@ Feature: TLS configuration for remote inference providers
     {"query": "Say hello", "model": "mock-tls-model", "provider": "tls-openai"}
     """
      Then The status code of the response is 200
+      And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference fails with TLS minimum version TLSv1.3 and untrusted CA certificate
     Given Llama Stack is configured with TLS minimum version "TLSv1.3" and CA certificate path "/certs/untrusted-ca.crt"

--- a/tests/e2e/mock_tls_inference_server/server.py
+++ b/tests/e2e/mock_tls_inference_server/server.py
@@ -75,10 +75,49 @@ class OpenAIHandler(BaseHTTPRequestHandler):
             request_data = {}
 
         model = request_data.get("model", MODEL_ID)
+        completion_id = "chatcmpl-tls-test-001"
+        response_text = "Hello from the TLS mock inference server."
+
+        # Llama Stack calls remote chat completions with stream=True and reads
+        # assistant text from delta.content chunks.
+        if request_data.get("stream"):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            content_chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": 1700000000,
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": response_text},
+                        "finish_reason": None,
+                    }
+                ],
+            }
+            self.wfile.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+            finish_chunk = {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": 1700000000,
+                "model": model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": 8,
+                    "completion_tokens": 9,
+                    "total_tokens": 17,
+                },
+            }
+            self.wfile.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            return
 
         self._send_json(
             {
-                "id": "chatcmpl-tls-test-001",
+                "id": completion_id,
                 "object": "chat.completion",
                 "created": 1700000000,
                 "model": model,
@@ -87,7 +126,7 @@ class OpenAIHandler(BaseHTTPRequestHandler):
                         "index": 0,
                         "message": {
                             "role": "assistant",
-                            "content": "Hello from the TLS mock inference server.",
+                            "content": response_text,
                         },
                         "finish_reason": "stop",
                     }


### PR DESCRIPTION
## Description

Fixes bug in tls e2e mock server that was previously returning empty response. This was not previously caught by e2e tests. This PR adds explicit check for the LLM response. 

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2310
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced TLS end-to-end test scenarios to validate successful response content across TLS verification configurations, including CA certificate verification, mutual TLS authentication, and TLSv1.3 minimum version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->