### PR TITLE
LCORE-1860: Add E2E tests for degraded mode startup scenarios

### DIFF
--- a/tests/e2e/configuration/server-mode/lightspeed-stack-degraded-mode.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-degraded-mode.yaml
@@ -1,0 +1,25 @@
+name: Lightspeed Core Service (LCS) - Degraded Mode Test
+service:
+  host: 0.0.0.0
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  # Server mode - connects to separate llama-stack service
+  use_as_library_client: false
+  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  api_key: xyzzy
+  # Enable degraded mode to allow startup without llama-stack
+  allow_degraded_mode: true
+user_data_collection:
+  feedback_enabled: true
+  feedback_storage: "/tmp/data/feedback"
+  transcripts_enabled: true
+  transcripts_storage: "/tmp/data/transcripts"
+authentication:
+  module: "noop"
+inference:
+  default_provider: openai
+  default_model: gpt-4o-mini

--- a/tests/e2e/features/degraded_mode_startup.feature
+++ b/tests/e2e/features/degraded_mode_startup.feature
@@ -1,0 +1,40 @@
+@e2e_group_3 @skip-in-library-mode @Authorized
+Feature: Degraded mode startup
+
+  End-to-end scenarios that test LCORE startup behavior when llama-stack
+  is NOT available at startup time and allow_degraded_mode is enabled.
+
+  These tests verify that LCORE metrics correctly reflect startup state
+  in both healthy and degraded modes.
+
+  Background:
+    Given The service is started locally
+      And The system is in default state
+      And REST API service prefix is /v1
+      And the Lightspeed stack configuration directory is "tests/e2e/configuration"
+
+  Scenario: Degraded mode metric is set to 0.0 when started with llama-stack
+    Given The service uses the lightspeed-stack-degraded-mode.yaml configuration
+      And The service is restarted
+    When I access endpoint "metrics" using HTTP GET method
+    Then The status code of the response is 200
+    And The response body contains "ls_started_in_degraded_mode 0.0"
+
+  Scenario: Degraded mode metric is set to 1.0 when started without llama-stack
+    Given The llama-stack connection is disrupted
+      And The service uses the lightspeed-stack-degraded-mode.yaml configuration
+      And The service is restarted
+    When I access endpoint "metrics" using HTTP GET method
+    Then The status code of the response is 200
+    And The response body contains "ls_started_in_degraded_mode 1.0"
+
+  Scenario: Readiness endpoint reports degraded state when started without llama-stack
+    Given The llama-stack connection is disrupted
+      And The service uses the lightspeed-stack-degraded-mode.yaml configuration
+      And The service is restarted
+    When I access endpoint "readiness" using HTTP GET method
+    Then The status code of the response is 503
+    And The body of the response, ignoring the "providers" field, is the following
+    """
+    {"ready": false, "reason": "Cannot connect to backend service", "overall_status": "unhealthy", "impacts": ["LLM inference unavailable", "Provider health checks unavailable"]}
+    """

--- a/tests/e2e/features/steps/common_http.py
+++ b/tests/e2e/features/steps/common_http.py
@@ -112,6 +112,19 @@ def check_response_body_does_not_contain(context: Context, substring: str) -> No
     ), f"The response text '{context.response.text}' contains '{substring}'"
 
 
+@then('The response body contains "{substring}"')
+def check_response_contains_substring(context: Context, substring: str) -> None:
+    """Check that response body contains a specific substring.
+
+    This step handles quoted strings and performs exact matching
+    (case-sensitive) for metrics and structured output validation.
+    """
+    assert context.response is not None, "Request needs to be performed first"
+    assert (
+        substring in context.response.text
+    ), f"Expected '{substring}' in response, but got: {context.response.text[:200]}"
+
+
 @then("The body of the response is the following")
 def check_prediction_result(context: Context) -> None:
     """Check the content of the response to be exactly the same.


### PR DESCRIPTION
## Description

Add end-to-end tests to verify LCORE behavior when starting without llama-stack and `allow_degraded_mode` is enabled.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for starting the service in degraded mode when a downstream dependency is unavailable.
  * Added checks for degraded-mode metrics and readiness responses during startup.

* **Bug Fixes**
  * Improved service startup validation so degraded mode behavior is verified through HTTP endpoints and response content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->