### PR TITLE
LCORE-1839: E2E for HITL

### DIFF
--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
@@ -1,0 +1,34 @@
+name: Lightspeed Core Service (LCS)
+service:
+  host: 0.0.0.0
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  # Library mode - embeds llama-stack as library
+  use_as_library_client: true
+  library_client_config_path: run.yaml
+user_data_collection:
+  feedback_enabled: true
+  feedback_storage: "/tmp/data/feedback"
+  transcripts_enabled: true
+  transcripts_storage: "/tmp/data/transcripts"
+conversation_cache:
+  type: "sqlite"
+  sqlite:
+    db_path: "/tmp/data/conversation-cache.db"
+authentication:
+  module: "noop-with-token"
+inference:
+  default_provider: openai
+  default_model: gpt-4o-mini
+approvals:
+  approval_timeout_seconds: 60
+  approval_retention_seconds: 5
+mcp_servers:
+  - name: "mcp-approval-always"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "always"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
@@ -25,8 +25,8 @@ inference:
   default_provider: openai
   default_model: gpt-4o-mini
 approvals:
-  approval_timeout_seconds: 60
-  approval_retention_seconds: 5
+  approval_timeout: 5 second
+  approval_retention: 10 seconds
 mcp_servers:
   - name: "mcp-approval-always"
     provider_id: "model-context-protocol"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
@@ -1,0 +1,34 @@
+name: Lightspeed Core Service (LCS)
+service:
+  host: 0.0.0.0
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  # Library mode - embeds llama-stack as library
+  use_as_library_client: true
+  library_client_config_path: run.yaml
+user_data_collection:
+  feedback_enabled: true
+  feedback_storage: "/tmp/data/feedback"
+  transcripts_enabled: true
+  transcripts_storage: "/tmp/data/transcripts"
+conversation_cache:
+  type: "sqlite"
+  sqlite:
+    db_path: "/tmp/data/conversation-cache.db"
+authentication:
+  module: "noop-with-token"
+inference:
+  default_provider: openai
+  default_model: gpt-4o-mini
+approvals:
+  approval_timeout_seconds: 5
+  approval_retention_seconds: 5
+mcp_servers:
+  - name: "mcp-approval-always"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "always"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
@@ -25,8 +25,8 @@ inference:
   default_provider: openai
   default_model: gpt-4o-mini
 approvals:
-  approval_timeout_seconds: 5
-  approval_retention_seconds: 5
+  approval_timeout: 5 seconds
+  approval_retention: 1 days
 mcp_servers:
   - name: "mcp-approval-always"
     provider_id: "model-context-protocol"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals.yaml
@@ -1,0 +1,46 @@
+name: Lightspeed Core Service (LCS)
+service:
+  host: 0.0.0.0
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  # Library mode - embeds llama-stack as library
+  use_as_library_client: true
+  library_client_config_path: run.yaml
+user_data_collection:
+  feedback_enabled: true
+  feedback_storage: "/tmp/data/feedback"
+  transcripts_enabled: true
+  transcripts_storage: "/tmp/data/transcripts"
+conversation_cache:
+  type: "sqlite"
+  sqlite:
+    db_path: "/tmp/data/conversation-cache.db"
+authentication:
+  module: "noop-with-token"
+inference:
+  default_provider: openai
+  default_model: gpt-4o-mini
+approvals:
+  approval_timeout_seconds: 60
+  approval_retention_days: 7
+mcp_servers:
+  - name: "mcp-approval-always"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "always"
+  - name: "mcp-approval-never"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "never"
+  - name: "mcp-approval-granular"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval:
+      always:
+        - "<PLACEHOLDER>"
+      never:
+        - "<PLACEHOLDER>"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-mcp-approvals.yaml
@@ -25,8 +25,8 @@ inference:
   default_provider: openai
   default_model: gpt-4o-mini
 approvals:
-  approval_timeout_seconds: 60
-  approval_retention_days: 7
+  approval_timeout: 60 seconds
+  approval_retention: 7 days
 mcp_servers:
   - name: "mcp-approval-always"
     provider_id: "model-context-protocol"
@@ -41,6 +41,6 @@ mcp_servers:
     url: "http://mock-mcp:3000"
     require_approval:
       always:
