### PR TITLE
LCORE-2337: Migration tool — dumb-mode lift-and-shift

### DIFF
--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -10,6 +10,7 @@ from argparse import ArgumentParser
 import constants
 from configuration import configuration
 from constants import LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR
+from llama_stack_configuration import migrate_config_dumb
 from log import get_logger, setup_logging
 from runners.quota_scheduler import start_quota_scheduler
 from runners.uvicorn import start_uvicorn
@@ -75,6 +76,31 @@ def create_argument_parser() -> ArgumentParser:
         f"{constants.DEFAULT_SYNTHESIZED_CONFIG_PATH})",
         default=None,
     )
+    parser.add_argument(
+        "--migrate-config",
+        dest="migrate_config",
+        help="migrate a legacy two-file config to a unified single file and "
+        "exit. Lifts the run.yaml given by --run-yaml into the "
+        "llama_stack.config.native_override of the -c lightspeed-stack.yaml "
+        "and writes the result to --migrate-output. Replace literal secrets "
+        "with ${env.VAR} references before or after migrating.",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--run-yaml",
+        dest="run_yaml",
+        help="path to the legacy Llama Stack run.yaml to migrate "
+        "(used with --migrate-config)",
+        default=None,
+    )
+    parser.add_argument(
+        "--migrate-output",
+        dest="migrate_output",
+        help="path to write the unified lightspeed-stack.yaml "
+        "(used with --migrate-config)",
+        default=None,
+    )
 
     return parser
 
@@ -90,9 +116,10 @@ def main() -> None:
       configuration.json and exits (exits with status 1 on failure).
     - If --dump-schema is provided, writes the active configuration schema to
       schema.json and exits (exits with status 1 on failure).
-    - If --generate-llama-stack-configuration is provided, generates and stores
-      the Llama Stack configuration to the specified output file and exits
-      (exits with status 1 on failure).
+    - If --migrate-config is provided, migrates the legacy two-file config
+      (--run-yaml plus the -c lightspeed-stack.yaml) into a unified single
+      file at --migrate-output and exits (status 1 on failure or missing
+      flags).
     - Otherwise, sets LIGHTSPEED_STACK_CONFIG_PATH for worker processes, starts
       the quota scheduler, and starts the Uvicorn web service.
 
@@ -107,6 +134,24 @@ def main() -> None:
     if args.verbose:
         os.environ[LIGHTSPEED_STACK_LOG_LEVEL_ENV_VAR] = "DEBUG"
         setup_logging()
