### PR TITLE
LCORE- Only apply latest tag to container if it is the latest stable tag

### DIFF
--- a/.github/workflows/build_and_push_release.yaml
+++ b/.github/workflows/build_and_push_release.yaml
@@ -31,6 +31,11 @@ jobs:
         with:
           # Fetch submodules (required for lightspeed-providers)
           submodules: 'recursive'
+          # Fetch all tags to determine latest stable version
+          fetch-tags: true
+      - name: Determine if latest tag should be applied
+        id: check_latest
+        run: ./scripts/latest-tag.py
       - name: Build image with Buildah
         id: build_image
         uses: redhat-actions/buildah-build@v2
@@ -38,7 +43,7 @@ jobs:
           image: ${{ env.IMAGE_NAME }}
           tags: |
             ${{ env.GIT_TAG }}
-            ${{ env.LATEST_TAG }}
+            ${{ steps.check_latest.outputs.apply_latest == 'true' && env.LATEST_TAG || '' }}
           containerfiles: |
             ${{ env.CONTAINER_FILE }}
           archs: amd64, arm64

--- a/.github/workflows/build_and_push_release.yaml
+++ b/.github/workflows/build_and_push_release.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Check manifest
         run: |
           set -x
-          buildah manifest inspect ${{ steps.build_image.outputs.image }}:${{ env.LATEST_TAG }}
+          buildah manifest inspect ${{ steps.build_image.outputs.image-with-tag }}
       - name: Push image to Quay.io
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/scripts/latest-tag.py
+++ b/scripts/latest-tag.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+
+def version_split(value: str) -> tuple[int, ...]:
+    """Split string into a tuple of ints."""
+    try:
+        return tuple(int(n) for n in value.split("."))
+    except ValueError:
+        return (-1,)
+
+
+def is_prerelease(tag: str) -> bool:
+    """Determine if a tag is a pre-release version."""
+    omit = {"rc", "alpha", "beta", "dev"}
+
+    return any(n in tag for n in omit)
+
+
+def get_latest_stable() -> str | None:
+    """Return the latest stable tag."""
+    stdout = subprocess.check_output(["git", "tag"], text=True)
+    tags = [tag for tag in stdout.splitlines() if not is_prerelease(tag)]
+    tags.sort(key=version_split)
+
+    return tags[-1] if tags else None
+
+
+def main() -> None:
+    if not (current_tag := os.environ.get("GIT_TAG")):
+        reason = "GIT_TAG environment variable not set, skipping latest tag"
+        apply_latest = "false"
+    elif is_prerelease(current_tag):
+        reason = f"{current_tag} is a pre-release"
+        apply_latest = "false"
+    else:
+        latest_stable = get_latest_stable()
+        if current_tag == latest_stable:
+            reason = f"{current_tag} is the latest stable"
+            apply_latest = "true"
+        else:
+            reason = f"{current_tag} is not the latest stable ({latest_stable} is)"
+            apply_latest = "false"
+
+    print(reason)
+
+    if github_output := os.environ.get("GITHUB_OUTPUT"):
+        with open(github_output, "a") as f:
+            f.write(f"apply_latest={apply_latest}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Add a program, `latest-tag.py`, to determine the latest stable tag and compare it to the tag that triggered the workflow run. Only apply the latest tag if they match.

Update the workflow to apply the latest tag based on the results of that program.

This prevents new tags for older releases as well as prereleases from getting the latest tag applied.

### Alternative approach ###
A simpler approach would be to change the trigger for the build-and-push-release job to something like `'0.5*`. That requires keeping the trigger and the release tags in sync. While this change is a bit more complicated, it should require no changes when the tags

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Opencode using Claude Opus 4.5

## Related Tickets & Documents

None

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
These tests were run with the current tags as of today which are:
```
0.1.0
0.1.1
0.1.2
0.1.3
0.2.0
0.3.0
0.3.1
0.4.0
0.4.1
0.4.2
0.4.3
0.4.3.1
0.5.0
0.5.1
0.5.1.1
0.6.0rc1
0.6.0rc2
```

Local Testing (without `GITHUB_OUTPUT` defined)
```shell
# Test: GIT_TAG not set - should warn and skip latest
./scripts/latest-tag.py
# Expected: "GIT_TAG environment variable not set, skipping latest tag"

# Test: Pre-release tag - should skip latest
GIT_TAG=0.6.0rc2 ./scripts/latest-tag.py
# Expected: "0.6.0rc2 is a pre-release"

# Test: Older stable tag - should skip latest
GIT_TAG=0.4.3 ./scripts/latest-tag.py
# Expected: "0.4.3 is not the latest stable (0.5.1.1 is)"

# Test: Latest stable tag - should apply latest
GIT_TAG=0.5.1.1 ./scripts/latest-tag.py
# Expected: "0.5.1.1 is the latest stable"
```

Local Testing (with GITHUB_OUTPUT)
```shell
# Simulate GitHub Actions environment
export GITHUB_OUTPUT=$(mktemp)

# Test: Latest stable tag
GIT_TAG=0.5.1.1 ./scripts/latest-tag.py
cat $GITHUB_OUTPUT
# Expected output: apply_latest=true

# Reset for next test
> $GITHUB_OUTPUT

# Test: Pre-release tag
GIT_TAG=0.6.0rc2 ./scripts/latest-tag.py
cat $GITHUB_OUTPUT
# Expected output: apply_latest=false

# Cleanup
rm $GITHUB_OUTPUT
unset GITHUB_OUTPUT
```

I also did some testing with tags such as `1.0.0` and `0.5.10` to make sure the sorting worked as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build pipeline to apply the `latest` image tag only to stable releases, not pre-releases. Pre-release versions will now use their specific version tag only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->