### PR TITLE
RHIDP-12952: persist interrupted conversation

### DIFF
--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -46,7 +46,6 @@ from client import AsyncLlamaStackClientHolder
 from configuration import configuration
 from constants import (
     ENDPOINT_PATH_STREAMING_QUERY,
-    INTERRUPTED_RESPONSE_MESSAGE,
     LLM_TOKEN_EVENT,
     LLM_TOOL_CALL_EVENT,
     LLM_TOOL_RESULT_EVENT,
@@ -122,6 +121,7 @@ from utils.shields import (
     validate_shield_ids_override,
 )
 from utils.stream_interrupts import (
+    build_interrupted_response,
     deregister_stream,
     persist_interrupted_turn,
     register_interrupt_callback,
@@ -634,9 +634,10 @@ async def generate_response(  # pylint: disable=too-many-arguments,too-many-posi
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.uncancel()
+        full_text, suffix = build_interrupted_response(turn_summary.partial_tokens)
         if not persist_guard[0]:
             persist_guard[0] = True
-            turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
+            turn_summary.llm_response = full_text
             await persist_interrupted_turn(
                 context,
                 responses_params,
@@ -644,6 +645,11 @@ async def generate_response(  # pylint: disable=too-many-arguments,too-many-posi
                 _background_topic_summary_tasks,
                 original_input,
             )
+        yield stream_event(
+            {"id": -1, "token": suffix},
+            LLM_TOKEN_EVENT,
+            context.query_request.media_type or MEDIA_TYPE_JSON,
+        )
         yield stream_interrupted_event(context.request_id)
     finally:
         deregister_stream(context.request_id)

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -646,7 +646,7 @@ async def generate_response(  # pylint: disable=too-many-arguments,too-many-posi
                 original_input,
             )
         yield stream_event(
-            {"id": -1, "token": suffix},
+            {"id": turn_summary.next_chunk_id, "token": suffix},
             LLM_TOKEN_EVENT,
             context.query_request.media_type or MEDIA_TYPE_JSON,
         )
@@ -780,6 +780,7 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
                 media_type,
             )
             chunk_id += 1
+            turn_summary.next_chunk_id = chunk_id
 
         # Store MCP call item info for later lookup when arguments.done event occurs
         elif event_type == "response.output_item.added":
@@ -805,6 +806,7 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
                 media_type,
             )
             chunk_id += 1
+            turn_summary.next_chunk_id = chunk_id
 
         # Final text of the output (capture, but emit at response.completed)
         elif event_type == "response.output_text.done":
@@ -893,6 +895,7 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
                 media_type,
             )
             chunk_id += 1
+            turn_summary.next_chunk_id = chunk_id
 
         # Incomplete or failed response - emit error
         elif event_type in ("response.incomplete", "response.failed"):

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -789,6 +789,7 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
         elif event_type == "response.output_text.delta":
             delta_chunk = cast(TextDeltaChunk, chunk)
             text_parts.append(delta_chunk.delta)
+            turn_summary.partial_tokens.append(delta_chunk.delta)
             yield stream_event(
                 {
                     "id": chunk_id,

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -771,16 +771,17 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
 
         # Content part started - emit an empty token to kick off UI streaming
         if event_type == "response.content_part.added":
+            event_id = chunk_id
+            chunk_id += 1
+            turn_summary.next_chunk_id = chunk_id
             yield stream_event(
                 {
-                    "id": chunk_id,
+                    "id": event_id,
                     "token": "",
                 },
                 LLM_TOKEN_EVENT,
                 media_type,
             )
-            chunk_id += 1
-            turn_summary.next_chunk_id = chunk_id
 
         # Store MCP call item info for later lookup when arguments.done event occurs
         elif event_type == "response.output_item.added":
@@ -797,16 +798,17 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
             delta_chunk = cast(TextDeltaChunk, chunk)
             text_parts.append(delta_chunk.delta)
             turn_summary.partial_tokens.append(delta_chunk.delta)
+            event_id = chunk_id
+            chunk_id += 1
+            turn_summary.next_chunk_id = chunk_id
             yield stream_event(
                 {
-                    "id": chunk_id,
+                    "id": event_id,
                     "token": delta_chunk.delta,
                 },
                 LLM_TOKEN_EVENT,
                 media_type,
             )
-            chunk_id += 1
-            turn_summary.next_chunk_id = chunk_id
 
         # Final text of the output (capture, but emit at response.completed)
         elif event_type == "response.output_text.done":
@@ -886,16 +888,17 @@ async def response_generator(  # pylint: disable=too-many-branches,too-many-stat
             # (LCORE-1572), so the persisted turn keeps non-text output items
             # rather than being flattened to the response text.
             turn_summary.output_items = list(latest_response_object.output or [])
+            event_id = chunk_id
+            chunk_id += 1
+            turn_summary.next_chunk_id = chunk_id
             yield stream_event(
                 {
-                    "id": chunk_id,
+                    "id": event_id,
                     "token": turn_summary.llm_response,
                 },
                 LLM_TURN_COMPLETE_EVENT,
                 media_type,
             )
-            chunk_id += 1
-            turn_summary.next_chunk_id = chunk_id
 
         # Incomplete or failed response - emit error
         elif event_type in ("response.incomplete", "response.failed"):

--- a/src/constants.py
+++ b/src/constants.py
@@ -25,7 +25,7 @@ DEFAULT_SYNTHESIZED_CONFIG_PATH: Final[str] = "./.generated/run.yaml"
 UNABLE_TO_PROCESS_RESPONSE: Final[str] = "Unable to process this request"
 
 # Response stored in the conversation when the user interrupts a streaming request
-INTERRUPTED_RESPONSE_MESSAGE: Final[str] = "You interrupted this request."
+INTERRUPTED_RESPONSE_MESSAGE: Final[str] = "Response stopped by the user."
 
 # Max seconds to wait for topic summary in background task after interrupt persist.
 TOPIC_SUMMARY_INTERRUPT_TIMEOUT_SECONDS: Final[float] = 30.0

--- a/src/models/common/turn_summary.py
+++ b/src/models/common/turn_summary.py
@@ -119,6 +119,11 @@ class TurnSummary(BaseModel):
         description="Accumulated text deltas during streaming, used to reconstruct "
         "partial content on interruption.",
     )
+    next_chunk_id: int = Field(
+        default=0,
+        description="Next monotonic SSE chunk index, kept in sync with the inner "
+        "generator so the interrupt handler can emit a sequentially valid id.",
+    )
 
 
 class ToolInfoSummary(BaseModel):

--- a/src/models/common/turn_summary.py
+++ b/src/models/common/turn_summary.py
@@ -114,6 +114,11 @@ class TurnSummary(BaseModel):
         description="Structured response output items, captured for compacted-mode "
         "turn persistence (LCORE-1572). Empty on the non-compacted path.",
     )
+    partial_tokens: list[str] = Field(
+        default_factory=list,
+        description="Accumulated text deltas during streaming, used to reconstruct "
+        "partial content on interruption.",
+    )
 
 
 class ToolInfoSummary(BaseModel):

--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -25,7 +25,7 @@ from pydantic_ai.messages import (
 )
 
 from configuration import configuration
-from constants import INTERRUPTED_RESPONSE_MESSAGE, MEDIA_TYPE_JSON
+from constants import MEDIA_TYPE_JSON
 from log import get_logger
 from models.common.agents import (
     AgentTurnAccumulator,
@@ -65,6 +65,7 @@ from utils.responses import (
     maybe_get_topic_summary,
 )
 from utils.stream_interrupts import (
+    build_interrupted_response,
     deregister_stream,
     persist_interrupted_turn,
     register_interrupt_callback,
@@ -197,9 +198,10 @@ async def generate_agent_response(
         current_task = asyncio.current_task()
         if current_task is not None:
             current_task.uncancel()
+        full_text, suffix = build_interrupted_response(turn_summary.partial_tokens)
         if not persist_guard[0]:
             persist_guard[0] = True
-            turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
+            turn_summary.llm_response = full_text
             await persist_interrupted_turn(
                 context,
                 responses_params,
@@ -207,6 +209,10 @@ async def generate_agent_response(
                 background_topic_summary_tasks,
                 original_input,
             )
+        yield serialize_event(
+            TokenStreamPayload.create(chunk_id=-1, token=suffix),
+            media_type,
+        )
         yield serialize_event(
             InterruptedStreamPayload.create(request_id=context.request_id),
             media_type,
@@ -347,6 +353,7 @@ def _process_token(
         Token stream payload containing the emitted token chunk.
     """
     state.text_parts.append(text)
+    state.turn_summary.partial_tokens.append(text)
     payload = TokenStreamPayload.create(
         chunk_id=state.chunk_id,
         token=text,

--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -210,7 +210,9 @@ async def generate_agent_response(
                 original_input,
             )
         yield serialize_event(
-            TokenStreamPayload.create(chunk_id=-1, token=suffix),
+            TokenStreamPayload.create(
+                chunk_id=turn_summary.next_chunk_id, token=suffix
+            ),
             media_type,
         )
         yield serialize_event(
@@ -359,6 +361,7 @@ def _process_token(
         token=text,
     )
     state.chunk_id += 1
+    state.turn_summary.next_chunk_id = state.chunk_id
     return payload
 
 
@@ -409,6 +412,7 @@ def _(
         token=final_text,
     )
     state.chunk_id += 1
+    state.turn_summary.next_chunk_id = state.chunk_id
     return payload
 
 

--- a/src/utils/markdown_repair.py
+++ b/src/utils/markdown_repair.py
@@ -39,39 +39,6 @@ _COMMENT_OPEN: Final[str] = "<!--"
 _COMMENT_CLOSE: Final[str] = "-->"
 
 
-def _strip_comments(line: str, in_comment: bool) -> tuple[str, bool]:
-    """Remove HTML comment regions from *line* for scanning purposes.
-
-    Parameters:
-        line: A single line of text to process.
-        in_comment: Whether we are currently inside an HTML comment
-            from a previous line.
-
-    Returns:
-        A tuple of (visible_content, updated_in_comment) where
-        visible_content has comment regions removed and
-        updated_in_comment reflects whether a comment is still open.
-    """
-    result: list[str] = []
-    i = 0
-    while i < len(line):
-        if in_comment:
-            end = line.find(_COMMENT_CLOSE, i)
-            if end == -1:
-                break
-            i = end + len(_COMMENT_CLOSE)
-            in_comment = False
-        else:
-            start = line.find(_COMMENT_OPEN, i)
-            if start == -1:
-                result.append(line[i:])
-                break
-            result.append(line[i:start])
-            i = start + len(_COMMENT_OPEN)
-            in_comment = True
-    return "".join(result), in_comment
-
-
 def _process_html_tags(line: str, html_stack: list[str]) -> Optional[str]:
     """Update *html_stack* with block-level HTML open/close tags found in *line*.
 

--- a/src/utils/markdown_repair.py
+++ b/src/utils/markdown_repair.py
@@ -1,12 +1,12 @@
 """Utilities for repairing truncated markdown content.
 
 Used when a streaming response is interrupted mid-content to close
-any open markdown constructs (code fences, HTML block tags) that
-would otherwise break rendering.
+any open markdown constructs (code fences, HTML block tags, HTML
+comments, raw-content tags) that would otherwise break rendering.
 """
 
 import re
-from typing import Final
+from typing import Final, Optional
 
 BLOCK_HTML_TAGS: Final[frozenset[str]] = frozenset(
     {
@@ -17,29 +17,98 @@ BLOCK_HTML_TAGS: Final[frozenset[str]] = frozenset(
         "th",
         "thead",
         "tbody",
+        "tfoot",
+        "caption",
         "details",
         "summary",
         "pre",
     }
 )
 
+RAW_HTML_TAGS: Final[frozenset[str]] = frozenset(
+    {
+        "script",
+        "style",
+    }
+)
+
 _FENCE_RE: Final[re.Pattern[str]] = re.compile(r"^(\s{0,3})((`{3,})|(~{3,}))")
 _TAG_RE: Final[re.Pattern[str]] = re.compile(r"<(/?)(\w+)([^>]*?)(/?)>")
 
+_COMMENT_OPEN: Final[str] = "<!--"
+_COMMENT_CLOSE: Final[str] = "-->"
 
-def _process_html_tags(line: str, html_stack: list[str]) -> None:
+
+def _strip_comments(line: str, in_comment: bool) -> tuple[str, bool]:
+    """Remove HTML comment regions from *line* for scanning purposes.
+
+    Parameters:
+        line: A single line of text to process.
+        in_comment: Whether we are currently inside an HTML comment
+            from a previous line.
+
+    Returns:
+        A tuple of (visible_content, updated_in_comment) where
+        visible_content has comment regions removed and
+        updated_in_comment reflects whether a comment is still open.
+    """
+    result: list[str] = []
+    i = 0
+    while i < len(line):
+        if in_comment:
+            end = line.find(_COMMENT_CLOSE, i)
+            if end == -1:
+                break
+            i = end + len(_COMMENT_CLOSE)
+            in_comment = False
+        else:
+            start = line.find(_COMMENT_OPEN, i)
+            if start == -1:
+                result.append(line[i:])
+                break
+            result.append(line[i:start])
+            i = start + len(_COMMENT_OPEN)
+            in_comment = True
+    return "".join(result), in_comment
+
+
+def _process_html_tags(line: str, html_stack: list[str]) -> Optional[str]:
     """Update *html_stack* with block-level HTML open/close tags found in *line*.
+
+    When a raw-content tag (``<script>``, ``<style>``) is encountered,
+    block-tag processing stops.  If the matching close tag appears on the
+    same line, processing resumes after it.  Otherwise the raw tag name
+    is returned so the caller can enter raw-tag mode.
 
     Parameters:
         line: A single line of text to scan for HTML tags.
         html_stack: Mutable stack tracking open block-level tags.
+
+    Returns:
+        The name of a raw tag that was opened and not closed on this
+        line, or ``None`` if no raw-content zone was entered.
     """
+    in_raw: Optional[str] = None
+
     for tag_match in _TAG_RE.finditer(line):
         is_closing = tag_match.group(1) == "/"
         tag_name = tag_match.group(2).lower()
         is_self_closing = tag_match.group(4) == "/"
 
-        if tag_name not in BLOCK_HTML_TAGS or is_self_closing:
+        if in_raw:
+            if is_closing and tag_name == in_raw:
+                in_raw = None
+            continue
+
+        if is_self_closing:
+            continue
+
+        if tag_name in RAW_HTML_TAGS:
+            if not is_closing:
+                in_raw = tag_name
+            continue
+
+        if tag_name not in BLOCK_HTML_TAGS:
             continue
 
         if is_closing:
@@ -48,13 +117,144 @@ def _process_html_tags(line: str, html_stack: list[str]) -> None:
         else:
             html_stack.append(tag_name)
 
+    return in_raw
+
+
+def _find_raw_close(line: str, raw_tag: str) -> Optional[int]:
+    """Find the closing tag for a raw-content element in *line*.
+
+    Parameters:
+        line: A single line of text to scan.
+        raw_tag: The raw tag name to look for (e.g. ``"script"``).
+
+    Returns:
+        The character position immediately after the closing tag,
+        or ``None`` if no close tag was found.
+    """
+    for tag_match in _TAG_RE.finditer(line):
+        if tag_match.group(1) == "/" and tag_match.group(2).lower() == raw_tag:
+            return tag_match.end()
+    return None
+
+
+def _raw_tag_open_at(line: str, position: int) -> bool:
+    """Return whether an unclosed raw-tag zone spans *position* in *line*.
+
+    Scans all HTML tags before *position*, tracking raw-tag open/close
+    state.  Returns ``True`` only if a raw tag is still open at
+    *position* (i.e. it opened but did not close before *position*).
+
+    Parameters:
+        line: A single line of text to scan.
+        position: Character index to check against.
+
+    Returns:
+        True if a raw-tag zone is open at *position*.
+    """
+    open_raw: Optional[str] = None
+    for tag_match in _TAG_RE.finditer(line):
+        if tag_match.start() >= position:
+            break
+        tag_name = tag_match.group(2).lower()
+        if tag_name not in RAW_HTML_TAGS:
+            continue
+        if tag_match.group(1) == "/":
+            if open_raw == tag_name:
+                open_raw = None
+        elif tag_match.group(4) != "/":
+            open_raw = tag_name
+    return open_raw is not None
+
+
+def _strip_comments_with_zone_priority(line: str, in_comment: bool) -> tuple[str, bool]:
+    """Strip comments from *line*, respecting zone-marker priority.
+
+    Processes comments incrementally.  After each closed comment is
+    consumed, the remaining visible suffix is re-evaluated: if a fence
+    marker or raw-tag opener appears before the next ``<!--``, that
+    zone takes priority and comment stripping stops.
+
+    Parameters:
+        line: A single line of text to process.
+        in_comment: Whether we are inside an HTML comment from a
+            previous line.
+
+    Returns:
+        A tuple of (processed_line, updated_in_comment).
+    """
+    result: list[str] = []
+    remaining = line
+
+    while remaining:
+        if in_comment:
+            end = remaining.find(_COMMENT_CLOSE)
+            if end == -1:
+                return "".join(result), True
+            remaining = remaining[end + len(_COMMENT_CLOSE) :]
+            in_comment = False
+            continue
+
+        if _FENCE_RE.match(remaining):
+            result.append(remaining)
+            return "".join(result), False
+
+        comment_pos = remaining.find(_COMMENT_OPEN)
+        if comment_pos == -1:
+            result.append(remaining)
+            return "".join(result), False
+
+        if _raw_tag_open_at(remaining, comment_pos):
+            result.append(remaining)
+            return "".join(result), False
+
+        result.append(remaining[:comment_pos])
+        remaining = remaining[comment_pos + len(_COMMENT_OPEN) :]
+        in_comment = True
+
+    return "".join(result), in_comment
+
+
+def _process_fence_match(
+    fence_match: re.Match[str],
+    line: str,
+    in_code_fence: bool,
+    fence_char: str,
+    fence_len: int,
+) -> tuple[bool, str, int]:
+    """Update fence state based on a fence regex match.
+
+    Parameters:
+        fence_match: A successful ``_FENCE_RE`` match object.
+        line: The full line containing the match.
+        in_code_fence: Whether we are currently inside a code fence.
+        fence_char: The character used for the current fence.
+        fence_len: The length of the current fence marker.
+
+    Returns:
+        Updated ``(in_code_fence, fence_char, fence_len)`` tuple.
+    """
+    group_3 = fence_match.group(3)
+    matched_group = group_3 or fence_match.group(4)
+    char = "`" if group_3 else "~"
+    if not in_code_fence:
+        return True, char, len(matched_group)
+    if (
+        char == fence_char
+        and len(matched_group) >= fence_len
+        and line[fence_match.end() :].strip(" \t") == ""
+    ):
+        return False, "", 0
+    return in_code_fence, fence_char, fence_len
+
 
 def close_open_markdown(text: str) -> str:
     """Return a suffix that closes any open markdown constructs in *text*.
 
-    Scans for unclosed fenced code blocks and unclosed HTML block-level
-    tags.  Returns only the closing characters (callers append the result).
-    Returns an empty string when nothing needs closing.
+    Scans for unclosed fenced code blocks, unclosed HTML block-level
+    tags, unclosed HTML comments, and unclosed raw-content tags
+    (``<script>``, ``<style>``).  Returns only the closing characters
+    (callers append the result).  Returns an empty string when nothing
+    needs closing.
 
     Parameters:
         text: Partial markdown content that may contain open constructs.
@@ -69,35 +269,43 @@ def close_open_markdown(text: str) -> str:
     in_code_fence = False
     fence_char = ""
     fence_len = 0
+    in_comment = False
+    in_raw_tag = ""
     html_stack: list[str] = []
 
     for line in lines:
+        if in_raw_tag:
+            end_pos = _find_raw_close(line, in_raw_tag)
+            if end_pos is None:
+                continue
+            in_raw_tag = ""
+            line = line[end_pos:]
+
+        if not in_code_fence:
+            line, in_comment = _strip_comments_with_zone_priority(line, in_comment)
+
         fence_match = _FENCE_RE.match(line)
+
         if not fence_match:
             if not in_code_fence:
-                _process_html_tags(line, html_stack)
+                raw_tag = _process_html_tags(line, html_stack)
+                if raw_tag:
+                    in_raw_tag = raw_tag
+                    in_comment = False
             continue
 
-        group_3 = fence_match.group(3)
-        group_4 = fence_match.group(4)
-        matched_group = group_3 or group_4
-        char = "`" if group_3 else "~"
-        if not in_code_fence:
-            in_code_fence = True
-            fence_char = char
-            fence_len = len(matched_group)
-        elif (
-            char == fence_char
-            and len(matched_group) >= fence_len
-            and line[fence_match.end() :].strip(" \t") == ""
-        ):
-            in_code_fence = False
-            fence_char = ""
-            fence_len = 0
+        in_code_fence, fence_char, fence_len = _process_fence_match(
+            fence_match, line, in_code_fence, fence_char, fence_len
+        )
 
     suffix_parts: list[str] = []
-    if in_code_fence:
+
+    if in_comment:
+        suffix_parts.append(f"\n{_COMMENT_CLOSE}")
+    elif in_code_fence:
         suffix_parts.append(f"\n{fence_char * fence_len}")
+    elif in_raw_tag:
+        suffix_parts.append(f"\n</{in_raw_tag}>")
 
     for tag in reversed(html_stack):
         suffix_parts.append(f"\n</{tag}>")

--- a/src/utils/markdown_repair.py
+++ b/src/utils/markdown_repair.py
@@ -86,7 +86,11 @@ def close_open_markdown(text: str) -> str:
             in_code_fence = True
             fence_char = char
             fence_len = len(matched_group)
-        elif char == fence_char and len(matched_group) >= fence_len:
+        elif (
+            char == fence_char
+            and len(matched_group) >= fence_len
+            and line[fence_match.end() :].strip(" \t") == ""
+        ):
             in_code_fence = False
             fence_char = ""
             fence_len = 0

--- a/src/utils/markdown_repair.py
+++ b/src/utils/markdown_repair.py
@@ -1,0 +1,101 @@
+"""Utilities for repairing truncated markdown content.
+
+Used when a streaming response is interrupted mid-content to close
+any open markdown constructs (code fences, HTML block tags) that
+would otherwise break rendering.
+"""
+
+import re
+from typing import Final
+
+BLOCK_HTML_TAGS: Final[frozenset[str]] = frozenset(
+    {
+        "div",
+        "table",
+        "tr",
+        "td",
+        "th",
+        "thead",
+        "tbody",
+        "details",
+        "summary",
+        "pre",
+    }
+)
+
+_FENCE_RE: Final[re.Pattern[str]] = re.compile(r"^(\s{0,3})((`{3,})|(~{3,}))")
+_TAG_RE: Final[re.Pattern[str]] = re.compile(r"<(/?)(\w+)([^>]*?)(/?)>")
+
+
+def _process_html_tags(line: str, html_stack: list[str]) -> None:
+    """Update *html_stack* with block-level HTML open/close tags found in *line*.
+
+    Parameters:
+        line: A single line of text to scan for HTML tags.
+        html_stack: Mutable stack tracking open block-level tags.
+    """
+    for tag_match in _TAG_RE.finditer(line):
+        is_closing = tag_match.group(1) == "/"
+        tag_name = tag_match.group(2).lower()
+        is_self_closing = tag_match.group(4) == "/"
+
+        if tag_name not in BLOCK_HTML_TAGS or is_self_closing:
+            continue
+
+        if is_closing:
+            if html_stack and html_stack[-1] == tag_name:
+                html_stack.pop()
+        else:
+            html_stack.append(tag_name)
+
+
+def close_open_markdown(text: str) -> str:
+    """Return a suffix that closes any open markdown constructs in *text*.
+
+    Scans for unclosed fenced code blocks and unclosed HTML block-level
+    tags.  Returns only the closing characters (callers append the result).
+    Returns an empty string when nothing needs closing.
+
+    Parameters:
+        text: Partial markdown content that may contain open constructs.
+
+    Returns:
+        A suffix string to append that closes open constructs.
+    """
+    if not text or not text.strip():
+        return ""
+
+    lines = text.split("\n")
+    in_code_fence = False
+    fence_char = ""
+    fence_len = 0
+    html_stack: list[str] = []
+
+    for line in lines:
+        fence_match = _FENCE_RE.match(line)
+        if not fence_match:
+            if not in_code_fence:
+                _process_html_tags(line, html_stack)
+            continue
+
+        group_3 = fence_match.group(3)
+        group_4 = fence_match.group(4)
+        matched_group = group_3 or group_4
+        char = "`" if group_3 else "~"
+        if not in_code_fence:
+            in_code_fence = True
+            fence_char = char
+            fence_len = len(matched_group)
+        elif char == fence_char and len(matched_group) >= fence_len:
+            in_code_fence = False
+            fence_char = ""
+            fence_len = 0
+
+    suffix_parts: list[str] = []
+    if in_code_fence:
+        suffix_parts.append(f"\n{fence_char * fence_len}")
+
+    for tag in reversed(html_stack):
+        suffix_parts.append(f"\n</{tag}>")
+
+    return "".join(suffix_parts)

--- a/src/utils/stream_interrupts.py
+++ b/src/utils/stream_interrupts.py
@@ -274,7 +274,7 @@ async def persist_interrupted_turn(
                 original_input,
                 [
                     OpenAIResponseMessage(
-                        role="assistant", content=INTERRUPTED_RESPONSE_MESSAGE
+                        role="assistant", content=turn_summary.llm_response
                     )
                 ],
             )
@@ -283,7 +283,7 @@ async def persist_interrupted_turn(
                 context.client,
                 responses_params.conversation,
                 cast(str, responses_params.input),
-                INTERRUPTED_RESPONSE_MESSAGE,
+                turn_summary.llm_response,
             )
     except Exception:  # pylint: disable=broad-except
         logger.exception(
@@ -365,7 +365,8 @@ def register_interrupt_callback(
         if guard[0]:
             return
         guard[0] = True
-        turn_summary.llm_response = INTERRUPTED_RESPONSE_MESSAGE
+        full_text, _ = build_interrupted_response(turn_summary.partial_tokens)
+        turn_summary.llm_response = full_text
         await persist_interrupted_turn(
             context,
             responses_params,

--- a/src/utils/stream_interrupts.py
+++ b/src/utils/stream_interrupts.py
@@ -20,6 +20,7 @@ from models.common.responses.responses_api_params import ResponsesApiParams
 from models.common.responses.types import ResponseInput
 from models.common.turn_summary import TurnSummary
 from utils.conversations import append_turn_items_to_conversation
+from utils.markdown_repair import close_open_markdown
 from utils.query import store_query_results, update_conversation_topic_summary
 from utils.responses import get_topic_summary
 from utils.shields import append_turn_to_conversation
@@ -213,6 +214,28 @@ async def background_update_topic_summary(
             "Failed to generate topic summary for interrupted turn, request %s",
             context.request_id,
         )
+
+
+def build_interrupted_response(partial_tokens: list[str]) -> tuple[str, str]:
+    """Build the final interrupted response text from accumulated tokens.
+
+    Joins partial tokens, repairs any open markdown constructs, and appends
+    an italicized interruption indicator.
+
+    Parameters:
+        partial_tokens: List of text deltas accumulated during streaming.
+
+    Returns:
+        A tuple of (full_response_text, suffix_to_emit) where full_response_text
+        is the complete message for persistence and suffix_to_emit is the new
+        content to send as a final SSE token event.
+    """
+    partial_text = "".join(partial_tokens)
+    repaired_text = close_open_markdown(partial_text)
+    interrupted_indicator = f"\n\n*{INTERRUPTED_RESPONSE_MESSAGE}*"
+    suffix = repaired_text + interrupted_indicator
+    final_text = partial_text + suffix
+    return final_text, suffix
 
 
 async def persist_interrupted_turn(

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -51,6 +51,7 @@ from app.endpoints.streaming_query import (
 )
 from configuration import AppConfig
 from constants import (
+    INTERRUPTED_RESPONSE_MESSAGE,
     MEDIA_TYPE_JSON,
     MEDIA_TYPE_TEXT,
 )
@@ -69,6 +70,8 @@ from models.common.turn_summary import (
 from models.config import Action
 from utils.stream_interrupts import StreamInterruptRegistry
 from utils.token_counter import TokenCounter
+
+INTERRUPTED_INDICATOR = f"\n\n*{INTERRUPTED_RESPONSE_MESSAGE}*"
 
 MOCK_AUTH_STREAMING = (
     "00000001-0001-0001-0001-000000000001",
@@ -1379,6 +1382,7 @@ class TestGenerateResponse:
             result.append(item)
 
         assert any("start" in item for item in result)
+        assert any('"event": "token"' in item for item in result)
         assert any('"event": "interrupted"' in item for item in result)
         assert not any('"event": "end"' in item for item in result)
         consume_query_tokens_mock.assert_not_called()
@@ -1387,13 +1391,13 @@ class TestGenerateResponse:
             mock_context.client,
             existing_conv_id,
             "test",
-            "You interrupted this request.",
+            INTERRUPTED_INDICATOR,
         )
         store_query_results_mock.assert_called_once()
         call_kwargs = store_query_results_mock.call_args[1]
         assert call_kwargs["user_id"] == "user_123"
         assert call_kwargs["conversation_id"] == existing_conv_id
-        assert call_kwargs["summary"].llm_response == "You interrupted this request."
+        assert call_kwargs["summary"].llm_response == INTERRUPTED_INDICATOR
         assert call_kwargs["topic_summary"] is None
 
         isolate_stream_interrupt_registry.deregister_stream.assert_called_once_with(

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -64,6 +64,8 @@ from utils.agents.streaming import (
 )
 from utils.token_counter import TokenCounter
 
+INTERRUPTED_INDICATOR = f"\n\n*{INTERRUPTED_RESPONSE_MESSAGE}*"
+
 TEST_CONVERSATION_ID = "123e4567-e89b-12d3-a456-426614174000"
 
 
@@ -715,9 +717,9 @@ class TestGenerateAgentResponse:
             )
         ]
 
-        assert _sse_event_types(result) == ["start", "token", "interrupted"]
+        assert _sse_event_types(result) == ["start", "token", "token", "interrupted"]
         persist_mock.assert_awaited_once()
-        assert turn_summary.llm_response == INTERRUPTED_RESPONSE_MESSAGE
+        assert turn_summary.llm_response == INTERRUPTED_INDICATOR
         stream_interrupt_mocks["deregister"].assert_called_once_with(context.request_id)
 
     @pytest.mark.asyncio
@@ -808,7 +810,7 @@ class TestGenerateAgentResponse:
             )
         ]
 
-        assert _sse_event_types(result) == ["start", "token", "interrupted"]
+        assert _sse_event_types(result) == ["start", "token", "token", "interrupted"]
         persist_mock.assert_not_awaited()
 
 

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -1055,7 +1055,9 @@ class TestInterruptPartialTokenAccumulation:
         num_chunks = len(chunk_ids)
         assert chunk_ids == sorted(chunk_ids), "chunk_ids must be monotonically ordered"
         assert all(cid >= 0 for cid in chunk_ids), "all chunk_ids must be non-negative"
-        assert num_chunks == len(set(chunk_ids)), "chunk_ids must not contain duplicates"
+        assert num_chunks == len(
+            set(chunk_ids)
+        ), "chunk_ids must not contain duplicates"
         assert chunk_ids[-1] == num_chunks - 1
 
     @pytest.mark.asyncio

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -963,6 +963,147 @@ class TestAgentResponseGenerator:
         assert turn_summary.token_usage.input_tokens == 0
 
 
+class TestInterruptPartialTokenAccumulation:
+    """Tests verifying real partial-text accumulation through the streaming pipeline on interrupt."""
+
+    @pytest.mark.asyncio
+    async def test_interrupt_accumulates_partial_tokens_and_persists(
+        self,
+        mocker: MockerFixture,
+        make_generator_context: Callable[..., ResponseGeneratorContext],
+        responses_params: ResponsesApiParams,
+    ) -> None:
+        """Cancel mid-stream through agent_response_generator and verify partial content is accumulated, repaired, and persisted."""
+        context = make_generator_context()
+        turn_summary = TurnSummary()
+        background_tasks: list[asyncio.Task[None]] = []
+
+        events_before_cancel = [
+            PartStartEvent(index=0, part=TextPart(content="Hello")),
+            PartDeltaEvent(index=0, delta=TextPartDelta(content_delta=" world")),
+        ]
+
+        def _cancelling_run_stream(
+            events: list[Any],
+        ) -> Any:
+            async def _event_stream() -> AsyncIterator[Any]:
+                for event in events:
+                    yield event
+                raise asyncio.CancelledError()
+
+            class _Ctx:
+                """Async context manager that cancels after yielding events."""
+
+                async def __aenter__(self) -> AsyncIterator[Any]:
+                    return _event_stream()
+
+                async def __aexit__(self, *_args: object) -> None:
+                    return None
+
+            return _Ctx()
+
+        mock_agent = mocker.Mock()
+        mock_agent.run_stream_events.return_value = _cancelling_run_stream(
+            events_before_cancel
+        )
+
+        persist_mock = mocker.patch(
+            "utils.agents.streaming.persist_interrupted_turn",
+            new=mocker.AsyncMock(),
+        )
+        mocker.patch(
+            "utils.agents.streaming.register_interrupt_callback",
+            return_value=[False],
+        )
+
+        inner = agent_response_generator(
+            mock_agent,
+            responses_params,
+            context,
+            turn_summary,
+            ENDPOINT_PATH_STREAMING_QUERY,
+        )
+
+        result = [
+            event
+            async for event in generate_agent_response(
+                inner,
+                context,
+                responses_params,
+                turn_summary,
+                background_tasks,
+            )
+        ]
+
+        event_types = _sse_event_types(result)
+        assert event_types == ["start", "token", "token", "token", "interrupted"]
+
+        assert turn_summary.partial_tokens == ["Hello", " world"]
+
+        assert "Hello world" in turn_summary.llm_response
+        assert INTERRUPTED_RESPONSE_MESSAGE in turn_summary.llm_response
+
+        persist_mock.assert_awaited_once()
+
+        token_events = [
+            json.loads(e.removeprefix("data: ").strip())
+            for e in result
+            if e.startswith("data: ")
+            and json.loads(e.removeprefix("data: ").strip())["event"] == "token"
+        ]
+        chunk_ids = [t["data"]["id"] for t in token_events]
+        assert chunk_ids == sorted(chunk_ids), "chunk_ids must be monotonically ordered"
+        assert all(cid >= 0 for cid in chunk_ids), "all chunk_ids must be non-negative"
+        assert chunk_ids[-1] == len(chunk_ids) - 1
+
+    @pytest.mark.asyncio
+    async def test_interrupt_with_no_tokens_uses_zero_chunk_id(
+        self,
+        mocker: MockerFixture,
+        make_generator_context: Callable[..., ResponseGeneratorContext],
+        responses_params: ResponsesApiParams,
+    ) -> None:
+        """Cancel before any tokens are emitted; interrupt suffix should use chunk_id 0."""
+        context = make_generator_context()
+        turn_summary = TurnSummary()
+        background_tasks: list[asyncio.Task[None]] = []
+
+        async def inner() -> AsyncIterator[str]:
+            raise asyncio.CancelledError()
+            yield ""  # pragma: no cover
+
+        persist_mock = mocker.patch(
+            "utils.agents.streaming.persist_interrupted_turn",
+            new=mocker.AsyncMock(),
+        )
+        mocker.patch(
+            "utils.agents.streaming.register_interrupt_callback",
+            return_value=[False],
+        )
+
+        result = [
+            event
+            async for event in generate_agent_response(
+                inner(),
+                context,
+                responses_params,
+                turn_summary,
+                background_tasks,
+            )
+        ]
+
+        token_events = [
+            json.loads(e.removeprefix("data: ").strip())
+            for e in result
+            if e.startswith("data: ")
+            and json.loads(e.removeprefix("data: ").strip())["event"] == "token"
+        ]
+        assert len(token_events) == 1
+        assert token_events[0]["data"]["id"] == 0
+
+        persist_mock.assert_awaited_once()
+
+
 def _sse_event_types(events: list[str]) -> list[str]:
     """Extract SSE event types from serialized stream lines."""
     types: list[str] = []

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -1052,9 +1052,11 @@ class TestInterruptPartialTokenAccumulation:
             and json.loads(e.removeprefix("data: ").strip())["event"] == "token"
         ]
         chunk_ids = [t["data"]["id"] for t in token_events]
+        num_chunks = len(chunk_ids)
         assert chunk_ids == sorted(chunk_ids), "chunk_ids must be monotonically ordered"
         assert all(cid >= 0 for cid in chunk_ids), "all chunk_ids must be non-negative"
-        assert chunk_ids[-1] == len(chunk_ids) - 1
+        assert num_chunks == len(set(chunk_ids)), "chunk_ids must not contain duplicates"
+        assert chunk_ids[-1] == num_chunks - 1
 
     @pytest.mark.asyncio
     async def test_interrupt_with_no_tokens_uses_zero_chunk_id(

--- a/tests/unit/utils/test_markdown_repair.py
+++ b/tests/unit/utils/test_markdown_repair.py
@@ -130,6 +130,346 @@ class TestCloseOpenMarkdownHtmlTags:
         result = close_open_markdown(text)
         assert result == ""
 
+    def test_unclosed_tfoot(self) -> None:
+        """Unclosed tfoot inside table gets closed."""
+        text = "<table>\n<tfoot>\n<tr><td>total</td></tr>"
+        result = close_open_markdown(text)
+        assert result == "\n</tfoot>\n</table>"
+
+    def test_unclosed_caption(self) -> None:
+        """Unclosed caption inside table gets closed."""
+        text = "<table>\n<caption>Title"
+        result = close_open_markdown(text)
+        assert result == "\n</caption>\n</table>"
+
+
+class TestCloseOpenMarkdownHtmlComments:
+    """Tests for core HTML comment handling."""
+
+    def test_tags_inside_single_line_comment_ignored(self) -> None:
+        """Tags inside a closed single-line comment are not tracked."""
+        text = "<!-- <table> -->\n<div>\ncontent"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_tags_inside_multi_line_comment_ignored(self) -> None:
+        """Tags inside a multi-line comment are not tracked."""
+        text = "<!--\n<table>\n-->\n<div>\ncontent"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_unclosed_comment_gets_closed(self) -> None:
+        """Unclosed HTML comment gets closed with -->."""
+        text = "<!-- partial content"
+        result = close_open_markdown(text)
+        assert result == "\n-->"
+
+    def test_comment_inside_code_fence_is_literal(self) -> None:
+        """Comment markers inside a code fence are literal text."""
+        text = "```\n<!-- <div>\n```"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_open_div_then_open_comment(self) -> None:
+        """Open div followed by unclosed comment closes both."""
+        text = "<div>\ncontent\n<!-- partial"
+        result = close_open_markdown(text)
+        assert result == "\n-->\n</div>"
+
+    def test_multiple_comments_on_one_line(self) -> None:
+        """Multiple comments on one line with a tag between them."""
+        text = "<!-- a --> <div> <!-- b --> content"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_comment_containing_fence_marker(self) -> None:
+        """Fence marker inside a comment is not a real fence."""
+        text = "<!-- ``` -->\nreal text"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_unclosed_comment_with_prior_open_tag(self) -> None:
+        """Unclosed comment after an open tag closes both."""
+        text = "<div>\n<!-- <table>"
+        result = close_open_markdown(text)
+        assert result == "\n-->\n</div>"
+
+
+class TestCloseOpenMarkdownCommentBoundaryEdgeCases:
+    """Tests for HTML comment boundary edge cases."""
+
+    def test_empty_comment(self) -> None:
+        """Empty comment is properly recognized and ignored."""
+        text = "<!---->\n<div>\ncontent"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_comment_with_only_whitespace(self) -> None:
+        """Comment containing only whitespace is properly closed."""
+        text = "<!--   -->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_comment_opener_at_end_of_text(self) -> None:
+        """Comment opener at the very end of text gets closed."""
+        text = "<div>\ntext<!--"
+        result = close_open_markdown(text)
+        assert result == "\n-->\n</div>"
+
+    def test_line_is_only_comment_opener(self) -> None:
+        """Line that is only <!-- opens a comment."""
+        text = "<div>\n<!--"
+        result = close_open_markdown(text)
+        assert result == "\n-->\n</div>"
+
+    def test_line_is_only_comment_closer(self) -> None:
+        """Bare --> on its own line closes a multi-line comment."""
+        text = "<!--\n<table>\n-->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_stray_close_when_not_in_comment(self) -> None:
+        """Stray --> when not in a comment is ignored as literal text."""
+        text = "-->\n<div>\ncontent"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_extra_dashes_on_close(self) -> None:
+        """---> closes a comment because it contains -->."""
+        text = "<!-- comment --->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_space_before_close_angle_not_a_close(self) -> None:
+        """-- > with space is not a comment close."""
+        text = "<!-- text -- > more"
+        result = close_open_markdown(text)
+        assert result == "\n-->"
+
+
+class TestCloseOpenMarkdownCommentCrossConstruct:
+    """Tests for comments interacting with other constructs."""
+
+    def test_adjacent_comments_no_space(self) -> None:
+        """Two adjacent comments with no space between them."""
+        text = "<!-- a --><!-- b -->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_three_comments_with_tags_between(self) -> None:
+        """Tags between comments on one line are processed normally."""
+        text = "<!-- x --> <div> <!-- y --> </div> <!-- z -->"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_comment_opens_mid_line_rest_eaten(self) -> None:
+        """Comment opening mid-line suppresses tags after it."""
+        text = "<div> <!-- unclosed <table>"
+        result = close_open_markdown(text)
+        assert result == "\n-->\n</div>"
+
+    def test_fence_marker_inside_unclosed_multi_line_comment(self) -> None:
+        """Fence marker inside an unclosed multi-line comment is ignored."""
+        text = "<div>\n<!-- comment\n```python"
+        result = close_open_markdown(text)
+        assert result == "\n-->\n</div>"
+
+    def test_tag_split_across_comment_boundary(self) -> None:
+        """Partial tag inside comment is harmless."""
+        text = "<!-- <di\nv> -->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_nested_comment_like_construct(self) -> None:
+        """First --> closes comment; second --> is literal text."""
+        text = "<!-- <!-- inner --> outer -->"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_comment_between_two_tags_same_line(self) -> None:
+        """Tags on both sides of a comment are tracked."""
+        text = "<div><!-- comment --><table>"
+        result = close_open_markdown(text)
+        assert result == "\n</table>\n</div>"
+
+    def test_empty_lines_inside_multi_line_comment(self) -> None:
+        """Empty lines inside a multi-line comment don't break state."""
+        text = "<!--\n\n\n-->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_fence_opens_before_comment_on_same_line(self) -> None:
+        """Fence at line start takes priority over <!-- later on the line."""
+        text = "```<!-- partial\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_comment_close_then_fence_on_next_line(self) -> None:
+        """Comment closes on one line, fence opens on the next."""
+        text = "<!-- comment -->\n```\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_fence_close_then_comment_on_next_line(self) -> None:
+        """Fence closes on one line, comment opens on the next."""
+        text = "```\ncode\n```\n<!-- partial"
+        result = close_open_markdown(text)
+        assert result == "\n-->"
+
+    def test_comment_close_reveals_fence_on_same_line(self) -> None:
+        """Comment close mid-line reveals a fence marker after it."""
+        text = "<!-- done -->```python\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_fence_inside_already_open_comment_ignored(self) -> None:
+        """Fence marker on a line while comment is open from prior line."""
+        text = "<!--\n```python\n-->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_fence_inside_already_open_comment_with_outer_tag(self) -> None:
+        """Fence inside open comment with an outer open tag."""
+        text = "<div>\n<!--\n```python\n-->\ncontent"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_closed_comment_then_fence_with_comment_inside(self) -> None:
+        """Closed comment before fence does not hide fence opener."""
+        text = "<!-- ok -->```<!-- partial\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+
+class TestCloseOpenMarkdownRawTags:
+    """Tests for raw-content tag zones (script, style)."""
+
+    def test_unclosed_script(self) -> None:
+        """Unclosed script tag gets closed."""
+        text = "<script>\nvar x = 1;"
+        result = close_open_markdown(text)
+        assert result == "\n</script>"
+
+    def test_unclosed_style(self) -> None:
+        """Unclosed style tag gets closed."""
+        text = "<style>\n.cls { color: red; }"
+        result = close_open_markdown(text)
+        assert result == "\n</style>"
+
+    def test_closed_script_no_repair(self) -> None:
+        """Properly closed script needs no repair."""
+        text = "<script>\nvar x = 1;\n</script>"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_tags_inside_closed_script_ignored(self) -> None:
+        """Tag-like strings inside script are not tracked."""
+        text = "<script>\nvar html = '<div>';\n</script>"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_tags_inside_unclosed_script_ignored(self) -> None:
+        """Tags inside unclosed script are ignored; outer div still tracked."""
+        text = "<div>\n<script>\nvar html = '<table>';"
+        result = close_open_markdown(text)
+        assert result == "\n</script>\n</div>"
+
+    def test_script_open_and_close_same_line(self) -> None:
+        """Script opened and closed on same line; subsequent tag tracked."""
+        text = "<script>var x=1;</script>\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_content_after_script_close_processed(self) -> None:
+        """Content after script close on same line is processed normally."""
+        text = "<script>x=1;</script><div>content"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_script_inside_code_fence_is_literal(self) -> None:
+        """Script tags inside a code fence are literal text."""
+        text = "```\n<script>\n```"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_script_inside_comment_is_ignored(self) -> None:
+        """Script tag inside a comment is not a real script zone."""
+        text = "<!-- <script> -->\n<div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_script_after_comment_on_same_line(self) -> None:
+        """Script tag after a comment close on the same line is tracked."""
+        text = "<!-- comment --><script>\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n</script>"
+
+    def test_comment_after_script_close_same_line(self) -> None:
+        """Comment after script close on same line is handled."""
+        text = "<script>x=1;</script><!-- <div> -->"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_multi_line_script_close_processes_remainder(self) -> None:
+        """After multi-line script closes, remainder of line is processed."""
+        text = "<script>\nvar x;\n</script><div>content"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_script_opens_before_comment_on_same_line(self) -> None:
+        """Script at line start takes priority over <!-- later on the line."""
+        text = "<script><!-- partial\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n</script>"
+
+    def test_style_opens_before_comment_on_same_line(self) -> None:
+        """Style at line start takes priority over <!-- later on the line."""
+        text = "<style><!-- partial\nbody{}"
+        result = close_open_markdown(text)
+        assert result == "\n</style>"
+
+    def test_script_same_line_close_after_comment_inside_raw(self) -> None:
+        """Script close after <!-- on the same line is still recognized."""
+        text = "<script><!-- partial</script><div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_style_same_line_close_after_comment_inside_raw(self) -> None:
+        """Style close after <!-- on the same line is still recognized."""
+        text = "<style><!-- partial</style><div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_style_same_line_close_after_comment_no_trailing(self) -> None:
+        """Style with inner <!-- that closes on same line needs no repair."""
+        text = "<style><!-- partial</style>"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_script_close_then_comment_then_tag_same_line(self) -> None:
+        """Closed script then closed comment then open tag on one line."""
+        text = "<script>x</script><!-- ok --><div>text"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_closed_comment_then_script_with_comment_inside(self) -> None:
+        """Closed comment before script does not hide script close."""
+        text = "<!-- ok --><script><!-- partial</script><div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_closed_comment_then_script_with_comment_no_trailing(self) -> None:
+        """Closed comment before script that closes after inner <!--."""
+        text = "<!-- ok --><script><!-- partial</script>"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_closed_comment_then_style_with_comment_inside(self) -> None:
+        """Closed comment before style does not hide style close."""
+        text = "<!-- ok --><style><!-- partial</style><div>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
 
 class TestCloseOpenMarkdownCombinations:
     """Tests for combinations of constructs."""

--- a/tests/unit/utils/test_markdown_repair.py
+++ b/tests/unit/utils/test_markdown_repair.py
@@ -60,6 +60,18 @@ class TestCloseOpenMarkdownCodeFences:
         result = close_open_markdown(text)
         assert result == "\n````"
 
+    def test_fence_with_trailing_text_not_closer(self) -> None:
+        """A fence marker with trailing non-whitespace inside a fence is content."""
+        text = "```python\nprint('x')\n```not a closer"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_fence_with_trailing_whitespace_is_closer(self) -> None:
+        """A fence marker with only trailing whitespace is a valid closer."""
+        text = "```python\nprint('x')\n```   "
+        result = close_open_markdown(text)
+        assert result == ""
+
 
 class TestCloseOpenMarkdownHtmlTags:
     """Tests for closing unclosed HTML block tags."""

--- a/tests/unit/utils/test_markdown_repair.py
+++ b/tests/unit/utils/test_markdown_repair.py
@@ -446,6 +446,10 @@ class TestCloseOpenMarkdownRawTags:
         result = close_open_markdown(text)
         assert result == ""
 
+
+class TestCloseOpenMarkdownRawTagCommentInteraction:
+    """Tests for raw-tag and comment interaction on the same line."""
+
     def test_script_close_then_comment_then_tag_same_line(self) -> None:
         """Closed script then closed comment then open tag on one line."""
         text = "<script>x</script><!-- ok --><div>text"

--- a/tests/unit/utils/test_markdown_repair.py
+++ b/tests/unit/utils/test_markdown_repair.py
@@ -1,0 +1,162 @@
+"""Unit tests for markdown repair utilities."""
+
+from utils.markdown_repair import close_open_markdown
+
+
+class TestCloseOpenMarkdownCodeFences:
+    """Tests for closing unclosed code fences."""
+
+    def test_unclosed_backtick_fence(self) -> None:
+        """Unclosed triple-backtick fence gets closed."""
+        text = "Some text\n```\ncode here"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_unclosed_tilde_fence(self) -> None:
+        """Unclosed tilde fence gets closed with tildes."""
+        text = "Some text\n~~~\ncode here"
+        result = close_open_markdown(text)
+        assert result == "\n~~~"
+
+    def test_unclosed_fence_with_language(self) -> None:
+        """Unclosed fence with language specifier gets closed."""
+        text = "Some text\n```python\ndef foo():\n    pass"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_closed_fence_no_repair(self) -> None:
+        """Properly closed fence needs no repair."""
+        text = "Some text\n```\ncode\n```\nmore text"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_multiple_fences_last_unclosed(self) -> None:
+        """Multiple fences where only the last is unclosed."""
+        text = "```\nfirst\n```\n\n```\nsecond block"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_backticks_mid_line_not_fence(self) -> None:
+        """Triple backticks not at line start are not fences."""
+        text = "Use ```code``` for inline code"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_fence_no_trailing_newline(self) -> None:
+        """Unclosed fence at end of text without trailing newline."""
+        text = "```\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_fence_with_text_after_backticks(self) -> None:
+        """Backticks at line start followed by text is a fence with info string."""
+        text = "```this is my sentence"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_shorter_fence_inside_longer_fence_not_closer(self) -> None:
+        """A 3-backtick line inside a 4-backtick fence is content, not a closer."""
+        text = "````python\ndef foo():\n```\n    pass"
+        result = close_open_markdown(text)
+        assert result == "\n````"
+
+
+class TestCloseOpenMarkdownHtmlTags:
+    """Tests for closing unclosed HTML block tags."""
+
+    def test_unclosed_div(self) -> None:
+        """Single unclosed div tag gets closed."""
+        text = "<div>\nsome content"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_unclosed_table(self) -> None:
+        """Single unclosed table tag gets closed."""
+        text = "<table>\n<tr><td>cell</td></tr>"
+        result = close_open_markdown(text)
+        assert result == "\n</table>"
+
+    def test_unclosed_pre(self) -> None:
+        """Single unclosed pre tag gets closed."""
+        text = "<pre>\nformatted text"
+        result = close_open_markdown(text)
+        assert result == "\n</pre>"
+
+    def test_multiple_unclosed_tags_reversed(self) -> None:
+        """Multiple unclosed tags are closed in reverse order."""
+        text = "<div>\n<table>\ncontent"
+        result = close_open_markdown(text)
+        assert result == "\n</table>\n</div>"
+
+    def test_nested_inner_closed(self) -> None:
+        """Nested tags where inner is closed but outer is not."""
+        text = "<div>\n<table>\ncontent\n</table>"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+    def test_properly_closed_tags_no_repair(self) -> None:
+        """Properly closed tags need no repair."""
+        text = "<div>\ncontent\n</div>"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_self_closing_tag_no_repair(self) -> None:
+        """Self-closing tags do not generate closing tags."""
+        text = "text with <br/> and <img src='x' />"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_partial_html_tag_ignored(self) -> None:
+        """Incomplete HTML tag (no closing >) is ignored."""
+        text = "text with <div"
+        result = close_open_markdown(text)
+        assert result == ""
+
+    def test_inline_tags_ignored(self) -> None:
+        """Inline tags like span, em, strong are not repaired."""
+        text = "<span>some <em>text"
+        result = close_open_markdown(text)
+        assert result == ""
+
+
+class TestCloseOpenMarkdownCombinations:
+    """Tests for combinations of constructs."""
+
+    def test_html_inside_unclosed_fence_ignored(self) -> None:
+        """HTML tags inside an unclosed code fence are literal text."""
+        text = "```\n<div>\n<table>"
+        result = close_open_markdown(text)
+        assert result == "\n```"
+
+    def test_html_before_unclosed_fence(self) -> None:
+        """HTML opened before a code fence is still tracked."""
+        text = "<div>\nsome text\n```\ncode"
+        result = close_open_markdown(text)
+        assert result == "\n```\n</div>"
+
+    def test_closed_fence_then_unclosed_html(self) -> None:
+        """Closed code fence followed by unclosed HTML."""
+        text = "```\ncode\n```\n<div>\ncontent"
+        result = close_open_markdown(text)
+        assert result == "\n</div>"
+
+
+class TestCloseOpenMarkdownEdgeCases:
+    """Tests for edge cases."""
+
+    def test_empty_string(self) -> None:
+        """Empty input returns empty suffix."""
+        assert close_open_markdown("") == ""
+
+    def test_plain_text(self) -> None:
+        """Plain text with no markdown constructs."""
+        assert close_open_markdown("Hello world\nThis is plain text.") == ""
+
+    def test_whitespace_only(self) -> None:
+        """Whitespace-only input returns empty suffix."""
+        assert close_open_markdown("   \n  \n") == ""
+
+    def test_inline_formatting_only(self) -> None:
+        """Bold, italic, links do not trigger repair."""
+        text = "Some **bold** and *italic* and [link](url)"
+        assert close_open_markdown(text) == ""

--- a/tests/unit/utils/test_stream_interrupts.py
+++ b/tests/unit/utils/test_stream_interrupts.py
@@ -5,15 +5,19 @@ import asyncio
 import pytest
 from pytest_mock import MockerFixture
 
+from constants import INTERRUPTED_RESPONSE_MESSAGE
 from models.api.requests import QueryRequest
 from models.common.responses.contexts import ResponseGeneratorContext
 from models.common.responses.responses_api_params import ResponsesApiParams
 from models.common.turn_summary import TurnSummary
 from utils.stream_interrupts import (
     StreamInterruptRegistry,
+    build_interrupted_response,
     persist_interrupted_turn,
     register_interrupt_callback,
 )
+
+INTERRUPTED_INDICATOR = f"\n\n*{INTERRUPTED_RESPONSE_MESSAGE}*"
 
 
 @pytest.mark.asyncio
@@ -158,3 +162,28 @@ def test_register_interrupt_callback_registers_current_task(
 
     asyncio.run(invoke_callback())
     persist_mock.assert_awaited_once()
+
+
+class TestBuildInterruptedResponse:
+    """Tests for build_interrupted_response helper."""
+
+    def test_plain_text_partial(self) -> None:
+        """Plain text tokens produce text + indicator."""
+        tokens = ["Hello ", "world"]
+        full, suffix = build_interrupted_response(tokens)
+        assert full == f"Hello world{INTERRUPTED_INDICATOR}"
+        assert suffix == INTERRUPTED_INDICATOR
+
+    def test_unclosed_code_fence(self) -> None:
+        """Unclosed code fence is closed before indicator."""
+        tokens = ["```python\n", "def foo():\n", "    pass"]
+        full, suffix = build_interrupted_response(tokens)
+        assert "```" in suffix
+        assert suffix.endswith(INTERRUPTED_INDICATOR)
+        assert full.startswith("```python\ndef foo():\n    pass")
+
+    def test_empty_tokens(self) -> None:
+        """Empty token list produces just the indicator."""
+        full, suffix = build_interrupted_response([])
+        assert full == INTERRUPTED_INDICATOR
+        assert suffix == INTERRUPTED_INDICATOR

--- a/tests/unit/utils/test_stream_interrupts.py
+++ b/tests/unit/utils/test_stream_interrupts.py
@@ -46,6 +46,7 @@ async def test_persist_interrupted_turn_compacted_uses_original_input(
     responses_params.input = ["explicit rewrite"]
 
     turn_summary = TurnSummary()
+    turn_summary.llm_response = f"partial content{INTERRUPTED_INDICATOR}"
     background_tasks: list[asyncio.Task[None]] = []
     items = mocker.patch(
         "utils.stream_interrupts.append_turn_items_to_conversation",
@@ -67,6 +68,8 @@ async def test_persist_interrupted_turn_compacted_uses_original_input(
 
     items.assert_awaited_once()
     assert items.call_args.args[2] == "the original query"
+    call_output = items.call_args.args[3]
+    assert call_output[0].content == f"partial content{INTERRUPTED_INDICATOR}"
     strs.assert_not_awaited()
 
 
@@ -94,6 +97,7 @@ async def test_persist_interrupted_turn_schedules_background_topic_summary(
     responses_params.input = "hello"
 
     turn_summary = TurnSummary()
+    turn_summary.llm_response = INTERRUPTED_INDICATOR
     background_tasks: list[asyncio.Task[None]] = []
 
     mocker.patch(


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- When query interruption was added initially it replaced the entire conversation portion that was interrupted with the interrupt message. This change allows the half-completed message to remain after fixing any breaking code fences/html/tables/etc.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude (Cursor)
- Generated by: Claude (Cursor)

## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/RHIDP-12952
- Closes https://redhat.atlassian.net/browse/RHIDP-12952

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Interrupted streaming responses now preserve partial text already sent and continue emitting the interruption update with correct, sequential chunk ordering.
  * Interruption output is reconstructed dynamically and includes automatic cleanup for truncated Markdown/HTML so rendering stays intact.

* **Bug Fixes**
  * Improved interruption persistence and display by rebuilding the interrupted message from the streamed content instead of using a static placeholder.

* **Updates**
  * Updated the interruption notice to: “Response stopped by the user.”

* **Tests**
  * Expanded unit coverage for interruption sequencing, partial-token accumulation, and Markdown repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->