### PR TITLE
LCORE-2916: Slack notification for providers e2e tests

### DIFF
--- a/.github/workflows/e2e_tests_providers.yaml
+++ b/.github/workflows/e2e_tests_providers.yaml
@@ -352,7 +352,8 @@ jobs:
           uv sync
 
           echo "Running comprehensive e2e test suite..."
-          make test-e2e
+          set -o pipefail
+          make test-e2e 2>&1 | tee e2e-test-output.log
 
       - name: Show logs on failure
         if: failure()
@@ -368,4 +369,97 @@ jobs:
           else
             echo "=== lightspeed-stack (library mode) logs ==="
             docker compose -f docker-compose-library.yaml logs lightspeed-stack
+          fi
+
+      - name: Record result for Slack summary
+        if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          mkdir -p ./e2e-result
+
+          # Extract the "Failing scenarios:" block that behave prints on failure.
+          FAILING_SCENARIOS=""
+          if [ -f e2e-test-output.log ]; then
+            FAILING_SCENARIOS=$(sed 's/\x1b\[[0-9;]*m//g' e2e-test-output.log \
+              | awk '/^Failing scenarios:/{flag=1; next} /^$/{flag=0} flag' \
+              | sed 's/^[[:space:]]*//')
+          fi
+
+          if [ -z "${FAILING_SCENARIOS}" ]; then
+            if [ "${JOB_STATUS}" == "success" ]; then
+              FAILING_SCENARIOS="None"
+            else
+              FAILING_SCENARIOS="Job ${JOB_STATUS} - no failing scenarios captured (see run logs)"
+            fi
+          fi
+
+          jq -n \
+            --arg mode "${{ matrix.mode }}" \
+            --arg environment "${{ matrix.environment }}" \
+            --arg status "${JOB_STATUS}" \
+            --arg failing_scenarios "${FAILING_SCENARIOS}" \
+            '{mode: $mode, environment: $environment, status: $status, failing_scenarios: $failing_scenarios}' \
+            > ./e2e-result/result.json
+
+      - name: Upload result artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-result-${{ matrix.mode }}-${{ matrix.environment }}
+          path: ./e2e-result/result.json
+          retention-days: 1
+
+  notify:
+    name: Notify Slack
+    needs: [e2e_tests]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all result artifacts
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: e2e-result-*
+          path: ./results
+
+      - name: Build and send consolidated Slack report
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_RESULT: ${{ needs.e2e_tests.result }}
+        run: |
+          if [ -z "${SLACK_WEBHOOK_URL}" ]; then
+            echo "SLACK_WEBHOOK_URL is not set, skipping Slack notification"
+            exit 0
+          fi
+
+          ALL_RESULTS=$(find ./results -name 'result.json' 2>/dev/null -exec cat {} \; | jq -s '.' 2>/dev/null || echo '[]')
+
+          echo "Workflow result: ${WORKFLOW_RESULT}"
+
+          # Base payload guarantees every mode/environment key is present even if a
+          # matrix job never uploaded a result artifact (e.g. it was skipped/cancelled).
+          BASE_FIELDS='{
+            "server_azure": "N/A",
+            "server_vertexai": "N/A",
+            "server_watsonx": "N/A",
+            "server_bedrock": "N/A",
+            "library_azure": "N/A",
+            "library_vertexai": "N/A",
+            "library_watsonx": "N/A",
+            "library_bedrock": "N/A"
+          }'
+
+          # Build one field per "<mode>_<environment>" key holding that job's failing scenarios.
+          payload=$(echo "${ALL_RESULTS}" | jq \
+            --argjson fields "${BASE_FIELDS}" \
+            --arg run "${RUN_URL}" \
+            '{run_url: $run} + (reduce .[] as $r ($fields; . + {(($r.mode + "_" + $r.environment)): $r.failing_scenarios}))')
+
+          echo "Payload: ${payload}"
+
+          if ! curl -fsSL -X POST -H 'Content-type: application/json' \
+            --data "${payload}" "${SLACK_WEBHOOK_URL}"; then
+            echo "::warning::Failed to post Slack notification (workflow result unchanged)"
           fi


### PR DESCRIPTION
## Description

Adds a consolidated Slack notification to the provider e2e test workflow so failures are reported per mode/environment combination instead of just an overall pass/fail. Each `e2e_tests` matrix job (2 modes × 4 environments) now captures its own `behave` output, extracts the `Failing scenarios:` block on failure, and uploads it as a result artifact. A new `notify` job downloads all artifacts and posts a single Slack webhook payload with one field per `<mode>_<environment>` key (e.g. `server_azure`, `library_watsonx`) containing that job's failing scenarios (or `"None"` on success, `"N/A"` if a job never ran), plus a `run_url` field linking back to the workflow run. This makes it much faster to see exactly which provider/mode combinations broke and why, straight from Slack, without digging through 8 separate CI job logs.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor (Claude Sonnet 5)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue LCORE-2916
- Closes LCORE-2916

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Validated the workflow YAML parses correctly.
- Dry-ran the `jq` payload-construction logic locally with sample data to confirm it produces the expected `{run_url, server_azure, server_vertexai, server_watsonx, server_bedrock, library_azure, library_vertexai, library_watsonx, library_bedrock}` shape, including correct escaping of multi-line failing-scenario strings.
- Verified the `awk`/`sed` extraction correctly pulls out the `Failing scenarios:` block from a sample `behave`-style log, including stripping ANSI color codes.
- Not yet verified against a live scheduled/dispatched workflow run — recommend triggering `workflow_dispatch` once merged to confirm the actual Slack message renders as expected against the real Slack workflow trigger's input variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reporting by capturing complete test output and identifying failing scenarios.
  * Added consolidated reporting across test modes and environments.
  * Enhanced Slack notifications with detailed failure information and fallback status details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->