### PR TITLE
[release/0.5] Only apply latest tag to container if it is the latest stable tag

### DIFF
--- a/.github/workflows/build_and_push_release.yaml
+++ b/.github/workflows/build_and_push_release.yaml
@@ -28,14 +28,22 @@ jobs:
           sudo apt install -y buildah qemu-user-static
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Fetch submodules (required for lightspeed-providers)
+          submodules: 'recursive'
+          # Fetch all tags to determine latest stable version
+          fetch-tags: true
+      - name: Determine if latest tag should be applied
+        id: check_latest
+        run: ./scripts/latest-tag.py
       - name: Build image with Buildah
         id: build_image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMAGE_NAME }}
-          tags: |
+          tags: >-
             ${{ env.GIT_TAG }}
-            ${{ env.LATEST_TAG }}
+            ${{ steps.check_latest.outputs.apply_latest == 'true' && env.LATEST_TAG || '' }}
           containerfiles: |
             ${{ env.CONTAINER_FILE }}
           archs: amd64, arm64
@@ -48,7 +56,7 @@ jobs:
       - name: Check manifest
         run: |
           set -x
-          buildah manifest inspect ${{ steps.build_image.outputs.image }}:${{ env.LATEST_TAG }}
+          buildah manifest inspect ${{ steps.build_image.outputs.image-with-tag }}
       - name: Push image to Quay.io
         uses: redhat-actions/push-to-registry@v2
         with:

--- a/scripts/latest-tag.py
+++ b/scripts/latest-tag.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+
+def version_split(value: str) -> tuple[int, ...]:
+    """Split string into a tuple of ints."""
+    try:
+        return tuple(int(n) for n in value.split("."))
+    except ValueError:
+        return (-1,)
+
+
+def is_prerelease(tag: str) -> bool:
+    """Determine if a tag is a pre-release version."""
+    omit = {"rc", "alpha", "beta", "dev"}
+
+    return any(n in tag for n in omit)
+
+
+def get_latest_stable() -> str | None:
+    """Return the latest stable tag."""
+    stdout = subprocess.check_output(["git", "tag"], text=True)
+    tags = [tag for tag in stdout.splitlines() if not is_prerelease(tag)]
+    tags.sort(key=version_split)
+
+    return tags[-1] if tags else None
+
+
+def main() -> None:
+    if not (current_tag := os.environ.get("GIT_TAG")):
+        reason = "GIT_TAG environment variable not set, skipping latest tag"
+        apply_latest = "false"
+    elif is_prerelease(current_tag):
+        reason = f"{current_tag} is a pre-release"
+        apply_latest = "false"
+    else:
+        latest_stable = get_latest_stable()
+        if current_tag == latest_stable:
+            reason = f"{current_tag} is the latest stable"
+            apply_latest = "true"
+        else:
+            reason = f"{current_tag} is not the latest stable ({latest_stable} is)"
+            apply_latest = "false"
+
+    print(reason)
+
+    if github_output := os.environ.get("GITHUB_OUTPUT"):
+        with open(github_output, "a") as f:
+            f.write(f"apply_latest={apply_latest}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/latest-tag.py
+++ b/scripts/latest-tag.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+"""Determine if the latest tag should be applied."""
+
 import os
 import subprocess
 
@@ -29,6 +31,7 @@ def get_latest_stable() -> str | None:
 
 
 def main() -> None:
+    """Determine latest tag."""
     if not (current_tag := os.environ.get("GIT_TAG")):
         reason = "GIT_TAG environment variable not set, skipping latest tag"
         apply_latest = "false"


### PR DESCRIPTION
## Description

Backport of #1921 and #1924 for Lightspeed Stack 0.5.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Just me

## Related Tickets & Documents

- Backport of #1921
- Backport of  #1924

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.
