### PR TITLE
LCORE-2346: add reference profiles and profile-path documentation

### DIFF
--- a/docs/deployment_guide.md
+++ b/docs/deployment_guide.md
@@ -96,6 +96,56 @@ When this mode is selected, Llama Stack is used as a regular Python library. Thi
 
 
 
+### Profiles
+
+In unified mode (where LCORE synthesizes the Llama Stack `run.yaml` from
+`lightspeed-stack.yaml` instead of reading an external file), the synthesis
+starts from a *baseline*. By default that is LCORE's built-in baseline; a
+**profile** replaces it with a file you author.
+
+A profile is an ordinary `run.yaml`-shaped YAML file — the same schema Llama
+Stack reads natively. Everything else in the unified pipeline (enrichment,
+the high-level `inference.providers` section, `native_override`) is applied
+*on top* of the profile, in that order.
+
+**Authoring a profile.** Start from one of the reference profiles shipped in
+[`examples/profiles/`](https://github.com/lightspeed-core/lightspeed-stack/tree/main/examples/profiles):
+
+- `openai-remote.yaml` — remote OpenAI inference plus inline
+  sentence-transformers embeddings and FAISS; boots with only
+  `OPENAI_API_KEY` set.
+- `inline-faiss.yaml` — fully inline (sentence-transformers + FAISS), no
+  remote provider and no API key; pair it with a chat provider via the
+  high-level `inference.providers` section.
+
+Keep secrets out of the file: write `${env.MY_KEY}` environment references,
+which Llama Stack resolves at startup.
+
+**Referencing a profile.** Point `llama_stack.config.profile` at the file:
+
+```yaml
+name: Lightspeed Core Service (LCS)
+service:
+  host: 0.0.0.0
+  port: 8080
+llama_stack:
+  use_as_library_client: true
+  config:
+    profile: ./profiles/openai-remote.yaml
+```
+
+A relative `profile:` path resolves against the directory of the loaded
+`lightspeed-stack.yaml` (not the current working directory); absolute paths
+are used as-is. When `profile` is set, the `baseline` selector is ignored,
+and `library_client_config_path` must not be set (unified and legacy inputs
+are mutually exclusive).
+
+The reference profiles are sanity-checked by the unit suite
+(`tests/unit/test_llama_stack_synthesize.py`), so they stay loadable as the
+synthesizer evolves.
+
+
+
 ### Llama Stack as a server
 
 When this mode is selected, Llama Stack is started as a separate REST API service. All communication with Llama Stack is performed via REST API calls, which means that Llama Stack can run on a separate machine if needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,6 +153,8 @@ product questions using backend LLM services, agents, and RAG databases.
 
 [Design](https://lightspeed-core.github.io/lightspeed-stack/design/llama-stack-config-merge/llama-stack-config-merge.html)
 
+[Profiles (Deployment Guide)](https://lightspeed-core.github.io/lightspeed-stack/deployment_guide.html#profiles)
+
 ### Low overhead deployment for server mode
 
 [Design](https://lightspeed-core.github.io/lightspeed-stack/design/low-overhead-deployment-for-server-mode/low-overhead-deployment-for-server-mode.html)

--- a/examples/profiles/inline-faiss.yaml
+++ b/examples/profiles/inline-faiss.yaml
@@ -1,0 +1,108 @@
+# Reference profile: fully inline providers (sentence-transformers + FAISS).
+#
+# Demonstrates a profile with no remote inference provider: the inline
+# sentence-transformers provider serves embeddings and FAISS serves
+# vector_io, so the stack boots offline with no API key. Embeddings-only —
+# pair it with a chat provider via the high-level `inference.providers`
+# section (or `native_override`) in lightspeed-stack.yaml before serving
+# real queries:
+#
+#   inference:
+#     providers:
+#       - type: openai
+#         api_key_env: OPENAI_API_KEY
+#   llama_stack:
+#     use_as_library_client: true
+#     config:
+#       profile: examples/profiles/inline-faiss.yaml
+#
+# Relative paths resolve against the directory of the loaded
+# lightspeed-stack.yaml — see docs/deployment_guide.md, section "Profiles".
+version: 2
+
+apis:
+- agents
+- files
+- inference
+- tool_runtime
+- vector_io
+
+image_name: starter
+external_providers_dir: ${env.EXTERNAL_PROVIDERS_DIR:=~/.llama/providers.d}
+
+providers:
+  inference:
+  - provider_id: sentence-transformers
+    provider_type: inline::sentence-transformers
+  files:
+  - config:
+      metadata_store:
+        table_name: files_metadata
+        backend: sql_default
+      storage_dir: ${env.SQLITE_STORE_DIR:=~/.llama/storage/files}
+    provider_id: meta-reference-files
+    provider_type: inline::localfs
+  tool_runtime:
+  - config: {}
+    provider_id: rag-runtime
+    provider_type: inline::rag-runtime
+  vector_io:
+  - config:
+      persistence:
+        namespace: vector_io::faiss
+        backend: kv_default
+    provider_id: faiss
+    provider_type: inline::faiss
+  agents:
+  - config:
+      persistence:
+        agent_state:
+          namespace: agents_state
+          backend: kv_default
+        responses:
+          table_name: agents_responses
+          backend: sql_default
+    provider_id: meta-reference
+    provider_type: inline::meta-reference
+
+storage:
+  backends:
+    kv_default:
+      type: kv_sqlite
+      db_path: ${env.KV_STORE_PATH:=~/.llama/storage/rag/kv_store.db}
+    sql_default:
+      type: sql_sqlite
+      db_path: ${env.SQL_STORE_PATH:=~/.llama/storage/sql_store.db}
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+    inference:
+      table_name: inference_store
+      backend: sql_default
+      max_write_queue_size: 10000
+      num_writers: 4
+    conversations:
+      table_name: openai_conversations
+      backend: sql_default
+    prompts:
+      namespace: prompts
+      backend: kv_default
+
+registered_resources:
+  models: []
+  shields: []
+  vector_stores: []
+  tool_groups:
+  - toolgroup_id: builtin::rag
+    provider_id: rag-runtime
+
+# REQUIRED for file_search tool calls to work. Without it, llama-stack's
+# rag-runtime silently fails all file_search operations with no error logged.
+vector_stores:
+  annotation_prompt_params:
+    enable_annotations: false
+  default_provider_id: faiss
+  default_embedding_model:
+    provider_id: sentence-transformers
+    model_id: nomic-ai/nomic-embed-text-v1.5

--- a/examples/profiles/openai-remote.yaml
+++ b/examples/profiles/openai-remote.yaml
@@ -100,14 +100,12 @@ storage:
 
 registered_resources:
   models: []
-  shields:
-  # Minimal placeholder shield so the profile boots with only OPENAI_API_KEY.
-  # provider_shield_id points at a chat model, NOT a real Llama Guard
-  # checkpoint, so it performs no real safety gating. Configure a real guard
-  # model (e.g. meta-llama/Llama-Guard-3-8B) per deployment.
-  - shield_id: llama-guard
-    provider_id: llama-guard
-    provider_shield_id: openai/gpt-4o-mini
+  # No shield is registered: a real safety gate needs a real guard model
+  # (e.g. meta-llama/Llama-Guard-3-8B) registered per deployment, with
+  # provider_shield_id pointing at that guard model and a matching
+  # safety.default_shield_id. A placeholder shield backed by a chat model
+  # would only *look* like moderation.
+  shields: []
   vector_stores: []
   tool_groups:
   - toolgroup_id: builtin::rag
@@ -122,6 +120,3 @@ vector_stores:
   default_embedding_model:
     provider_id: sentence-transformers
     model_id: nomic-ai/nomic-embed-text-v1.5
-
-safety:
-  default_shield_id: llama-guard

--- a/examples/profiles/openai-remote.yaml
+++ b/examples/profiles/openai-remote.yaml
@@ -1,0 +1,127 @@
+# Reference profile: OpenAI-backed remote inference.
+#
+# A profile is a user-authored, run.yaml-shaped file that unified mode uses as
+# the synthesis baseline instead of LCORE's built-in default. Reference it from
+# lightspeed-stack.yaml:
+#
+#   llama_stack:
+#     use_as_library_client: true
+#     config:
+#       profile: examples/profiles/openai-remote.yaml
+#
+# Relative paths resolve against the directory of the loaded
+# lightspeed-stack.yaml. Enrichment (Azure Entra ID, BYOK RAG, Solr/OKP),
+# high-level `inference.providers`, and `native_override` are applied on top
+# of this baseline — see docs/deployment_guide.md, section "Profiles".
+#
+# This profile boots with only OPENAI_API_KEY set. The inline
+# sentence-transformers provider serves embeddings for vector_io (FAISS).
+version: 2
+
+apis:
+- agents
+- files
+- inference
+- safety
+- tool_runtime
+- vector_io
+
+image_name: starter
+external_providers_dir: ${env.EXTERNAL_PROVIDERS_DIR:=~/.llama/providers.d}
+
+providers:
+  inference:
+  - provider_id: openai
+    provider_type: remote::openai
+    config:
+      api_key: ${env.OPENAI_API_KEY}
+      allowed_models: ["${env.OPENAI_MODEL:=gpt-4o-mini}"]
+  - provider_id: sentence-transformers
+    provider_type: inline::sentence-transformers
+  files:
+  - config:
+      metadata_store:
+        table_name: files_metadata
+        backend: sql_default
+      storage_dir: ${env.SQLITE_STORE_DIR:=~/.llama/storage/files}
+    provider_id: meta-reference-files
+    provider_type: inline::localfs
+  safety:
+  - config:
+      excluded_categories: []
+    provider_id: llama-guard
+    provider_type: inline::llama-guard
+  tool_runtime:
+  - config: {}
+    provider_id: rag-runtime
+    provider_type: inline::rag-runtime
+  vector_io:
+  - config:
+      persistence:
+        namespace: vector_io::faiss
+        backend: kv_default
+    provider_id: faiss
+    provider_type: inline::faiss
+  agents:
+  - config:
+      persistence:
+        agent_state:
+          namespace: agents_state
+          backend: kv_default
+        responses:
+          table_name: agents_responses
+          backend: sql_default
+    provider_id: meta-reference
+    provider_type: inline::meta-reference
+
+storage:
+  backends:
+    kv_default:
+      type: kv_sqlite
+      db_path: ${env.KV_STORE_PATH:=~/.llama/storage/rag/kv_store.db}
+    sql_default:
+      type: sql_sqlite
+      db_path: ${env.SQL_STORE_PATH:=~/.llama/storage/sql_store.db}
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+    inference:
+      table_name: inference_store
+      backend: sql_default
+      max_write_queue_size: 10000
+      num_writers: 4
+    conversations:
+      table_name: openai_conversations
+      backend: sql_default
+    prompts:
+      namespace: prompts
+      backend: kv_default
+
+registered_resources:
+  models: []
+  shields:
+  # Minimal placeholder shield so the profile boots with only OPENAI_API_KEY.
+  # provider_shield_id points at a chat model, NOT a real Llama Guard
+  # checkpoint, so it performs no real safety gating. Configure a real guard
+  # model (e.g. meta-llama/Llama-Guard-3-8B) per deployment.
+  - shield_id: llama-guard
+    provider_id: llama-guard
+    provider_shield_id: openai/gpt-4o-mini
+  vector_stores: []
+  tool_groups:
+  - toolgroup_id: builtin::rag
+    provider_id: rag-runtime
+
+# REQUIRED for file_search tool calls to work. Without it, llama-stack's
+# rag-runtime silently fails all file_search operations with no error logged.
+vector_stores:
+  annotation_prompt_params:
+    enable_annotations: false
+  default_provider_id: faiss
+  default_embedding_model:
+    provider_id: sentence-transformers
+    model_id: nomic-ai/nomic-embed-text-v1.5
+
+safety:
+  default_shield_id: llama-guard

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -469,3 +469,28 @@ def test_migrate_config_dumb_rejects_non_mapping_inputs(tmp_path: Path) -> None:
     empty_run.write_text("", encoding="utf-8")
     with pytest.raises(ValueError, match="did not parse to a mapping"):
         migrate_config_dumb(str(empty_run), lcs_path, out_path)
+
+
+# ---------------------------------------------------------------------------
+# reference profiles (LCORE-2346)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parents[2]
+REFERENCE_PROFILES = sorted((REPO_ROOT / "examples" / "profiles").glob("*.yaml"))
+
+
+def test_reference_profiles_exist() -> None:
+    """The reference profiles shipped in examples/profiles/ are present."""
+    names = {p.name for p in REFERENCE_PROFILES}
+    assert {"openai-remote.yaml", "inline-faiss.yaml"} <= names
+
+
+@pytest.mark.parametrize("profile_path", REFERENCE_PROFILES, ids=lambda p: p.name)
+def test_reference_profile_loads_via_synthesizer(profile_path: Path) -> None:
+    """Every examples/profiles/*.yaml loads cleanly as a synthesis baseline."""
+    lcs = {"llama_stack": {"config": {"profile": profile_path.name}}}
+    result = synthesize_configuration(lcs, config_file_dir=str(profile_path.parent))
+    # The profile drives the baseline: run.yaml-shaped keys survive synthesis.
+    assert result["version"] == 2
+    assert "inference" in result["apis"]
+    assert result["providers"]["inference"], "profile must configure inference"


### PR DESCRIPTION
## Description

Adds reference profile examples and operator documentation for the unified-mode
`llama_stack.config.profile` path (LCORE-2346, part of the LCORE-836 unified
config initiative).

- `examples/profiles/openai-remote.yaml` — remote-provider (OpenAI) reference
  profile; boots with only `OPENAI_API_KEY` set. Fleshed out from the design
  doc's Appendix B skeleton using the built-in default baseline shape.
- `examples/profiles/inline-faiss.yaml` — inline-provider reference profile
  (sentence-transformers + FAISS); boots offline with no API key.
- New "Profiles" section in `docs/deployment_guide.md`: what a profile is, how
  to author one, where to place it, how to reference it (including the
  relative-path resolution rule, R8), with a worked wrapper example. Linked
  from the config-merge entry in `docs/index.md`. (The section was placed in
  the deployment guide rather than `docs/config.md` because `config.md` is a
  generated schema reference.)
- Parametrized unit test that runs every `examples/profiles/*.yaml` through
  the synthesizer, so the reference profiles stay loadable as it evolves.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-2346
- Closes # LCORE-2346

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Run the synthesizer sanity tests for the reference profiles:
   `uv run pytest tests/unit/test_llama_stack_synthesize.py -q`
   Expected: all pass (observed: 29 passed, including
   `test_reference_profile_loads_via_synthesizer[openai-remote.yaml]` and
   `[inline-faiss.yaml]`).
2. Run the full unit suite: `uv run make test-unit`
   Expected: green (observed: 2930 passed, 1 skipped, coverage 89.36%).
3. Boot LCS with the remote profile. Create a wrapper `lightspeed-stack.yaml`
   with `llama_stack.use_as_library_client: true` and
   `llama_stack.config.profile: examples/profiles/openai-remote.yaml`, export
   a real `OPENAI_API_KEY`, then:
   `uv run python src/lightspeed_stack.py -c <wrapper.yaml>`
   Expected: startup log shows
   `Loading synthesis baseline from profile .../examples/profiles/openai-remote.yaml`,
   `Wrote synthesized Llama Stack configuration to .generated/run.yaml (mode 0600)`,
   and `App startup complete` (observed).
4. Boot LCS with the inline profile: switch the wrapper's `profile:` to
   `examples/profiles/inline-faiss.yaml`; no API key needed.
   Expected: same profile-loading and `App startup complete` markers
   (observed; startup ~2 s).
5. `uv run make verify`: passes except 16 pre-existing mypy errors in
   `tests/integration/container_lifecycle/` and `tests/unit/conftest.py`,
   which exist on upstream/main and do not fail CI (none of the files in
   this PR are affected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Profiles” section to the Deployment Guide, explaining how profile-based configuration is applied, including YAML shape requirements, merging behavior, and usage constraints.
  * Added new reference profiles for offline inline providers and a remote OpenAI-backed setup.

* **Documentation**
  * Linked to the new “Profiles” guidance from the main configuration design section.

* **Tests**
  * Added unit tests to verify reference profiles ship correctly and can be synthesized/loaded as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->