### PR TITLE
LCORE-2707: Bump up `litellm` to 1.84.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
     "jsonpath-ng>=1.6.1",
     "psycopg2-binary>=2.9.10",
     # LCORE-1565
-    "litellm>=1.83.7",
+    "litellm>=1.84.0",
     "urllib3>=2.6.3",
     # Used for agent card configuration
     "PyYAML>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2086,7 +2086,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "jsonpath-ng", specifier = ">=1.6.1" },
     { name = "kubernetes", specifier = ">=30.1.0" },
-    { name = "litellm", specifier = ">=1.83.7" },
+    { name = "litellm", specifier = ">=1.84.0" },
     { name = "llama-stack", specifier = "==0.6.0" },
     { name = "llama-stack-api", specifier = "==0.6.0" },
     { name = "llama-stack-client", specifier = "==0.6.0" },


### PR DESCRIPTION
## Description

Bump the `litellm` dependency minimum version from `1.83.7` to `1.84.0` in `pyproject.toml` and regenerate the lockfile. This keeps the project aligned with the latest litellm release.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue LCORE-2707

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Ran local unit and integration tests to verify no regressions from the version bump.