+
+    # --migrate-config converts a legacy two-file config to a unified single
+    # file and exits. It reads the legacy files raw (the -c config still uses
+    # the legacy library_client_config_path shape), so it must run before
+    # load_configuration, which would validate against the current schema.
+    if args.migrate_config:
+        if args.run_yaml is None or args.migrate_output is None:
+            logger.error("--migrate-config requires --run-yaml and --migrate-output")
+            raise SystemExit(1)
+        try:
+            migrate_config_dumb(args.run_yaml, args.config_file, args.migrate_output)
+            logger.info(
+                "Migrated unified configuration written to %s", args.migrate_output
+            )
+        except Exception as e:
+            logger.error("Failed to migrate configuration: %s", e)
+            raise SystemExit(1) from e
+        return
 
     configuration.load_configuration(args.config_file)
     logger.info("Configuration: %s", configuration.configuration)

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -16,6 +16,8 @@ Two related responsibilities live here:
   operator-facing artifact.
 """
 
+# pylint: disable=too-many-lines
+
 import copy
 import os
 from argparse import ArgumentParser
@@ -898,6 +900,70 @@ def synthesize_to_file(
     os.chmod(str(path), 0o600)
 
     logger.info("Wrote synthesized Llama Stack configuration to %s (mode 0600)", path)
+
+
+# =============================================================================
+# Migration: legacy two-file config -> unified single file (LCORE-2337)
+# =============================================================================
+
+
+def migrate_config_dumb(
+    run_yaml_path: str,
+    lightspeed_yaml_path: str,
+    output_path: str,
+) -> None:
+    """Migrate a legacy two-file config to a unified single file (dumb mode).
+
+    "Dumb" lift-and-shift: the operator's ``lightspeed-stack.yaml`` is kept
+    verbatim except for its ``llama_stack`` section, where
+    ``library_client_config_path`` is dropped and replaced by a unified
+    ``config`` block that lifts the *entire* legacy ``run.yaml`` body into
+    ``native_override`` with ``baseline: empty``. Synthesizing the result then
+    starts from an empty baseline and deep-merges only the lifted run.yaml, so
+    it reproduces the original run.yaml (Decision T7) — a lossless round-trip,
+    without trying to factor anything into high-level sections (that "smart"
+    mode is deferred future work).
+
+    All other ``lightspeed-stack.yaml`` content (name, service, byok_rag, …) is
+    preserved untouched, so any existing enrichment keeps working in unified
+    mode exactly as it did in legacy mode.
+
+    Parameters:
+        run_yaml_path: Path to the legacy Llama Stack ``run.yaml``.
+        lightspeed_yaml_path: Path to the legacy ``lightspeed-stack.yaml``.
+        output_path: Path to write the unified ``lightspeed-stack.yaml``.
+
+    Returns:
+        None.
+
+    Raises:
+        OSError: If an input file cannot be read or the output cannot be
+            written.
+        yaml.YAMLError: If an input file is not valid YAML.
+    """
+    with open(run_yaml_path, "r", encoding="utf-8") as file:
+        run_yaml = yaml.safe_load(file)
+    with open(lightspeed_yaml_path, "r", encoding="utf-8") as file:
+        lcs_config = yaml.safe_load(file)
+
+    # Preserve the whole lightspeed-stack.yaml; only rewrite the llama_stack
+    # section: drop the legacy path, add the unified config block.
+    llama_stack = dict(lcs_config.get("llama_stack") or {})
+    llama_stack.pop("library_client_config_path", None)
+    llama_stack["config"] = {
+        "baseline": "empty",
+        "native_override": run_yaml,
+    }
+    lcs_config["llama_stack"] = llama_stack
+
+    logger.info(
+        "Migrating legacy config (%s + %s) to unified %s",
+        lightspeed_yaml_path,
+        run_yaml_path,
+        output_path,
+    )
+    with open(output_path, "w", encoding="utf-8") as file:
+        yaml.dump(lcs_config, file, Dumper=YamlDumper, default_flow_style=False)
 
 
 # =============================================================================

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -940,11 +940,22 @@ def migrate_config_dumb(
         OSError: If an input file cannot be read or the output cannot be
             written.
         yaml.YAMLError: If an input file is not valid YAML.
+        ValueError: If either input file does not parse to a mapping (e.g. an
+            empty or comment-only file).
     """
     with open(run_yaml_path, "r", encoding="utf-8") as file:
         run_yaml = yaml.safe_load(file)
     with open(lightspeed_yaml_path, "r", encoding="utf-8") as file:
         lcs_config = yaml.safe_load(file)
+
+    # An empty or comment-only YAML file parses to None; fail with a clear
+    # message rather than a downstream AttributeError/TypeError.
+    if not isinstance(lcs_config, dict):
+        raise ValueError(
+            f"{lightspeed_yaml_path} did not parse to a mapping; cannot migrate."
+        )
+    if not isinstance(run_yaml, dict):
+        raise ValueError(f"{run_yaml_path} did not parse to a mapping; cannot migrate.")
 
     # Preserve the whole lightspeed-stack.yaml; only rewrite the llama_stack
     # section: drop the legacy path, add the unified config block.
@@ -962,8 +973,13 @@ def migrate_config_dumb(
         run_yaml_path,
         output_path,
     )
