### PR TITLE
OSPRH-31896: Internal Server Error for UnexpectedModelBehavior

### DIFF
--- a/src/utils/agents/query.py
+++ b/src/utils/agents/query.py
@@ -116,8 +116,11 @@ def map_pydantic_agent_run_error(
     match exc:
         case ContentFilterError() as filter_exc:
             return InternalServerErrorResponse.query_failed(str(filter_exc))
-        case IncompleteToolCall() | UnexpectedModelBehavior():
+        case IncompleteToolCall():
             return PromptTooLongResponse(model=model_id)
+        case UnexpectedModelBehavior():
+            logger.error("Unexpected model behavior: %s", exc, exc_info=True)
+            return InternalServerErrorResponse.generic()
         case UsageLimitExceeded():
             return QuotaExceededResponse.model(model_id)
         case ModelHTTPError() as http_exc if is_context_length_error(str(http_exc)):


### PR DESCRIPTION
## Description

Currently, PromptTooLongResponse does not represent the actual error. This change logs the underlying exception and uses a more generic Internal Server Error.

When developing [https://github.com/openstack-k8s-operators/lightspeed-operator](openstack-lightspeed), we are seeing a lot of "prompt too long" errors and we would like get access to the underlying errors.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- All unit tests are passing and I verified that that the /streaming_query now correctly responds with Internal Server Error in case of UnexpectedModelBehavior exception.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for incomplete tool calls and unexpected model behavior.
  * Incomplete tool calls still map to a “prompt too long” style response.
  * Unexpected model behavior now returns a general server error instead, with error logging added to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->