### PR TITLE
LCORE-2311: Relocated stream interruption utilities

### DIFF
--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -1,7 +1,5 @@
 """Streaming query handler using Responses API."""
 
-# pylint: disable=too-many-lines
-
 import asyncio
 import datetime
 from collections.abc import AsyncIterator
@@ -10,7 +8,6 @@ from typing import Annotated, Any, Optional, cast
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from llama_stack_api import (
-    OpenAIResponseMessage,
     OpenAIResponseObject,
     OpenAIResponseObjectStream,
 )
@@ -56,7 +53,6 @@ from constants import (
     MEDIA_TYPE_EVENT_STREAM,
     MEDIA_TYPE_JSON,
     MEDIA_TYPE_TEXT,
-    TOPIC_SUMMARY_INTERRUPT_TIMEOUT_SECONDS,
 )
 from log import get_logger
 from metrics import recording
@@ -100,7 +96,6 @@ from utils.query import (
     is_context_length_error,
     prepare_input,
     store_query_results,
-    update_conversation_topic_summary,
     validate_attachments_metadata,
     validate_model_provider_override,
 )
@@ -118,11 +113,14 @@ from utils.responses import (
     prepare_responses_params,
 )
 from utils.shields import (
-    append_turn_to_conversation,
     run_shield_moderation,
     validate_shield_ids_override,
 )
