### PR TITLE
LCORE-3013: Integration tests are not started in Konflux for new PRs [release/0.5]

### DIFF
--- a/.tekton/integration-tests/pipeline/lightspeed-stack-integration-test.yaml
+++ b/.tekton/integration-tests/pipeline/lightspeed-stack-integration-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: lightspeed-stack-integration-tests-pipeline
+  name: lightspeed-stack-0-5-integration-tests-pipeline
 spec:
   description: |
     This pipeline automates the process of running end-to-end tests for Lightspeed Stack
@@ -12,7 +12,7 @@ spec:
   params:
     - name: SNAPSHOT
       description: 'The JSON string representing the snapshot of the application under test (includes lightspeed-stack image).'
-      default: '{"components": [{"name":"lightspeed-stack", "containerImage": "quay.io/example/lightspeed-stack:latest"}]}'
+      default: '{"components": [{"name":"lightspeed-stack-0-5", "containerImage": "quay.io/example/lightspeed-stack-0-5:latest"}]}'
       type: string
     - name: llama-stack-image
       description: 'Llama Stack runs from source on UBI (init container clones repo and installs deps). Kept for logging/backwards compatibility.'
@@ -20,7 +20,7 @@ spec:
       type: string
     - name: test-name
       description: 'The name of the test corresponding to a defined Konflux integration test.'
-      default: 'lightspeed-stack-e2e-tests'
+      default: 'lightspeed-stack-0-5-e2e-tests'
     - name: namespace
       description: 'Namespace to run tests in'
       default: 'lightspeed-stack'
@@ -117,8 +117,8 @@ spec:
                 description: "commit sha to be used to store artifacts"
             script: |
               dnf -y install jq
-              echo -n "$(jq -r --arg n "lightspeed-stack" '.components[] | select(.name == $n) | .containerImage // ""' <<< "$SNAPSHOT")" > $(step.results.lightspeed-stack-image.path)
-              echo -n "$(jq -r --arg n "lightspeed-stack" '.components[] | select(.name == $n) | .source.git.revision // "latest"' <<< "$SNAPSHOT")" > $(step.results.commit.path)
+              echo -n "$(jq -r --arg n "lightspeed-stack-0-5" '.components[] | select(.name == $n) | .containerImage // ""' <<< "$SNAPSHOT")" > $(step.results.lightspeed-stack-image.path)
+              echo -n "$(jq -r --arg n "lightspeed-stack-0-5" '.components[] | select(.name == $n) | .source.git.revision // "latest"' <<< "$SNAPSHOT")" > $(step.results.commit.path)
     - name: echo-integration-params
       description: Echo all params passed to lightspeed-stack-integration-tests for verification before the test runs.
       runAfter:
@@ -276,8 +276,8 @@ spec:
               tar -xzf oc.tar.gz && chmod +x kubectl oc && mv oc kubectl /usr/local/bin/
               echo "[e2e] 4/8 SNAPSHOT (length ${#SNAPSHOT} chars; clone URL fixed — SNAPSHOT is main/upstream, not fork)..."
               # Fixed fork + branch: Konflux SNAPSHOT points at main repo/rev, not the PR/fork under test.
-              REPO_URL=$(jq -r '.components[] | select(.name == "lightspeed-stack") | .source.git.url // "https://github.com/lightspeed-core/lightspeed-stack.git"' <<< "$SNAPSHOT")
-              REPO_REV=$(jq -r '.components[] | select(.name == "lightspeed-stack") | .source.git.revision // "main"' <<< "$SNAPSHOT")
+              REPO_URL=$(jq -r '.components[] | select(.name == "lightspeed-stack-0-5") | .source.git.url // "https://github.com/lightspeed-core/lightspeed-stack.git"' <<< "$SNAPSHOT")
+              REPO_REV=$(jq -r '.components[] | select(.name == "lightspeed-stack-0-5") | .source.git.revision // "release/0.5"' <<< "$SNAPSHOT")
               echo "[e2e] 5/8 Clone $REPO_URL @ $REPO_REV"
               git clone -q "$REPO_URL" /workspace/lightspeed-stack
               cd /workspace/lightspeed-stack && git fetch origin "$REPO_REV" && git checkout -q "$REPO_REV"


### PR DESCRIPTION
## Description

Adjust the ligthspeed-stack-e2e tests on the release/0.5 branch for the lighspeed-stack-0-5 component name.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-3013
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
