### PR TITLE
LCORE-2799: Post 0.5.2 fixes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -70,10 +70,11 @@ RUN set -eux; \
 RUN if [ -f /cachi2/cachi2.env ]; then \
     . /cachi2/cachi2.env && \
     python3.12 -c "import os,re;d=os.environ['PIP_FIND_LINKS'];fs=os.listdir(d);rp={re.split(r'-\d+-(?:cp|py|pp)',f)[0] for f in fs if f.endswith('.whl') and re.search(r'-\d+-(?:cp|py|pp)',f)};[os.remove(os.path.join(d,f)) for f in fs if f.endswith('.whl') and not re.search(r'-\d+-(?:cp|py|pp)',f) and f.rsplit('-',3)[0] in rp]" && \
-    uv venv && \
+    uv venv --python python3.12 && \
     . .venv/bin/activate && \
-    pip3.12 install --no-cache-dir --ignore-installed --no-index --find-links ${PIP_FIND_LINKS} --no-deps -r requirements.hashes.wheel.txt -r requirements.hashes.wheel.pypi.txt -r requirements.hashes.source.txt && \
-    pip3.12 check; \
+    sed -i '/^--index-url/d' requirements.hashes.wheel.txt requirements.hashes.wheel.pypi.txt requirements.hashes.source.txt && \
+    uv pip install --no-cache --reinstall --no-index --find-links ${PIP_FIND_LINKS} --no-deps -r requirements.hashes.wheel.txt -r requirements.hashes.wheel.pypi.txt -r requirements.hashes.source.txt && \
+    uv pip check; \
     else \
     uv sync --locked --no-dev --group llslibdev; \
     fi


### PR DESCRIPTION
## Description

Post 0.5.2 fixes
Summary: Packages installed into wrong Python environment in hermetic Containerfile build

Problem: The released registry.redhat.io/lightspeed-core/lightspeed-stack-rhel9:0.5.2 image failed at startup with ModuleNotFoundError: No module named 'yaml' — PyYAML and all other dependencies were installed into the system site-packages instead of the application's .venv.

Root cause: The Containerfile's hermetic install step was:
```
uv venv --seed --no-index --find-links ${PIP_FIND_LINKS} && \
. .venv/bin/activate && \
pip install --no-cache-dir ... -r requirements.hashes.wheel.txt ...
```

Three issues cascaded:

uv venv --seed fails hermetically — it tries to download pip from the network. In the Konflux no-network build, --seed can't install pip into the venv.
Without --seed, the venv has no pip — so pip install (or python3.12 -m pip) can't run from within the venv.
System pip3.12 ignores the venv — calling /usr/bin/pip3.12 directly installs to /opt/app-root/lib64/python3.12/site-packages/ (the system/base-image location), not /app-root/.venv/. The activate script modifies PATH and VIRTUAL_ENV, but system pip doesn't honor those — it uses its own sys.prefix.
The result: all 126 packages landed in system site-packages. The image's PATH points to .venv/bin, and Python at runtime uses .venv — which is empty.

Fix: Replace pip install with uv pip install, which natively targets the active venv without needing pip installed there:
```
uv venv --python python3.12 && \
. .venv/bin/activate && \
sed -i '/^--index-url/d' requirements.hashes.wheel.txt requirements.hashes.wheel.pypi.txt requirements.hashes.source.txt && \
uv pip install --no-cache --reinstall --no-index --find-links ${PIP_FIND_LINKS} --no-deps -r requirements.hashes.wheel.txt -r requirements.hashes.wheel.pypi.txt -r requirements.hashes.source.txt && \
uv pip check
```
Key changes:
```
uv venv --python python3.12 — no --seed (no network needed), explicit Python version (base image defaults to 3.9)
sed -i '/^--index-url/d' — strips conflicting --index-url directives from requirements files (uv rejects multiple index URLs even with --no-index)
uv pip install — installs directly into the active venv; no pip module needed in the venv
uv pip check — verifies all dependencies are satisfied in the venv
```
Why this wasn't caught in testing:

Unit and E2E tests run via uv run in the development venv — not inside the container
The Konflux integration test pipeline deploys the image on a ROSA cluster, but only runs post-release — too late
No lightweight container smoke test (e.g., podman run --rm $IMAGE python3.12 -c "from configuration import configuration") exists in the build pipeline


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2799
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
