### PR TITLE
RHIDP-14000: update mcp and query interrupt tests

### DIFF
--- a/tests/integration/endpoints/test_stream_interrupt_integration.py
+++ b/tests/integration/endpoints/test_stream_interrupt_integration.py
@@ -34,6 +34,7 @@ async def test_stream_interrupt_full_round_trip(
     """Full lifecycle: register, interrupt, then verify deregistration."""
     # test_config loads configuration so @authorize on the handler can resolve.
     _ = test_config
+
     async def pending_stream() -> None:
         await asyncio.sleep(10)
 

--- a/tests/integration/endpoints/test_stream_interrupt_integration.py
+++ b/tests/integration/endpoints/test_stream_interrupt_integration.py
@@ -4,13 +4,16 @@ import asyncio
 from collections.abc import Generator
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, status
+from fastapi.testclient import TestClient
 
 from app.endpoints.stream_interrupt import stream_interrupt_endpoint_handler
+from configuration import AppConfig
 from models.api.requests import StreamingInterruptRequest
 from utils.stream_interrupts import StreamInterruptRegistry
 
 TEST_REQUEST_ID = "123e4567-e89b-12d3-a456-426614174003"
+REQUEST_ID_NOT_IN_REGISTRY = "00000000-0000-0000-0000-000000000000"
 OWNER_USER_ID = "00000001-0001-0001-0001-000000000001"
 
 
@@ -25,10 +28,12 @@ def registry_fixture() -> Generator[StreamInterruptRegistry, None, None]:
 
 @pytest.mark.asyncio
 async def test_stream_interrupt_full_round_trip(
+    test_config: AppConfig,
     registry: StreamInterruptRegistry,
 ) -> None:
     """Full lifecycle: register, interrupt, then verify deregistration."""
-
+    # test_config loads configuration so @authorize on the handler can resolve.
+    _ = test_config
     async def pending_stream() -> None:
         await asyncio.sleep(10)
 
@@ -64,3 +69,15 @@ async def test_stream_interrupt_full_round_trip(
             registry=registry,
         )
     assert exc_info.value.status_code == 404
+
+
+def test_stream_interrupt_nonexistent_request_returns_404(
+    integration_http_client: TestClient,
+) -> None:
+    """POST /v1/streaming_query/interrupt for unknown stream returns 404."""
+    response = integration_http_client.post(
+        "/v1/streaming_query/interrupt",
+        json={"request_id": REQUEST_ID_NOT_IN_REGISTRY},
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/unit/app/endpoints/test_mcp_servers.py
+++ b/tests/unit/app/endpoints/test_mcp_servers.py
@@ -6,8 +6,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from fastapi import HTTPException
-from llama_stack_client import APIConnectionError
+from fastapi import HTTPException, status
+from llama_stack_client import APIConnectionError, NotFoundError
 from pydantic import AnyHttpUrl, SecretStr
 from pytest_mock import MockerFixture
 
@@ -388,6 +388,64 @@ async def test_delete_mcp_server_llama_stack_failure(
             request=mocker.Mock(), name="to-delete-fail", auth=MOCK_AUTH
         )
     assert exc_info.value.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_toolgroup_not_found_is_idempotent(
+    mocker: MockerFixture,
+    mock_configuration: Configuration,
+) -> None:
+    """Deleting a dynamic server succeeds when Llama Stack toolgroup is already gone."""
+    app_config = _make_app_config(mocker, mock_configuration)
+    client = _mock_client(mocker)
+    client.toolgroups.register.return_value = None
+    client.toolgroups.unregister.side_effect = NotFoundError(
+        message="Toolgroup not found",
+        response=mocker.Mock(request=None),
+        body=None,
+    )
+
+    body = MCPServerRegistrationRequest(
+        name="orphan-server",
+        url="http://localhost:7777/mcp",
+        provider_id="MCP provider ID",
+    )
+    await mcp_servers.register_mcp_server_handler(
+        request=mocker.Mock(), body=body, auth=MOCK_AUTH
+    )
+    assert app_config.is_dynamic_mcp_server("orphan-server")
+
+    result = await mcp_servers.delete_mcp_server_handler(
+        request=mocker.Mock(), name="orphan-server", auth=MOCK_AUTH
+    )
+
+    assert isinstance(result, MCPServerDeleteResponse)
+    assert result.name == "orphan-server"
+    assert result.deleted is True
+    assert not app_config.is_dynamic_mcp_server("orphan-server")
+    assert not any(s.name == "orphan-server" for s in app_config.mcp_servers)
+
+
+@pytest.mark.asyncio
+async def test_list_mcp_servers_configuration_not_loaded(
+    mocker: MockerFixture,
+) -> None:
+    """Test listing MCP servers returns 500 when configuration is not loaded."""
+    mock_config = AppConfig()
+    mock_config._configuration = None  # pylint: disable=protected-access
+    mocker.patch("app.endpoints.mcp_servers.configuration", mock_config)
+    mocker.patch("app.endpoints.mcp_servers.authorize", lambda _: lambda func: func)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await mcp_servers.list_mcp_servers_handler(
+            request=mocker.Mock(), auth=MOCK_AUTH
+        )
+
+    assert exc_info.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    raw_detail = exc_info.value.detail
+    assert isinstance(raw_detail, dict)
+    detail: dict[str, Any] = raw_detail
+    assert detail["response"] == "Configuration is not loaded"
 
 
 def test_mcp_server_registration_request_validation() -> None:

--- a/tests/unit/app/endpoints/test_stream_interrupt.py
+++ b/tests/unit/app/endpoints/test_stream_interrupt.py
@@ -1,6 +1,7 @@
 """Unit tests for streaming query interrupt endpoint."""
 
 import asyncio
+import threading
 from collections.abc import Generator
 
 import pytest
@@ -9,12 +10,16 @@ from fastapi import HTTPException
 from app.endpoints.stream_interrupt import stream_interrupt_endpoint_handler
 from models.api.requests import StreamingInterruptRequest
 from models.api.responses.successful import StreamingInterruptResponse
-from utils.stream_interrupts import StreamInterruptRegistry
+from utils.stream_interrupts import CancelStreamResult, StreamInterruptRegistry
 
 REQUEST_ID_SUCCESS = "123e4567-e89b-12d3-a456-426614174000"
 REQUEST_ID_NOT_FOUND = "123e4567-e89b-12d3-a456-426614174001"
 REQUEST_ID_WRONG_USER = "123e4567-e89b-12d3-a456-426614174002"
 REQUEST_ID_ALREADY_COMPLETED = "123e4567-e89b-12d3-a456-426614174004"
+
+# CI-friendly sync timeouts for concurrent registry tests.
+_CONCURRENT_BARRIER_TIMEOUT_S = 5.0
+_CONCURRENT_THREAD_JOIN_TIMEOUT_S = 5.0
 
 OWNER_USER_ID = "00000001-0001-0001-0001-000000000001"
 NON_OWNER_USER_ID = "00000001-0001-0001-0001-000000000999"
@@ -148,3 +153,75 @@ async def test_stream_interrupt_endpoint_already_completed(
     assert isinstance(response, StreamingInterruptResponse)
     assert response.request_id == REQUEST_ID_ALREADY_COMPLETED
     assert response.interrupted is False
+
+
+@pytest.mark.asyncio
+async def test_stream_interrupt_registry_concurrent_cancel_and_deregister(
+    registry: StreamInterruptRegistry,
+) -> None:
+    """Concurrent cancel and deregister do not raise under the registry lock."""
+
+    async def pending_stream() -> None:
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(pending_stream())
+    registry.register_stream(REQUEST_ID_SUCCESS, OWNER_USER_ID, task)
+
+    barrier = threading.Barrier(2)
+    errors: list[Exception] = []
+
+    def deregister_in_thread() -> None:
+        try:
+            barrier.wait(timeout=_CONCURRENT_BARRIER_TIMEOUT_S)
+            registry.deregister_stream(REQUEST_ID_SUCCESS)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            errors.append(exc)
+
+    thread = threading.Thread(target=deregister_in_thread)
+    thread.start()
+    barrier.wait(timeout=_CONCURRENT_BARRIER_TIMEOUT_S)
+
+    result = registry.cancel_stream(REQUEST_ID_SUCCESS, OWNER_USER_ID)
+    thread.join(timeout=_CONCURRENT_THREAD_JOIN_TIMEOUT_S)
+    assert not thread.is_alive(), "Deregister thread did not complete within timeout"
+
+    assert not errors
+    assert result in (
+        CancelStreamResult.CANCELLED,
+        CancelStreamResult.NOT_FOUND,
+    )
+
+    if not task.done():
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_stream_interrupt_endpoint_double_interrupt(
+    registry: StreamInterruptRegistry,
+) -> None:
+    """Second interrupt on the same stream returns interrupted=False."""
+
+    async def pending_stream() -> None:
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(pending_stream())
+    registry.register_stream(REQUEST_ID_SUCCESS, OWNER_USER_ID, task)
+
+    first_response = await stream_interrupt_endpoint_handler(
+        interrupt_request=StreamingInterruptRequest(request_id=REQUEST_ID_SUCCESS),
+        auth=(OWNER_USER_ID, "mock_username", False, "mock_token"),
+        registry=registry,
+    )
+    assert first_response.interrupted is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    second_response = await stream_interrupt_endpoint_handler(
+        interrupt_request=StreamingInterruptRequest(request_id=REQUEST_ID_SUCCESS),
+        auth=(OWNER_USER_ID, "mock_username", False, "mock_token"),
+        registry=registry,
+    )
+    assert second_response.interrupted is False

--- a/tests/unit/pydantic_ai_lightspeed/llamastack/test_transport.py
+++ b/tests/unit/pydantic_ai_lightspeed/llamastack/test_transport.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access
 
 import json
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import httpx
@@ -45,7 +46,7 @@ class TestAsyncByteStream:
     async def test_iterates_chunks(self) -> None:
         """Test that _AsyncByteStream yields all chunks from the wrapped generator."""
 
-        async def gen():
+        async def gen() -> AsyncGenerator[bytes, None]:
             yield b"chunk1"
             yield b"chunk2"
             yield b"chunk3"
@@ -59,7 +60,7 @@ class TestAsyncByteStream:
     async def test_empty_generator(self) -> None:
         """Test that _AsyncByteStream handles an empty generator gracefully."""
 
-        async def gen():
+        async def gen() -> AsyncGenerator[bytes, None]:
             return
             yield  # pragma: no cover
 
@@ -134,7 +135,7 @@ class TestHandleAsyncRequest:
             content=json.dumps(body).encode("utf-8"),
         )
 
-        async def mock_stream_result():
+        async def mock_stream_result() -> AsyncGenerator[dict[str, int], None]:
             yield {"chunk": 1}
             yield {"chunk": 2}
 
@@ -317,7 +318,7 @@ class TestHandleStreaming:  # pylint: disable=too-few-public-methods
     ) -> None:
         """Test that streaming responses produce SSE-formatted byte chunks."""
 
-        async def mock_stream():
+        async def mock_stream() -> AsyncGenerator[dict[str, str], None]:
             yield {"delta": "hello"}
             yield {"delta": "world"}
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

**MCP**

- `test_delete_mcp_server_toolgroup_not_found_is_idempotent`
   - dynamic server in local config; Llama Stack returns NotFoundError on unregister → still returns 200 with deleted=True and removes local config
- `test_list_mcp_servers_configuration_not_loaded`
   - list handler returns 500 when configuration is not loaded

**Benefits:** Covers the idempotent delete path when the Llama Stack toolgroup is already gone (previously untested). Aligns list handler with config-not-loaded coverage on other endpoints.

**Stream Interrupt**

Unit tests:

- `test_stream_interrupt_registry_concurrent_cancel_and_deregister`
   - races cancel_stream vs deregister_stream under the registry lock; asserts no exceptions and CI-friendly timeouts
- `test_stream_interrupt_endpoint_double_interrupt`
   - second interrupt after successful cancel returns interrupted=False (no error on client retry)

Integration:

- `test_stream_interrupt_nonexistent_request_returns_404`
   - HTTP POST with valid SUID but no active stream → 404 through full FastAPI stack
- `test_stream_interrupt_full_round_trip`
   - fixed to load config via test_config so `@authorize` resolves correctly

**Benefits:** Protects thread-safe registry behavior and double-interrupt semantics. The HTTP 404 test validates routing/auth/handler wiring that direct handler calls miss.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [x] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Composer 2.5
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/RHIDP-14000
- Closes https://redhat.atlassian.net/browse/RHIDP-14000

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration test verifying interrupt endpoint returns 404 for unknown requests.
  * Expanded streaming interrupt tests to cover double-interrupt idempotency and concurrent cancel/deregister race conditions.
  * Added unit tests ensuring MCP server delete remains idempotent when upstream toolgroup is missing.
  * Added unit test asserting listing servers returns a clear error when configuration is not loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->