### PR TITLE
LCORE-2858: Removed unused Pyright clause

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2521,7 +2521,7 @@ class Configuration(ConfigurationBase):
         Returns:
             Self: The model instance after validation.
         """
-        # Get authentication module value (pyright: ignore attribute access on Field)
+        # Get authentication module value
         auth_module = getattr(self.authentication, "module", None)
 
         # Filter out misconfigured MCP servers


### PR DESCRIPTION
## Description

LCORE-2858: Removed unused Pyright clause

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2858
