### PR TITLE
CWFHEALTH-4934: add trusted-proxy authentication module

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -11613,6 +11613,16 @@
                                 "type": "null"
                             }
                         ]
+                    },
+                    "trusted_proxy_config": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/TrustedProxyConfiguration"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 },
                 "additionalProperties": false,
@@ -19756,6 +19766,57 @@
                         ]
                     }
                 ]
+            },
+            "TrustedProxyConfiguration": {
+                "properties": {
+                    "user_header": {
+                        "type": "string",
+                        "title": "User identity header",
+                        "description": "HTTP header containing the forwarded user identity.",
+                        "default": "X-Forwarded-User"
+                    },
+                    "allowed_service_accounts": {
+                        "anyOf": [
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/TrustedProxyServiceAccount"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Allowed service accounts",
+                        "description": "Optional allowlist of Kubernetes ServiceAccount identities permitted to act as trusted proxies. When set to null/omitted, any ServiceAccount with a valid token is accepted. When set to a non-empty list, only the listed ServiceAccounts are allowed. An empty list behaves the same as null (no restriction)."
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "TrustedProxyConfiguration",
+                "description": "Configuration for trusted-proxy auth module."
+            },
+            "TrustedProxyServiceAccount": {
+                "properties": {
+                    "namespace": {
+                        "type": "string",
+                        "title": "Namespace",
+                        "description": "Kubernetes namespace of the ServiceAccount."
+                    },
+                    "name": {
+                        "type": "string",
+                        "title": "Name",
+                        "description": "Name of the Kubernetes ServiceAccount."
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                    "namespace",
+                    "name"
+                ],
+                "title": "TrustedProxyServiceAccount",
+                "description": "A Kubernetes ServiceAccount identity for trusted-proxy allowlist."
             },
             "UnauthorizedResponse": {
                 "properties": {

--- a/src/authentication/__init__.py
+++ b/src/authentication/__init__.py
@@ -10,6 +10,7 @@ from authentication import (
     noop,
     noop_with_token,
     rh_identity,
+    trusted_proxy,
 )
 from authentication.interface import AuthInterface
 from configuration import LogicError, configuration
@@ -18,7 +19,7 @@ from log import get_logger
 logger = get_logger(__name__)
 
 
-def get_auth_dependency(
+def get_auth_dependency(  # pylint: disable=too-many-return-statements
     virtual_path: str = constants.DEFAULT_VIRTUAL_PATH,
 ) -> AuthInterface:
     """Select the configured authentication dependency interface.
@@ -80,6 +81,11 @@ def get_auth_dependency(
         case constants.AUTH_MOD_APIKEY_TOKEN:
             return api_key_token.APIKeyTokenAuthDependency(
                 config=configuration.authentication_configuration.api_key_configuration,
+                virtual_path=virtual_path,
+            )
+        case constants.AUTH_MOD_TRUSTED_PROXY:
+            return trusted_proxy.TrustedProxyAuthDependency(
+                config=configuration.authentication_configuration.trusted_proxy_configuration,
                 virtual_path=virtual_path,
             )
         case _:

--- a/src/authentication/trusted_proxy.py
+++ b/src/authentication/trusted_proxy.py
@@ -1,0 +1,127 @@
+"""Trusted-proxy authentication module for requests forwarded by a K8s proxy."""
+
+from typing import cast
+
+import kubernetes.client
+from fastapi import HTTPException, Request
+
+from authentication.interface import NO_AUTH_TUPLE, AuthInterface, AuthTuple
+from authentication.k8s import get_user_info
+from authentication.utils import extract_user_token
+from configuration import configuration
+from constants import DEFAULT_VIRTUAL_PATH, NO_USER_TOKEN
+from log import get_logger
+from models.api.responses.error import ForbiddenResponse, UnauthorizedResponse
+from models.config import TrustedProxyConfiguration
+
+logger = get_logger(__name__)
+
+
+class TrustedProxyAuthDependency(
+    AuthInterface
+):  # pylint: disable=too-few-public-methods
+    """FastAPI dependency for trusted-proxy authentication.
+
+    Validates that the caller is an expected Kubernetes ServiceAccount
+    via TokenReview, then extracts the end user's identity from a
+    configurable HTTP header set by the proxy.
+    """
+
+    def __init__(
+        self,
+        config: TrustedProxyConfiguration,
+        virtual_path: str = DEFAULT_VIRTUAL_PATH,
+    ) -> None:
+        """Initialize the trusted-proxy authentication dependency.
+
+        Parameters:
+        ----------
+            config: Trusted-proxy configuration with user header
+                    and optional SA allowlist.
+            virtual_path: The request path used for authorization checks;
+                          defaults to DEFAULT_VIRTUAL_PATH.
+        """
+        self.config = config
+        self.virtual_path = virtual_path
+        self.skip_userid_check = True
+
+    async def __call__(self, request: Request) -> AuthTuple:
+        """Validate the proxy's SA token and extract forwarded user identity.
+
+        Parameters:
+        ----------
+            request: The FastAPI request object.
+
+        Returns:
+        -------
+            AuthTuple with the forwarded user identity.
+
+        Raises:
+        ------
+            HTTPException: If authentication fails.
+        """
+        if not request.headers.get("Authorization"):
+            if configuration.authentication_configuration.skip_for_health_probes:
+                if request.url.path in ("/readiness", "/liveness"):
+                    return NO_AUTH_TUPLE
+            if configuration.authentication_configuration.skip_for_metrics:
+                if request.url.path == "/metrics":
+                    return NO_AUTH_TUPLE
+            response = UnauthorizedResponse(cause="Missing Authorization header")
+            raise HTTPException(**response.model_dump())
+
+        token = extract_user_token(request.headers)
+        user_info = get_user_info(token)
+
+        if user_info is None:
+            response = UnauthorizedResponse(
+                cause="Invalid or expired proxy service account token"
+            )
+            raise HTTPException(**response.model_dump())
+
+        user = cast(kubernetes.client.V1UserInfo, user_info.user)
+        if not user or not hasattr(user, "username"):
+            response = UnauthorizedResponse(
+                cause="Invalid service account token: missing user information"
+            )
+            raise HTTPException(**response.model_dump())
+
+        sa_username = cast(str, user.username)
+        if not sa_username:
+            response = UnauthorizedResponse(
+                cause="Invalid service account token: missing username"
+            )
+            raise HTTPException(**response.model_dump())
+
+        if self.config.allowed_service_accounts:
+            allowed = {
+                f"system:serviceaccount:{sa.namespace}:{sa.name}"
+                for sa in self.config.allowed_service_accounts
+            }
+            if sa_username not in allowed:
+                logger.warning(
+                    "Service account '%s' is not in the trusted-proxy allowlist",
+                    sa_username,
+                )
+                response = ForbiddenResponse.endpoint(user_id=sa_username)
+                raise HTTPException(**response.model_dump())
+
+        forwarded_user = (request.headers.get(self.config.user_header) or "").strip()
+        if not forwarded_user:
+            response = UnauthorizedResponse(
+                cause=f"Missing required header '{self.config.user_header}'"
+            )
+            raise HTTPException(**response.model_dump())
+
+        logger.debug(
+            "Trusted-proxy auth: proxy='%s', forwarded_user_present=%s",
+            sa_username,
+            True,
+        )
+
+        return (
+            forwarded_user,
+            forwarded_user,
+            self.skip_userid_check,
+            NO_USER_TOKEN,
+        )

--- a/src/authorization/middleware.py
+++ b/src/authorization/middleware.py
@@ -79,7 +79,7 @@ def get_authorization_resolvers() -> tuple[RolesResolver, AccessResolver]:
                 GenericAccessResolver(authorization_cfg.access_rules),
             )
 
-        case constants.AUTH_MOD_RH_IDENTITY:
+        case constants.AUTH_MOD_RH_IDENTITY | constants.AUTH_MOD_TRUSTED_PROXY:
             # rh-identity uses access rules for authorization, but doesn't extract
             # roles from the identity header - all authenticated users get the "*" role
             if len(authorization_cfg.access_rules) == 0:

--- a/src/constants.py
+++ b/src/constants.py
@@ -119,6 +119,7 @@ AUTH_MOD_NOOP_WITH_TOKEN: Final[str] = "noop-with-token"
 AUTH_MOD_APIKEY_TOKEN: Final[str] = "api-key-token"
 AUTH_MOD_JWK_TOKEN: Final[str] = "jwk-token"
 AUTH_MOD_RH_IDENTITY: Final[str] = "rh-identity"
+AUTH_MOD_TRUSTED_PROXY: Final[str] = "trusted-proxy"
 # Supported authentication modules
 SUPPORTED_AUTHENTICATION_MODULES: Final[frozenset[str]] = frozenset(
     {
@@ -128,6 +129,7 @@ SUPPORTED_AUTHENTICATION_MODULES: Final[frozenset[str]] = frozenset(
         AUTH_MOD_JWK_TOKEN,
         AUTH_MOD_APIKEY_TOKEN,
         AUTH_MOD_RH_IDENTITY,
+        AUTH_MOD_TRUSTED_PROXY,
     }
 )
 DEFAULT_AUTHENTICATION_MODULE: Final[str] = AUTH_MOD_NOOP

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1265,6 +1265,40 @@ class APIKeyTokenConfiguration(ConfigurationBase):
     )
 
 
+class TrustedProxyServiceAccount(ConfigurationBase):
+    """A Kubernetes ServiceAccount identity for trusted-proxy allowlist."""
+
+    namespace: str = Field(
+        ...,
+        title="Namespace",
+        description="Kubernetes namespace of the ServiceAccount.",
+    )
+    name: str = Field(
+        ...,
+        title="Name",
+        description="Name of the Kubernetes ServiceAccount.",
+    )
+
+
+class TrustedProxyConfiguration(ConfigurationBase):
+    """Configuration for trusted-proxy auth module."""
+
+    user_header: str = Field(
+        "X-Forwarded-User",
+        title="User identity header",
+        description="HTTP header containing the forwarded user identity.",
+    )
+    allowed_service_accounts: Optional[list[TrustedProxyServiceAccount]] = Field(
+        None,
+        title="Allowed service accounts",
+        description="Optional allowlist of Kubernetes ServiceAccount identities "
+        "permitted to act as trusted proxies. "
+        "When set to null/omitted, any ServiceAccount with a valid token is accepted. "
+        "When set to a non-empty list, only the listed ServiceAccounts are allowed. "
+        "An empty list behaves the same as null (no restriction).",
+    )
+
+
 class AuthenticationConfiguration(ConfigurationBase):
     """Authentication configuration."""
 
@@ -1287,6 +1321,7 @@ class AuthenticationConfiguration(ConfigurationBase):
     jwk_config: Optional[JwkConfiguration] = None
     api_key_config: Optional[APIKeyTokenConfiguration] = None
     rh_identity_config: Optional[RHIdentityConfiguration] = None
+    trusted_proxy_config: Optional[TrustedProxyConfiguration] = None
 
     @model_validator(mode="after")
     def check_authentication_model(self) -> Self:
@@ -1333,6 +1368,13 @@ class AuthenticationConfiguration(ConfigurationBase):
             if self.api_key_config.api_key.get_secret_value() is None:
                 raise ValueError(
                     "api_key parameter must be specified when using API_KEY token authentication"
+                )
+
+        if self.module == constants.AUTH_MOD_TRUSTED_PROXY:
+            if self.trusted_proxy_config is None:
+                raise ValueError(
+                    "Trusted proxy configuration must be specified "
+                    "when using trusted-proxy authentication"
                 )
 
         return self
@@ -1387,6 +1429,26 @@ class AuthenticationConfiguration(ConfigurationBase):
         if self.api_key_config is None:
             raise ValueError("API Key configuration should not be None")
         return self.api_key_config
+
+    @property
+    def trusted_proxy_configuration(self) -> TrustedProxyConfiguration:
+        """Return trusted-proxy configuration if the module is trusted-proxy.
+
+        Returns:
+            TrustedProxyConfiguration: The configured trusted-proxy settings.
+
+        Raises:
+            ValueError: If the active authentication module is not trusted-proxy.
+            ValueError: If the trusted-proxy configuration is missing.
+        """
+        if self.module != constants.AUTH_MOD_TRUSTED_PROXY:
+            raise ValueError(
+                "Trusted proxy configuration is only available "
+                "for trusted-proxy authentication module"
+            )
+        if self.trusted_proxy_config is None:
+            raise ValueError("Trusted proxy configuration should not be None")
+        return self.trusted_proxy_config
 
 
 @dataclass

--- a/tests/unit/authentication/test_auth.py
+++ b/tests/unit/authentication/test_auth.py
@@ -1,8 +1,20 @@
 """Unit tests for functions defined in authentication/__init__.py"""
 
-from authentication import get_auth_dependency, k8s, noop, noop_with_token
+from authentication import (
+    get_auth_dependency,
+    k8s,
+    noop,
+    noop_with_token,
+    trusted_proxy,
+)
 from configuration import configuration
-from constants import AUTH_MOD_K8S, AUTH_MOD_NOOP, AUTH_MOD_NOOP_WITH_TOKEN
+from constants import (
+    AUTH_MOD_K8S,
+    AUTH_MOD_NOOP,
+    AUTH_MOD_NOOP_WITH_TOKEN,
+    AUTH_MOD_TRUSTED_PROXY,
+)
+from models.config import TrustedProxyConfiguration
 
 
 def test_get_auth_dependency_noop() -> None:
@@ -27,3 +39,14 @@ def test_get_auth_dependency_k8s() -> None:
     configuration.authentication_configuration.module = AUTH_MOD_K8S
     auth_dependency = get_auth_dependency()
     assert isinstance(auth_dependency, k8s.K8SAuthDependency)
+
+
+def test_get_auth_dependency_trusted_proxy() -> None:
+    """Test getting trusted-proxy authentication dependency."""
+    assert configuration.authentication_configuration is not None
+    configuration.authentication_configuration.module = AUTH_MOD_TRUSTED_PROXY
+    configuration.authentication_configuration.trusted_proxy_config = (
+        TrustedProxyConfiguration()
+    )
+    auth_dependency = get_auth_dependency()
+    assert isinstance(auth_dependency, trusted_proxy.TrustedProxyAuthDependency)

--- a/tests/unit/authentication/test_trusted_proxy.py
+++ b/tests/unit/authentication/test_trusted_proxy.py
@@ -1,0 +1,507 @@
+"""Unit tests for authentication/trusted_proxy module."""
+
+from typing import cast
+
+import pytest
+from fastapi import HTTPException, Request
+from pytest_mock import MockerFixture
+
+from authentication.trusted_proxy import TrustedProxyAuthDependency
+from configuration import AppConfig
+from constants import NO_USER_TOKEN
+from models.config import TrustedProxyConfiguration, TrustedProxyServiceAccount
+
+
+def _make_config(
+    user_header: str = "X-Forwarded-User",
+    allowed_service_accounts: list[TrustedProxyServiceAccount] | None = None,
+) -> TrustedProxyConfiguration:
+    """Create a TrustedProxyConfiguration for testing."""
+    return TrustedProxyConfiguration(
+        user_header=user_header,
+        allowed_service_accounts=allowed_service_accounts,
+    )
+
+
+def _make_token_review_status(
+    mocker: MockerFixture,
+    username: str = "system:serviceaccount:konflux-ui:konflux-ui-proxy",
+    uid: str = "sa-uid",
+) -> object:
+    """Create a mock V1TokenReviewStatus."""
+    user = mocker.Mock()
+    user.username = username
+    user.uid = uid
+    status = mocker.Mock()
+    status.user = user
+    status.authenticated = True
+    return status
+
+
+@pytest.mark.asyncio
+async def test_valid_proxy_token_and_user_header(mocker: MockerFixture) -> None:
+    """Test successful auth with valid proxy token and forwarded user header."""
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(mocker)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer proxy-sa-token"),
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    user_id, username, skip_userid_check, token = await dependency(request)
+
+    assert user_id == "jane.doe@example.com"
+    assert username == "jane.doe@example.com"
+    assert skip_userid_check is True
+    assert token == NO_USER_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header() -> None:
+    """Test that missing Authorization header raises 401."""
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 401
+    detail = cast(dict[str, str], exc_info.value.detail)
+    assert detail["cause"] == "Missing Authorization header"
+
+
+@pytest.mark.asyncio
+async def test_invalid_token(mocker: MockerFixture) -> None:
+    """Test that an invalid/expired proxy token raises 401."""
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = None
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer invalid-token"),
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 401
+    detail = cast(dict[str, str], exc_info.value.detail)
+    assert detail["cause"] == "Invalid or expired proxy service account token"
+
+
+@pytest.mark.asyncio
+async def test_token_review_missing_user_info(mocker: MockerFixture) -> None:
+    """Test that a token review response with no user info raises 401."""
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    status = mocker.Mock()
+    status.authenticated = True
+    status.user = None
+    mock_get_user_info.return_value = status
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer proxy-sa-token"),
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 401
+    detail = cast(dict[str, str], exc_info.value.detail)
+    assert detail["cause"] == "Invalid service account token: missing user information"
+
+
+@pytest.mark.asyncio
+async def test_token_review_missing_username(mocker: MockerFixture) -> None:
+    """Test that a token review response with empty username raises 401."""
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(mocker, username="")
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer proxy-sa-token"),
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 401
+    detail = cast(dict[str, str], exc_info.value.detail)
+    assert detail["cause"] == "Invalid service account token: missing username"
+
+
+@pytest.mark.asyncio
+async def test_sa_not_in_allowlist(mocker: MockerFixture) -> None:
+    """Test that a valid token from an unlisted SA raises 403."""
+    config = _make_config(
+        allowed_service_accounts=[
+            TrustedProxyServiceAccount(namespace="konflux-ui", name="konflux-ui-proxy"),
+        ],
+    )
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(
+        mocker, username="system:serviceaccount:other-ns:other-sa"
+    )
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer other-sa-token"),
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_sa_in_allowlist(mocker: MockerFixture) -> None:
+    """Test that a valid token from an allowed SA succeeds."""
+    config = _make_config(
+        allowed_service_accounts=[
+            TrustedProxyServiceAccount(namespace="konflux-ui", name="konflux-ui-proxy"),
+        ],
+    )
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(mocker)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer proxy-sa-token"),
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    user_id, username, skip_userid_check, token = await dependency(request)
+
+    assert user_id == "jane.doe@example.com"
+    assert username == "jane.doe@example.com"
+    assert skip_userid_check is True
+    assert token == NO_USER_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_user_header(mocker: MockerFixture) -> None:
+    """Test that whitespace-only user identity header raises 401."""
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(mocker)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer proxy-sa-token"),
+                (b"x-forwarded-user", b"   "),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 401
+    detail = cast(dict[str, str], exc_info.value.detail)
+    assert detail["cause"] == "Missing required header 'X-Forwarded-User'"
+
+
+@pytest.mark.asyncio
+async def test_missing_user_header(mocker: MockerFixture) -> None:
+    """Test that missing user identity header raises 401."""
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(mocker)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer proxy-sa-token"),
+            ],
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 401
+    detail = cast(dict[str, str], exc_info.value.detail)
+    assert detail["cause"] == "Missing required header 'X-Forwarded-User'"
+
+
+@pytest.mark.asyncio
+async def test_no_allowlist_accepts_any_sa(mocker: MockerFixture) -> None:
+    """Test that without an allowlist, any authenticated SA is accepted."""
+    config = _make_config(allowed_service_accounts=None)
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(
+        mocker, username="system:serviceaccount:any-ns:any-sa"
+    )
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer any-sa-token"),
+                (b"x-forwarded-user", b"jane.doe@example.com"),
+            ],
+        }
+    )
+
+    user_id, username, skip_userid_check, token = await dependency(request)
+
+    assert user_id == "jane.doe@example.com"
+    assert username == "jane.doe@example.com"
+    assert skip_userid_check is True
+    assert token == NO_USER_TOKEN
+
+
+@pytest.mark.asyncio
+async def test_health_probe_skip_enabled(mocker: MockerFixture) -> None:
+    """Test that health probes return NO_AUTH_TUPLE when skip is enabled."""
+    config_dict = {
+        "name": "test",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "test-key",
+            "url": "http://test.com:1234",
+            "use_as_library_client": False,
+        },
+        "authentication": {
+            "module": "trusted-proxy",
+            "skip_for_health_probes": True,
+            "trusted_proxy_config": {
+                "user_header": "X-Forwarded-User",
+            },
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+            "feedback_storage": ".",
+            "transcripts_enabled": False,
+            "transcripts_storage": ".",
+        },
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+    mocker.patch("authentication.trusted_proxy.configuration", cfg)
+
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    for path in ("/readiness", "/liveness"):
+        request = Request(
+            scope={
+                "type": "http",
+                "headers": [],
+                "path": path,
+            }
+        )
+
+        user_id, username, skip_userid_check, token = await dependency(request)
+
+        assert user_id == "00000000-0000-0000-0000-000"
+        assert username == "lightspeed-user"
+        assert skip_userid_check is True
+        assert token == ""
+
+
+@pytest.mark.asyncio
+async def test_health_probe_skip_disabled(mocker: MockerFixture) -> None:
+    """Test that health probes require auth when skip is disabled."""
+    config_dict = {
+        "name": "test",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "test-key",
+            "url": "http://test.com:1234",
+            "use_as_library_client": False,
+        },
+        "authentication": {
+            "module": "trusted-proxy",
+            "skip_for_health_probes": False,
+            "trusted_proxy_config": {
+                "user_header": "X-Forwarded-User",
+            },
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+            "feedback_storage": ".",
+            "transcripts_enabled": False,
+            "transcripts_storage": ".",
+        },
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+    mocker.patch("authentication.trusted_proxy.configuration", cfg)
+
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [],
+            "path": "/readiness",
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await dependency(request)
+
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_metrics_skip_enabled(mocker: MockerFixture) -> None:
+    """Test that metrics endpoint returns NO_AUTH_TUPLE when skip is enabled."""
+    config_dict = {
+        "name": "test",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "test-key",
+            "url": "http://test.com:1234",
+            "use_as_library_client": False,
+        },
+        "authentication": {
+            "module": "trusted-proxy",
+            "skip_for_metrics": True,
+            "trusted_proxy_config": {
+                "user_header": "X-Forwarded-User",
+            },
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+            "feedback_storage": ".",
+            "transcripts_enabled": False,
+            "transcripts_storage": ".",
+        },
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+    mocker.patch("authentication.trusted_proxy.configuration", cfg)
+
+    config = _make_config()
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [],
+            "path": "/metrics",
+        }
+    )
+
+    user_id, username, skip_userid_check, token = await dependency(request)
+
+    assert user_id == "00000000-0000-0000-0000-000"
+    assert username == "lightspeed-user"
+    assert skip_userid_check is True
+    assert token == ""
+
+
+@pytest.mark.asyncio
+async def test_custom_user_header(mocker: MockerFixture) -> None:
+    """Test that a custom user header name is respected."""
+    config = _make_config(user_header="X-Auth-Request-User")
+    dependency = TrustedProxyAuthDependency(config=config)
+
+    mock_get_user_info = mocker.patch("authentication.trusted_proxy.get_user_info")
+    mock_get_user_info.return_value = _make_token_review_status(mocker)
+
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer proxy-sa-token"),
+                (b"x-auth-request-user", b"custom-user"),
+            ],
+        }
+    )
+
+    user_id, username, skip_userid_check, token = await dependency(request)
+
+    assert user_id == "custom-user"
+    assert username == "custom-user"
+    assert skip_userid_check is True
+    assert token == NO_USER_TOKEN

--- a/tests/unit/authorization/test_middleware.py
+++ b/tests/unit/authorization/test_middleware.py
@@ -99,6 +99,10 @@ class TestGetAuthorizationResolvers:
                 constants.AUTH_MOD_NOOP_WITH_TOKEN,
                 (NoopRolesResolver, NoopAccessResolver),
             ),
+            (
+                constants.AUTH_MOD_TRUSTED_PROXY,
+                (NoopRolesResolver, NoopAccessResolver),
+            ),
         ],
     )
     def test_noop_auth_modules(
@@ -179,6 +183,27 @@ class TestGetAuthorizationResolvers:
 
         roles_resolver, access_resolver = get_authorization_resolvers()
         assert isinstance(roles_resolver, JwtRolesResolver)
+        assert isinstance(access_resolver, GenericAccessResolver)
+
+    def test_trusted_proxy_with_access_rules(
+        self,
+        mocker: MockerFixture,
+        mock_configuration: MockType,
+        sample_access_rule: AccessRule,
+    ) -> None:
+        """Test trusted-proxy with access rules returns GenericAccessResolver."""
+        get_authorization_resolvers.cache_clear()
+
+        mock_configuration.authentication_configuration.module = (
+            constants.AUTH_MOD_TRUSTED_PROXY
+        )
+        mock_configuration.authorization_configuration.access_rules = [
+            sample_access_rule
+        ]
+        mocker.patch("authorization.middleware.configuration", mock_configuration)
+
+        roles_resolver, access_resolver = get_authorization_resolvers()
+        assert isinstance(roles_resolver, NoopRolesResolver)
         assert isinstance(access_resolver, GenericAccessResolver)
 
     def test_unknown_auth_module(

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -154,6 +154,7 @@ def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -363,6 +364,7 @@ def test_dump_configuration_valid_values(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -716,6 +718,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -968,6 +971,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -1200,6 +1204,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -1422,6 +1427,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -1794,6 +1800,7 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -2012,6 +2019,7 @@ def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -2230,6 +2238,7 @@ def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {
@@ -2455,6 +2464,7 @@ def test_dump_configuration_specific_compaction_values(tmp_path: Path) -> None:
                 "jwk_config": None,
                 "api_key_config": None,
                 "rh_identity_config": None,
+                "trusted_proxy_config": None,
             },
             "customization": None,
             "inference": {


### PR DESCRIPTION
Implements the trusted-proxy authentication module for lightspeed-stack, enabling the Konflux UI proxy to authenticate requests on behalf of end users without forwarding their JWT tokens between services.

## Description

In the Konflux architecture, the UI proxy sits between the user's browser and lightspeed-stack. The original approach would have required passing the user's JWT token from the proxy to lightspeed-stack, which is undesirable as it exposes user credentials to internal services and couples lightspeed-stack to the UI's identity provider. This was raised during the architecture design review of konflux-lightspeed (section 4.2 - Authentication Flow).

**How it works**

The trusted-proxy module separates proxy authentication from user identification:

1. Proxy authentication: The UI proxy authenticates itself by sending its Kubernetes ServiceAccount token in the Authorization: Bearer header. lightspeed-stack validates this token via the Kubernetes TokenReview API.
2. User identification: The end user's identity is forwarded in a configurable HTTP header (default: X-Forwarded-User). No user JWT or credentials are passed or stored.
3. SA allowlist (optional): An allowlist of ServiceAccount identities can restrict which proxies are permitted to forward requests, preventing unauthorized services from impersonating the proxy.
4. Health probe and metrics skip: When configured, unauthenticated requests to /readiness, /liveness, and /metrics are allowed through, matching the behavior of existing auth modules.

**Configuration**

```
authentication:
  module: trusted-proxy
  skip_for_health_probes: true
  skip_for_metrics: true
  trusted_proxy_config:
    user_header: "X-Forwarded-User"
    allowed_service_accounts:
      - namespace: "konflux-lightspeed"
        name: "ui-proxy"
```

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [X] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.

1. Deploy lightspeed-stack with trusted-proxy auth on a kind cluster running Konflux:

```
authentication:
  module: trusted-proxy
  skip_for_health_probes: true
  skip_for_metrics: true
  trusted_proxy_config:
    user_header: "X-Forwarded-User"
    allowed_service_accounts:
      - namespace: "konflux-lightspeed"
        name: "test-proxy"
```

2. Create a test-proxy ServiceAccount and grant tokenreview-creator ClusterRole to the lightspeed-stack SA.

3. Create a test pod using the test-proxy SA and run the following tests against the lightspeed-stack pod:

- Health probe without auth: `curl http://<pod-ip>:8080/readiness` = 200
- Liveness probe without auth: `curl http://<pod-ip>:8080/liveness` = 200
- Valid proxy token + user header on readiness: `curl -H "Authorization: Bearer $TOKEN" -H "X-Forwarded-User: user@test" http://<pod-ip>:8080/readiness` = 200
- Valid proxy token + user header on query: `curl -X POST -H "Authorization: Bearer $TOKEN" -H "X-Forwarded-User: user@test" -H "Content-Type: application/json" -d '{"query":"hello"}' http://<pod-ip>:8080/v1/query` = 200
- No auth header on query: `curl -X POST -H "Content-Type: application/json" -d '{"query":"hello"}' http://<pod-ip>:8080/v1/query` = 401
- Valid token, missing user header: `curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" -d '{"query":"hello"}' http://<pod-ip>:8080/v1/query` = 401
- Invalid token: `curl -X POST -H "Authorization: Bearer faketoken" -H "X-Forwarded-User: user@test" -H "Content-Type: application/json" -d '{"query":"hello"}' http://<pod-ip>:8080/v1/query` = 401
- SA not in allowlist: Use a token from a different SA (e.g., lightspeed-stack) = 403

- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added trusted-proxy authentication for Kubernetes proxy scenarios: service-account validation, optional allowlisting, and configurable forwarded-user header.
  * Optional bypass of auth for health probes and metrics when enabled.
* **Authorization**
  * Trusted-proxy flows reuse existing authorization resolver path (access-rule enforcement).
* **Documentation**
  * OpenAPI updated with trusted-proxy configuration schemas.
* **Tests**
  * Added comprehensive unit tests for trusted-proxy behavior and resolver selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->