### PR TITLE
LCORE-2339: warn at startup when legacy two-file config is used

### DIFF
--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -159,6 +159,18 @@ def main() -> None:
         "Llama stack configuration: %s", configuration.llama_stack_configuration
     )
 
+    # Deprecation schedule (Decision S2): the legacy two-file path keeps
+    # working through 0.6 with this single startup WARN and is removed in 0.7.
+    if configuration.llama_stack_configuration.library_client_config_path is not None:
+        logger.warning(
+            "DEPRECATED: the two-file configuration "
+            "(llama_stack.library_client_config_path + external run.yaml) is "
+            "deprecated and will be removed in release 0.7. Migrate to the "
+            "unified lightspeed-stack.yaml: https://lightspeed-core.github.io"
+            "/lightspeed-stack/design/llama-stack-config-merge"
+            "/llama-stack-config-merge.html#migration--backwards-compatibility"
+        )
+
     # -d or --dump-configuration CLI flags are used to dump the actual configuration
     # to a JSON file w/o doing any other operation
     if args.dump_configuration:

--- a/tests/unit/test_lightspeed_stack.py
+++ b/tests/unit/test_lightspeed_stack.py
@@ -1,11 +1,30 @@
 """Unit tests for functions defined in src/lightspeed_stack.py."""
 
+import logging
 from pathlib import Path
 
 import pytest
 import yaml
 
+import lightspeed_stack
+from configuration import AppConfig
 from lightspeed_stack import create_argument_parser, main
+
+LEGACY_DEPRECATION_MARKER = "DEPRECATED: the two-file configuration"
+
+COMMON_CONFIG_SECTIONS = """
+name: test
+service:
+  host: localhost
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+user_data_collection:
+  feedback_enabled: false
+mcp_servers: []
+"""
 
 
 def test_create_argument_parser() -> None:
@@ -97,3 +116,82 @@ def test_main_migrate_config_requires_run_yaml_and_output(
     )
     with pytest.raises(SystemExit):
         main()
+
+
+def run_main_with_config(
+    config_yaml: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run main() against a config file, with the runners stubbed out.
+
+    Writes ``config_yaml`` to a temporary file, points argv at it, replaces
+    the module-level configuration singleton with a fresh AppConfig (so the
+    shared singleton is not mutated for other tests), and stubs the quota
+    scheduler and uvicorn runners.
+    """
+    cfg_file = tmp_path / "lightspeed-stack.yaml"
+    cfg_file.write_text(config_yaml, encoding="utf-8")
+    monkeypatch.setattr("sys.argv", ["lightspeed-stack", "-c", str(cfg_file)])
+    monkeypatch.setattr(lightspeed_stack, "configuration", AppConfig())
+    monkeypatch.setattr(lightspeed_stack, "start_quota_scheduler", lambda _: None)
+    monkeypatch.setattr(lightspeed_stack, "start_uvicorn", lambda _: None)
+    main()
+
+
+def test_main_warns_on_legacy_two_file_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A legacy library_client_config_path config emits one deprecation WARN."""
+    run_yaml = tmp_path / "run.yaml"
+    run_yaml.write_text("version: 2\n", encoding="utf-8")
+    config_yaml = COMMON_CONFIG_SECTIONS + f"""
+llama_stack:
+  use_as_library_client: true
+  library_client_config_path: {run_yaml}
+"""
+    with caplog.at_level(logging.WARNING):
+        run_main_with_config(config_yaml, tmp_path, monkeypatch)
+    warnings = [
+        r for r in caplog.records if LEGACY_DEPRECATION_MARKER in r.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert warnings[0].levelno == logging.WARNING
+    # the WARN carries a stable link to the migration doc
+    assert "#migration--backwards-compatibility" in warnings[0].getMessage()
+
+
+def test_main_does_not_warn_in_unified_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A unified-mode config (llama_stack.config) emits no deprecation WARN."""
+    config_yaml = COMMON_CONFIG_SECTIONS + """
+llama_stack:
+  use_as_library_client: true
+  config:
+    baseline: default
+"""
+    with caplog.at_level(logging.WARNING):
+        run_main_with_config(config_yaml, tmp_path, monkeypatch)
+    assert not any(LEGACY_DEPRECATION_MARKER in r.getMessage() for r in caplog.records)
+
+
+def test_main_does_not_warn_in_server_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A server-mode config (url, no legacy fields) emits no deprecation WARN."""
+    config_yaml = COMMON_CONFIG_SECTIONS + """
+llama_stack:
+  use_as_library_client: false
+  url: http://localhost:8321
+  api_key: xyzzy
+"""
+    with caplog.at_level(logging.WARNING):
+        run_main_with_config(config_yaml, tmp_path, monkeypatch)
+    assert not any(LEGACY_DEPRECATION_MARKER in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Description

Emits a one-line startup deprecation WARNING when the legacy two-file
configuration (`llama_stack.library_client_config_path` + external `run.yaml`)
is used (LCORE-2339, part of the LCORE-836 unified config initiative; Decision
S2 deprecation schedule: legacy fully functional in 0.6, removed in 0.7).

- The warning is emitted once per service start, from the launcher process in
  `main()` right after configuration load — not from the Pydantic validator,
  which fires on every model instantiation (unit tests, workers,
  `--dump-schema`) and would violate the "single WARN line" requirement.
- The line carries a stable URL fragment to the migration section of the
  config-merge design doc (anchor verified against the rendered GitHub Pages
  output).
- Legacy mode keeps fully working; no warning in unified or server mode.
- No Pydantic model changes.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-2339
- Closes # LCORE-2339

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Run the entrypoint unit tests:
   `uv run pytest tests/unit/test_lightspeed_stack.py -q`
   Expected: all pass (observed: 4 passed — legacy emits exactly one WARN
   carrying the migration-doc anchor; unified mode and server mode emit none).
2. Run the full unit suite: `uv run make test-unit`
   Expected: green (observed: 2930 passed, 1 skipped, coverage 89.48%).
3. Boot with a legacy config. Create a wrapper `lightspeed-stack.yaml` with
   `llama_stack.use_as_library_client: true` and
   `library_client_config_path: tests/e2e/configs/run-ci.yaml` (do not use the
   repo-root run.yaml locally — it references a container-only external
   providers path), then:
   `uv run python src/lightspeed_stack.py -c <wrapper.yaml>`
   Expected: exactly one line
   `WARNING: DEPRECATED: the two-file configuration ... removed in release 0.7.
   Migrate to the unified lightspeed-stack.yaml: ...#migration--backwards-compatibility`
   followed by a normal `App startup complete` (observed: WARN count 1,
   startup count 1 — legacy keeps working).
4. Boot with a unified config (same wrapper but `llama_stack.config.baseline:
   default` instead of `library_client_config_path`).
   Expected: no DEPRECATED line, normal startup (observed: WARN count 0,
   startup count 1).
5. `uv run make verify`: passes except 16 pre-existing mypy errors in
   `tests/integration/container_lifecycle/` and `tests/unit/conftest.py`,
   which exist on upstream/main and do not fail CI (no files in this PR are
   affected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a startup warning for older configuration setups so users are informed when a legacy two-file configuration is still in use.
  * Included a clear migration message directing users to the unified configuration format.
  * Verified that the warning appears only for legacy setups and stays silent for newer supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->