### PR TITLE
LCORE- Update checkout action to v7

### DIFF
--- a/.github/workflows/build_and_push_release.yaml
+++ b/.github/workflows/build_and_push_release.yaml
@@ -27,7 +27,7 @@ jobs:
           # qemu is required for arm64 builds
           sudo apt install -y buildah qemu-user-static
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Fetch submodules (required for lightspeed-providers)
           submodules: 'recursive'

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -24,7 +24,7 @@ jobs:
       E2E_LLAMA_HOSTNAME: ${{ vars.E2E_LLAMA_HOSTNAME || 'llama-stack' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # On PR_TARGET → the fork (or same repo) that opened the PR.
           # On push      → falls back to the current repository.

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -34,6 +34,11 @@ jobs:
           # On push      → the pushed commit that triggered the workflow.
           ref: ${{ github.event.pull_request.head.ref || github.sha }}
 
+          # Tests need access to secrets.
+          # This should be refactored if possible to mitigate the risk.
+          # https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
+
           # Don’t keep credentials when running untrusted PR code under PR_TARGET.
           persist-credentials: ${{ github.event_name != 'pull_request_target' }}
 

--- a/.github/workflows/e2e_tests_lightspeed_evaluation.yaml
+++ b/.github/workflows/e2e_tests_lightspeed_evaluation.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # On PR_TARGET → the fork (or same repo) that opened the PR.
           # On push      → falls back to the current repository.
@@ -47,7 +47,7 @@ jobs:
           git log --oneline -5
 
       - name: Checkout lightspeed-Evaluation
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: lightspeed-core/lightspeed-evaluation
           path: lightspeed-evaluation

--- a/.github/workflows/e2e_tests_lightspeed_evaluation.yaml
+++ b/.github/workflows/e2e_tests_lightspeed_evaluation.yaml
@@ -30,6 +30,11 @@ jobs:
           # Don’t keep credentials when running untrusted PR code under PR_TARGET.
           persist-credentials: ${{ github.event_name != 'pull_request_target' }}
 
+          # Tests need access to secrets.
+          # This should be refactored if possible to mitigate the risk.
+          # https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
+
           # Fetch submodules (required for lightspeed-providers)
           submodules: 'recursive'
 

--- a/.github/workflows/e2e_tests_providers.yaml
+++ b/.github/workflows/e2e_tests_providers.yaml
@@ -49,7 +49,7 @@ jobs:
       E2E_DEFAULT_PROVIDER_OVERRIDE: ${{ matrix.e2e_default_provider }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # On PR_TARGET → the fork (or same repo) that opened the PR.
           # On push      → falls back to the current repository.
@@ -58,6 +58,11 @@ jobs:
           # On PR_TARGET → the PR head *commit* (reproducible).
           # On push      → the pushed commit that triggered the workflow.
           ref: ${{ github.event.pull_request.head.ref || github.sha }}
+
+          # Tests need access to secrets.
+          # This should be refactored if possible to mitigate the risk.
+          # https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
 
           # Don’t keep credentials when running untrusted PR code under PR_TARGET.
           persist-credentials: ${{ github.event_name != 'pull_request_target' }}

--- a/.github/workflows/e2e_tests_rhaiis.yaml
+++ b/.github/workflows/e2e_tests_rhaiis.yaml
@@ -38,7 +38,7 @@ jobs:
       E2E_DEFAULT_PROVIDER_OVERRIDE: vllm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # On PR_TARGET → the fork (or same repo) that opened the PR.
           # On push      → falls back to the current repository.

--- a/.github/workflows/e2e_tests_rhaiis.yaml
+++ b/.github/workflows/e2e_tests_rhaiis.yaml
@@ -48,6 +48,11 @@ jobs:
           # On push      → the pushed commit that triggered the workflow.
           ref: ${{ github.event.pull_request.head.ref || github.sha }}
 
+          # Tests need access to secrets.
+          # This should be refactored if possible to mitigate the risk.
+          # https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
+
           # Don’t keep credentials when running untrusted PR code under PR_TARGET.
           persist-credentials: ${{ github.event_name != 'pull_request_target' }}
 

--- a/.github/workflows/radon.yaml
+++ b/.github/workflows/radon.yaml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: read
     name: "radon"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: davidslusser/actions_python_radon@v1.0.0
         with:
           src: "src"


### PR DESCRIPTION
## Description

Update `actions/checkout` to v7 in all cases. This addresses a bug where a [job triggered by a tag would fail](https://github.com/actions/checkout/pull/2356), which is what caused the 0.6.0 job run to fail.

This brings to light a risky configuration that exists currently. Jobs that are triggered by `pull_request_target` are running code from PRs from forks because access to secrets is needed for the tests to run. This is a [common scenario](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) but carries risk. It is possible to do this [securely](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target). That will require refactoring how the tests run to separate the parts that need access to secrets from code submitted in PRs from forks.

Once this is merged to `main`, it will need to be back port to all release branches. Then we need to do two things:
1. Open a PR against this repo from a branch from a fork to make jobs using `pull_request_target` run as expected.
2. Push a new tag and verify that an image is successfully [published to quay.io](https://github.com/lightspeed-core/lightspeed-stack/actions/workflows/build_and_push_release.yaml).

Unfortunately there is no way to re-run the job to publish 0.6.0 since it contains the old version of the action with the bug. We will have to manually build and publish that image if we want it to exist in https://quay.io/repository/lightspeed-core/lightspeed-stack, or publish a new tag. Fix it forward, as they say.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- My brain
- A whole lot of documentation

## Related Tickets & Documents

None

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Submit a PR from a fork _after_ this change is merged to `main`. I simulated this by creating a [fork of my fork](https://github.com/samdoran/lightspeed-stack/pull/1), duplicating the failure, then running again with the changes in this PR merged to `main` in my fork.
- Observer that the code is checkout out and jobs runs as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository checkout actions across release, build, and end-to-end testing workflows.
  * Improved pull-request test checkout configuration for workflows requiring secure access to secrets.
  * Maintained multi-architecture release image builds and existing code-quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->