### PR TITLE
LCORE-1651: Link to upgrade guidance and migration paths for each version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,8 @@ The version X.Y.Z indicates:
 * Y is the minor version (backward-compatible), and
 * Z is the patch version (backward-compatible bug fix).
 
+For upgrade instructions between versions, see the [Migration Guides](docs/migrations/).
+
 # Konflux
 
 The official image of Lightspeed Core Stack is built on [Konflux](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/lightspeed-core-tenant/applications/lightspeed-stack).

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,10 @@ See the full documentation at [`../README.md`](../README.md) or browse sub-pages
 
 [Unsupported versions](https://lightspeed-core.github.io/lightspeed-stack/versions_unsupported.html)
 
+## Migration guides
+
+[Migration guides](https://lightspeed-core.github.io/lightspeed-stack/migrations/)
+
 ## Info for developers
 
 [Contributing guide](https://lightspeed-core.github.io/lightspeed-stack/contributing_guide.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,10 @@ product questions using backend LLM services, agents, and RAG databases.
 
 [Unsupported versions](https://lightspeed-core.github.io/lightspeed-stack/versions_unsupported.html)
 
+## Migration guides
+
+[Migration guides](https://lightspeed-core.github.io/lightspeed-stack/migrations/)
+
 ## Info for developers
 
 [Contributing guide](https://lightspeed-core.github.io/lightspeed-stack/contributing_guide.html)

--- a/docs/migrations/index.md
+++ b/docs/migrations/index.md
@@ -1,0 +1,8 @@
+# Migration Guides
+
+This page lists upgrade and migration guides for each Lightspeed Core Stack
+release that includes breaking or notable configuration changes.
+
+| Version | Description |
+|---------|-------------|
+| [v0.7.0](v0.7.0.md) | RAG configuration restructured under a unified `rag` section |


### PR DESCRIPTION
## Description
Create docs/migrations/index.md as a central landing page for version migration guides and link it from `docs/index.md`, `docs/README.md`, and the root `README.md`.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Code (Claude Opus 4.6)

## Related Tickets & Documents

- Closes LCORE-1651

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **Migration guides** section to the docs navigation and main documentation index.
  * Introduced a dedicated migration guides landing page with upgrade resources organized by release.
  * Updated the versioning documentation to point to migration guidance for upgrading between versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->