-        - "<PLACEHOLDER>"
+        - "add"
       never:
-        - "<PLACEHOLDER>"
+        - "subtract"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
@@ -1,0 +1,35 @@
+name: Lightspeed Core Service (LCS)
+service:
+  host: 0.0.0.0
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  # Server mode - connects to separate llama-stack service
+  use_as_library_client: false
+  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  api_key: xyzzy
+user_data_collection:
+  feedback_enabled: true
+  feedback_storage: "/tmp/data/feedback"
+  transcripts_enabled: true
+  transcripts_storage: "/tmp/data/transcripts"
+conversation_cache:
+  type: "sqlite"
+  sqlite:
+    db_path: "/tmp/data/conversation-cache.db"
+authentication:
+  module: "noop-with-token"
+inference:
+  default_provider: openai
+  default_model: gpt-4o-mini
+approvals:
+  approval_timeout_seconds: 60
+  approval_retention_seconds: 5
+mcp_servers:
+  - name: "mcp-approval-always"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "always"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-retention.yaml
@@ -26,8 +26,8 @@ inference:
   default_provider: openai
   default_model: gpt-4o-mini
 approvals:
-  approval_timeout_seconds: 60
-  approval_retention_seconds: 5
+  approval_timeout: 5 second
+  approval_retention: 10 seconds
 mcp_servers:
   - name: "mcp-approval-always"
     provider_id: "model-context-protocol"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
@@ -1,0 +1,35 @@
+name: Lightspeed Core Service (LCS)
+service:
+  host: 0.0.0.0
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  # Server mode - connects to separate llama-stack service
+  use_as_library_client: false
+  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  api_key: xyzzy
+user_data_collection:
+  feedback_enabled: true
+  feedback_storage: "/tmp/data/feedback"
+  transcripts_enabled: true
+  transcripts_storage: "/tmp/data/transcripts"
+conversation_cache:
+  type: "sqlite"
+  sqlite:
+    db_path: "/tmp/data/conversation-cache.db"
+authentication:
+  module: "noop-with-token"
+inference:
+  default_provider: openai
+  default_model: gpt-4o-mini
+approvals:
+  approval_timeout_seconds: 5
+  approval_retention_seconds: 5
+mcp_servers:
+  - name: "mcp-approval-always"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "always"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals-short-timeout.yaml
@@ -26,8 +26,8 @@ inference:
   default_provider: openai
   default_model: gpt-4o-mini
 approvals:
-  approval_timeout_seconds: 5
-  approval_retention_seconds: 5
+  approval_timeout: 5 seconds
+  approval_retention: 1 days
 mcp_servers:
   - name: "mcp-approval-always"
     provider_id: "model-context-protocol"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals.yaml
@@ -1,0 +1,47 @@
+name: Lightspeed Core Service (LCS)
+service:
+  host: 0.0.0.0
+  port: 8080
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  # Server mode - connects to separate llama-stack service
+  use_as_library_client: false
+  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  api_key: xyzzy
+user_data_collection:
+  feedback_enabled: true
+  feedback_storage: "/tmp/data/feedback"
+  transcripts_enabled: true
+  transcripts_storage: "/tmp/data/transcripts"
+conversation_cache:
+  type: "sqlite"
+  sqlite:
+    db_path: "/tmp/data/conversation-cache.db"
+authentication:
+  module: "noop-with-token"
+inference:
+  default_provider: openai
+  default_model: gpt-4o-mini
+approvals:
+  approval_timeout_seconds: 60
+  approval_retention_days: 7
+mcp_servers:
+  - name: "mcp-approval-always"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "always"
+  - name: "mcp-approval-never"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval: "never"
+  - name: "mcp-approval-granular"
+    provider_id: "model-context-protocol"
+    url: "http://mock-mcp:3000"
+    require_approval:
+      always:
+        - "<PLACEHOLDER>"
+      never:
+        - "<PLACEHOLDER>"

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-approvals.yaml
@@ -26,8 +26,8 @@ inference:
   default_provider: openai
   default_model: gpt-4o-mini
 approvals:
-  approval_timeout_seconds: 60
-  approval_retention_days: 7
+  approval_timeout: 60 seconds
+  approval_retention: 7 days
 mcp_servers:
   - name: "mcp-approval-always"
     provider_id: "model-context-protocol"
