### PR TITLE
RHIDP-14303: add config fields for saved prompts

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -12223,6 +12223,11 @@
                         ],
                         "title": "Agent skills",
                         "description": "Agent skills configuration. Specifies paths to skill directories."
+                    },
+                    "saved_prompts": {
+                        "$ref": "#/components/schemas/SavedPromptsConfiguration",
+                        "title": "Saved prompts configuration",
+                        "description": "Configuration for saved prompts feature limits including maximum prompts per user, display name length, and content length."
                     }
                 },
                 "additionalProperties": false,
@@ -19265,6 +19270,53 @@
                 ],
                 "title": "SQLiteDatabaseConfiguration",
                 "description": "SQLite database configuration."
+            },
+            "SavedPromptsConfiguration": {
+                "properties": {
+                    "max_prompts_per_user": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "exclusiveMinimum": 0.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max prompts per user",
+                        "description": "Maximum number of saved prompts a user can create. Defaults to 50. Cannot exceed 200."
+                    },
+                    "max_display_name_length": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "exclusiveMinimum": 0.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max display name length",
+                        "description": "Maximum character length for prompt display name (title). Defaults to 255. Cannot exceed 255."
+                    },
+                    "max_content_length": {
+                        "anyOf": [
+                            {
+                                "type": "integer",
+                                "exclusiveMinimum": 0.0
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Max content length",
+                        "description": "Maximum character length for the prompt content body. Defaults to 10000. Cannot exceed 30000."
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "SavedPromptsConfiguration",
+                "description": "Configuration for saved prompts feature limits.\n\nControls the maximum number of prompts a user can save, the maximum\ndisplay name (title) length, and the maximum prompt content length.\nAll fields are optional and default to values defined in constants.\n\nAttributes:\n    max_prompts_per_user: Maximum number of saved prompts allowed per user.\n    max_display_name_length: Maximum character length for the prompt display name.\n    max_content_length: Maximum character length for the prompt content body."
             },
             "SearchRankingOptions": {
                 "properties": {

--- a/src/constants.py
+++ b/src/constants.py
@@ -357,7 +357,9 @@ DEFAULT_RETRY_DELAY: Final[int] = 2
 # Upper bounds prevent operators from exceeding DB or application limits.
 SAVED_PROMPTS_DEFAULT_MAX_PER_USER: Final[int] = 50
 SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND: Final[int] = 200
-SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH: Final[int] = 255 # database column limit
-SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND: Final[int] = 255 # database column limit
+SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH: Final[int] = 255  # database column limit
+SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND: Final[int] = (
+    255  # database column limit
+)
 SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH: Final[int] = 10_000
 SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND: Final[int] = 30_000

--- a/src/constants.py
+++ b/src/constants.py
@@ -351,3 +351,13 @@ SENTRY_CA_CERTS_ENV_VAR: Final[str] = "SENTRY_CA_CERTS"
 # first version check.
 DEFAULT_MAX_RETRIES: Final[int] = 5
 DEFAULT_RETRY_DELAY: Final[int] = 2
+
+# Saved prompts configuration defaults and upper bounds.
+# Defaults are used when a field is omitted from lightspeed-stack.yaml.
+# Upper bounds prevent operators from exceeding DB or application limits.
+SAVED_PROMPTS_DEFAULT_MAX_PER_USER: Final[int] = 50
+SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND: Final[int] = 200
+SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH: Final[int] = 255 # database column limit
+SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND: Final[int] = 255 # database column limit
+SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH: Final[int] = 10_000
+SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND: Final[int] = 30_000

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2417,7 +2417,7 @@ class SavedPromptsConfiguration(ConfigurationBase):
             self.max_content_length = constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH
             logger.info(
                 "saved_prompts.max_content_length not configured, "
-                "using default: %d",
+                + "using default: %d",
                 constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH,
             )
         elif (

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2330,6 +2330,108 @@ class SkillsConfiguration(ConfigurationBase):
     )
 
 
+class SavedPromptsConfiguration(ConfigurationBase):
+    """Configuration for saved prompts feature limits.
+
+    Controls the maximum number of prompts a user can save, the maximum
+    display name (title) length, and the maximum prompt content length.
+    All fields are optional and default to values defined in constants.
+
+    Attributes:
+        max_prompts_per_user: Maximum number of saved prompts allowed per user.
+        max_display_name_length: Maximum character length for the prompt display name.
+        max_content_length: Maximum character length for the prompt content body.
+    """
+
+    max_prompts_per_user: Optional[PositiveInt] = Field(
+        default=None,
+        title="Max prompts per user",
+        description="Maximum number of saved prompts a user can create. "
+        f"Defaults to {constants.SAVED_PROMPTS_DEFAULT_MAX_PER_USER}. "
+        f"Cannot exceed {constants.SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND}.",
+    )
+
+    max_display_name_length: Optional[PositiveInt] = Field(
+        default=None,
+        title="Max display name length",
+        description="Maximum character length for prompt display name (title). "
+        f"Defaults to {constants.SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH}. "
+        f"Cannot exceed {constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND}.",
+    )
+
+    max_content_length: Optional[PositiveInt] = Field(
+        default=None,
+        title="Max content length",
+        description="Maximum character length for the prompt content body. "
+        f"Defaults to {constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH}. "
+        f"Cannot exceed {constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND}.",
+    )
+
+    @model_validator(mode="after")
+    def apply_defaults_and_validate_bounds(self) -> Self:
+        """Apply default values for None fields and validate upper bounds.
+
+        Logs an info message for each field that falls back to its default.
+
+        Returns:
+            Self: The validated model instance with defaults applied.
+
+        Raises:
+            ValueError: If any value exceeds its upper bound.
+        """
+        if self.max_prompts_per_user is None:
+            self.max_prompts_per_user = constants.SAVED_PROMPTS_DEFAULT_MAX_PER_USER
+            logger.info(
+                "saved_prompts.max_prompts_per_user not configured, "
+                "using default: %d",
+                constants.SAVED_PROMPTS_DEFAULT_MAX_PER_USER,
+            )
+        elif (
+            self.max_prompts_per_user > constants.SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND
+        ):
+            raise ValueError(
+                f"max_prompts_per_user ({self.max_prompts_per_user}) exceeds "
+                f"upper bound ({constants.SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND})."
+            )
+
+        if self.max_display_name_length is None:
+            self.max_display_name_length = (
+                constants.SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH
+            )
+            logger.info(
+                "saved_prompts.max_display_name_length not configured, "
+                "using default: %d",
+                constants.SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH,
+            )
+        elif (
+            self.max_display_name_length
+            > constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND
+        ):
+            raise ValueError(
+                f"max_display_name_length ({self.max_display_name_length}) exceeds "
+                f"database column limit "
+                f"({constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND})."
+            )
+
+        if self.max_content_length is None:
+            self.max_content_length = constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH
+            logger.info(
+                "saved_prompts.max_content_length not configured, "
+                + "using default: %d",
+                constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH,
+            )
+        elif (
+            self.max_content_length
+            > constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND
+        ):
+            raise ValueError(
+                f"max_content_length ({self.max_content_length}) exceeds "
+                f"upper bound ({constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND})."
+            )
+
+        return self
+
+
 class QuestionValidityConfig(ConfigurationBase):
     """Configuration for the question validity guardrail."""
 
@@ -2620,6 +2722,13 @@ class Configuration(ConfigurationBase):
         default=None,
         title="Agent skills",
         description="Agent skills configuration. Specifies paths to skill directories.",
+    )
+
+    saved_prompts: SavedPromptsConfiguration = Field(
+        default_factory=SavedPromptsConfiguration,
+        title="Saved prompts configuration",
+        description="Configuration for saved prompts feature limits including "
+        "maximum prompts per user, display name length, and content length.",
     )
 
     @model_validator(mode="after")

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2417,7 +2417,7 @@ class SavedPromptsConfiguration(ConfigurationBase):
             self.max_content_length = constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH
             logger.info(
                 "saved_prompts.max_content_length not configured, "
-                + "using default: %d",
+                "using default: %d",
                 constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH,
             )
         elif (

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -34,6 +34,12 @@ _DEFAULT_APPROVALS_DUMP: dict[str, int] = {
     "approval_retention_days": 30,
 }
 
+_DEFAULT_SAVED_PROMPTS_DUMP: dict[str, int] = {
+    "max_prompts_per_user": constants.SAVED_PROMPTS_DEFAULT_MAX_PER_USER,
+    "max_display_name_length": constants.SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH,
+    "max_content_length": constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH,
+}
+
 _MCP_SERVER_DUMP_DEFAULTS: dict[str, Any] = {
     "authorization_headers": {},
     "headers": [],
@@ -223,6 +229,7 @@ def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -445,6 +452,7 @@ def test_dump_configuration_valid_values(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -818,6 +826,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -1075,6 +1084,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -1312,6 +1322,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -1529,6 +1540,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -1906,6 +1918,7 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -2129,6 +2142,7 @@ def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -2352,6 +2366,7 @@ def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }
 
@@ -2582,5 +2597,6 @@ def test_dump_configuration_specific_compaction_values(tmp_path: Path) -> None:
                 "enabled": False,
                 "model": "cross-encoder/ms-marco-MiniLM-L6-v2",
             },
+            "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
         }

--- a/tests/unit/models/test_saved_prompts_config.py
+++ b/tests/unit/models/test_saved_prompts_config.py
@@ -99,13 +99,17 @@ class TestSavedPromptsConfigurationUpperBoundValidation:
     def test_max_display_name_length_exceeds_upper_bound(self) -> None:
         """Value above DB column limit raises ValidationError."""
         with pytest.raises(ValidationError, match="max_display_name_length"):
-            overloaded_value = constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND + 1
+            overloaded_value = (
+                constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND + 1
+            )
             SavedPromptsConfiguration(max_display_name_length=overloaded_value)
 
     def test_max_content_length_exceeds_upper_bound(self) -> None:
         """Value above upper bound raises ValidationError."""
         with pytest.raises(ValidationError, match="max_content_length"):
-            overloaded_value = constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND + 1
+            overloaded_value = (
+                constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND + 1
+            )
             SavedPromptsConfiguration(max_content_length=overloaded_value)
 
 

--- a/tests/unit/models/test_saved_prompts_config.py
+++ b/tests/unit/models/test_saved_prompts_config.py
@@ -1,0 +1,200 @@
+"""Unit tests for SavedPromptsConfiguration."""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+import constants
+from models.config import Configuration, SavedPromptsConfiguration
+
+
+class TestSavedPromptsConfigurationDefaults:
+    """Test cases for default value application."""
+
+    def test_all_defaults_when_no_fields_provided(self) -> None:
+        """All fields receive their default values when omitted."""
+        config = SavedPromptsConfiguration()
+        assert (
+            config.max_prompts_per_user == constants.SAVED_PROMPTS_DEFAULT_MAX_PER_USER
+        )
+        assert (
+            config.max_display_name_length
+            == constants.SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH
+        )
+        assert (
+            config.max_content_length
+            == constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH
+        )
+
+    def test_partial_fields_receive_defaults(self) -> None:
+        """Omitted fields get defaults while explicit values are preserved."""
+        config = SavedPromptsConfiguration(max_prompts_per_user=10)
+        assert config.max_prompts_per_user == 10
+        assert (
+            config.max_display_name_length
+            == constants.SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH
+        )
+        assert (
+            config.max_content_length
+            == constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH
+        )
+
+
+class TestSavedPromptsConfigurationValidValues:
+    """Test cases for explicit valid values."""
+
+    def test_explicit_values_within_bounds(self) -> None:
+        """Explicit values within bounds are preserved."""
+        config = SavedPromptsConfiguration(
+            max_prompts_per_user=100,
+            max_display_name_length=128,
+            max_content_length=5000,
+        )
+        assert config.max_prompts_per_user == 100
+        assert config.max_display_name_length == 128
+        assert config.max_content_length == 5000
+
+    def test_exact_upper_bound_values_accepted(self) -> None:
+        """Values exactly at the upper bound are accepted."""
+        config = SavedPromptsConfiguration(
+            max_prompts_per_user=constants.SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND,
+            max_display_name_length=constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND,
+            max_content_length=constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND,
+        )
+        assert (
+            config.max_prompts_per_user
+            == constants.SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND
+        )
+        assert (
+            config.max_display_name_length
+            == constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND
+        )
+        assert (
+            config.max_content_length
+            == constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND
+        )
+
+    def test_minimum_value_of_one_accepted(self) -> None:
+        """The minimum valid value (1) is accepted for all fields."""
+        config = SavedPromptsConfiguration(
+            max_prompts_per_user=1,
+            max_display_name_length=1,
+            max_content_length=1,
+        )
+        assert config.max_prompts_per_user == 1
+        assert config.max_display_name_length == 1
+        assert config.max_content_length == 1
+
+
+class TestSavedPromptsConfigurationUpperBoundValidation:
+    """Test cases for upper bound validation."""
+
+    def test_max_prompts_per_user_exceeds_upper_bound(self) -> None:
+        """Value above upper bound raises ValidationError."""
+        with pytest.raises(ValidationError, match="max_prompts_per_user"):
+            overloaded_value = constants.SAVED_PROMPTS_MAX_PER_USER_UPPER_BOUND + 1
+            SavedPromptsConfiguration(max_prompts_per_user=overloaded_value)
+
+    def test_max_display_name_length_exceeds_upper_bound(self) -> None:
+        """Value above DB column limit raises ValidationError."""
+        with pytest.raises(ValidationError, match="max_display_name_length"):
+            overloaded_value = constants.SAVED_PROMPTS_MAX_DISPLAY_NAME_LENGTH_UPPER_BOUND + 1
+            SavedPromptsConfiguration(max_display_name_length=overloaded_value)
+
+    def test_max_content_length_exceeds_upper_bound(self) -> None:
+        """Value above upper bound raises ValidationError."""
+        with pytest.raises(ValidationError, match="max_content_length"):
+            overloaded_value = constants.SAVED_PROMPTS_MAX_CONTENT_LENGTH_UPPER_BOUND + 1
+            SavedPromptsConfiguration(max_content_length=overloaded_value)
+
+
+class TestSavedPromptsConfigurationLowerBoundValidation:
+    """Test cases for lower bound validation (PositiveInt rejects zero/negative)."""
+
+    def test_zero_max_prompts_per_user_rejected(self) -> None:
+        """Zero is rejected by PositiveInt."""
+        with pytest.raises(ValidationError):
+            SavedPromptsConfiguration(max_prompts_per_user=0)
+
+    def test_negative_max_prompts_per_user_rejected(self) -> None:
+        """Negative values are rejected."""
+        with pytest.raises(ValidationError):
+            SavedPromptsConfiguration(max_prompts_per_user=-1)
+
+    def test_zero_max_display_name_length_rejected(self) -> None:
+        """Zero is rejected by PositiveInt."""
+        with pytest.raises(ValidationError):
+            SavedPromptsConfiguration(max_display_name_length=0)
+
+    def test_negative_max_display_name_length_rejected(self) -> None:
+        """Negative values are rejected."""
+        with pytest.raises(ValidationError):
+            SavedPromptsConfiguration(max_display_name_length=-5)
+
+    def test_zero_max_content_length_rejected(self) -> None:
+        """Zero is rejected by PositiveInt."""
+        with pytest.raises(ValidationError):
+            SavedPromptsConfiguration(max_content_length=0)
+
+    def test_negative_max_content_length_rejected(self) -> None:
+        """Negative values are rejected."""
+        with pytest.raises(ValidationError):
+            SavedPromptsConfiguration(max_content_length=-100)
+
+
+class TestSavedPromptsConfigurationExtraFields:  # pylint: disable=too-few-public-methods
+    """Test cases for extra field rejection (ConfigurationBase forbids extra)."""
+
+    def test_unknown_field_rejected(self) -> None:
+        """Unknown fields are rejected due to extra='forbid'."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            SavedPromptsConfiguration(
+                unknown_field=42
+            )  # pyright: ignore[reportCallIssue]
+
+
+def _build_config_dict(**overrides: Any) -> dict[str, Any]:
+    """Build a minimal Configuration dict with optional overrides.
+
+    Args:
+        **overrides: Keys to override in the base config dict.
+
+    Returns:
+        A dict suitable for Configuration(**dict).
+    """
+    base: dict[str, Any] = {
+        "name": "test",
+        "service": {"host": "localhost", "port": 8080},
+        "llama_stack": {
+            "api_key": "test-key",
+            "url": "http://test.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {},
+        "authentication": {"module": "noop"},
+        "authorization": {"access_rules": []},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSavedPromptsIntegration:  # pylint: disable=too-few-public-methods
+    """Test saved_prompts field on the root Configuration class."""
+
+    def test_configuration_has_saved_prompts_with_defaults(self) -> None:
+        """Configuration object has saved_prompts with all defaults when omitted."""
+        config = Configuration(**_build_config_dict())
+        saved_prompts_config = config.model_dump()["saved_prompts"]
+        assert (
+            saved_prompts_config["max_prompts_per_user"]
+            == constants.SAVED_PROMPTS_DEFAULT_MAX_PER_USER
+        )
+        assert (
+            saved_prompts_config["max_display_name_length"]
+            == constants.SAVED_PROMPTS_DEFAULT_MAX_DISPLAY_NAME_LENGTH
+        )
+        assert (
+            saved_prompts_config["max_content_length"]
+            == constants.SAVED_PROMPTS_DEFAULT_MAX_CONTENT_LENGTH
+        )


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Adds additional field to the LCORE configuration file for customizing the allowable saved prompts and its content length
**- Currently is just the fields, logic utilizing these fields will come in follow up PRs**

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/RHIDP-14303
- Closes https://redhat.atlassian.net/browse/RHIDP-14303

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable saved-prompt limits, including maximum prompts per user, display name length, and content length.
  * Included these settings in the app’s main configuration with sensible defaults.

* **Bug Fixes**
  * Added validation to prevent saved-prompt settings from exceeding allowed bounds.
  * Ensured missing saved-prompt settings are automatically filled with default values.

* **Tests**
  * Expanded test coverage for saved-prompt configuration defaults, limits, and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->