### PR TITLE
LCORE-2342: migrate in-repo e2e test configs to unified mode

### DIFF
--- a/tests/e2e/configuration/README.md
+++ b/tests/e2e/configuration/README.md
@@ -7,6 +7,32 @@ This directory contains configuration files used for end-to-end testing of Light
 - `server-mode/` - Configurations for testing when LCore connects to a separate Llama Stack service
 - `library-mode/` - Configurations for testing when LCore embeds Llama Stack as a library
 
+## Library mode uses unified configs (LCORE-2342)
+
+The library-mode configurations use the unified single-file format: instead of
+the legacy `llama_stack.library_client_config_path`, they carry
+
+```yaml
+llama_stack:
+  use_as_library_client: true
+  config:
+    profile: run.yaml
+```
+
+The harness/CI copies the provider-specific run config
+(`tests/e2e/configs/run-<environment>.yaml`) to `./run.yaml` in the repo root,
+and the active `lightspeed-stack.yaml` is also copied to the repo root — so the
+relative `profile:` path resolves to that materialized file, which the unified
+synthesizer consumes as its baseline. LS behavior is identical to the legacy
+two-file path (requirement R7 in the config-merge design doc); the wiring that
+selects a provider config stays unchanged.
+
+The `tests/e2e/configs/run-*.yaml` files therefore serve a dual role: in
+server mode they are the run configuration of the standalone Llama Stack
+service, and in library mode they are consumed as the unified-mode synthesis
+profile. They are referenced by the legacy mechanism by no in-repo test config
+anymore.
+
 ## Common Configuration Features
 
 ### Default Configurations (`lightspeed-stack.yaml`)

--- a/tests/e2e/configuration/README.md
+++ b/tests/e2e/configuration/README.md
@@ -30,7 +30,7 @@ selects a provider config stays unchanged.
 The `tests/e2e/configs/run-*.yaml` files therefore serve a dual role: in
 server mode they are the run configuration of the standalone Llama Stack
 service, and in library mode they are consumed as the unified-mode synthesis
-profile. They are referenced by the legacy mechanism by no in-repo test config
+profile. No in-repo test config references them via the legacy mechanism
 anymore.
 
 ## Common Configuration Features

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-auth-noop-token.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-auth-noop-token.yaml
@@ -8,7 +8,10 @@ service:
   access_log: true
 llama_stack:
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-auth-rh-identity.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-auth-rh-identity.yaml
@@ -8,7 +8,10 @@ service:
   access_log: true
 llama_stack:
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-byok-pdf.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-byok-pdf.yaml
@@ -8,7 +8,10 @@ service:
   access_log: true
 llama_stack:
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-inline-rag.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-inline-rag.yaml
@@ -8,7 +8,10 @@ service:
   access_log: true
 llama_stack:
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-invalid-feedback-storage.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-invalid-feedback-storage.yaml
@@ -8,7 +8,10 @@ service:
   access_log: true
 llama_stack:
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/invalid"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-invalid-mcp-file-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-invalid-mcp-file-auth.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-auth.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-client-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-client-auth.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-file-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-file-auth.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-oauth-auth.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-oauth-auth.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-no-cache.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-no-cache.yaml
@@ -8,7 +8,10 @@ service:
   access_log: true
 llama_stack:
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-rbac.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-rbac.yaml
@@ -9,7 +9,10 @@ service:
 
 llama_stack:
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-skills-directory.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-skills-directory.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-skills.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-skills.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack.yaml
@@ -9,7 +9,10 @@ service:
 llama_stack:
   # Library mode - embeds llama-stack as library
   use_as_library_client: true
-  library_client_config_path: run.yaml
+  # Unified mode: run.yaml (materialized per provider by CI/the harness)
+  # is consumed as the synthesis profile instead of the legacy two-file path.
+  config:
+    profile: run.yaml
 user_data_collection:
   feedback_enabled: true
   feedback_storage: "/tmp/data/feedback"


### PR DESCRIPTION
## Description

Migrates the in-repo e2e test configurations to the unified single-file format
(LCORE-2342, part of the LCORE-836 unified config initiative).

