### PR TITLE
LCORE-2921: update the AIPCC base image

### DIFF
--- a/.konflux/build-args-konflux.conf
+++ b/.konflux/build-args-konflux.conf
@@ -1,4 +1,4 @@
-BUILDER_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.2-1782270165
+BUILDER_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.2-1782914778
 BUILDER_DNF_COMMAND=dnf
-RUNTIME_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.2-1782270165
+RUNTIME_BASE_IMAGE=quay.io/aipcc/base-images/cpu:3.4.2-1782914778
 RUNTIME_DNF_COMMAND=dnf

--- a/.konflux/rpms.in.yaml
+++ b/.konflux/rpms.in.yaml
@@ -7,12 +7,6 @@ packages:
     cmake,
     cargo,
   ]
-upgradePackages:
-  [
-    gnutls,
-    libxslt,
-    openssl-fips-provider,
-  ]
 contentOrigin:
   repofiles: ["./redhat.repo"]
 arches: [x86_64, aarch64]

--- a/.konflux/rpms.lock.yaml
+++ b/.konflux/rpms.lock.yaml
@@ -39,13 +39,6 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.2.aarch64.rpm
-    repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
-    size: 244531
-    checksum: sha256:b87f5b4991bb04771ce1c6c26611a9eeb754fa80ffc257199e68db6ed5f03959
-    name: libxslt
-    evr: 1.1.34-13.el9_6.2
-    sourcerpm: libxslt-1.1.34-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/appstream/os/Packages/p/patch-2.7.6-16.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-eus-rpms__9_DOT_6
     size: 129037
@@ -74,13 +67,6 @@ arches:
     name: ed
     evr: 1.14.2-12.el9
     sourcerpm: ed-1.14.2-12.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.4.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
-    size: 1051990
-    checksum: sha256:e766b1d568983ae2dff7ae7ccec729f5edd49795ef367a806ed06810ee4c68de
-    name: gnutls
-    evr: 3.8.3-6.el9_6.4
-    sourcerpm: gnutls-3.8.3-6.el9_6.4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/i/info-6.7-15.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
     size: 230301
@@ -88,20 +74,6 @@ arches:
     name: info
     evr: 6.7-15.el9
     sourcerpm: texinfo-6.7-15.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_0.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
-    size: 10281
-    checksum: sha256:29f0ed0694669438654fd2f7ed288262aafddd84f09ff9fa017cc71ee4990df1
-    name: openssl-fips-provider
-    evr: 3.0.7-11.el9_0
-    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/aarch64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_0.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-eus-rpms__9_DOT_6
-    size: 522978
-    checksum: sha256:6699bd711fa3e30f576a062029c62529f362a93657066dd87fc8704d730cff42
-    name: openssl-fips-provider-so
-    evr: 3.0.7-11.el9_0
-    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
   source: []
   module_metadata: []
 - arch: x86_64
@@ -141,13 +113,6 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/l/libxslt-1.1.34-13.el9_6.2.x86_64.rpm
-    repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
-    size: 247315
-    checksum: sha256:fbaad5f1ca8422cd20ede7324bf4fc2cc013e5ef106f698f89f50271727b6152
-    name: libxslt
-    evr: 1.1.34-13.el9_6.2
-    sourcerpm: libxslt-1.1.34-13.el9_6.2.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/appstream/os/Packages/p/patch-2.7.6-16.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_6
     size: 133240
@@ -176,13 +141,6 @@ arches:
     name: ed
     evr: 1.14.2-12.el9
     sourcerpm: ed-1.14.2-12.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/g/gnutls-3.8.3-6.el9_6.4.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
-    size: 1127930
-    checksum: sha256:4e2c0319c285bf9be7db3f2ec0e1437c07f99ce2f7b32f3de4de946670119dfc
-    name: gnutls
-    evr: 3.8.3-6.el9_6.4
-    sourcerpm: gnutls-3.8.3-6.el9_6.4.src.rpm
   - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/i/info-6.7-15.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
     size: 233806
@@ -190,19 +148,5 @@ arches:
     name: info
     evr: 6.7-15.el9
     sourcerpm: texinfo-6.7-15.el9.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-fips-provider-3.0.7-11.el9_0.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
-    size: 10316
-    checksum: sha256:9cd99e98e91da4b15eb773b4be035aaee63a369fda70cbb38371455c3217bed1
-    name: openssl-fips-provider
-    evr: 3.0.7-11.el9_0
-    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
-  - url: https://cdn.redhat.com/content/eus/rhel9/9.6/x86_64/baseos/os/Packages/o/openssl-fips-provider-so-3.0.7-11.el9_0.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_6
-    size: 588706
-    checksum: sha256:8b6af65ac0eafbd1eb85d0f73c8255ea979418032fd4aa189a4a65004bcf1ef3
-    name: openssl-fips-provider-so
-    evr: 3.0.7-11.el9_0
-    sourcerpm: openssl-fips-provider-3.0.7-11.el9_0.src.rpm
   source: []
   module_metadata: []


### PR DESCRIPTION
## Description

Update the AIPCC base image to pick up the latest RPM CVE fixes and get the CHI of A.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2921
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