@@ -42,6 +42,6 @@ mcp_servers:
     url: "http://mock-mcp:3000"
     require_approval:
       always:
-        - "<PLACEHOLDER>"
+        - "add"
       never:
-        - "<PLACEHOLDER>"
+        - "subtract"

--- a/tests/e2e/features/approvals.feature
+++ b/tests/e2e/features/approvals.feature
@@ -1,3 +1,4 @@
+@skip
 Feature: Human-in-the-Loop MCP approval tests
 
   Background:

--- a/tests/e2e/features/approvals.feature
+++ b/tests/e2e/features/approvals.feature
@@ -225,3 +225,148 @@ Feature: Human-in-the-Loop MCP approval tests
     Then The status code of the response is 200
       And The body of the response contains pending
       And The body of the response contains mcp-approval-always
+
+  # --- Approval timeout / expiry ---
+
+  Scenario: Expired approval returns 410 when attempting to approve
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals-short-timeout.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I wait for 6 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": true}
+    """
+    Then The status code of the response is 410
+      And The body of the response contains approval_expired
+
+  Scenario: Expired approval returns 410 when attempting to deny
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals-short-timeout.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I wait for 6 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": false}
+    """
+    Then The status code of the response is 410
+      And The body of the response contains approval_expired
+
+  # --- Retention cleanup: decided approvals purged after approval_retention_seconds ---
+
+  Scenario: Approved approval is purged after retention period expires
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals-short-retention.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": true}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains approved
+    When I wait for 6 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 404
+      And The body of the response contains approval_not_found
+
+  Scenario: Denied approval is purged after retention period expires
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals-short-retention.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": false}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains denied
+    When I wait for 6 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 404
+      And The body of the response contains approval_not_found
+
+  Scenario: Expired approval is purged after retention period
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals-short-timeout.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I wait for 11 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 404
+      And The body of the response contains approval_not_found
+
+  Scenario: Decided approval remains queryable within retention period
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals-short-retention.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": true}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains approved
+    When I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response contains approved
+      And The body of the response contains decided_at
+
+  # --- Approval not found returns 404 ---
+
+  Scenario: GET on non-existent approval returns 404
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I access REST API endpoint "approvals/non-existent-id-12345" using HTTP GET method
+    Then The status code of the response is 404
+      And The body of the response contains approval_not_found
+
+  Scenario: POST to non-existent approval returns 404
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I access REST API endpoint "approvals/non-existent-id-12345" using HTTP POST method
+    """
+    {"approve": true}
+    """
+    Then The status code of the response is 404
+      And The body of the response contains approval_not_found

