### PR TITLE
LCORE-3013: Integration tests are not started in Konflux for new PRs

### DIFF
--- a/.tekton/integration-tests/pipeline/lightspeed-stack-integration-test.yaml
+++ b/.tekton/integration-tests/pipeline/lightspeed-stack-integration-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: lightspeed-stack-integration-tests-pipeline
+  name: lightspeed-stack-0-7-integration-tests-pipeline
 spec:
   description: |
     This pipeline automates the process of running end-to-end tests for Lightspeed Stack
@@ -12,7 +12,7 @@ spec:
   params:
     - name: SNAPSHOT
       description: 'The JSON string representing the snapshot of the application under test (includes lightspeed-stack image).'
-      default: '{"components": [{"name":"lightspeed-stack", "containerImage": "quay.io/example/lightspeed-stack:latest"}]}'
+      default: '{"components": [{"name":"lightspeed-stack-0-7", "containerImage": "quay.io/example/lightspeed-stack-0-7:latest"}]}'
       type: string
     - name: llama-stack-image
       description: 'Llama Stack runs from source on UBI (init container clones repo and installs deps). Kept for logging/backwards compatibility.'
@@ -20,7 +20,7 @@ spec:
       type: string
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
-      default: 'lightspeed-stack-e2e-tests'
+      default: 'lightspeed-stack-0-7-e2e-tests'
     - name: namespace
       description: 'Namespace to run tests in'
       default: 'lightspeed-stack'
@@ -117,8 +117,8 @@ spec:
                 description: "commit sha to be used to store artifacts"
             script: |
               dnf -y install jq
-              echo -n "$(jq -r --arg n "lightspeed-stack" '.components[] | select(.name == $n) | .containerImage // ""' <<< "$SNAPSHOT")" > $(step.results.lightspeed-stack-image.path)
-              echo -n "$(jq -r --arg n "lightspeed-stack" '.components[] | select(.name == $n) | .source.git.revision // "latest"' <<< "$SNAPSHOT")" > $(step.results.commit.path)
+              echo -n "$(jq -r --arg n "lightspeed-stack-0-7" '.components[] | select(.name == $n) | .containerImage // ""' <<< "$SNAPSHOT")" > $(step.results.lightspeed-stack-image.path)
+              echo -n "$(jq -r --arg n "lightspeed-stack-0-7" '.components[] | select(.name == $n) | .source.git.revision // "latest"' <<< "$SNAPSHOT")" > $(step.results.commit.path)
     - name: echo-integration-params
       description: Echo all params passed to lightspeed-stack-integration-tests for verification before the test runs.
       runAfter:
@@ -278,8 +278,8 @@ spec:
               tar -xzf oc.tar.gz && chmod +x kubectl oc && mv oc kubectl /usr/local/bin/
               echo "[e2e] 4/8 SNAPSHOT (length ${#SNAPSHOT} chars; clone URL fixed — SNAPSHOT is main/upstream, not fork)..."
               # Fixed fork + branch: Konflux SNAPSHOT points at main repo/rev, not the PR/fork under test.
-              REPO_URL=$(jq -r '.components[] | select(.name == "lightspeed-stack") | .source.git.url // "https://github.com/lightspeed-core/lightspeed-stack.git"' <<< "$SNAPSHOT")
-              REPO_REV=$(jq -r '.components[] | select(.name == "lightspeed-stack") | .source.git.revision // "main"' <<< "$SNAPSHOT")
+              REPO_URL=$(jq -r '.components[] | select(.name == "lightspeed-stack-0-7") | .source.git.url // "https://github.com/lightspeed-core/lightspeed-stack.git"' <<< "$SNAPSHOT")
+              REPO_REV=$(jq -r '.components[] | select(.name == "lightspeed-stack-0-7") | .source.git.revision // "main"' <<< "$SNAPSHOT")
               echo "[e2e] 5/8 Clone $REPO_URL @ $REPO_REV"
               git clone -q "$REPO_URL" /workspace/lightspeed-stack
               cd /workspace/lightspeed-stack && git fetch origin "$REPO_REV" && git checkout -q "$REPO_REV"

