### PR TITLE
LCORE-2852: `no_tools` affects skills

### DIFF
--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -234,6 +234,7 @@ async def query_endpoint_handler(
         moderation_result,
         endpoint_path,
         compaction.original_input if compaction.compacted else None,
+        no_tools=bool(query_request.no_tools),
     )
 
     if moderation_result.decision == "passed":

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -338,6 +338,7 @@ async def streaming_query_endpoint_handler(  # pylint: disable=too-many-locals
         responses_params=responses_params,
         context=context,
         endpoint_path=endpoint_path,
+        no_tools=bool(query_request.no_tools),
     )
 
     # Combine inline RAG results (BYOK + Solr) with tool-based results

--- a/src/utils/agents/query.py
+++ b/src/utils/agents/query.py
@@ -283,6 +283,7 @@ async def retrieve_agent_response(
     moderation_result: ShieldModerationResult,
     endpoint_path: str,
     _original_input: Optional[ResponseInput] = None,
+    no_tools: bool = False,
 ) -> TurnSummary:
     """Retrieve a turn summary from a blocking agent run.
 
@@ -294,7 +295,7 @@ async def retrieve_agent_response(
         moderation_result: Shield moderation outcome for the turn.
         endpoint_path: Endpoint path used for metric labeling.
         _original_input: Original user input before the explicit-input rewrite.
-
+        no_tools: Whether to skip tool processing.
     Returns:
         Turn summary for the completed agent run.
 
@@ -313,7 +314,9 @@ async def retrieve_agent_response(
             llm_response=moderation_result.message,
         )
     try:
-        agent = build_agent(client, responses_params, configuration.skills)
+        agent = build_agent(
+            client, responses_params, configuration.skills, no_tools=no_tools
+        )
         logger.debug("Starting agent non-streaming response processing")
         run_result = await agent.run(cast(str, responses_params.input))
     except (AgentRunError, APIStatusError, APIConnectionError, RuntimeError) as exc:

--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -85,6 +85,7 @@ async def retrieve_agent_response_generator(
     responses_params: ResponsesApiParams,
     context: ResponseGeneratorContext,
     endpoint_path: str,
+    no_tools: bool = False,
 ) -> tuple[AsyncIterator[str], TurnSummary]:
     """Return the SSE generator and mutable turn summary for an agent run.
 