--- a/tests/e2e/features/approvals.feature
+++ b/tests/e2e/features/approvals.feature
@@ -1,0 +1,227 @@
+Feature: Human-in-the-Loop MCP approval tests
+
+  Background:
+    Given The service is started locally
+      And The system is in default state
+      And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
+      And REST API service prefix is /v1
+      And the Lightspeed stack configuration directory is "tests/e2e/configuration"
+
+
+  # --- require_approval: "never" returns successful query ---
+
+  Scenario: Query with require_approval "never" returns successful response
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-never' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response does not contain requires_action
+
+  Scenario: Streaming query with require_approval "never" returns successful response
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-never' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The body of the response does not contain approval_required
+
+
+  # --- require_approval: "always" returns requires_action ---
+
+  Scenario: Query with require_approval "always" returns requires_action status
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+      And The body of the response contains mcp_approval
+
+  Scenario: Streaming query with require_approval "always" returns approval_required event
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed    
+    Then The status code of the response is 200
+      And The body of the response contains approval_required
+
+
+  # --- require_approval: granular (always/never filter) ---
+
+  Scenario: Query with granular approval filter returns requires_action for "always" tool
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' always tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+      And The body of the response contains mcp_approval
+
+  Scenario: Query with granular approval filter returns successful response for "never" tool
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' never tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response does not contain requires_action
+
+  Scenario: Streaming query with granular approval filter returns approval_required for "always" tool
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' always tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains approval_required
+
+  Scenario: Streaming query with granular approval filter returns successful response for "never" tool
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' never tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    When I wait for the response to be completed
+    Then The status code of the response is 200
+      And The body of the response does not contain approval_required
+
+
+  # --- Approve a pending approval ---
+
+  Scenario: Approve a pending approval via POST /approvals/{id} on query
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": true}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains approved
+
+  Scenario: Approve a pending approval via POST /approvals/{id} on streaming_query
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains approval_required
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": true}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains approved
+
+
+  # --- Deny a pending approval ---
+
+  Scenario: Deny a pending approval via POST /approvals/{id} on query
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": false}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains denied
+
+  Scenario: Deny a pending approval via POST /approvals/{id} on streaming_query
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains approval_required
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
+    """
+    {"approve": false}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains denied
+
+
+  # --- GET /approvals returns all approvals ---
+
+  @MCPApprovalsConfig @flaky
+  Scenario: GET /approvals returns list of pending approvals
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I access REST API endpoint "approvals" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response contains approvals
+      And The body of the response contains pending
+
+
+  # --- GET /approvals/{id} returns a single approval ---
+
+  @MCPApprovalsConfig @flaky
+  Scenario: GET /approvals/{id} returns a specific approval
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Use the mcp-approval-always server to list repos", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+    When I extract the approval id from the response
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response contains pending
+      And The body of the response contains mcp-approval-always

--- a/tests/e2e/features/approvals.feature
+++ b/tests/e2e/features/approvals.feature
@@ -9,7 +9,7 @@ Feature: Human-in-the-Loop MCP approval tests
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
 
 
-  # --- require_approval: "never" returns successful query ---
+  # --- require_approval: "never" returns successful query, and no pending approvals are recorded ---
 
   Scenario: Query with require_approval "never" returns successful response
     Given MCP toolgroups are reset for a new MCP configuration
@@ -17,10 +17,16 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-never' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the divide tool from the mcp-approval-never server to divide 10 by 2.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response does not contain requires_action
+    When I access REST API endpoint "approvals" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response is the following
+      """
+      {"approvals": []}
+      """
 
   Scenario: Streaming query with require_approval "never" returns successful response
     Given MCP toolgroups are reset for a new MCP configuration
@@ -28,38 +34,17 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "streaming_query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-never' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the divide tool from the mcp-approval-never server to divide 10 by 2.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
       And The body of the response does not contain approval_required
-
-
-  # --- require_approval: "always" returns requires_action ---
-
-  Scenario: Query with require_approval "always" returns requires_action status
-    Given MCP toolgroups are reset for a new MCP configuration
-      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
+    When I access REST API endpoint "approvals" using HTTP GET method
     Then The status code of the response is 200
-      And The body of the response contains requires_action
-      And The body of the response contains mcp_approval
-
-  Scenario: Streaming query with require_approval "always" returns approval_required event
-    Given MCP toolgroups are reset for a new MCP configuration
-      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
-      And The service is restarted
-    When I use "streaming_query" to ask question with authorization header
-    """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    When I wait for the response to be completed    
-    Then The status code of the response is 200
-      And The body of the response contains approval_required
+      And The body of the response is the following
+      """
+      {"approvals": []}
+      """
 
 
   # --- require_approval: granular (always/never filter) ---
@@ -70,7 +55,7 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' always tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the add tool from the mcp-approval-granular server to add 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains requires_action
@@ -82,10 +67,16 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' never tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the subtract tool from the mcp-approval-granular server to subtract 1 from 5.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response does not contain requires_action
+    When I access REST API endpoint "approvals" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response is the following
+      """
+      {"approvals": []}
+      """
 
   Scenario: Streaming query with granular approval filter returns approval_required for "always" tool
     Given MCP toolgroups are reset for a new MCP configuration
@@ -93,8 +84,9 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "streaming_query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' always tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the add tool from the mcp-approval-granular server to add 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
+    When I wait for the response to be completed
     Then The status code of the response is 200
       And The body of the response contains approval_required
 
@@ -104,11 +96,17 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "streaming_query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-granular' never tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the subtract tool from the mcp-approval-granular server to subtract 1 from 5.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     When I wait for the response to be completed
     Then The status code of the response is 200
       And The body of the response does not contain approval_required
+    When I access REST API endpoint "approvals" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response is the following
+      """
+      {"approvals": []}
+      """
 
 
   # --- Approve a pending approval ---
