### PR TITLE
LCORE-1724: pin MAPT to v0.14.2, update RHEL AI provider docs

### DIFF
--- a/.tekton/integration-tests/pipeline/lightspeed-stack-rhelai-test.yaml
+++ b/.tekton/integration-tests/pipeline/lightspeed-stack-rhelai-test.yaml
@@ -75,8 +75,7 @@ spec:
                     path: token
         steps:
           - name: create-instance
-            # TODO(are-ces): pin to v0.14.2 once released
-            image: quay.io/redhat-developer/mapt:v1.0.0-dev
+            image: quay.io/redhat-developer/mapt:v0.14.2
             imagePullPolicy: Always
             env:
               - name: HOME
@@ -445,8 +444,7 @@ spec:
                     path: token
         steps:
           - name: destroy-instance
-            # TODO(are-ces): pin to v0.14.2 once released
-            image: quay.io/redhat-developer/mapt:v1.0.0-dev
+            image: quay.io/redhat-developer/mapt:v0.14.2
             imagePullPolicy: Always
             env:
               - name: HOME

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Lightspeed Core Stack is based on the FastAPI framework (Uvicorn). The service i
   | IBM WatsonX     | https://www.ibm.com/products/watsonx                                  |
   | AWS Bedrock     | https://aws.amazon.com/bedrock                                        |
   | RHOAI (vLLM)    | See tests/e2e-prow/rhoai/configs/run.yaml                             |
-  | RHEL AI (vLLM)  | See tests/e2e/configs/run-rhelai.yaml                                 |
+  | RHEL AI (RHAIIS/vLLM) | See tests/e2e/configs/run-rhelai.yaml                            |
 
   See `docs/providers.md` for configuration details.
 
@@ -242,8 +242,7 @@ __Note__: Support for individual models is dependent on the specific inference p
 | OpenAI         | gpt-5, gpt-4o, gpt-4-turbo, gpt-4.1, o1, o3, o4                               | Yes           | remote::openai   | [1](examples/openai-faiss-run.yaml) [2](examples/openai-pgvector-run.yaml) |
 | OpenAI         | gpt-3.5-turbo, gpt-4                                                         | No            | remote::openai   |                                                                            |
 | RHOAI (vLLM)   | meta-llama/Llama-3.2-1B-Instruct                                             | Yes           | remote::vllm     | [1](tests/e2e-prow/rhoai/configs/run.yaml)                                 |
-| RHAIIS (vLLM)  | meta-llama/Llama-3.1-8B-Instruct                                             | Yes           | remote::vllm     | [1](tests/e2e/configs/run-rhaiis.yaml)                                     |
-| RHEL AI (vLLM) | meta-llama/Llama-3.1-8B-Instruct                                             | Yes           | remote::vllm     | [1](tests/e2e/configs/run-rhelai.yaml)                                     |
+| RHEL AI (RHAIIS/vLLM) | meta-llama/Llama-3.1-8B-Instruct                                      | Yes           | remote::vllm     | [1](tests/e2e/configs/run-rhelai.yaml) [2](tests/e2e/configs/run-rhaiis.yaml) |
 | Azure          | gpt-5, gpt-5-mini, gpt-5-nano, gpt-4o-mini, o3-mini, o4-mini, o1             | Yes           | remote::azure    | [1](examples/azure-run.yaml)                                               |
 | Azure          | gpt-5-chat, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano,  o1-mini                    | No or limited | remote::azure    |                                                                            |
 | VertexAI       | google/gemini-2.0-flash, google/gemini-2.5-flash, google/gemini-2.5-pro [^1] | Yes           | remote::vertexai | [1](examples/vertexai-run.yaml)                                            |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -62,8 +62,7 @@ Red Hat providers:
 | Name           | Version Tested                 | Type   | Pip Dependencies | Supported in LCS |
 |----------------|--------------------------------|--------|------------------|:----------------:|
 | RHOAI (vllm)   | latest operator                | remote | `openai`         | ✅               |
-| RHAIIS (vllm)  | 3.2.3 (on RHEL 9.20250429.0.4) | remote | `openai`         | ✅               |
-| RHEL AI (vllm) | 1.5.2                          | remote | `openai`         | ✅               |
+| RHEL AI (RHAIIS/vllm) | 3.4.0 GA (vLLM 0.18.0)  | remote | `openai`         | ✅               |
 
 ### Azure Provider - Entra ID Authentication Guide
 


### PR DESCRIPTION
## Description

- Pin MAPT image to `v0.14.2` (released) instead of `v1.0.0-dev`
- Update `docs/providers.md`: consolidate RHAIIS and RHEL AI entries — RHEL AI 3.4.0 GA with RHAIIS (vLLM 0.18.0)
- Update `README.md`: consolidate RHAIIS and RHEL AI into a single provider entry

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude Opus 4.6
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: [LCORE-1724](https://redhat.atlassian.net/browse/LCORE-1724)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- MAPT v0.14.2 verified to include `--vllm-extra-args` flag
- RHEL AI 3.4.0 GA tested with RHAIIS (vLLM 0.18.0)