### PR TITLE
LCORE-2802: Bake embedding model into image and make HF_HUB_OFFLINE o…

### DIFF
--- a/deploy/lightspeed-stack/Containerfile
+++ b/deploy/lightspeed-stack/Containerfile
@@ -132,9 +132,8 @@ ENV PYTHONPATH="/app-root"
 
 # Pre-download embedding model for OKP/Solr vector search (~61MB, baked into image).
 # Uses a dedicated path so the docker-compose HF cache volume mount does not shadow it.
-ENV HF_HOME=/app-root/.hf-models
 RUN mkdir -p /app-root/.hf-models && \
-    python3.12 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('ibm-granite/granite-embedding-30m-english')" && \
+    HF_HOME=/app-root/.hf-models python3.12 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('ibm-granite/granite-embedding-30m-english')" && \
     chown -R 1001:1001 /app-root/.hf-models
 
 # Run the application

--- a/deploy/lightspeed-stack/Containerfile
+++ b/deploy/lightspeed-stack/Containerfile
@@ -130,6 +130,13 @@ ENV PATH="/app-root/.venv/bin:$PATH"
 # We place them at /app-root/providers.d. YAMLs there reference lightspeed_stack_providers.*, so that package must be on PYTHONPATH.
 ENV PYTHONPATH="/app-root"
 
+# Pre-download embedding model for OKP/Solr vector search (~61MB, baked into image).
+# Uses a dedicated path so the docker-compose HF cache volume mount does not shadow it.
+ENV HF_HOME=/app-root/.hf-models
+RUN mkdir -p /app-root/.hf-models && \
+    python3.12 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('ibm-granite/granite-embedding-30m-english')" && \
+    chown -R 1001:1001 /app-root/.hf-models
+
 # Run the application
 EXPOSE 8080
 ENTRYPOINT ["python3.12", "src/lightspeed_stack.py"]

--- a/docker-compose-library.yaml
+++ b/docker-compose-library.yaml
@@ -60,8 +60,6 @@ services:
       - FAISS_VECTOR_STORE_ID=${FAISS_VECTOR_STORE_ID:-}
       # Pass env var from shell into container to access OKP
       - RH_SERVER_OKP=${RH_SERVER_OKP:-}
-      # HuggingFace cache override — set to /app-root/.hf-models to use the baked embedding model.
-      - HF_HOME=${HF_HOME:-}
       # Prevent HuggingFace Hub update checks (HTTP 429 rate-limiting in CI from parallel jobs).
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-1}
     healthcheck:

--- a/docker-compose-library.yaml
+++ b/docker-compose-library.yaml
@@ -58,8 +58,10 @@ services:
       - LLAMA_STACK_LOGGING=${LLAMA_STACK_LOGGING:-}
       # FAISS test and inline RAG config
       - FAISS_VECTOR_STORE_ID=${FAISS_VECTOR_STORE_ID:-}
+      # Pass env var from shell into container to access OKP
+      - RH_SERVER_OKP=${RH_SERVER_OKP:-}
       # Prevent HuggingFace Hub update checks (HTTP 429 rate-limiting in CI from parallel jobs).
-      - HF_HUB_OFFLINE=1
+      - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-1}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/liveness"]
       interval: 10s   # how often to run the check

--- a/docker-compose-library.yaml
+++ b/docker-compose-library.yaml
@@ -60,6 +60,8 @@ services:
       - FAISS_VECTOR_STORE_ID=${FAISS_VECTOR_STORE_ID:-}
       # Pass env var from shell into container to access OKP
       - RH_SERVER_OKP=${RH_SERVER_OKP:-}
+      # HuggingFace cache override — set to /app-root/.hf-models to use the baked embedding model.
+      - HF_HOME=${HF_HOME:-}
       # Prevent HuggingFace Hub update checks (HTTP 429 rate-limiting in CI from parallel jobs).
       - HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-1}
     healthcheck:


### PR DESCRIPTION
## Description

Pre-downloads the `ibm-granite/granite-embedding-30m-english` embedding model (~61MB) into the Docker image at build time for OKP/Solr vector search.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude (Claude Code CLI)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes # [LCORE-2802](https://redhat.atlassian.net/browse/LCORE-2802)

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.

Build verification:
  1. `docker compose -f docker-compose-library.yaml build lightspeed-stack`: image builds successfully with model download completing in ~20s
  2. `docker run --rm --entrypoint ls lightspeed-stack-lightspeed-stack /app-root/.hf-models/hub/`: confirms `models--ibm-granite--granite-embedding-30m-english` is present in the image

End-to-end verification (GitLab CI):
  - Full evaluation pipeline ran successfully against mimir OKP server: 97 conversations, 506 evaluations (303 Pass, 155 Fail, 15 Error, 33 Skipped)
  - RAG queries return populated `rag_chunks` with OKP content (scores ~1489), confirming the baked embedding model works correctly
  - Pipeline completed within the 2-hour timeout on GitLab CI runner

`HF_HUB_OFFLINE` override verified:
  - Default behavior (offline) unchanged when env var is not set
  - Setting `HF_HUB_OFFLINE=0` correctly allows runtime downloads when needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preloads the embedding model used for vector search during image build, helping the app start without needing to fetch it later.
  * Adds support for a new runtime environment variable for OKP-related access.
* **Bug Fixes**
  * Improves container behavior when Hugging Face Hub access is offline by making the setting configurable instead of fixed.
  * Ensures model cache files are stored with the correct ownership for reliable runtime use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->