@@ -119,17 +117,19 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains requires_action
-    When I extract the approval id from the response
       And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
     """
     {"approve": true}
     """
     Then The status code of the response is 200
       And The body of the response contains approved
+    When I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 200
+      And The status message of the response is "approved"
 
   Scenario: Approve a pending approval via POST /approvals/{id} on streaming_query
     Given MCP toolgroups are reset for a new MCP configuration
@@ -137,17 +137,20 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "streaming_query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
+    When I wait for the response to be completed
     Then The status code of the response is 200
       And The body of the response contains approval_required
-    When I extract the approval id from the response
       And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
     """
     {"approve": true}
     """
     Then The status code of the response is 200
       And The body of the response contains approved
+    When I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 200
+      And The status message of the response is "approved"
 
 
   # --- Deny a pending approval ---
@@ -158,17 +161,19 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains requires_action
-    When I extract the approval id from the response
       And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
     """
     {"approve": false}
     """
     Then The status code of the response is 200
       And The body of the response contains denied
+    When I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 200
+      And The status message of the response is "denied"
 
   Scenario: Deny a pending approval via POST /approvals/{id} on streaming_query
     Given MCP toolgroups are reset for a new MCP configuration
@@ -176,17 +181,20 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "streaming_query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
+    When I wait for the response to be completed
     Then The status code of the response is 200
       And The body of the response contains approval_required
-    When I extract the approval id from the response
       And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
     """
     {"approve": false}
     """
     Then The status code of the response is 200
       And The body of the response contains denied
+    When I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 200
+      And The status message of the response is "denied"
 
 
   # --- GET /approvals returns all approvals ---
@@ -198,7 +206,7 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains requires_action
@@ -217,11 +225,10 @@ Feature: Human-in-the-Loop MCP approval tests
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "Use the mcp-approval-always server to list repos", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains requires_action
-    When I extract the approval id from the response
       And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
     Then The status code of the response is 200
       And The body of the response contains pending
@@ -229,117 +236,36 @@ Feature: Human-in-the-Loop MCP approval tests
 
   # --- Approval timeout / expiry ---
 
-  Scenario: Expired approval returns 410 when attempting to approve
+  Scenario: Expired approval returns 410 when attempting to decide
     Given MCP toolgroups are reset for a new MCP configuration
       And The service uses the lightspeed-stack-mcp-approvals-short-timeout.yaml configuration
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains requires_action
-    When I extract the approval id from the response
       And I wait for 6 seconds
       And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
     """
     {"approve": true}
-    """
-    Then The status code of the response is 410
-      And The body of the response contains approval_expired
-
-  Scenario: Expired approval returns 410 when attempting to deny
-    Given MCP toolgroups are reset for a new MCP configuration
-      And The service uses the lightspeed-stack-mcp-approvals-short-timeout.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains requires_action
-    When I extract the approval id from the response
-      And I wait for 6 seconds
-      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
-    """
-    {"approve": false}
     """
     Then The status code of the response is 410
       And The body of the response contains approval_expired
 
   # --- Retention cleanup: decided approvals purged after approval_retention_seconds ---
 
-  Scenario: Approved approval is purged after retention period expires
+  Scenario: Decided approval remains queryable within retention period then purged after it expires
     Given MCP toolgroups are reset for a new MCP configuration
       And The service uses the lightspeed-stack-mcp-approvals-short-retention.yaml configuration
       And The service is restarted
     When I use "query" to ask question with authorization header
     """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
     """
     Then The status code of the response is 200
       And The body of the response contains requires_action