All 17 `tests/e2e/configuration/library-mode/*.yaml` configs replace the legacy
`llama_stack.library_client_config_path: run.yaml` with the unified block:

```yaml
llama_stack:
  use_as_library_client: true
  config:
    profile: run.yaml
```

Design notes:

- The ticket's literal option ("fold run.yaml content into the corresponding
  lightspeed-stack.yaml") is not implementable: CI pairs 7 provider run
  configs (`tests/e2e/configs/run-<env>.yaml`, copied to `./run.yaml` at
  runtime) with 15 test configs as a runtime matrix — there is no static
  correspondence — and server-mode e2e boots a standalone Llama Stack from the
  same `run-*.yaml` files, so they cannot be deleted. Instead, the materialized
  `run.yaml` is consumed as the unified-mode synthesis **profile**: LS behavior
  is identical (R7 synthesis parity), no CI wiring changes, no content
  duplication. The `--migrate-config` dumb-mode tool (LCORE-2337) was not used
  for these files because its lift-and-shift embedding would freeze one
  provider's run.yaml content into configs shared by all providers.
- `tests/e2e-prow/rhoai/` is untouched: its run.yaml feeds a standalone Llama
  Stack server ConfigMap (server mode), not the legacy two-file mechanism.
- `tests/e2e/configuration/README.md` documents the new wiring and the dual
  role of `run-*.yaml` (server-mode run config + library-mode profile).

No test config uses the legacy `library_client_config_path` mechanism anymore;
no tests were deleted or skipped.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-2342
- Closes # LCORE-2342

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

1. Validate all migrated configs parse:
   every `tests/e2e/configuration/library-mode/*.yaml` loads via the
   configuration model with `llama_stack.config.profile == "run.yaml"` and no
   legacy path (observed: 17/17 OK after rebasing onto main, which added the
   two skills configs; some need `FAISS_VECTOR_STORE_ID` set, as in CI).
2. Boot the library-mode stack from the migrated config:
   `cp tests/e2e/configuration/library-mode/lightspeed-stack.yaml lightspeed-stack.yaml`,
   `cp tests/e2e/configs/run-ci.yaml run.yaml`,
   `FAISS_VECTOR_STORE_ID=<id> docker compose -f docker-compose-library.yaml up -d --build`.
   Expected: startup log shows
   `Loading synthesis baseline from profile /app-root/run.yaml` and readiness
   returns `"ready":true` (observed).
3. Run the e2e suite in library mode the way CI does (one `@e2e_group_*` shard
   per run): `E2E_DEPLOYMENT_MODE=library FAISS_VECTOR_STORE_ID=<id>`
   `E2E_BEHAVE_TAG_EXPR="not @skip and @e2e_group_<n>" make test-e2e-tagged`.
   Observed across full local runs: all scenarios pass except two clusters
   with verified non-migration causes:
   - startup races when the container restarts with a cold HuggingFace cache
     (pass on warm rerun, e.g. authorized_noop + responses 29/29);
   - `query`/`streaming_query` "413 when question is too long (with shields)"
     fail identically under the LEGACY mechanism on this branch (A/B:
     migrated 0/2 across 3 isolated runs, legacy 0/2 across 2) — pre-existing,
     tracked separately.
   Also note for local full-suite runs (all groups, one workspace): the MCP
   toolgroup reset step (`rm -rf ~/.llama` in the container) deletes the
   mounted `tests/e2e/rag/` fixtures mid-run; restore them between groups
   (CI is unaffected — sharded jobs use fresh workspaces).
4. `uv run make verify`: passes except 16 pre-existing mypy errors in
   `tests/integration/container_lifecycle/` and `tests/unit/conftest.py`
   (present on the base branch, not in CI; no files in this PR affected).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the updated library-mode configuration flow and how test environments generate the active `run.yaml` file.
  * Clarified how unified library-mode settings should be referenced across E2E test configs.

* **Chores**
  * Updated multiple E2E configuration fixtures to use the new unified profile-based format for library mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->