### PR TITLE
LCORE-2755: schema and models dumper refactoring

### DIFF
--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -14,7 +14,7 @@ from llama_stack_configuration import migrate_config_dumb
 from log import get_logger, setup_logging
 from runners.quota_scheduler import start_quota_scheduler
 from runners.uvicorn import start_uvicorn
-from utils import models_dumper, schema_dumper
+from utils import config_dumper, models_dumper
 
 setup_logging()
 logger = get_logger(__name__)
@@ -195,7 +195,7 @@ def main() -> None:
     # into a JSON file that is compatible with OpenAPI schema specification
     if args.dump_schema:
         try:
-            schema_dumper.dump_schema("schema.json")
+            config_dumper.dump_schema("schema.json")
             logger.info("Configuration schema dumped to schema.json")
         except Exception as e:
             logger.error("Failed to dump configuration schema: %s", e)

--- a/src/utils/config_dumper.py
+++ b/src/utils/config_dumper.py
@@ -1,7 +1,5 @@
 """Function to dump the configuration schema into OpenAPI-compatible format."""
 
-import json
-
 from models.config import Configuration
 from utils.openapi_schema_dumper import dump_openapi_schema
 

--- a/src/utils/models_dumper.py
+++ b/src/utils/models_dumper.py
@@ -2,10 +2,8 @@
 
 import json
 
-from pydantic.json_schema import models_json_schema
-
 import models.compaction as models_compaction
-from utils.json_schema_updater import recursive_update
+from utils.openapi_schema_dumper import dump_openapi_schema
 
 
 def dump_models(filename: str) -> None:
@@ -23,29 +21,5 @@ def dump_models(filename: str) -> None:
     ------
         IOError: If the file cannot be written.
     """
-    with open(filename, "w", encoding="utf-8") as fout:
-        # retrieve the schema
-        _, schemas = models_json_schema(
-            [
-                (model, "validation")
-                for model in [models_compaction.ConversationSummary]
-            ],
-            ref_template="#/components/schemas/{model}",
-        )
-
-        # fix the schema
-        schemas = recursive_update(schemas)
-
-        # add all required metadata
-        openapi_schema = {
-            "openapi": "3.0.0",
-            "info": {
-                "title": "Lightspeed Core Stack",
-                "version": "0.3.0",
-            },
-            "components": {
-                "schemas": schemas.get("$defs", {}),
-            },
-            "paths": {},
-        }
-        json.dump(openapi_schema, fout, indent=4)
+    models = [models_compaction.ConversationSummary]
+    dump_openapi_schema(models, filename)

--- a/src/utils/models_dumper.py
+++ b/src/utils/models_dumper.py
@@ -1,7 +1,5 @@
 """Function to dump the schema of all data models into OpenAPI-compatible format."""
 
-import json
-
 import models.compaction as models_compaction
 from utils.openapi_schema_dumper import dump_openapi_schema
 

--- a/src/utils/openapi_schema_dumper.py
+++ b/src/utils/openapi_schema_dumper.py
@@ -1,6 +1,9 @@
+"""Utility function to dump schema with list of models into OpenAPI-compatible JSON format."""
+
 import json
 
 from pydantic.json_schema import models_json_schema
+
 from utils.json_schema_updater import recursive_update
 
 

--- a/src/utils/openapi_schema_dumper.py
+++ b/src/utils/openapi_schema_dumper.py
@@ -1,0 +1,36 @@
+import json
+
+from pydantic.json_schema import models_json_schema
+from utils.json_schema_updater import recursive_update
+
+
+def dump_openapi_schema(models: list, filename: str) -> None:
+    """Write an OpenAPI-compatible JSON schema for the given models to a file.
+
+    Parameters:
+    ----------
+        - models: list - Pydantic model classes to include in the schema
+        - filename: str - name of file to export the schema to
+
+    Raises:
+    ------
+        IOError: If the file cannot be written.
+    """
+    with open(filename, "w", encoding="utf-8") as fout:
+        _, schemas = models_json_schema(
+            [(model, "validation") for model in models],
+            ref_template="`#/components/schemas/`{model}",
+        )
+        schemas = recursive_update(schemas)
+        openapi_schema = {
+            "openapi": "3.0.0",
+            "info": {
+                "title": "Lightspeed Core Stack",
+                "version": "0.3.0",
+            },
+            "components": {
+                "schemas": schemas.get("$defs", {}),
+            },
+            "paths": {},
+        }
+        json.dump(openapi_schema, fout, indent=4)

--- a/src/utils/schema_dumper.py
+++ b/src/utils/schema_dumper.py
@@ -2,10 +2,8 @@
 
 import json
 
-from pydantic.json_schema import models_json_schema
-
 from models.config import Configuration
-from utils.json_schema_updater import recursive_update
+from utils.openapi_schema_dumper import dump_openapi_schema
 
 
 def dump_schema(filename: str) -> None:
@@ -23,26 +21,5 @@ def dump_schema(filename: str) -> None:
     ------
         IOError: If the file cannot be written.
     """
-    with open(filename, "w", encoding="utf-8") as fout:
-        # retrieve the schema
-        _, schemas = models_json_schema(
-            [(model, "validation") for model in [Configuration]],
-            ref_template="#/components/schemas/{model}",
-        )
-
-        # fix the schema
-        schemas = recursive_update(schemas)
-
-        # add all required metadata
-        openapi_schema = {
-            "openapi": "3.0.0",
-            "info": {
-                "title": "Lightspeed Core Stack",
-                "version": "0.3.0",
-            },
-            "components": {
-                "schemas": schemas.get("$defs", {}),
-            },
-            "paths": {},
-        }
-        json.dump(openapi_schema, fout, indent=4)
+    models = [Configuration]
+    dump_openapi_schema(models, filename)

--- a/tests/unit/utils/test_config_dumper.py
+++ b/tests/unit/utils/test_config_dumper.py
@@ -1,9 +1,9 @@
-"""Unit tests for utils/schema_dumper module."""
+"""Unit tests for utils/config_dumper module."""
 
 from json import load
 from pathlib import Path
 
-from utils.schema_dumper import dump_schema
+from utils.config_dumper import dump_schema
 
 
 def test_dump_schema(tmpdir: Path) -> None:


### PR DESCRIPTION
## Description

LCORE-2755: schema and models dumper refactoring

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2755


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting the application configuration schema as an OpenAPI-compatible JSON file.
  * Added reusable schema export handling for configuration and model definitions.

* **Bug Fixes**
  * Updated the schema export command to use the correct configuration schema exporter.

* **Tests**
  * Updated schema export tests to cover the new configuration export path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->