### PR TITLE
LCORE-3027: Debug skills E2E

### DIFF
--- a/tests/e2e/features/steps/llm_query_response.py
+++ b/tests/e2e/features/steps/llm_query_response.py
@@ -93,6 +93,7 @@ def wait_for_complete_response(context: Context) -> None:
     """Wait for the response to be complete."""
     context.response_data = _parse_streaming_response(context.response.text)
     context.response.raise_for_status()
+    print(f"Response data: {context.response_data}")
     assert context.response_data["finished"] is True
     context.use_streaming_response_data = True
 


### PR DESCRIPTION
## Description

Add debug print statement to the `wait_for_complete_response` E2E step to log the parsed streaming response data before assertions. This aids in diagnosing intermittent skills E2E test failures by making the actual response payload visible in CI output.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue LCORE-3027

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

Verified via CI pipeline. The added print statement outputs the parsed streaming response data during E2E test runs, providing visibility into the response payload when skills feature tests execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added diagnostic output of parsed response data during end-to-end response completion checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->