@@ -92,6 +93,7 @@ async def retrieve_agent_response_generator(
         responses_params: Prepared Responses API parameters.
         context: Streaming request context and moderation result.
         endpoint_path: Endpoint path used for metric labeling.
+        no_tools: Whether to skip tool processing.
 
     Returns:
         Tuple of SSE async iterator and mutable turn summary.
@@ -118,7 +120,9 @@ async def retrieve_agent_response_generator(
                 turn_summary,
             )
 
-        agent = build_agent(context.client, responses_params, configuration.skills)
+        agent = build_agent(
+            context.client, responses_params, configuration.skills, no_tools=no_tools
+        )
 
         return (
             agent_response_generator(

--- a/src/utils/pydantic_ai.py
+++ b/src/utils/pydantic_ai.py
@@ -7,7 +7,7 @@ from typing import Any, Final, Optional, cast
 from llama_stack.core.library_client import AsyncLlamaStackAsLibraryClient
 from llama_stack_client import AsyncLlamaStackClient
 from pydantic_ai.agent import Agent
-from pydantic_ai.capabilities import AgentCapability
+from pydantic_ai.capabilities import AbstractCapability, AgentCapability
 from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 from pydantic_ai_skills import SkillsCapability
 
@@ -98,18 +98,29 @@ def _skills_capability(
 
 def _agent_capabilities(
     skills: Optional[SkillsConfiguration],
-) -> Optional[list[AgentCapability[Any]]]:
+    no_tools: bool = False,
+) -> Optional[list[AgentCapability[object]]]:
     """Assemble pydantic-ai capabilities for an LCS agent.
 
     Args:
         skills: Agent skills configuration from LCS, or None when skills are disabled.
+        no_tools: When True, omit capabilities that expose a toolset via ``get_toolset()``.
 
     Returns:
         Configured capabilities, or None when no capabilities are enabled.
     """
-    capabilities: list[AgentCapability[SkillsCapability]] = []
+    capabilities: list[AgentCapability[object]] = []
     if skills_capability := _skills_capability(skills):
         capabilities.append(skills_capability)
+    if no_tools:
+        capabilities = [
+            capability
+            for capability in capabilities
+            if not (
+                isinstance(capability, AbstractCapability)
+                and capability.get_toolset() is not None
+            )
+        ]
     return capabilities or None
 
 
@@ -117,6 +128,7 @@ def build_agent(
     client: AsyncLlamaStackClient | AsyncLlamaStackAsLibraryClient,
     responses_params: ResponsesApiParams,
     skills: Optional[SkillsConfiguration],
+    no_tools: bool = False,
 ) -> Agent[None, str]:
     """Build a Pydantic AI agent that mirrors ``responses_params`` on the Llama Stack backend.
 
@@ -129,6 +141,7 @@ def build_agent(
         client: Initialized Llama Stack client from ``AsyncLlamaStackClientHolder().get_client()``.
         responses_params: Parameters produced by ``prepare_responses_params`` for this turn.
         skills: Agent skills configuration from LCS, or None when skills are disabled.
+        no_tools: When True, omit capabilities that expose a toolset via ``get_toolset()``.
 
     Returns:
         ``Agent`` configured for ``await agent.run(...)`` (or streaming) against the same
@@ -136,6 +149,7 @@ def build_agent(
     """
     provider = llama_stack_provider_from_client(client)
     settings = _model_settings_from_responses_params(responses_params)
+    capabilities = _agent_capabilities(skills, no_tools=no_tools)
 
     model = LlamaStackResponsesModel(
         responses_params.model,
@@ -145,6 +159,6 @@ def build_agent(
     return Agent(
         model,
         instructions=responses_params.instructions,
-        capabilities=_agent_capabilities(skills),
+        capabilities=capabilities,
         defer_model_check=True,
     )

--- a/tests/unit/utils/test_pydantic_ai.py
+++ b/tests/unit/utils/test_pydantic_ai.py
@@ -344,3 +344,22 @@ class TestBuildAgent:
             type(capability) for capability in agent._root_capability.capabilities
         }
         assert SkillsCapability not in capability_types
+
+    def test_agent_excludes_tool_capabilities_when_no_tools(
+        self,
+        mock_client: AsyncLlamaStackClient,
+        mock_params: ResponsesApiParams,
+        mock_skills_configuration: SkillsConfiguration,
+    ) -> None:
+        """Test that build_agent omits tool-bearing capabilities when no_tools=True."""
+        agent = build_agent(
+            mock_client,
+            mock_params,
+            mock_skills_configuration,
+            no_tools=True,
+        )
+
+        capability_types = {
+            type(capability) for capability in agent._root_capability.capabilities
+        }
+        assert SkillsCapability not in capability_types


### PR DESCRIPTION
## Description

When clients set `no_tools=true` on query or streaming query requests, the agent should not register tool-bearing capabilities (including skills). Previously, `no_tools` was not passed through to agent construction, so skills could still be attached even when tools were explicitly disabled.

This change threads the `no_tools` flag from the query and streaming query endpoints into `build_agent`, and filters out any pydantic-ai capability that exposes a toolset via `get_toolset()`. A unit test confirms that `SkillsCapability` is omitted when `no_tools=True`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: Cursor

## Related Tickets & Documents

- Related Issue #LCORE-2852
- Closes #LCORE-2852

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Added unit test `test_agent_excludes_tool_capabilities_when_no_tools` in `tests/unit/utils/test_pydantic_ai.py` to verify `SkillsCapability` is excluded when `no_tools=True`.
- Manually verified query and streaming query endpoints with `no_tools=true` to confirm skills/tool capabilities are not attached to the agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `no tools` option for query responses, allowing requests to skip tool-enabled processing.
  * Added the same `no tools` option to streaming responses for consistent behavior.
* **Bug Fixes**
  * Tool usage now cleanly defaults to normal when the `no tools` preference is unset.
* **Tests**
  * Added a unit test to verify tool-related capabilities are excluded when `no tools` is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->