--- a/.tekton/integration-tests/pipeline/lightspeed-stack-rhelai-test.yaml
+++ b/.tekton/integration-tests/pipeline/lightspeed-stack-rhelai-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: lightspeed-stack-rhelai-tests-pipeline
+  name: lightspeed-stack-0-7-rhelai-tests-pipeline
 spec:
   description: |
     This pipeline provisions a RHEL AI instance on AWS (vLLM), an ephemeral
@@ -11,11 +11,11 @@ spec:
   params:
     - name: SNAPSHOT
       description: 'The JSON string representing the snapshot of the application under test.'
-      default: '{"components": [{"name":"lightspeed-stack", "containerImage": "quay.io/example/lightspeed-stack:latest"}]}'
+      default: '{"components": [{"name":"lightspeed-stack-0-7", "containerImage": "quay.io/example/lightspeed-stack-0-7:latest"}]}'
       type: string
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
-      default: 'lightspeed-stack-rhelai-tests'
+      default: 'lightspeed-stack-0-7-rhelai-tests'
     - name: rhelai-version
       description: 'RHEL AI version to provision.'
       default: '3.4.0'
@@ -285,8 +285,8 @@ spec:
                 type: string
             script: |
               dnf -y install jq
-              echo -n "$(jq -r --arg n "lightspeed-stack" '.components[] | select(.name == $n) | .containerImage // ""' <<< "$SNAPSHOT")" > $(step.results.lightspeed-stack-image.path)
-              echo -n "$(jq -r --arg n "lightspeed-stack" '.components[] | select(.name == $n) | .source.git.revision // "latest"' <<< "$SNAPSHOT")" > $(step.results.commit.path)
+              echo -n "$(jq -r --arg n "lightspeed-stack-0-7" '.components[] | select(.name == $n) | .containerImage // ""' <<< "$SNAPSHOT")" > $(step.results.lightspeed-stack-image.path)
+              echo -n "$(jq -r --arg n "lightspeed-stack-0-7" '.components[] | select(.name == $n) | .source.git.revision // "latest"' <<< "$SNAPSHOT")" > $(step.results.commit.path)
 
     # ── Full E2E tests (runs after both RHEL AI and OpenShift are ready) ──
     - name: rhelai-e2e-tests
@@ -407,8 +407,8 @@ spec:
               curl -sL -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.19/openshift-client-linux-amd64-rhel9.tar.gz
               tar -xzf oc.tar.gz && chmod +x kubectl oc && mv oc kubectl /usr/local/bin/
               echo "[e2e] 4/8 VLLM_URL=$VLLM_URL"
-              REPO_URL=$(jq -r '.components[] | select(.name == "lightspeed-stack") | .source.git.url // "https://github.com/lightspeed-core/lightspeed-stack.git"' <<< "$SNAPSHOT")
-              REPO_REV=$(jq -r '.components[] | select(.name == "lightspeed-stack") | .source.git.revision // "main"' <<< "$SNAPSHOT")
+              REPO_URL=$(jq -r '.components[] | select(.name == "lightspeed-stack-0-7") | .source.git.url // "https://github.com/lightspeed-core/lightspeed-stack.git"' <<< "$SNAPSHOT")
+              REPO_REV=$(jq -r '.components[] | select(.name == "lightspeed-stack-0-7") | .source.git.revision // "main"' <<< "$SNAPSHOT")
               echo "[e2e] 5/8 Clone $REPO_URL @ $REPO_REV"
               git clone -q "$REPO_URL" /workspace/lightspeed-stack
               cd /workspace/lightspeed-stack && git fetch origin "$REPO_REV" && git checkout -q "$REPO_REV"


### PR DESCRIPTION
## Description

On the main branch, adjust the Konflux integration tests for the lightspeed-stack-0-7 component name.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-3013
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated integration test pipelines to target the `lightspeed-stack-0-7` release variant.
  - Renamed pipeline and test identifiers to reflect the updated stack version.
  - Updated default snapshot, image, repository, and revision selections for end-to-end and RHEL AI tests.
  - Improved fallback values used when repository metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->