### PR TITLE
LCORE-2503: Added ServiceAccount for rh_identity

### DIFF
--- a/docs/auth/rh-identity.md
+++ b/docs/auth/rh-identity.md
@@ -9,7 +9,7 @@ validates the `x-rh-identity` header provided by Red Hat's authentication proxy.
 The `rh-identity` module:
 1. Extracts the `x-rh-identity` header from incoming requests
 2. Base64 decodes and parses the JSON payload
-3. Validates the identity structure based on type (User or System)
+3. Validates the identity structure based on type (User, System, or ServiceAccount)
 4. Optionally validates service entitlements
 5. Extracts user identity for downstream use
 
@@ -62,7 +62,7 @@ entitlement validation entirely.
 
 ## Identity Types
 
-The `x-rh-identity` header supports two identity types, each with different
+The `x-rh-identity` header supports three identity types, each with different
 structure and use cases.
 
 ### User Identity
@@ -163,15 +163,50 @@ A developer-subscription System identity omits the account number:
 | `cn` | string | Certificate Common Name (system UUID) |
 | `cert_type` | string | Certificate type (usually "system") |
 
+### ServiceAccount Identity
+
+OAuth service accounts authenticated via JWT. Used when automated services or
+integrations access APIs using client credentials.
+
+**Identity extraction:**
+- `user_id`: From `identity.service_account.client_id`
+- `username`: From `identity.service_account.username`
+
+**Header structure:**
+```json
+{
+  "identity": {
+    "account_number": "123456",
+    "org_id": "654321",
+    "type": "ServiceAccount",
+    "auth_type": "jwt-auth",
+    "service_account": {
+      "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+      "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd"
+    }
+  },
+  "entitlements": {
+    "rhel": {"is_entitled": true, "is_trial": false}
+  }
+}
+```
+
+**Available ServiceAccount fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `client_id` | string | OAuth client identifier (used as user_id) |
+| `username` | string | Service account username |
+
 ## Common Identity Fields
 
-Both identity types share these top-level fields:
+All identity types share these top-level fields:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `account_number` | string | Red Hat account number (optional for System identities; may be empty for developer subscriptions) |
 | `org_id` | string | Organization ID (required for System identities) |
-| `type` | string | Identity type: "User" or "System" |
+| `type` | string | Identity type: "User", "System", or "ServiceAccount" |
 
 ## Entitlements
 
@@ -214,8 +249,8 @@ async def my_endpoint(request: Request):
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `get_user_id()` | `str` | User ID or system CN |
-| `get_username()` | `str` | Username or account number |
+| `get_user_id()` | `str` | User ID, system CN, or service account client_id |
+| `get_username()` | `str` | Username, account number, or service account username |
 | `get_org_id()` | `str` | Organization ID |
 | `has_entitlement(service)` | `bool` | Check single entitlement |
 | `has_entitlements(services)` | `bool` | Check ALL entitlements in list |