-    with open(output_path, "w", encoding="utf-8") as file:
+    # The lifted run.yaml may carry literal secrets, so write owner-only (0600),
+    # matching synthesize_to_file. O_CREAT's mode only applies on create, so
+    # chmod after the write also tightens a pre-existing file.
+    fd = os.open(output_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as file:
         yaml.dump(lcs_config, file, Dumper=YamlDumper, default_flow_style=False)
+    os.chmod(output_path, 0o600)
 
 
 # =============================================================================

--- a/tests/unit/test_lightspeed_stack.py
+++ b/tests/unit/test_lightspeed_stack.py
@@ -1,6 +1,11 @@
 """Unit tests for functions defined in src/lightspeed_stack.py."""
 
-from lightspeed_stack import create_argument_parser
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lightspeed_stack import create_argument_parser, main
 
 
 def test_create_argument_parser() -> None:
@@ -14,3 +19,81 @@ def test_create_argument_parser() -> None:
     arg_parser = create_argument_parser()
     # nothing more to test w/o actual parsing is done
     assert arg_parser is not None
+
+
+def test_argument_parser_accepts_migrate_flags() -> None:
+    """The parser accepts --migrate-config, --run-yaml, and --migrate-output."""
+    args = create_argument_parser().parse_args(
+        [
+            "--migrate-config",
+            "--run-yaml",
+            "run.yaml",
+            "-c",
+            "lightspeed-stack.yaml",
+            "--migrate-output",
+            "unified.yaml",
+        ]
+    )
+    assert args.migrate_config is True
+    assert args.run_yaml == "run.yaml"
+    assert args.config_file == "lightspeed-stack.yaml"
+    assert args.migrate_output == "unified.yaml"
+
+
+def test_main_migrate_config_writes_unified_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--migrate-config` migrates the legacy pair and exits without starting the service."""
+    run_path = tmp_path / "run.yaml"
+    run_path.write_text(
+        yaml.dump({"version": 2, "apis": ["inference"]}), encoding="utf-8"
+    )
+    lcs_path = tmp_path / "lightspeed-stack.yaml"
+    lcs_path.write_text(
+        yaml.dump(
+            {
+                "name": "LCS",
+                "llama_stack": {
+                    "use_as_library_client": True,
+                    "library_client_config_path": "run.yaml",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    out_path = tmp_path / "unified.yaml"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "lightspeed-stack",
+            "--migrate-config",
+            "--run-yaml",
+            str(run_path),
+            "-c",
+            str(lcs_path),
+            "--migrate-output",
+            str(out_path),
+        ],
+    )
+
+    main()  # returns early, never starts uvicorn
+
+    migrated = yaml.safe_load(out_path.read_text(encoding="utf-8"))
+    assert "library_client_config_path" not in migrated["llama_stack"]
+    assert migrated["llama_stack"]["config"]["baseline"] == "empty"
+    assert migrated["llama_stack"]["config"]["native_override"] == {
+        "version": 2,
+        "apis": ["inference"],
+    }
+
+
+def test_main_migrate_config_requires_run_yaml_and_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--migrate-config` without --run-yaml / --migrate-output exits with status 1."""
+    monkeypatch.setattr(
+        "sys.argv",
+        ["lightspeed-stack", "--migrate-config", "-c", "lightspeed-stack.yaml"],
+    )
+    with pytest.raises(SystemExit):
+        main()

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -19,6 +19,7 @@ from llama_stack_configuration import (
     apply_high_level_inference,
     deep_merge_list_replace,
     load_default_baseline,
+    migrate_config_dumb,
     synthesize_configuration,
     synthesize_to_file,
 )
@@ -369,3 +370,78 @@ def test_synthesize_to_file_tightens_perms_on_overwrite(tmp_path: Path) -> None:
     synthesize_to_file(lcs, str(out), str(tmp_path))
     assert stat.S_IMODE(os.stat(out).st_mode) == 0o600
     assert yaml.safe_load(out.read_text(encoding="utf-8")) == {"v": 3}
+
+
+# ---------------------------------------------------------------------------
+# migrate_config_dumb (LCORE-2337)
+# ---------------------------------------------------------------------------
+
+
+# A representative legacy run.yaml body with nested maps, lists, and env refs.
+_LEGACY_RUN_YAML: dict[str, Any] = {
+    "version": 2,
+    "apis": ["agents", "inference", "safety", "vector_io"],
+    "providers": {
+        "inference": [
+            {
+                "provider_id": "openai",
+                "provider_type": "remote::openai",
+                "config": {
+                    "api_key": "${env.OPENAI_API_KEY}",
+                    "allowed_models": ["gpt-4o-mini"],
+                },
+            },
+            {
+                "provider_id": "sentence-transformers",
+                "provider_type": "inline::sentence-transformers",
+            },
+        ],
+    },
+    "safety": {"default_shield_id": "llama-guard", "excluded_categories": []},
+}
+
+
+def _write_legacy_pair(tmp_path: Path) -> tuple[str, str]:
+    """Write a legacy run.yaml + lightspeed-stack.yaml pair, return their paths."""
+    run_path = tmp_path / "run.yaml"
+    run_path.write_text(yaml.dump(_LEGACY_RUN_YAML), encoding="utf-8")
+    lcs = {
+        "name": "LCS",
+        "service": {"host": "localhost", "port": 8080},
+        "llama_stack": {
+            "use_as_library_client": True,
+            "library_client_config_path": "run.yaml",
+        },
+    }
+    lcs_path = tmp_path / "lightspeed-stack.yaml"
+    lcs_path.write_text(yaml.dump(lcs), encoding="utf-8")
+    return str(run_path), str(lcs_path)
+
+
+def test_migrate_config_dumb_structure(tmp_path: Path) -> None:
+    """Dumb migration lifts run.yaml into native_override and drops the legacy path."""
+    run_path, lcs_path = _write_legacy_pair(tmp_path)
+    out_path = tmp_path / "unified.yaml"
+    migrate_config_dumb(run_path, lcs_path, str(out_path))
+
+    migrated = yaml.safe_load(out_path.read_text(encoding="utf-8"))
+    # unrelated top-level content preserved
+    assert migrated["name"] == "LCS"
+    assert migrated["service"] == {"host": "localhost", "port": 8080}
+    # legacy path dropped; use_as_library_client preserved
+    assert "library_client_config_path" not in migrated["llama_stack"]
+    assert migrated["llama_stack"]["use_as_library_client"] is True
+    # whole run.yaml lifted into native_override with an empty baseline
+    assert migrated["llama_stack"]["config"]["baseline"] == "empty"
+    assert migrated["llama_stack"]["config"]["native_override"] == _LEGACY_RUN_YAML
+
+
+def test_migrate_then_synthesize_reproduces_run_yaml(tmp_path: Path) -> None:
+    """Round-trip: migrate -> synthesize reproduces the original run.yaml (R4)."""
+    run_path, lcs_path = _write_legacy_pair(tmp_path)
+    out_path = tmp_path / "unified.yaml"
+    migrate_config_dumb(run_path, lcs_path, str(out_path))
+
+    migrated = yaml.safe_load(out_path.read_text(encoding="utf-8"))
+    synthesized = synthesize_configuration(migrated)
+    assert synthesized == _LEGACY_RUN_YAML

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -445,3 +445,27 @@ def test_migrate_then_synthesize_reproduces_run_yaml(tmp_path: Path) -> None:
     migrated = yaml.safe_load(out_path.read_text(encoding="utf-8"))
     synthesized = synthesize_configuration(migrated)
     assert synthesized == _LEGACY_RUN_YAML
+
+
+def test_migrate_config_dumb_writes_output_0600(tmp_path: Path) -> None:
+    """The migrated file may carry lifted secrets, so it is written owner-only."""
+    run_path, lcs_path = _write_legacy_pair(tmp_path)
+    out_path = tmp_path / "unified.yaml"
+    migrate_config_dumb(run_path, lcs_path, str(out_path))
+    assert stat.S_IMODE(os.stat(out_path).st_mode) == 0o600
+
+
+def test_migrate_config_dumb_rejects_non_mapping_inputs(tmp_path: Path) -> None:
+    """An empty/comment-only input fails with a clear ValueError, not AttributeError."""
+    run_path, lcs_path = _write_legacy_pair(tmp_path)
+    out_path = str(tmp_path / "unified.yaml")
+
+    empty_lcs = tmp_path / "empty-lcs.yaml"
+    empty_lcs.write_text("# only a comment\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="did not parse to a mapping"):
+        migrate_config_dumb(run_path, str(empty_lcs), out_path)
+
+    empty_run = tmp_path / "empty-run.yaml"
+    empty_run.write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="did not parse to a mapping"):
+        migrate_config_dumb(str(empty_run), lcs_path, out_path)


### PR DESCRIPTION
## Description

Implements LCORE-2337 — the dumb-mode migration tool, sibling of the merged
LCORE-2336 (unified `lightspeed-stack.yaml` schema + synthesizer).

Adds `--migrate-config`, a lift-and-shift that converts a legacy two-file config
(`run.yaml` + `lightspeed-stack.yaml`) into a unified single file: it drops
`library_client_config_path` and lifts the **entire** `run.yaml` body under
`llama_stack.config.native_override` with `baseline: empty`, preserving all
other `lightspeed-stack.yaml` content. Synthesizing the result reproduces the
original `run.yaml` exactly (lossless round-trip), so existing enrichment keeps
working unchanged. No attempt is made to factor the run.yaml into high-level
sections — that "smart" mode is deferred future work.

- `migrate_config_dumb()` in `src/llama_stack_configuration.py`.
- `--migrate-config`, `--run-yaml`, `--migrate-output` flags in
  `src/lightspeed_stack.py`, dispatched in `main()` before `load_configuration`
  (the `-c` file still uses the legacy shape and is read raw). Missing
  `--run-yaml`/`--migrate-output` exits with status 1; `--help` documents the
  flags and advises replacing literal secrets with `${env.VAR}` references.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-2337
- Closes # LCORE-2337

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

### Manual verification (migrate a legacy config, then boot it)

1. Migrate the repo's CI run.yaml + a legacy lightspeed-stack.yaml:

   ```
   uv run lightspeed-stack --migrate-config \
     --run-yaml tests/e2e/configs/run-ci.yaml \
     -c examples/lightspeed-stack-lls-library.yaml \
     --migrate-output /tmp/unified.yaml
   ```

   The output drops `library_client_config_path` and carries the whole run.yaml
   under `llama_stack.config.native_override` with `baseline: empty`.

2. Boot library mode with the migrated file and query it:

   ```
   export OPENAI_API_KEY=<key>
   uv run lightspeed-stack -c /tmp/unified.yaml
   curl -s localhost:8080/readiness          # {"ready":true,...}
   curl -s -X POST localhost:8080/v1/query -H 'Content-Type: application/json' \
     -d '{"query":"Name three primary colors."}'   # real model response
   ```

3. Lossless round-trip — synthesizing the migrated config reproduces the
   original run.yaml (dict-equal):

   ```
   synthesize_configuration(migrated) == yaml.safe_load(run-ci.yaml)   # True
   ```

### Tests specific to this change

```
uv run python -m pytest tests/unit/test_llama_stack_synthesize.py \
    tests/unit/test_lightspeed_stack.py -q
```

Covers `migrate_config_dumb` structure, the migrate→synthesize round-trip, flag
parsing, the `main()` dispatch, and the missing-flag exit.

### Full unit suite

```
uv run python -m pytest tests/unit/ -q
# 2929 passed, 1 skipped
```

`uv run make verify` passes for all files changed in this PR (black, pylint
10.00/10, ruff, pyright, pydocstyle). NOTE: `make verify`'s `check-types-tests`
is currently red on two pre-existing upstream test-annotation issues
(`tests/unit/conftest.py`, `tests/integration/container_lifecycle/test_container_lifecycle.py`),
neither touched by this PR; CI's mypy scope passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line migration flow to convert older split configuration files into a single unified config and exit.
  * The migration requires input and output file paths and reports success or failure during the process.

* **Bug Fixes**
  * Improved startup behavior so the migration runs before normal app initialization.
  * Unified configuration handling now preserves existing settings while removing deprecated fields during conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->