### PR TITLE
RSPEED-3297: remove dead rlsapi_v1 error redactor

### DIFF
--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -5,7 +5,6 @@ from the RHEL Lightspeed Command Line Assistant (CLA).
 """
 
 import functools
-import re
 import time
 from datetime import UTC, datetime
 from typing import Annotated, Any, Optional, cast
@@ -84,9 +83,6 @@ _INFER_HANDLED_EXCEPTIONS = (
     OpenAIAPIStatusError,
 )
 
-_PRIVATE_ERROR_BLOCK_PATTERN = re.compile(r"\bPRIVATE\b[^\r\n,;)]*", re.IGNORECASE)
-_SECRET_KEY_PATTERN = re.compile(r"\bsk-[A-Za-z0-9][A-Za-z0-9_-]*")
-
 
 infer_responses: dict[int | str, dict[str, Any]] = {
     200: RlsapiV1InferResponse.openapi_response(),
@@ -101,23 +97,6 @@ infer_responses: dict[int | str, dict[str, Any]] = {
         examples=["llama stack", "kubernetes api"]
     ),
 }
-
-
-def _redact_sensitive_error_text(error_text: str) -> str:
-    """Redact sensitive substrings from backend error text before telemetry.
-
-    Backend exceptions can include provider request snippets or credentials in
-    their string representation.  Splunk events need enough context to explain
-    the failure, but they must not contain private prompt blocks or API keys.
-
-    Args:
-        error_text: Raw exception string returned by ``str(error)``.
-
-    Returns:
-        Error text with known sensitive substrings replaced by placeholders.
-    """
-    redacted_text = _PRIVATE_ERROR_BLOCK_PATTERN.sub("PRIVATE [REDACTED]", error_text)
-    return _SECRET_KEY_PATTERN.sub("sk-[REDACTED]", redacted_text)
 
 
 def _build_instructions(systeminfo: RlsapiV1SystemInfo) -> str:

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -27,7 +27,6 @@ from app.endpoints.rlsapi_v1 import (
     _build_instructions,
     _compile_prompt_template,
     _get_default_model_id,
-    _redact_sensitive_error_text,
     _resolve_quota_subject,
     infer_endpoint,
     retrieve_simple_response,
@@ -244,25 +243,6 @@ def test_build_instructions_no_customization(mocker: MockerFixture) -> None:
     result = _build_instructions(systeminfo)
 
     assert result == constants.DEFAULT_SYSTEM_PROMPT
-
-
-@pytest.mark.parametrize(
-    ("error_text", "expected"),
-    [
-        (
-            "APIStatusError: PRIVATE prompt sk-backend-secret failed",
-            "APIStatusError: PRIVATE [REDACTED]",
-        ),
-        (
-            "provider rejected token sk-proj-secret_key with status 401",
-            "provider rejected token sk-[REDACTED] with status 401",
-        ),
-    ],
-    ids=["private_block", "secret_key"],
-)
-def test_redact_sensitive_error_text(error_text: str, expected: str) -> None:
-    """Test backend error text redaction removes prompt and key secrets."""
-    assert _redact_sensitive_error_text(error_text) == expected
 
 
 # --- Test Jinja2 template rendering ---


### PR DESCRIPTION
## Description

RSPEED-3297: Remove the unused `rlsapi_v1` sensitive error redactor and its dedicated tests. The helper no longer has callers, so this keeps the endpoint smaller without changing runtime behavior.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: pi, CodeRabbit
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #RSPEED-3297
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- `uv run pytest tests/unit/app/endpoints/test_rlsapi_v1.py`
- `uv run make format`
- `uv run make verify` (fails on existing missing type annotations in `tests/integration/container_lifecycle/test_container_lifecycle.py`, unrelated to this PR)
- `~/bin/coderabbit review --agent --base origin/main -c .coderabbit.yaml` (0 findings)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified backend error handling by removing a previously applied layer of error text masking.
  * Updated automated tests to match the revised error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->