### PR TITLE
Fix OKP Guide Solr filter by version

### DIFF
--- a/docs/okp_guide.md
+++ b/docs/okp_guide.md
@@ -73,7 +73,7 @@ podman run --rm -d -p 8081:8080 registry.redhat.io/offline-knowledge-portal/rhok
 
 > **Note:** The default OKP URL is configured via the `RH_SERVER_OKP` environment variable
 > (see Step 2). You can override this by setting a different value for
-> `RH_SERVER_OKP`, or by changing the `okp.rhokp_url` field in 
+> `RH_SERVER_OKP`, or by changing the `okp.rhokp_url` field in
 > `lightspeed-stack.yaml`.
 ---
 
@@ -140,7 +140,7 @@ If you want to filter the docs to a specific product, you can include a static q
 ```yaml
 okp:
   offline: true
-  chunk_filter_query: "product:*openshift*"
+  chunk_filter_query: "product:*openshift* AND product_version:4.21"
 ```
 
 When you launch Lightspeed stack it will augment the Llamastack run.yaml with
@@ -220,7 +220,7 @@ curl -sX POST http://localhost:8080/v1/query \
           "type": "and",
           "filters": [
             {"type": "eq", "key": "product", "value": "openshift_container_platform"},
-            {"type": "eq", "key": "version", "value": "4.21"}
+            {"type": "eq", "key": "product_version", "value": "4.21"}
           ]
         }
       }


### PR DESCRIPTION
## Description

In Solr, the field is defined as "product_version" rather than "version". As a result, filtering on version returns the error: undefined field version.

Ref: https://gitlab.cee.redhat.com/offline-program/mince/-/blob/fee1ab8ae4856a7a1dcc5bb410996f4a097111ba/src/solr/configs/portal-rag/conf/schema.xml#L125

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

None

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Just try the Solr filter :-)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OKP and Lightspeed Stack setup guidance for clearer configuration.
  * Refined the example search filter to target OpenShift content for a specific product version.
  * Adjusted the dynamic filter example to use the updated version field name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->