### PR TITLE
LCORE-2980: Fix failing skills E2E

### DIFF
--- a/src/pydantic_ai_lightspeed/llamastack/_model.py
+++ b/src/pydantic_ai_lightspeed/llamastack/_model.py
@@ -53,7 +53,6 @@ _LLS_RESPONSES_EXTRA_FIELDS: Final[frozenset[str]] = frozenset(
     {
         "conversation",
         "max_infer_iters",
-        "tools",
         "tool_choice",
         "include",
         "text",
@@ -84,6 +83,8 @@ def _model_settings_from_responses_params(
     if responses_params.extra_headers:
         settings_dict["extra_headers"] = dict(responses_params.extra_headers)
     settings_dict["openai_store"] = responses_params.store
+    if responses_params.tools is not None:
+        settings_dict["openai_native_tools"] = responses_params.tools
     if responses_params.previous_response_id is not None:
         settings_dict["openai_previous_response_id"] = (
             responses_params.previous_response_id

--- a/tests/unit/pydantic_ai_lightspeed/llamastack/test_model.py
+++ b/tests/unit/pydantic_ai_lightspeed/llamastack/test_model.py
@@ -86,7 +86,6 @@ class TestModelSettingsFromResponsesParams:
         params = _make_params(
             max_infer_iters=5,
             max_tool_calls=10,
-            tools=[{"type": "function", "name": "test-function", "parameters": {}}],
         )
         settings = _model_settings_from_responses_params(params)
 
@@ -95,9 +94,16 @@ class TestModelSettingsFromResponsesParams:
         assert settings["extra_body"]["max_infer_iters"] == 5
         assert settings["extra_body"]["max_tool_calls"] == 10
         assert settings["extra_body"]["conversation"] == "conv-1"
-        assert settings["extra_body"]["tools"] == [
-            {"type": "function", "name": "test-function", "parameters": {}}
-        ]
+
+    def test_tools_maps_to_openai_native_tools(self) -> None:
+        """Test that tools maps to openai_native_tools, not extra_body."""
+        tools = [{"type": "function", "name": "test-function", "parameters": {}}]
+        params = _make_params(tools=tools)
+        settings = _model_settings_from_responses_params(params)
+
+        assert "openai_native_tools" in settings
+        assert settings["openai_native_tools"] is params.tools
+        assert "tools" not in settings.get("extra_body", {})
 
     def test_none_fields_excluded(self) -> None:
         """Test that None optional fields do not appear in the result."""
@@ -581,7 +587,6 @@ class TestLlsResponsesExtraFields:
         expected = {
             "conversation",
             "max_infer_iters",
-            "tools",
             "tool_choice",
             "include",
             "text",


### PR DESCRIPTION
## Description

Fixes intermittent e2e skills test failures in server mode caused by `"tools"` being incorrectly included in `_LLS_RESPONSES_EXTRA_FIELDS`. When present, `responses_params.tools` (containing RAG/MCP tools) was passed via `extra_body["tools"]`, which overrides the capability-derived tools (e.g., `list_skills`, `load_skill`) that pydantic_ai computes from agent capabilities. This caused the LLM to not see skills tools and fail to invoke them. The issue was introduced in PR #2025 when restructuring pydantic_ai utils.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue LCORE-2980
- Closes LCORE-2980

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Verified via CI pipeline running e2e skills tests in server mode
- The fix ensures `responses_params.tools` (RAG/file_search tools) are no longer passed through `extra_body`, preventing them from overriding pydantic_ai's capability-derived tools (skills tools) in the OpenAI Responses API request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted how request options are passed so tool-related settings are handled more reliably, improving compatibility when using response generation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->