### PR TITLE
RHIDP-14062: update provider types for synthesizer

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -20056,6 +20056,8 @@
                         "type": "string",
                         "enum": [
                             "openai",
+                            "ollama",
+                            "vllm",
                             "sentence_transformers",
                             "azure",
                             "vertexai",

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -749,13 +749,13 @@ def apply_high_level_inference(
         }
 
         provider_config: dict[str, Any] = {}
+        if provider.get("extra"):
+            provider_config.update(provider["extra"])
         if provider.get("api_key_env"):
             key_field = API_KEY_FIELD_MAP.get(ls_provider_type, "api_key")
             provider_config[key_field] = "${env." + provider["api_key_env"] + "}"
         if provider.get("allowed_models"):
             provider_config["allowed_models"] = provider["allowed_models"]
-        if provider.get("extra"):
-            provider_config.update(provider["extra"])
         if provider_config:
             entry["config"] = provider_config
 

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -38,12 +38,20 @@ logger = get_logger(__name__)
 # a unit test so a new Literal value cannot be added without a mapping.
 PROVIDER_TYPE_MAP: dict[str, str] = {
     "openai": "remote::openai",
+    "ollama": "remote::ollama",
+    "vllm": "remote::vllm",
     "sentence_transformers": "inline::sentence-transformers",
     "azure": "remote::azure",
     "vertexai": "remote::vertexai",
     "watsonx": "remote::watsonx",
     "vllm_rhaiis": "remote::vllm",
     "vllm_rhel_ai": "remote::vllm",
+}
+
+# Maps Llama Stack provider_type -> config field name for the auth token.
+# Providers not listed default to "api_key".
+API_KEY_FIELD_MAP: dict[str, str] = {
+    "remote::vllm": "api_token",
 }
 
 # Package-relative path to the built-in default baseline run.yaml shipped with
@@ -734,14 +742,16 @@ def apply_high_level_inference(
     for provider in providers:
         provider_type = provider["type"]
         emitted_id = provider_type.replace("_", "-")
+        ls_provider_type = PROVIDER_TYPE_MAP[provider_type]
         entry: dict[str, Any] = {
             "provider_id": emitted_id,
-            "provider_type": PROVIDER_TYPE_MAP[provider_type],
+            "provider_type": ls_provider_type,
         }
 
         provider_config: dict[str, Any] = {}
         if provider.get("api_key_env"):
-            provider_config["api_key"] = "${env." + provider["api_key_env"] + "}"
+            key_field = API_KEY_FIELD_MAP.get(ls_provider_type, "api_key")
+            provider_config[key_field] = "${env." + provider["api_key_env"] + "}"
         if provider.get("allowed_models"):
             provider_config["allowed_models"] = provider["allowed_models"]
         if provider.get("extra"):

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -678,6 +678,8 @@ class UnifiedInferenceProvider(ConfigurationBase):
 
     type: Literal[
         "openai",
+        "ollama",
+        "vllm",
         "sentence_transformers",
         "azure",
         "vertexai",

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -220,6 +220,31 @@ def test_apply_high_level_inference_maps_vllm() -> None:
     assert entry["config"]["base_url"] == "${env.VLLM_URL:=}"
 
 
+def test_apply_high_level_inference_extra_cannot_override_api_key_env() -> None:
+    """api_key_env always wins over a conflicting key in extra."""
+    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    inference = {
+        "providers": [
+            {
+                "type": "vllm",
+                "api_key_env": "VLLM_API_KEY",
+                "extra": {"api_token": "hardcoded"},
+            }
+        ]
+    }
+    apply_high_level_inference(ls_config, inference)
+    entry = ls_config["providers"]["inference"][0]
+    assert entry["config"]["api_token"] == "${env.VLLM_API_KEY}"
+
+
+def test_unified_inference_provider_accepts_ollama_and_vllm() -> None:
+    """Pydantic model accepts the new ollama and vllm Literal values."""
+    ollama = UnifiedInferenceProvider(type="ollama")
+    assert ollama.type == "ollama"
+    vllm = UnifiedInferenceProvider(type="vllm")
+    assert vllm.type == "vllm"
+
+
 def test_apply_high_level_inference_empty_is_noop() -> None:
     """No providers -> the inference list is left as-is."""
     ls_config: dict[str, Any] = {"providers": {"inference": [{"provider_id": "x"}]}}

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -164,6 +164,62 @@ def test_apply_high_level_inference_merges_extra() -> None:
     assert entry["config"] == {"url": "http://x", "tls_verify": False}
 
 
+def test_apply_high_level_inference_emits_api_token_for_vllm() -> None:
+    """vLLM providers emit api_token from api_key_env, not api_key."""
+    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    inference = {
+        "providers": [
+            {"type": "vllm", "api_key_env": "VLLM_API_KEY"},
+            {"type": "vllm_rhaiis", "api_key_env": "VLLM_API_KEY"},
+        ]
+    }
+    apply_high_level_inference(ls_config, inference)
+    vllm = ls_config["providers"]["inference"][0]
+    vllm_rhaiis = ls_config["providers"]["inference"][1]
+    assert vllm["provider_id"] == "vllm"
+    assert vllm["provider_type"] == "remote::vllm"
+    assert vllm["config"]["api_token"] == "${env.VLLM_API_KEY}"
+    assert "api_key" not in vllm["config"]
+    assert vllm_rhaiis["provider_id"] == "vllm-rhaiis"
+    assert vllm_rhaiis["config"]["api_token"] == "${env.VLLM_API_KEY}"
+    assert "api_key" not in vllm_rhaiis["config"]
+
+
+def test_apply_high_level_inference_maps_ollama() -> None:
+    """ollama maps to remote::ollama with extra config merged."""
+    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    inference = {
+        "providers": [
+            {"type": "ollama", "extra": {"base_url": "http://localhost:11434"}}
+        ]
+    }
+    apply_high_level_inference(ls_config, inference)
+    entry = ls_config["providers"]["inference"][0]
+    assert entry["provider_id"] == "ollama"
+    assert entry["provider_type"] == "remote::ollama"
+    assert entry["config"]["base_url"] == "http://localhost:11434"
+
+
+def test_apply_high_level_inference_maps_vllm() -> None:
+    """vllm maps to remote::vllm with extra config merged."""
+    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    inference = {
+        "providers": [
+            {
+                "type": "vllm",
+                "api_key_env": "VLLM_API_KEY",
+                "extra": {"base_url": "${env.VLLM_URL:=}"},
+            }
+        ]
+    }
+    apply_high_level_inference(ls_config, inference)
+    entry = ls_config["providers"]["inference"][0]
+    assert entry["provider_id"] == "vllm"
+    assert entry["provider_type"] == "remote::vllm"
+    assert entry["config"]["api_token"] == "${env.VLLM_API_KEY}"
+    assert entry["config"]["base_url"] == "${env.VLLM_URL:=}"
+
+
 def test_apply_high_level_inference_empty_is_noop() -> None:
     """No providers -> the inference list is left as-is."""
     ls_config: dict[str, Any] = {"providers": {"inference": [{"provider_id": "x"}]}}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Adds basic `vllm` instead of making users feel like they are locking into a certain provider for `vllm` such as `rhaiss`
- Adds `ollama` as a provider
- Fixes api key handling for `vllm` remote types, as it needs `api_token`
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/RHIDP-14062
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional unified inference provider types, including `ollama` and `vllm`.
  * Improved handling of provider-specific authentication fields so credentials are placed in the correct config key automatically.

* **Bug Fixes**
  * Fixed provider configuration output for certain backends so environment-based API credentials are now generated in the expected format.
  * Ensured extra provider settings are preserved when building inference configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->