### PR TITLE
LCORE-2799: Build and release Lightspeed Stack 0.5.2 - bump CHI to A

### DIFF
--- a/.konflux/rpms.in.yaml
+++ b/.konflux/rpms.in.yaml
@@ -7,6 +7,12 @@ packages:
     cmake,
     cargo,
   ]
+upgradePackages:
+  [
+    gnutls,
+    libxslt,
+    openssl-fips-provider,
+  ]
 contentOrigin:
   repofiles: ["./redhat.repo"]
 arches: [x86_64, aarch64]

--- a/.konflux/rpms.lock.yaml
+++ b/.konflux/rpms.lock.yaml
@@ -39,6 +39,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.2.aarch64.rpm
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    size: 244531
+    checksum: sha256:b87f5b4991bb04771ce1c6c26611a9eeb754fa80ffc257199e68db6ed5f03959
+    name: libxslt
+    evr: 1.1.34-13.el9_6.2
+    sourcerpm: libxslt-1.1.34-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/patch-2.7.6-16.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-eus-rpms
     size: 129037
@@ -67,6 +74,13 @@ arches:
     name: ed
     evr: 1.14.2-12.el9
     sourcerpm: ed-1.14.2-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.4.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 1051990
+    checksum: sha256:e766b1d568983ae2dff7ae7ccec729f5edd49795ef367a806ed06810ee4c68de
+    name: gnutls
+    evr: 3.8.3-6.el9_6.4
+    sourcerpm: gnutls-3.8.3-6.el9_6.4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/i/info-6.7-15.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-eus-rpms
     size: 230301
@@ -74,6 +88,20 @@ arches:
     name: info
     evr: 6.7-15.el9
     sourcerpm: texinfo-6.7-15.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_0.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 10281
+    checksum: sha256:29f0ed0694669438654fd2f7ed288262aafddd84f09ff9fa017cc71ee4990df1
+    name: openssl-fips-provider
+    evr: 3.0.7-11.el9_0
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_0.aarch64.rpm
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    size: 522978
+    checksum: sha256:6699bd711fa3e30f576a062029c62529f362a93657066dd87fc8704d730cff42
+    name: openssl-fips-provider-so
+    evr: 3.0.7-11.el9_0
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
@@ -113,6 +141,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.2.x86_64.rpm
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    size: 247315
+    checksum: sha256:fbaad5f1ca8422cd20ede7324bf4fc2cc013e5ef106f698f89f50271727b6152
+    name: libxslt
+    evr: 1.1.34-13.el9_6.2
+    sourcerpm: libxslt-1.1.34-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/patch-2.7.6-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms
     size: 133240
@@ -141,6 +176,13 @@ arches:
     name: ed
     evr: 1.14.2-12.el9
     sourcerpm: ed-1.14.2-12.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.4.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 1127930
+    checksum: sha256:4e2c0319c285bf9be7db3f2ec0e1437c07f99ce2f7b32f3de4de946670119dfc
+    name: gnutls
+    evr: 3.8.3-6.el9_6.4
+    sourcerpm: gnutls-3.8.3-6.el9_6.4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/i/info-6.7-15.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms
     size: 233806
@@ -148,5 +190,19 @@ arches:
     name: info
     evr: 6.7-15.el9
     sourcerpm: texinfo-6.7-15.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_0.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 10316
+    checksum: sha256:9cd99e98e91da4b15eb773b4be035aaee63a369fda70cbb38371455c3217bed1
+    name: openssl-fips-provider
+    evr: 3.0.7-11.el9_0
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_0.x86_64.rpm
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    size: 588706
+    checksum: sha256:8b6af65ac0eafbd1eb85d0f73c8255ea979418032fd4aa189a4a65004bcf1ef3
+    name: openssl-fips-provider-so
+    evr: 3.0.7-11.el9_0
+    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
   source: []
   module_metadata: []

--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,8 @@ USER root
 # Install gcc - required by polyleven python package on aarch64
 # (dependency of autoevals, no pre-built binary wheels for linux on aarch64)
 # cmake and cargo are required by fastuuid, maturin
-RUN ${BUILDER_DNF_COMMAND} install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs gcc gcc-c++ cmake cargo
+RUN ${BUILDER_DNF_COMMAND} install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs gcc gcc-c++ cmake cargo && \
+    ${BUILDER_DNF_COMMAND} update -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs gnutls libxslt openssl-fips-provider
 
 # Install uv package manager
 RUN pip3.12 install "uv>=0.8.15"
@@ -114,7 +115,8 @@ COPY --from=builder /app-root/LICENSE /licenses/
 USER root
 
 # Additional tools for derived images
-RUN ${RUNTIME_DNF_COMMAND} install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs jq patch
+RUN ${RUNTIME_DNF_COMMAND} install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs jq patch && \
+    ${RUNTIME_DNF_COMMAND} update -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs gnutls libxslt openssl-fips-provider
 
 # Create llama-stack directories for library mode
 RUN mkdir -p /opt/app-root/src/.llama/storage /opt/app-root/src/.llama/providers.d && \


### PR DESCRIPTION
## Description

The following fixable CVEs were identified in the stage image registry.stage.redhat.io/lightspeed-core/lightspeed-stack-rhel9:0.5.2 resulting in CHI of B:

```
Package  | Installed | Fixed Version | CVEs | Errata
gnutls   | 3.8.3-6.el9_6.3 | 3.8.3-6.el9_6.4 | 12 CVEs (4 Important, 7 Moderate, 1 Low) | RHSA-2026:30004
libxslt    | 1.1.34-13.el9_6.1 | 1.1.34-14.el9_4 / 1.1.34-13.el9_6.2 | 2 CVEs (Moderate) | RHSA-2025:9016, RHSA-2026:29807
openssl-fips-provider | 3.0.7-6.el9_5 | 3.0.7-11.el9_0 | 1 CVE (Moderate) | RHSA-2026:28832
```

This branch is applying updates to those packages to fix these CVEs and bump the CHI to A

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #  https://redhat.atlassian.net/browse/LCORE-2799
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
