### PR TITLE
LCORE-2900: Add __9_DOT_6 suffixes to the RPM repos to avoid CVE false positives from Clair

### DIFF
--- a/.konflux/redhat.repo
+++ b/.konflux/redhat.repo
@@ -1,4 +1,4 @@
-[codeready-builder-for-rhel-9-$basearch-eus-rpms]
+[codeready-builder-for-rhel-9-$basearch-eus-rpms__9_DOT_6]
 name = Red Hat CodeReady Linux Builder for RHEL 9 $basearch - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/codeready-builder/os
 enabled = 1
@@ -12,7 +12,7 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-appstream-eus-rpms]
+[rhel-9-for-$basearch-appstream-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/appstream/os
 enabled = 1
@@ -26,38 +26,10 @@ enabled_metadata = 0
 sslclientkey = $SSL_CLIENT_KEY
 sslclientcert = $SSL_CLIENT_CERT
 
-[rhel-9-for-$basearch-baseos-eus-rpms]
+[rhel-9-for-$basearch-baseos-eus-rpms__9_DOT_6]
 name = Red Hat Enterprise Linux 9 for $basearch - BaseOS - Extended Update Support (RPMs)
 baseurl = https://cdn.redhat.com/content/eus/rhel9/9.6/$basearch/baseos/os
 enabled = 1
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/os
-enabled = 0
-gpgcheck = 1
-gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
-sslverify = 1
-sslcacert = /etc/rhsm/ca/redhat-uep.pem
-sslverifystatus = 1
-metadata_expire = 86400
-enabled_metadata = 0
-sslclientkey = $SSL_CLIENT_KEY
-sslclientcert = $SSL_CLIENT_CERT
-
-[rhocp-4.17-for-rhel-9-$basearch-source-rpms]
-name = Red Hat OpenShift Container Platform 4.17 for RHEL 9 $basearch (Source RPMs)
-baseurl = https://cdn.redhat.com/content/dist/layered/rhel9/$basearch/rhocp/4.17/source/SRPMS
-enabled = 0
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 sslverify = 1

--- a/.konflux/rpms.lock.yaml
+++ b/.konflux/rpms.lock.yaml
@@ -5,98 +5,98 @@ arches:
 - arch: aarch64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cargo-1.84.1-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 7744425
     checksum: sha256:5db626d49748f31fb02916c24fa1a7e5759ce7b905ac3e781d42079fba8fa1c4
     name: cargo
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cmake-3.26.5-2.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 7432689
     checksum: sha256:6ac0e5e9a4fd761f8688678ac83580c7eebeacf6c241bd8089d72c4a477b22c3
     name: cmake
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cmake-data-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 2488227
     checksum: sha256:84da65a7b8921f031d15903d91c5967022620f9e96b7493c8ab8024014755ee7
     name: cmake-data
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/c/cmake-rpm-macros-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 12250
     checksum: sha256:1c74969c8a4f21851f5b89f25ac55c689b75bed1318d0435fc3a14a49c39d0e3
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 150129
     checksum: sha256:4dc8a40da74e0f9823356460ee11f183c70f382953700fffef0c448198a677cc
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 244531
     checksum: sha256:b87f5b4991bb04771ce1c6c26611a9eeb754fa80ffc257199e68db6ed5f03959
     name: libxslt
     evr: 1.1.34-13.el9_6.2
     sourcerpm: libxslt-1.1.34-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/patch-2.7.6-16.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 129037
     checksum: sha256:335c720da3caa41822737dd431d91a4adc79c85dedbe4483ecaf58bc83767610
     name: patch
     evr: 2.7.6-16.el9
     sourcerpm: patch-2.7.6-16.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rust-1.84.1-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 26093725
     checksum: sha256:5be9185a7d684022bc0686049c22ef901c4df6dce2822bdec16a1a47c46b6861
     name: rust
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/r/rust-std-static-1.84.1-1.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms
+    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 39259196
     checksum: sha256:5889bced81144c4ea201085e5bfd040300c56048e5d7987e9eb69d4d252f87bf
     name: rust-std-static
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/e/ed-1.14.2-12.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 78931
     checksum: sha256:3bce4ce6243886c448e58f589b79e3ac829fcde53d1ff13d5906a8cdc22be091
     name: ed
     evr: 1.14.2-12.el9
     sourcerpm: ed-1.14.2-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 1051990
     checksum: sha256:e766b1d568983ae2dff7ae7ccec729f5edd49795ef367a806ed06810ee4c68de
     name: gnutls
     evr: 3.8.3-6.el9_6.4
     sourcerpm: gnutls-3.8.3-6.el9_6.4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/i/info-6.7-15.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 230301
     checksum: sha256:c5ae65876c73c6f4e240081431745f5ba0a91d10a4bfb8a5d162ca3d6f039202
     name: info
     evr: 6.7-15.el9
     sourcerpm: texinfo-6.7-15.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_0.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 10281
     checksum: sha256:29f0ed0694669438654fd2f7ed288262aafddd84f09ff9fa017cc71ee4990df1
     name: openssl-fips-provider
     evr: 3.0.7-11.el9_0
     sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_0.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms
+    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 522978
     checksum: sha256:6699bd711fa3e30f576a062029c62529f362a93657066dd87fc8704d730cff42
     name: openssl-fips-provider-so
@@ -107,98 +107,98 @@ arches:
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cargo-1.84.1-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 8292467
     checksum: sha256:7dd011cd79a635654ade4e3186c5f7545d692de81157d1ce1d42656eaa6993b2
     name: cargo
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cmake-3.26.5-2.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 9159462
     checksum: sha256:f553370cb02b87e7388697468256556e765b102c2fcb56be6bc250cb2351e8ad
     name: cmake
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cmake-data-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 2488227
     checksum: sha256:84da65a7b8921f031d15903d91c5967022620f9e96b7493c8ab8024014755ee7
     name: cmake-data
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/c/cmake-rpm-macros-3.26.5-2.el9.noarch.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 12250
     checksum: sha256:1c74969c8a4f21851f5b89f25ac55c689b75bed1318d0435fc3a14a49c39d0e3
     name: cmake-rpm-macros
     evr: 3.26.5-2.el9
     sourcerpm: cmake-3.26.5-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 154427
     checksum: sha256:e1fab39251239ccaad2fb4dbe6c55ec1ae60f76d4ae81582b06e6a58e30879b2
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 247315
     checksum: sha256:fbaad5f1ca8422cd20ede7324bf4fc2cc013e5ef106f698f89f50271727b6152
     name: libxslt
     evr: 1.1.34-13.el9_6.2
     sourcerpm: libxslt-1.1.34-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/patch-2.7.6-16.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 133240
     checksum: sha256:d2e0307a2d1d4eff0c2db406841030461b35864926916f2a92244427d89316be
     name: patch
     evr: 2.7.6-16.el9
     sourcerpm: patch-2.7.6-16.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rust-1.84.1-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 28050444
     checksum: sha256:9ba3c53fd811af2f294e31360d75e33e4cb89893130c7b3fe0c6191e20a09f3e
     name: rust
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/r/rust-std-static-1.84.1-1.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms
+    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 41211472
     checksum: sha256:73bb90884432e2b43758f1043f107a570b5d54b38f17d5d0af51bac103ceb4f5
     name: rust-std-static
     evr: 1.84.1-1.el9
     sourcerpm: rust-1.84.1-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/e/ed-1.14.2-12.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 79993
     checksum: sha256:5fb3c625fd1ace94f133522bdaf4768abd78f029e20886b8e4aed2d6d1aac664
     name: ed
     evr: 1.14.2-12.el9
     sourcerpm: ed-1.14.2-12.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 1127930
     checksum: sha256:4e2c0319c285bf9be7db3f2ec0e1437c07f99ce2f7b32f3de4de946670119dfc
     name: gnutls
     evr: 3.8.3-6.el9_6.4
     sourcerpm: gnutls-3.8.3-6.el9_6.4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/i/info-6.7-15.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 233806
     checksum: sha256:3643f98b45cc973073096608aaa45976d722fe284590ff7c1d5f93ad77ba0f8b
     name: info
     evr: 6.7-15.el9
     sourcerpm: texinfo-6.7-15.el9.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_0.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 10316
     checksum: sha256:9cd99e98e91da4b15eb773b4be035aaee63a369fda70cbb38371455c3217bed1
     name: openssl-fips-provider
     evr: 3.0.7-11.el9_0
     sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_0.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms
+    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 588706
     checksum: sha256:8b6af65ac0eafbd1eb85d0f73c8255ea979418032fd4aa189a4a65004bcf1ef3
     name: openssl-fips-provider-so


### PR DESCRIPTION
## Description

Add __9_DOT_6 suffixes to the RPM repos to avoid CVE false positives from Clair

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2900
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