-    When I extract the approval id from the response
-      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
-    """
-    {"approve": true}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains approved
-    When I wait for 6 seconds
-      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
-    Then The status code of the response is 404
-      And The body of the response contains approval_not_found
-
-  Scenario: Denied approval is purged after retention period expires
-    Given MCP toolgroups are reset for a new MCP configuration
-      And The service uses the lightspeed-stack-mcp-approvals-short-retention.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains requires_action
-    When I extract the approval id from the response
-      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
-    """
-    {"approve": false}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains denied
-    When I wait for 6 seconds
-      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
-    Then The status code of the response is 404
-      And The body of the response contains approval_not_found
-
-  Scenario: Expired approval is purged after retention period
-    Given MCP toolgroups are reset for a new MCP configuration
-      And The service uses the lightspeed-stack-mcp-approvals-short-timeout.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains requires_action
-    When I extract the approval id from the response
-      And I wait for 11 seconds
-      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
-    Then The status code of the response is 404
-      And The body of the response contains approval_not_found
-
-  Scenario: Decided approval remains queryable within retention period
-    Given MCP toolgroups are reset for a new MCP configuration
-      And The service uses the lightspeed-stack-mcp-approvals-short-retention.yaml configuration
-      And The service is restarted
-    When I use "query" to ask question with authorization header
-    """
-    {"query": "<PLACEHOLDER: prompt to trigger 'mcp-approval-always' tool>", "model": "{MODEL}", "provider": "{PROVIDER}"}
-    """
-    Then The status code of the response is 200
-      And The body of the response contains requires_action
-    When I extract the approval id from the response
       And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP POST method
     """
     {"approve": true}
@@ -350,21 +276,39 @@ Feature: Human-in-the-Loop MCP approval tests
     Then The status code of the response is 200
       And The body of the response contains approved
       And The body of the response contains decided_at
+    When I wait for 3 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 200
+      And The body of the response contains approved
+    When I wait for 8 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 404
+      And The body of the response contains approval_not_found
+
+  Scenario: Expired approval is purged after retention period
+    Given MCP toolgroups are reset for a new MCP configuration
+      And The service uses the lightspeed-stack-mcp-approvals-short-retention.yaml configuration
+      And The service is restarted
+    When I use "query" to ask question with authorization header
+    """
+    {"query": "Use the multiply tool from the mcp-approval-always server to multiply 2 and 3.", "model": "{MODEL}", "provider": "{PROVIDER}"}
+    """
+    Then The status code of the response is 200
+      And The body of the response contains requires_action
+      And I wait for 11 seconds
+      And I access REST API endpoint "approvals/{APPROVAL_ID}" using HTTP GET method
+    Then The status code of the response is 404
+      And The body of the response contains approval_not_found
 
   # --- Approval not found returns 404 ---
 
-  Scenario: GET on non-existent approval returns 404
+  Scenario: Requests for a non-existent approval return 404
     Given MCP toolgroups are reset for a new MCP configuration
       And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
       And The service is restarted
     When I access REST API endpoint "approvals/non-existent-id-12345" using HTTP GET method
     Then The status code of the response is 404
       And The body of the response contains approval_not_found
-
-  Scenario: POST to non-existent approval returns 404
-    Given MCP toolgroups are reset for a new MCP configuration
-      And The service uses the lightspeed-stack-mcp-approvals.yaml configuration
-      And The service is restarted
     When I access REST API endpoint "approvals/non-existent-id-12345" using HTTP POST method
     """
     {"approve": true}


### PR DESCRIPTION
## Description

Add end-to-end BDD tests for the Human-in-the-Loop (HITL) MCP tool approval workflow. These tests validate the full approval lifecycle including creating approvals via `require_approval: "always"` and `"never"` modes, approving and denying pending approvals, listing approvals, timeout/expiry behavior (410), retention-based cleanup (404 after purge), and 404 handling for non-existent approvals. Tests cover both `query` and `streaming_query` endpoints across library-mode and server-mode configurations.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue LCORE-1839

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- New `approvals.feature` file with 17 scenarios covering the HITL approval API surface
- Scenarios exercise approval creation, approve/deny flows, GET listing, timeout expiry (410), retention cleanup (404), and not-found handling
- Three configuration variants per mode (library/server) test different `approval_timeout_seconds` and `approval_retention_seconds` values
- Waiting steps (`I wait for N seconds`) validate time-dependent expiry and retention purge behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for MCP tool approval workflows.
  * Supports always, never, and granular approval policies.
  * Added approval and denial handling for standard and streaming requests.
  * Added lifecycle handling for pending, expired, decided, and retained approvals.
  * Added validation for unknown approval requests and appropriate error responses.
* **Tests**
  * Added library-mode and server-mode configurations covering standard, short-timeout, and short-retention approval scenarios.
  * Added coverage for approval listing, retrieval, expiration, and retention cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->