-from utils.stream_interrupts import get_stream_interrupt_registry
+from utils.stream_interrupts import (
+    deregister_stream,
+    persist_interrupted_turn,
+    register_interrupt_callback,
+)
 from utils.streaming_sse import (
     http_exception_stream_event,
     shield_violation_generator,
@@ -430,43 +428,6 @@ async def retrieve_response_generator(
         raise HTTPException(**error_response.model_dump()) from e
 
 
-async def _background_update_topic_summary(
-    context: ResponseGeneratorContext,
-    model: str,
-) -> None:
-    """Generate topic summary and update DB/cache in the background.
-
-    Runs as a fire-and-forget task after an interrupted turn is persisted.
-    All errors are caught and logged.
-    """
-    try:
-        topic_summary = await asyncio.wait_for(
-            get_topic_summary(
-                context.query_request.query,
-                context.client,
-                model,
-            ),
-            timeout=TOPIC_SUMMARY_INTERRUPT_TIMEOUT_SECONDS,
-        )
-        if topic_summary:
-            update_conversation_topic_summary(
-                context.conversation_id,
-                topic_summary,
-                user_id=context.user_id,
-                skip_userid_check=context.skip_userid_check,
-            )
-    except asyncio.TimeoutError:
-        logger.warning(
-            "Topic summary timed out for interrupted turn, request %s",
-            context.request_id,
-        )
-    except Exception:  # pylint: disable=broad-except
-        logger.exception(
-            "Failed to generate topic summary for interrupted turn, request %s",
-            context.request_id,
-        )
-
-
 async def shutdown_background_topic_summary_tasks() -> None:
     """Cancel and await outstanding background topic summary tasks on shutdown.
 
@@ -483,148 +444,6 @@ async def shutdown_background_topic_summary_tasks() -> None:
     for task in tasks:
         task.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
-
-
-async def _persist_interrupted_turn(
-    context: ResponseGeneratorContext,
-    responses_params: ResponsesApiParams,
-    turn_summary: TurnSummary,
-    original_input: Optional[ResponseInput] = None,
-) -> None:
-    """Persist the user query and an interrupted response into the conversation.
-
-    Called when a streaming request is cancelled so the exchange is not lost.
-    Persists immediately with topic_summary=None so the conversation exists
-    when the client fetches. Topic summary is generated in a background task
-    and updated when ready.
-
-    Parameters:
-    ----------
-        context: The response generator context.
-        responses_params: The Responses API parameters.
-        turn_summary: TurnSummary with llm_response already set to the
-            interrupted message.
-        original_input: In compacted mode, the original user input before the
-            explicit-input rewrite. When set, the turn is persisted against it
-            (the ``conversation`` parameter was dropped, and
-            ``responses_params.input`` is the explicit rewrite); ``None``
-            otherwise (LCORE-1572).
-    """
-    try:
-        if original_input is not None:
-            await append_turn_items_to_conversation(
-                context.client,
-                responses_params.conversation,
-                original_input,
-                [
-                    OpenAIResponseMessage(
-                        role="assistant", content=INTERRUPTED_RESPONSE_MESSAGE
-                    )
-                ],
-            )
-        else:
-            await append_turn_to_conversation(
-                context.client,
-                responses_params.conversation,
-                cast(str, responses_params.input),
-                INTERRUPTED_RESPONSE_MESSAGE,
-            )
-    except Exception:  # pylint: disable=broad-except
-        logger.exception(
-            "Failed to append interrupted turn to conversation for request %s",
-            context.request_id,
-        )
-
-    try:
-        completed_at = datetime.datetime.now(datetime.UTC).strftime(
-            "%Y-%m-%dT%H:%M:%SZ"
-        )
-        store_query_results(
-            user_id=context.user_id,
-            conversation_id=context.conversation_id,
-            model=responses_params.model,
-            completed_at=completed_at,
-            started_at=context.started_at,
-            summary=turn_summary,
-            query=context.query_request.query,
-            skip_userid_check=context.skip_userid_check,
-            topic_summary=None,
-        )
-
-        if (
-            not context.query_request.conversation_id
-            and context.query_request.generate_topic_summary
-        ):
-            task = asyncio.create_task(
-                _background_update_topic_summary(
-                    context=context,
-                    model=responses_params.model,
-                )
-            )
-            _background_topic_summary_tasks.append(task)
-            task.add_done_callback(_background_topic_summary_tasks.remove)
-    except Exception:  # pylint: disable=broad-except
-        logger.exception(
-            "Failed to store interrupted query results for request %s",
-            context.request_id,
-        )
-
-
-def _register_interrupt_callback(
-    context: ResponseGeneratorContext,
-    responses_params: ResponsesApiParams,
-    turn_summary: TurnSummary,
-    original_input: Optional[ResponseInput] = None,
-) -> list[bool]:
-    """Build an interrupt callback and register the stream for cancellation.
-
-    The callback is invoked by ``cancel_stream`` when the client
-    interrupts, so persistence runs regardless of where the
-    ``CancelledError`` is raised in the ASGI stack.
-
-    A mutable one-element list is used as a shared guard so the
-    callback and the in-generator ``CancelledError`` handler never
-    both persist the same turn.
-
-    Parameters:
-    ----------
-        context: The response generator context.
-        responses_params: The Responses API parameters.
-        turn_summary: TurnSummary populated during streaming.
-
-    Returns:
-    -------
-        A mutable list ``[False]`` used as a persist-done guard; the
-        caller should check ``guard[0]`` before persisting and set
-        it to ``True`` afterwards.
-    """
-    guard: list[bool] = [False]
-
-    async def _on_interrupt() -> None:
-        if guard[0]:
-            return
-        guard[0] = True
-        turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
-        await _persist_interrupted_turn(
-            context, responses_params, turn_summary, original_input
-        )
-
-    current_task = asyncio.current_task()
-    if current_task is not None:
-        get_stream_interrupt_registry().register_stream(
-            request_id=context.request_id,
-            user_id=context.user_id,
-            task=current_task,
-            on_interrupt=_on_interrupt,
-        )
-    else:
-        logger.warning(
-            "No current asyncio task for request %s; "
-            "stream interruption will not be available",
-            context.request_id,
-        )
-
-    return guard
 
 
 async def generate_response_with_compaction(
@@ -759,8 +578,12 @@ async def generate_response(  # pylint: disable=too-many-arguments,too-many-posi
     Yields:
         SSE-formatted strings from the wrapped generator
     """
-    persist_guard = _register_interrupt_callback(
-        context, responses_params, turn_summary, original_input
+    persist_guard = register_interrupt_callback(
+        context,
+        responses_params,
+        turn_summary,
+        _background_topic_summary_tasks,
+        original_input,
     )
 
     stream_completed = False
@@ -802,12 +625,16 @@ async def generate_response(  # pylint: disable=too-many-arguments,too-many-posi
         if not persist_guard[0]:
             persist_guard[0] = True
             turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
-            await _persist_interrupted_turn(
-                context, responses_params, turn_summary, original_input
+            await persist_interrupted_turn(
+                context,
+                responses_params,
+                turn_summary,
+                _background_topic_summary_tasks,
+                original_input,
             )
         yield stream_interrupted_event(context.request_id)
     finally:
-        get_stream_interrupt_registry().deregister_stream(context.request_id)
+        deregister_stream(context.request_id)
 
     if not stream_completed:
         return

--- a/src/utils/stream_interrupts.py
+++ b/src/utils/stream_interrupts.py
@@ -1,13 +1,28 @@
-"""In-memory registry for interrupting active streaming requests."""
+"""Stream interrupt registry and persistence utilities."""
 
 import asyncio
+import datetime
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from enum import Enum
 from threading import Lock
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
+from llama_stack_api import OpenAIResponseMessage
+
+from constants import (
+    INTERRUPTED_RESPONSE_MESSAGE,
+    TOPIC_SUMMARY_INTERRUPT_TIMEOUT_SECONDS,
+)
 from log import get_logger
+from models.common.responses.contexts import ResponseGeneratorContext
+from models.common.responses.responses_api_params import ResponsesApiParams
+from models.common.responses.types import ResponseInput
+from models.common.turn_summary import TurnSummary
+from utils.conversations import append_turn_items_to_conversation
+from utils.query import store_query_results, update_conversation_topic_summary
+from utils.responses import get_topic_summary
+from utils.shields import append_turn_to_conversation
 from utils.types import Singleton
 
 logger = get_logger(__name__)
@@ -146,3 +161,209 @@ def get_stream_interrupt_registry() -> StreamInterruptRegistry:
     and overridden in tests via ``app.dependency_overrides``.
     """
     return StreamInterruptRegistry()
+
+
+def deregister_stream(request_id: str) -> None:
+    """Remove a stream from the interrupt registry after completion or cancellation.
+
+    Parameters:
+    ----------
+        request_id: Unique streaming request identifier.
+    """
+    get_stream_interrupt_registry().deregister_stream(request_id)
+
+
+async def background_update_topic_summary(
+    context: ResponseGeneratorContext,
+    model: str,
+) -> None:
+    """Generate topic summary and update DB/cache in the background.
+
+    Runs as a fire-and-forget task after an interrupted turn is persisted.
+    All errors are caught and logged.
+
+    Parameters:
+    ----------
+        context: The response generator context.
+        model: Model identifier used for topic summary generation.
+    """
+    try:
+        topic_summary = await asyncio.wait_for(
+            get_topic_summary(
+                context.query_request.query,
+                context.client,
+                model,
+            ),
+            timeout=TOPIC_SUMMARY_INTERRUPT_TIMEOUT_SECONDS,
+        )
+        if topic_summary:
+            update_conversation_topic_summary(
+                context.conversation_id,
+                topic_summary,
+                user_id=context.user_id,
+                skip_userid_check=context.skip_userid_check,
+            )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Topic summary timed out for interrupted turn, request %s",
+            context.request_id,
+        )
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to generate topic summary for interrupted turn, request %s",
+            context.request_id,
+        )
+
+
+async def persist_interrupted_turn(
+    context: ResponseGeneratorContext,
+    responses_params: ResponsesApiParams,
+    turn_summary: TurnSummary,
+    background_topic_summary_tasks: list[asyncio.Task[None]],
+    original_input: Optional[ResponseInput] = None,
+) -> None:
+    """Persist the user query and an interrupted response into the conversation.
+
+    Called when a streaming request is cancelled so the exchange is not lost.
+    Persists immediately with topic_summary=None so the conversation exists
+    when the client fetches. Topic summary is generated in a background task
+    and updated when ready.
+
+    Parameters:
+    ----------
+        context: The response generator context.
+        responses_params: The Responses API parameters.
+        turn_summary: TurnSummary with llm_response already set to the
+            interrupted message.
+        background_topic_summary_tasks: Mutable list tracking fire-and-forget
+            topic summary tasks for graceful shutdown.
+        original_input: In compacted mode, the original user input before the
+            explicit-input rewrite. When set, the turn is persisted against it
+            (the ``conversation`` parameter was dropped, and
+            ``responses_params.input`` is the explicit rewrite); ``None``
+            otherwise (LCORE-1572).
+    """
+    try:
+        if original_input is not None:
+            await append_turn_items_to_conversation(
+                context.client,
+                responses_params.conversation,
+                original_input,
+                [
+                    OpenAIResponseMessage(
+                        role="assistant", content=INTERRUPTED_RESPONSE_MESSAGE
+                    )
+                ],
+            )
+        else:
+            await append_turn_to_conversation(
+                context.client,
+                responses_params.conversation,
+                cast(str, responses_params.input),
+                INTERRUPTED_RESPONSE_MESSAGE,
+            )
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to append interrupted turn to conversation for request %s",
+            context.request_id,
+        )
+
+    try:
+        completed_at = datetime.datetime.now(datetime.UTC).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        store_query_results(
+            user_id=context.user_id,
+            conversation_id=context.conversation_id,
+            model=responses_params.model,
+            completed_at=completed_at,
+            started_at=context.started_at,
+            summary=turn_summary,
+            query=context.query_request.query,
+            skip_userid_check=context.skip_userid_check,
+            topic_summary=None,
+        )
+
+        if (
+            not context.query_request.conversation_id
+            and context.query_request.generate_topic_summary
+        ):
+            task = asyncio.create_task(
+                background_update_topic_summary(
+                    context=context,
+                    model=responses_params.model,
+                )
+            )
+            background_topic_summary_tasks.append(task)
+            task.add_done_callback(background_topic_summary_tasks.remove)
+    except Exception:  # pylint: disable=broad-except
+        logger.exception(
+            "Failed to store interrupted query results for request %s",
+            context.request_id,
+        )
+
+
+def register_interrupt_callback(
+    context: ResponseGeneratorContext,
+    responses_params: ResponsesApiParams,
+    turn_summary: TurnSummary,
+    background_topic_summary_tasks: list[asyncio.Task[None]],
+    original_input: Optional[ResponseInput] = None,
+) -> list[bool]:
+    """Build an interrupt callback and register the stream for cancellation.
+
+    The callback is invoked by ``cancel_stream`` when the client
+    interrupts, so persistence runs regardless of where the
+    ``CancelledError`` is raised in the ASGI stack.
+
+    A mutable one-element list is used as a shared guard so the
+    callback and the in-generator ``CancelledError`` handler never
+    both persist the same turn.
+
+    Parameters:
+    ----------
+        context: The response generator context.
+        responses_params: The Responses API parameters.
+        turn_summary: TurnSummary populated during streaming.
+        background_topic_summary_tasks: Mutable list tracking fire-and-forget
+            topic summary tasks for graceful shutdown.
+        original_input: In compacted mode, the original user input before the
+            explicit-input rewrite; ``None`` otherwise.
+
+    Returns:
+    -------
+        A mutable list ``[False]`` used as a persist-done guard; the
+        caller should check ``guard[0]`` before persisting and set
+        it to ``True`` afterwards.
+    """
+    guard: list[bool] = [False]
+
+    async def _on_interrupt() -> None:
+        if guard[0]:
+            return
+        guard[0] = True
+        turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
+        await persist_interrupted_turn(
+            context,
+            responses_params,
+            turn_summary,
+            background_topic_summary_tasks,
+            original_input,
+        )
+
+    current_task = asyncio.current_task()
+    if current_task is not None:
+        get_stream_interrupt_registry().register_stream(
+            request_id=context.request_id,
+            user_id=context.user_id,
+            task=current_task,
+            on_interrupt=_on_interrupt,
+        )
+    else:
+        logger.warning(
+            "No current asyncio task for request %s; "
+            "stream interruption will not be available",
+            context.request_id,
+        )
+
+    return guard

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -44,7 +44,6 @@ from llama_stack_client import APIConnectionError, APIStatusError, AsyncLlamaSta
 from pytest_mock import MockerFixture
 
 from app.endpoints.streaming_query import (
-    _persist_interrupted_turn,
     generate_response,
     response_generator,
     retrieve_response_generator,
@@ -958,7 +957,7 @@ class TestGenerateResponse:
         """Patch registry accessor with a per-test mock registry instance."""
         test_registry = mocker.Mock(spec=StreamInterruptRegistry)
         mocker.patch(
-            "app.endpoints.streaming_query.get_stream_interrupt_registry",
+            "utils.stream_interrupts.get_stream_interrupt_registry",
             return_value=test_registry,
         )
         return test_registry
@@ -1323,6 +1322,7 @@ class TestGenerateResponse:
         assert len(result) > 0
         assert any("error" in item for item in result)
 
+    @pytest.mark.asyncio
     async def test_generate_response_cancelled_persists_interrupted_turn(
         self,
         mocker: MockerFixture,
@@ -1359,10 +1359,10 @@ class TestGenerateResponse:
             "app.endpoints.streaming_query.consume_query_tokens"
         )
         store_query_results_mock = mocker.patch(
-            "app.endpoints.streaming_query.store_query_results"
+            "utils.stream_interrupts.store_query_results"
         )
         append_turn_mock = mocker.patch(
-            "app.endpoints.streaming_query.append_turn_to_conversation",
+            "utils.stream_interrupts.append_turn_to_conversation",
             new_callable=mocker.AsyncMock,
         )
 
@@ -1437,17 +1437,17 @@ class TestGenerateResponse:
 
         mocker.patch("app.endpoints.streaming_query.consume_query_tokens")
         get_topic_summary_mock = mocker.patch(
-            "app.endpoints.streaming_query.get_topic_summary",
+            "utils.stream_interrupts.get_topic_summary",
             new=mocker.AsyncMock(return_value="Kubernetes container orchestration"),
         )
         store_query_results_mock = mocker.patch(
-            "app.endpoints.streaming_query.store_query_results"
+            "utils.stream_interrupts.store_query_results"
         )
         update_topic_summary_mock = mocker.patch(
-            "app.endpoints.streaming_query.update_conversation_topic_summary"
+            "utils.stream_interrupts.update_conversation_topic_summary"
         )
         mocker.patch(
-            "app.endpoints.streaming_query.append_turn_to_conversation",
+            "utils.stream_interrupts.append_turn_to_conversation",
             new_callable=mocker.AsyncMock,
         )
 
@@ -1517,14 +1517,14 @@ class TestGenerateResponse:
 
         mocker.patch("app.endpoints.streaming_query.consume_query_tokens")
         mocker.patch(
-            "app.endpoints.streaming_query.get_topic_summary",
+            "utils.stream_interrupts.get_topic_summary",
             new=mocker.AsyncMock(side_effect=Exception("err")),
         )
         store_query_results_mock = mocker.patch(
-            "app.endpoints.streaming_query.store_query_results"
+            "utils.stream_interrupts.store_query_results"
         )
         mocker.patch(
-            "app.endpoints.streaming_query.append_turn_to_conversation",
+            "utils.stream_interrupts.append_turn_to_conversation",
             new_callable=mocker.AsyncMock,
         )
 
@@ -1584,14 +1584,14 @@ class TestGenerateResponse:
 
         mocker.patch("app.endpoints.streaming_query.consume_query_tokens")
         get_topic_summary_mock = mocker.patch(
-            "app.endpoints.streaming_query.get_topic_summary",
+            "utils.stream_interrupts.get_topic_summary",
             new=mocker.AsyncMock(return_value="Docker containerization"),
         )
         store_query_results_mock = mocker.patch(
-            "app.endpoints.streaming_query.store_query_results"
+            "utils.stream_interrupts.store_query_results"
         )
         mocker.patch(
-            "app.endpoints.streaming_query.append_turn_to_conversation",
+            "utils.stream_interrupts.append_turn_to_conversation",
             new_callable=mocker.AsyncMock,
         )
 
@@ -1643,10 +1643,10 @@ class TestGenerateResponse:
 
         mocker.patch("app.endpoints.streaming_query.consume_query_tokens")
         store_query_results_mock = mocker.patch(
-            "app.endpoints.streaming_query.store_query_results"
+            "utils.stream_interrupts.store_query_results"
         )
         mocker.patch(
-            "app.endpoints.streaming_query.append_turn_to_conversation",
+            "utils.stream_interrupts.append_turn_to_conversation",
             new_callable=mocker.AsyncMock,
             side_effect=RuntimeError("Llama Stack unavailable"),
         )
@@ -1702,10 +1702,10 @@ class TestGenerateResponse:
 
         mocker.patch("app.endpoints.streaming_query.consume_query_tokens")
         store_query_results_mock = mocker.patch(
-            "app.endpoints.streaming_query.store_query_results"
+            "utils.stream_interrupts.store_query_results"
         )
         append_turn_mock = mocker.patch(
-            "app.endpoints.streaming_query.append_turn_to_conversation",
+            "utils.stream_interrupts.append_turn_to_conversation",
             new_callable=mocker.AsyncMock,
         )
 
@@ -2701,48 +2701,3 @@ async def test_response_generator_failed_captures_output_items(
         pass
 
     assert turn_summary.output_items == [out_item]
-
-
-@pytest.mark.asyncio
-async def test_persist_interrupted_turn_compacted_uses_original_input(
-    mocker: MockerFixture,
-) -> None:
-    """Interrupted compacted turn persists the original input (LCORE-1572).
-
-    Not the explicit rewrite carried on responses_params.input.
-    """
-    conv = "123e4567-e89b-12d3-a456-426614174000"
-    context = mocker.Mock(spec=ResponseGeneratorContext)
-    context.client = mocker.AsyncMock()
-    context.request_id = "req-1"
-    context.user_id = "user_1"
-    context.conversation_id = conv
-    context.started_at = "2024-01-01T00:00:00Z"
-    context.skip_userid_check = False
-    context.query_request = QueryRequest(
-        query="hi", conversation_id=conv
-    )  # pyright: ignore[reportCallIssue]
-
-    responses_params = mocker.Mock(spec=ResponsesApiParams)
-    responses_params.conversation = conv
-    responses_params.model = "provider1/model1"
-    responses_params.input = ["explicit rewrite"]
-
-    turn_summary = TurnSummary()
-    items = mocker.patch(
-        "app.endpoints.streaming_query.append_turn_items_to_conversation",
-        new=mocker.AsyncMock(),
-    )
-    strs = mocker.patch(
-        "app.endpoints.streaming_query.append_turn_to_conversation",
-        new=mocker.AsyncMock(),
-    )
-    mocker.patch("app.endpoints.streaming_query.store_query_results")
-
-    await _persist_interrupted_turn(
-        context, responses_params, turn_summary, original_input="the original query"
-    )
-
-    items.assert_awaited_once()
-    assert items.call_args.args[2] == "the original query"
-    strs.assert_not_awaited()

--- a/tests/unit/utils/test_stream_interrupts.py
+++ b/tests/unit/utils/test_stream_interrupts.py
@@ -1,0 +1,160 @@
+"""Unit tests for stream interrupt registry and persistence utilities."""
+
+import asyncio
+
+import pytest
+from pytest_mock import MockerFixture
+
+from models.api.requests import QueryRequest
+from models.common.responses.contexts import ResponseGeneratorContext
+from models.common.responses.responses_api_params import ResponsesApiParams
+from models.common.turn_summary import TurnSummary
+from utils.stream_interrupts import (
+    StreamInterruptRegistry,
+    persist_interrupted_turn,
+    register_interrupt_callback,
+)
+
+
+@pytest.mark.asyncio
+async def test_persist_interrupted_turn_compacted_uses_original_input(
+    mocker: MockerFixture,
+) -> None:
+    """Interrupted compacted turn persists the original input (LCORE-1572).
+
+    Not the explicit rewrite carried on responses_params.input.
+    """
+    conv = "123e4567-e89b-12d3-a456-426614174000"
+    context = mocker.Mock(spec=ResponseGeneratorContext)
+    context.client = mocker.AsyncMock()
+    context.request_id = "req-1"
+    context.user_id = "user_1"
+    context.conversation_id = conv
+    context.started_at = "2024-01-01T00:00:00Z"
+    context.skip_userid_check = False
+    context.query_request = QueryRequest(
+        query="hi", conversation_id=conv
+    )  # pyright: ignore[reportCallIssue]
+
+    responses_params = mocker.Mock(spec=ResponsesApiParams)
+    responses_params.conversation = conv
+    responses_params.model = "provider1/model1"
+    responses_params.input = ["explicit rewrite"]
+
+    turn_summary = TurnSummary()
+    background_tasks: list[asyncio.Task[None]] = []
+    items = mocker.patch(
+        "utils.stream_interrupts.append_turn_items_to_conversation",
+        new=mocker.AsyncMock(),
+    )
+    strs = mocker.patch(
+        "utils.stream_interrupts.append_turn_to_conversation",
+        new=mocker.AsyncMock(),
+    )
+    mocker.patch("utils.stream_interrupts.store_query_results")
+
+    await persist_interrupted_turn(
+        context,
+        responses_params,
+        turn_summary,
+        background_tasks,
+        original_input="the original query",
+    )
+
+    items.assert_awaited_once()
+    assert items.call_args.args[2] == "the original query"
+    strs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_interrupted_turn_schedules_background_topic_summary(
+    mocker: MockerFixture,
+) -> None:
+    """New conversations with generate_topic_summary enqueue a background task."""
+    context = mocker.Mock(spec=ResponseGeneratorContext)
+    context.client = mocker.AsyncMock()
+    context.request_id = "req-1"
+    context.user_id = "user_1"
+    context.conversation_id = "conv_new"
+    context.started_at = "2024-01-01T00:00:00Z"
+    context.skip_userid_check = False
+    context.query_request = QueryRequest(
+        query="hello",
+        conversation_id=None,
+        generate_topic_summary=True,
+    )  # pyright: ignore[reportCallIssue]
+
+    responses_params = mocker.Mock(spec=ResponsesApiParams)
+    responses_params.conversation = "conv_new"
+    responses_params.model = "provider1/model1"
+    responses_params.input = "hello"
+
+    turn_summary = TurnSummary()
+    background_tasks: list[asyncio.Task[None]] = []
+
+    mocker.patch(
+        "utils.stream_interrupts.append_turn_to_conversation",
+        new=mocker.AsyncMock(),
+    )
+    mocker.patch("utils.stream_interrupts.store_query_results")
+    background_mock = mocker.patch(
+        "utils.stream_interrupts.background_update_topic_summary",
+        new=mocker.AsyncMock(),
+    )
+
+    await persist_interrupted_turn(
+        context, responses_params, turn_summary, background_tasks
+    )
+
+    assert len(background_tasks) == 1
+    await background_tasks[0]
+    background_mock.assert_awaited_once_with(
+        context=context,
+        model="provider1/model1",
+    )
+
+
+def test_register_interrupt_callback_registers_current_task(
+    mocker: MockerFixture,
+) -> None:
+    """register_interrupt_callback binds the current asyncio task to the registry."""
+    registry = mocker.Mock(spec=StreamInterruptRegistry)
+    mocker.patch(
+        "utils.stream_interrupts.get_stream_interrupt_registry",
+        return_value=registry,
+    )
+    persist_mock = mocker.patch(
+        "utils.stream_interrupts.persist_interrupted_turn",
+        new=mocker.AsyncMock(),
+    )
+
+    context = mocker.Mock(spec=ResponseGeneratorContext)
+    context.request_id = "req-1"
+    context.user_id = "user_1"
+    responses_params = mocker.Mock(spec=ResponsesApiParams)
+    turn_summary = TurnSummary()
+    background_tasks: list[asyncio.Task[None]] = []
+
+    async def run() -> list[bool]:
+        return register_interrupt_callback(
+            context,
+            responses_params,
+            turn_summary,
+            background_tasks,
+        )
+
+    guard = asyncio.run(run())
+
+    assert guard == [False]
+    registry.register_stream.assert_called_once()
+    assert registry.register_stream.call_args.kwargs["request_id"] == "req-1"
+    assert registry.register_stream.call_args.kwargs["user_id"] == "user_1"
+    assert persist_mock.await_count == 0
+
+    on_interrupt = registry.register_stream.call_args.kwargs["on_interrupt"]
+
+    async def invoke_callback() -> None:
+        await on_interrupt()
+
+    asyncio.run(invoke_callback())
+    persist_mock.assert_awaited_once()


### PR DESCRIPTION
## Description

Relocates stream interruption utilities from streaming query endpoint to dedicated utils file.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2311
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted streaming responses to ensure graceful cleanup and persistence.

* **Chores**
  * Refactored internal stream interruption and persistence logic into shared utilities for better maintainability and consistency.
  * Enhanced background topic summary generation during stream interruptions with improved error handling and timeout management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->