@@ -277,6 +312,34 @@ curl http://localhost:8080/v1/query \
   -d '{"query": "Hello"}'
 ```
 
+### ServiceAccount Identity Example
+
+```bash
+# ServiceAccount identity
+IDENTITY='{
+  "identity": {
+    "account_number": "123456",
+    "org_id": "654321",
+    "type": "ServiceAccount",
+    "auth_type": "jwt-auth",
+    "service_account": {
+      "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+      "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd"
+    }
+  },
+  "entitlements": {
+    "rhel": {"is_entitled": true, "is_trial": false}
+  }
+}'
+
+HEADER=$(echo -n "$IDENTITY" | base64)
+
+curl http://localhost:8080/v1/query \
+  -H "Content-Type: application/json" \
+  -H "x-rh-identity: $HEADER" \
+  -d '{"query": "Hello"}'
+```
+
 ## Error Responses
 
 | Status | Condition | Response |
@@ -292,6 +355,9 @@ curl http://localhost:8080/v1/query \
 | 400 | Missing `system` for System type | `{"detail": "Missing 'system' field for System type"}` |
 | 400 | Missing `cn` in system | `{"detail": "Missing 'cn' in system data"}` |
 | 400 | Missing `org_id` for System | `{"detail": "Missing 'org_id' for System type"}` |
+| 400 | Missing `service_account` for ServiceAccount type | `{"detail": "Invalid identity data"}` |
+| 400 | Missing `client_id` in service_account | `{"detail": "Invalid identity data"}` |
+| 400 | Missing `username` in service_account | `{"detail": "Invalid identity data"}` |
 | 400 | Unsupported identity type | `{"detail": "Unsupported identity type: X"}` |
 | 403 | Missing required entitlements | `{"detail": "Missing required entitlement: rhel"}` |
 

--- a/examples/lightspeed-stack-rh-identity.yaml
+++ b/examples/lightspeed-stack-rh-identity.yaml
@@ -9,6 +9,7 @@
 # Identity Types Supported:
 #   - User: Console users authenticated via Red Hat SSO
 #   - System: Certificate-authenticated RHEL systems
+#   - ServiceAccount: OAuth service accounts authenticated via JWT
 #
 # Security Note: This module trusts the x-rh-identity header. Only use
 # behind Red Hat's authentication proxy - never expose directly to the internet.

--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -1,7 +1,8 @@
 """Red Hat Identity header authentication for FastAPI endpoints.
 
-This module provides authentication via the x-rh-identity header, supporting both
-User and System identity types with optional entitlement validation.
+This module provides authentication via the x-rh-identity header, supporting
+User, System, and ServiceAccount identity types with optional entitlement
+validation.
 """
 
 import base64
@@ -36,9 +37,10 @@ def _get_request_id(request: Request) -> str:
 class RHIdentityData:
     """Extracts and validates Red Hat Identity header data.
 
-    Supports two identity types:
+    Supports three identity types:
     - User: Console users with user_id, username, is_org_admin
     - System: Certificate-authenticated RHEL systems with cn as identifier
+    - ServiceAccount: OAuth service accounts with client_id, username, user_id
     """
 
     def __init__(
@@ -82,6 +84,8 @@ class RHIdentityData:
             self._validate_user_fields(identity)
         elif identity_type == "System":
             self._validate_system_fields(identity)
+        elif identity_type == "ServiceAccount":
+            self._validate_service_account_fields(identity)
         else:
             logger.warning("Identity validation failed: unsupported identity type")
             raise HTTPException(status_code=400, detail="Invalid identity data")
@@ -153,6 +157,31 @@ class RHIdentityData:
         if account_number is not None and account_number != "":
             self._validate_string_field("account_number", account_number)
 
+    def _validate_service_account_fields(self, identity: dict) -> None:
+        """Validate required fields for ServiceAccount identity type.
+
+        Args:
+            identity: The identity dict containing service_account data
+
+        Raises:
+            HTTPException: 400 if required ServiceAccount fields are missing or malformed
+        """
+        if "service_account" not in identity:
+            logger.warning(
+                "Identity validation failed: missing 'service_account' field "
+                "for ServiceAccount type"
+            )
+            raise HTTPException(status_code=400, detail="Invalid identity data")
+        service_account = identity["service_account"]
+        for field in ("client_id", "username"):
+            if field not in service_account:
+                logger.warning(
+                    "Identity validation failed: missing '%s' in service_account data",
+                    field,
+                )
+                raise HTTPException(status_code=400, detail="Invalid identity data")
+            self._validate_string_field(field, service_account[field])
+
     def _validate_string_field(
         self, field_name: str, value: Any, max_length: int = 256
     ) -> None:
@@ -194,7 +223,7 @@ class RHIdentityData:
             raise HTTPException(status_code=400, detail="Invalid identity data")
 
     def _get_identity_type(self) -> str:
-        """Get the identity type (User or System).
+        """Get the identity type (User, System, or ServiceAccount).
 
         Returns:
             Identity type string
@@ -205,12 +234,16 @@ class RHIdentityData:
         """Extract user ID based on identity type.
 
         Returns:
-            User ID (user.user_id for User type, system.cn for System type)
+            User ID (user.user_id for User type, system.cn for System type,
+            service_account.client_id for ServiceAccount type)
         """
         identity = self.identity_data["identity"]
+        identity_type = self._get_identity_type()
 
-        if self._get_identity_type() == "User":
+        if identity_type == "User":
             return identity["user"]["user_id"]
+        if identity_type == "ServiceAccount":
+            return identity["service_account"]["client_id"]
         return identity["system"]["cn"]
 
     def get_username(self) -> str:
@@ -222,13 +255,18 @@ class RHIdentityData:
         a stable non-empty identifier in that case.
 
         Returns:
-            Username (user.username for User type; account_number or system.cn
-            for System type)
+            Username (user.username for User type;
+            service_account.username for ServiceAccount type;
+            account_number or system.cn for System type)
         """
         identity = self.identity_data["identity"]
+        identity_type = self._get_identity_type()
 
-        if self._get_identity_type() == "User":
+        if identity_type == "User":
             return identity["user"]["username"]
+
+        if identity_type == "ServiceAccount":
+            return identity["service_account"]["username"]
 
         account_number = identity.get("account_number")
         if account_number:
@@ -302,7 +340,8 @@ class RHIdentityAuthDependency(AuthInterface):  # pylint: disable=too-few-public
     """Red Hat Identity header authentication dependency for FastAPI.
 
     Authenticates requests using the x-rh-identity header with base64-encoded JSON.
-    Supports both User and System identity types with optional entitlement validation.
+    Supports User, System, and ServiceAccount identity types with optional
+    entitlement validation.
     """
 
     def __init__(

--- a/tests/integration/test_rh_identity_integration.py
+++ b/tests/integration/test_rh_identity_integration.py
@@ -93,6 +93,36 @@ def system_identity_json() -> dict:
     }
 
 
+@pytest.fixture
+def service_account_identity_json() -> dict:
+    """Fixture providing valid ServiceAccount identity JSON.
+
+    Returns:
+        dict: JSON with keys:
+            - "identity": contains "account_number", "org_id", "type" set to
+              "ServiceAccount", "auth_type", and "service_account" with
+              "client_id", "username", and "user_id".
+            - "entitlements": contains "rhel" with "is_entitled" and "is_trial"
+              boolean flags.
+    """
+    return {
+        "identity": {
+            "account_number": "789",
+            "org_id": "987",
+            "type": "ServiceAccount",
+            "auth_type": "jwt-auth",
+            "service_account": {
+                "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                "user_id": "60ce65dc-4b5a-4812-8b65-b48178d92b12",
+            },
+        },
+        "entitlements": {
+            "rhel": {"is_entitled": True, "is_trial": False},
+        },
+    }
+
+
 def encode_identity(identity_json: dict) -> str:
     """Encode identity JSON to base64.
 
@@ -135,6 +165,17 @@ class TestRHIdentityIntegration:
     ) -> None:
         """Test successful request with valid System identity."""
         headers = {"x-rh-identity": encode_identity(system_identity_json)}
+
+        response = client.get("/api/v1/conversations", headers=headers)
+
+        # Should succeed (200) or return empty conversations list
+        assert response.status_code in [200, 404]
+
+    def test_valid_service_account_identity(
+        self, client: TestClient, service_account_identity_json: dict
+    ) -> None:
+        """Test successful request with valid ServiceAccount identity."""
+        headers = {"x-rh-identity": encode_identity(service_account_identity_json)}
 
         response = client.get("/api/v1/conversations", headers=headers)
 

--- a/tests/unit/authentication/test_rh_identity.py
+++ b/tests/unit/authentication/test_rh_identity.py
@@ -1,6 +1,6 @@
 """Unit tests for Red Hat Identity authentication module."""
 
-# pylint: disable=redefined-outer-name
+# pylint: disable=redefined-outer-name,too-many-lines
 
 import base64
 import json
@@ -84,6 +84,35 @@ def system_identity_data() -> dict:
     }
 
 
+@pytest.fixture
+def service_account_identity_data() -> dict:
+    """Fixture providing valid ServiceAccount identity data.
+
+    Mirrors the canonical ServiceAccount payload from the identity-schemas repo.
+    The service_account object contains client_id, username, and user_id.
+
+    Returns:
+        dict: A ServiceAccount identity dictionary with identity and entitlements.
+    """
+    return {
+        "identity": {
+            "account_number": "123",
+            "org_id": "321",
+            "type": "ServiceAccount",
+            "auth_type": "jwt-auth",
+            "service_account": {
+                "client_id": "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                "username": "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+                "user_id": "60ce65dc-4b5a-4812-8b65-b48178d92b12",
+            },
+        },
+        "entitlements": {
+            "rhel": {"is_entitled": True, "is_trial": False},
+            "ansible": {"is_entitled": True, "is_trial": False},
+        },
+    }
+
+
 def create_auth_header(identity_data: dict) -> str:
     """Helper to create base64-encoded x-rh-identity header value.
 
@@ -145,8 +174,28 @@ class TestRHIdentityData:
         assert rh_identity.get_user_id() == "c87dcb4c-8af1-40dd-878e-60c744edddd0"
         assert rh_identity.get_username() == "123"
 
+    def test_service_account_type_extraction(
+        self, service_account_identity_data: dict
+    ) -> None:
+        """Test extraction of ServiceAccount identity fields."""
+        rh_identity = RHIdentityData(service_account_identity_data)
+
+        assert rh_identity.get_user_id() == "b69eaf9e-e6a6-4f9e-805e-02987daddfbd"
+        assert (
+            rh_identity.get_username()
+            == "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd"
+        )
+
+    def test_service_account_system_id_empty(
+        self, service_account_identity_data: dict
+    ) -> None:
+        """Test that get_system_id returns empty string for ServiceAccount type."""
+        rh_identity = RHIdentityData(service_account_identity_data)
+        assert rh_identity.get_system_id() == ""
+
     @pytest.mark.parametrize(
-        "fixture_name", ["user_identity_data", "system_identity_data"]
+        "fixture_name",
+        ["user_identity_data", "system_identity_data", "service_account_identity_data"],
     )
     def test_get_org_id(
         self, fixture_name: str, request: pytest.FixtureRequest
@@ -303,6 +352,38 @@ class TestRHIdentityData:
                 },
                 "Invalid identity data",
             ),
+            # ServiceAccount without service_account object is rejected.
+            (
+                {
+                    "identity": {
+                        "type": "ServiceAccount",
+                        "org_id": "123",
+                    }
+                },
+                "Invalid identity data",
+            ),
+            # ServiceAccount without client_id is rejected.
+            (
+                {
+                    "identity": {
+                        "type": "ServiceAccount",
+                        "org_id": "123",
+                        "service_account": {"username": "svc"},
+                    }
+                },
+                "Invalid identity data",
+            ),
+            # ServiceAccount without username is rejected.
+            (
+                {
+                    "identity": {
+                        "type": "ServiceAccount",
+                        "org_id": "123",
+                        "service_account": {"client_id": "abc"},
+                    }
+                },
+                "Invalid identity data",
+            ),
         ],
     )
     def test_validation_failures(
@@ -370,11 +451,31 @@ class TestRHIdentityAuthDependency:
         assert token == NO_USER_TOKEN
 
     @pytest.mark.asyncio
+    async def test_service_account_authentication_success(
+        self, mocker: MockerFixture, service_account_identity_data: dict
+    ) -> None:
+        """Test successful ServiceAccount authentication."""
+        auth_dep = RHIdentityAuthDependency()
+        header_value = create_auth_header(service_account_identity_data)
+        request = create_request_with_header(mocker, header_value)
+
+        user_id, username, skip_check, token = await auth_dep(request)
+
+        assert user_id == "b69eaf9e-e6a6-4f9e-805e-02987daddfbd"
+        assert username == "service-account-b69eaf9e-e6a6-4f9e-805e-02987daddfbd"
+        assert skip_check is False
+        assert token == NO_USER_TOKEN
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "fixture_name,expected_user_id",
         [
             ("user_identity_data", "abc123"),
             ("system_identity_data", "c87dcb4c-8af1-40dd-878e-60c744edddd0"),
+            (
+                "service_account_identity_data",
+                "b69eaf9e-e6a6-4f9e-805e-02987daddfbd",
+            ),
         ],
     )
     async def test_rh_identity_stored_in_request_state(
@@ -697,7 +798,7 @@ class TestRHIdentityHeaderSizeLimit:
         assert mock_warning.call_args.args[2] == max_size
 
 
-class TestRHIdentityFieldValidation:
+class TestRHIdentityFieldValidation:  # pylint: disable=too-many-public-methods
     """Test suite for RHIdentityData string field validation."""
 
     @pytest.mark.parametrize(
@@ -751,6 +852,32 @@ class TestRHIdentityFieldValidation:
             identity[field_path[0]][field_path[1]] = bad_value
         with pytest.raises(HTTPException) as exc_info:
             RHIdentityData(system_identity_data)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.parametrize(
+        "field_path,bad_value",
+        [
+            (("service_account", "client_id"), None),
+            (("service_account", "client_id"), 12345),
+            (("service_account", "client_id"), True),
+            (("service_account", "client_id"), []),
+            (("service_account", "client_id"), {}),
+            (("service_account", "username"), None),
+            (("service_account", "username"), 12345),
+        ],
+    )
+    def test_service_account_non_string_types_rejected(
+        self,
+        service_account_identity_data: dict,
+        field_path: tuple[str, str],
+        bad_value: object,
+    ) -> None:
+        """Reject non-string values in ServiceAccount identity string fields."""
+        service_account_identity_data["identity"][field_path[0]][
+            field_path[1]
+        ] = bad_value
+        with pytest.raises(HTTPException) as exc_info:
+            RHIdentityData(service_account_identity_data)
         assert exc_info.value.status_code == 400
 
     @pytest.mark.parametrize("bad_value", ["", "   ", "\t", "\n"])
@@ -837,6 +964,12 @@ class TestRHIdentityFieldValidation:
     def test_valid_system_data_still_passes(self, system_identity_data: dict) -> None:
         """Regression: valid System identity data passes validation."""
         RHIdentityData(system_identity_data)
+
+    def test_valid_service_account_data_still_passes(
+        self, service_account_identity_data: dict
+    ) -> None:
+        """Regression: valid ServiceAccount identity data passes validation."""
+        RHIdentityData(service_account_identity_data)
 
     @pytest.mark.parametrize("account_number", ["", None])
     def test_system_empty_or_absent_account_number_accepted(


### PR DESCRIPTION
## Description

Added ServiceAccount for rh_identity as well as updated docs.

## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [X] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [X] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor (Opus 4.6)
- Generated by: Cursor (Opus 4.6)

## Related Tickets & Documents

- Related Issue LCORE-2503
- Closes LCORE-2503

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ServiceAccount identity type as a third authentication method alongside User and System identities, enabling OAuth service account authentication via JWT.

* **Documentation**
  * Updated Red Hat Identity authentication documentation to include ServiceAccount identity type specification, validation rules, error responses, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->