### PR TITLE
LCORE-3198: Add Shields Configuration

### DIFF
--- a/src/configuration.py
+++ b/src/configuration.py
@@ -32,6 +32,7 @@ from models.config import (
     RerankerConfiguration,
     RlsapiV1Configuration,
     ServiceConfiguration,
+    ShieldConfiguration,
     SkillsConfiguration,
     SplunkConfiguration,
     UserDataCollection,
@@ -552,6 +553,13 @@ class AppConfig:  # pylint: disable=too-many-public-methods
         if self._configuration is None:
             raise LogicError("logic error: configuration is not loaded")
         return self._configuration.skills
+
+    @property
+    def shields(self) -> list[ShieldConfiguration]:
+        """Return the list of configured guardrail shields."""
+        if self._configuration is None:
+            raise LogicError("logic error: configuration is not loaded")
+        return self._configuration.shields
 
     @property
     def rag_id_mapping(self) -> dict[str, str]:

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -7,7 +7,7 @@ from enum import Enum
 from functools import cached_property
 from pathlib import Path
 from re import Pattern
-from typing import Any, Literal, Optional, Self
+from typing import Annotated, Any, Literal, Optional, Self
 
 import jsonpath_ng
 import yaml
@@ -2590,6 +2590,74 @@ class RedactionConfig(ConfigurationBase):
         return list(self._compiled_patterns)
 
 
+class QuestionValidityShieldConfiguration(ConfigurationBase):
+    """Configuration for a named question-validity guardrail shield.
+
+    Attributes:
+        name: Unique, user-facing name identifying this shield instance.
+        type: Discriminator identifying this as a question-validity shield.
+        config: Question-validity-specific configuration.
+    """
+
+    name: str = Field(
+        ...,
+        title="Shield name",
+        description="Unique, user-facing name identifying this shield instance.",
+    )
+
+    type: Literal["question_validity"] = Field(
+        ...,
+        title="Shield type",
+        description="Discriminator identifying this as a question-validity shield.",
+    )
+
+    config: QuestionValidityConfig = Field(
+        ...,
+        title="Shield configuration",
+        description="Question-validity-specific configuration for this shield.",
+    )
+
+
+class RedactionShieldConfiguration(ConfigurationBase):
+    """Configuration for a named PII-redaction guardrail shield.
+
+    Attributes:
+        name: Unique, user-facing name identifying this shield instance.
+        type: Discriminator identifying this as a redaction shield.
+        config: Redaction-specific configuration.
+    """
+
+    name: str = Field(
+        ...,
+        title="Shield name",
+        description="Unique, user-facing name identifying this shield instance.",
+    )
+
+    type: Literal["redaction"] = Field(
+        ...,
+        title="Shield type",
+        description="Discriminator identifying this as a redaction shield.",
+    )
+
+    config: RedactionConfig = Field(
+        ...,
+        title="Shield configuration",
+        description="Redaction-specific configuration for this shield.",
+    )
+
+
+ShieldConfiguration = Annotated[
+    QuestionValidityShieldConfiguration | RedactionShieldConfiguration,
+    Field(discriminator="type"),
+]
+"""Configuration for a single named guardrail shield (question validity or redaction).
+
+A discriminated union on ``type``: Pydantic selects
+``QuestionValidityShieldConfiguration`` or ``RedactionShieldConfiguration``
+and validates ``config`` against the matching model.
+"""
+
+
 class Configuration(ConfigurationBase):
     """Global service configuration."""
 
@@ -2774,6 +2842,33 @@ class Configuration(ConfigurationBase):
         description="Configuration for saved prompts feature limits including "
         "maximum prompts per user, display name length, and content length.",
     )
+
+    shields: list[ShieldConfiguration] = Field(
+        default_factory=list,
+        title="Shields configuration",
+        description="List of pydantic-ai-lightspeed agent guardrail shields "
+        "(question validity and PII redaction). Each entry has a unique 'name', "
+        "a 'type' ('question_validity' or 'redaction'), and a type-specific "
+        "'config'.",
+    )
+
+    @model_validator(mode="after")
+    def validate_shield_names_unique(self) -> Self:
+        """Reject shields lists containing duplicate names.
+
+        Returns:
+            Self: The model instance after validation.
+
+        Raises:
+            ValueError: If two or more shields share the same name.
+        """
+        names = [shield.name for shield in self.shields]
+        duplicates = {name for name in names if names.count(name) > 1}
+        if duplicates:
+            raise ValueError(
+                f"Shield names must be unique, found duplicates: {sorted(duplicates)}"
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_mcp_auth_headers(self) -> Self:

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -231,6 +231,7 @@ def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -454,6 +455,7 @@ def test_dump_configuration_valid_values(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -828,6 +830,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -1086,6 +1089,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -1324,6 +1328,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -1542,6 +1547,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -1920,6 +1926,7 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -2144,6 +2151,7 @@ def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -2368,6 +2376,7 @@ def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }
 
 
@@ -2599,4 +2608,5 @@ def test_dump_configuration_specific_compaction_values(tmp_path: Path) -> None:
             },
             "saved_prompts": _DEFAULT_SAVED_PROMPTS_DUMP,
             "skills": None,
+            "shields": [],
         }

--- a/tests/unit/models/config/test_shields_configuration.py
+++ b/tests/unit/models/config/test_shields_configuration.py
@@ -1,0 +1,196 @@
+"""Unit tests for ShieldConfiguration model and the Configuration.shields list."""
+
+# pylint: disable=no-member
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from models.config import (
+    CompactionConfiguration,
+    Configuration,
+    LlamaStackConfiguration,
+    QuestionValidityConfig,
+    QuestionValidityShieldConfiguration,
+    RedactionConfig,
+    RedactionRule,
+    RedactionShieldConfiguration,
+    ServiceConfiguration,
+    ShieldConfiguration,
+    UserDataCollection,
+)
+
+ShieldConfigurationAdapter = TypeAdapter(ShieldConfiguration)
+
+
+class TestShieldConfiguration:
+    """Tests for the ShieldConfiguration discriminated union."""
+
+    def test_question_validity_shield(self) -> None:
+        """A question_validity shield parses config into QuestionValidityConfig."""
+        shield = ShieldConfigurationAdapter.validate_python(
+            {
+                "name": "topic-guard",
+                "type": "question_validity",
+                "config": {"model_id": "test-model"},
+            }
+        )
+        assert shield.name == "topic-guard"
+        assert shield.type == "question_validity"
+        assert isinstance(shield.config, QuestionValidityConfig)
+        assert shield.config.model_id == "test-model"
+
+    def test_redaction_shield(self) -> None:
+        """A redaction shield parses config into RedactionConfig."""
+        shield = ShieldConfigurationAdapter.validate_python(
+            {
+                "name": "pii-guard",
+                "type": "redaction",
+                "config": {"rules": [{"pattern": r"\d+", "replacement": "[NUM]"}]},
+            }
+        )
+        assert shield.name == "pii-guard"
+        assert shield.type == "redaction"
+        assert isinstance(shield.config, RedactionConfig)
+        assert len(shield.config.compiled_patterns) == 1
+
+    def test_accepts_already_constructed_config_instance(self) -> None:
+        """config may be passed as an already-constructed model instance."""
+        shield = ShieldConfigurationAdapter.validate_python(
+            {
+                "name": "topic-guard",
+                "type": "question_validity",
+                "config": QuestionValidityConfig(model_id="test-model"),
+            }
+        )
+        assert isinstance(shield.config, QuestionValidityConfig)
+
+    def test_rejects_config_mismatched_with_type(self) -> None:
+        """A redaction type with question_validity-shaped config is rejected."""
+        with pytest.raises(ValidationError, match="model_id"):
+            ShieldConfigurationAdapter.validate_python(
+                {
+                    "name": "bad",
+                    "type": "redaction",
+                    "config": {"model_id": "oops"},
+                }
+            )
+
+    def test_rejects_unknown_type(self) -> None:
+        """An unrecognized shield type is rejected."""
+        with pytest.raises(ValidationError):
+            ShieldConfigurationAdapter.validate_python(
+                {
+                    "name": "bad",
+                    "type": "unknown_type",
+                    "config": {"model_id": "test-model"},
+                }
+            )
+
+    def test_rejects_unknown_fields(self) -> None:
+        """Unknown fields are forbidden on ShieldConfiguration."""
+        with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+            ShieldConfigurationAdapter.validate_python(
+                {
+                    "name": "topic-guard",
+                    "type": "question_validity",
+                    "config": {"model_id": "test-model"},
+                    "unknown_field": "value",
+                }
+            )
+
+
+def _minimal_configuration_kwargs() -> dict:
+    return {
+        "name": "test",
+        "service": ServiceConfiguration(),
+        "llama_stack": LlamaStackConfiguration(
+            use_as_library_client=True,
+            library_client_config_path="tests/configuration/run.yaml",
+        ),
+        "user_data_collection": UserDataCollection(
+            feedback_enabled=False, feedback_storage=None
+        ),
+        "compaction": CompactionConfiguration(),
+    }
+
+
+def test_root_configuration_has_shields_field() -> None:
+    """The root Configuration declares a shields list field, empty by default."""
+    field_info = Configuration.model_fields.get("shields")
+    assert field_info is not None
+
+    factory = field_info.default_factory
+    assert factory is not None
+    assert factory() == []  # type: ignore[call-arg]
+
+
+def test_root_configuration_default_shields_is_empty() -> None:
+    """Configuration constructed without shields defaults to an empty list."""
+    cfg = Configuration(**_minimal_configuration_kwargs())
+    assert cfg.shields == []
+
+
+def test_root_configuration_accepts_multiple_shields_of_same_type() -> None:
+    """Multiple shields of the same type may be configured with distinct names."""
+    cfg = Configuration(
+        **_minimal_configuration_kwargs(),
+        shields=[
+            QuestionValidityShieldConfiguration(
+                name="topic-guard-a",
+                type="question_validity",
+                config=QuestionValidityConfig(model_id="model-a"),
+            ),
+            QuestionValidityShieldConfiguration(
+                name="topic-guard-b",
+                type="question_validity",
+                config=QuestionValidityConfig(model_id="model-b"),
+            ),
+        ],
+    )
+    assert len(cfg.shields) == 2
+    assert cfg.shields[0].name == "topic-guard-a"
+    assert cfg.shields[1].name == "topic-guard-b"
+
+
+def test_root_configuration_accepts_mixed_shield_types() -> None:
+    """Shields of different types may be mixed in the same list."""
+    cfg = Configuration(
+        **_minimal_configuration_kwargs(),
+        shields=[
+            QuestionValidityShieldConfiguration(
+                name="topic-guard",
+                type="question_validity",
+                config=QuestionValidityConfig(model_id="test-model"),
+            ),
+            RedactionShieldConfiguration(
+                name="pii-guard",
+                type="redaction",
+                config=RedactionConfig(
+                    rules=[RedactionRule(pattern=r"\d+", replacement="[NUM]")]
+                ),
+            ),
+        ],
+    )
+    assert len(cfg.shields) == 2
+    assert cfg.shields[0].type == "question_validity"
+    assert cfg.shields[1].type == "redaction"
+
+
+def test_root_configuration_rejects_duplicate_shield_names() -> None:
+    """Shield names must be unique across the shields list."""
+    with pytest.raises(ValidationError, match="Shield names must be unique"):
+        Configuration(
+            **_minimal_configuration_kwargs(),
+            shields=[
+                QuestionValidityShieldConfiguration(
+                    name="dup",
+                    type="question_validity",
+                    config=QuestionValidityConfig(model_id="model-a"),
+                ),
+                RedactionShieldConfiguration(
+                    name="dup",
+                    type="redaction",
+                    config=RedactionConfig(),
+                ),
+            ],
+        )

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -130,6 +130,10 @@ def test_default_configuration() -> None:
         # try to read property
         _ = cfg.deployment_environment  # pylint: disable=pointless-statement
 
+    with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
+        # try to read property
+        _ = cfg.shields  # pylint: disable=pointless-statement
+
 
 def test_configuration_is_singleton() -> None:
     """Test that configuration is singleton."""
@@ -241,6 +245,70 @@ def test_init_from_dict() -> None:
 
     # check token usage history
     assert cfg.token_usage_history is None
+
+    # check shields - not configured in config_dict, defaults to empty list
+    assert cfg.shields == []
+
+
+def test_init_from_dict_with_shields() -> None:
+    """Test initialization with guardrail shields configuration."""
+    config_dict: dict[str, Any] = {
+        "name": "foo",
+        "service": {
+            "host": "localhost",
+            "port": 8080,
+            "auth_enabled": False,
+            "workers": 1,
+            "color_log": True,
+            "access_log": True,
+        },
+        "llama_stack": {
+            "api_key": "xyzzy",
+            "url": "http://x.y.com:1234",
+            "use_as_library_client": False,
+        },
+        "user_data_collection": {
+            "feedback_enabled": False,
+        },
+        "mcp_servers": [],
+        "customization": None,
+        "authentication": {
+            "module": "noop",
+        },
+        "shields": [
+            {
+                "name": "topic-guard-a",
+                "type": "question_validity",
+                "config": {"model_id": "test-model"},
+            },
+            {
+                "name": "topic-guard-b",
+                "type": "question_validity",
+                "config": {"model_id": "test-model-2"},
+            },
+            {
+                "name": "pii-guard",
+                "type": "redaction",
+                "config": {
+                    "rules": [
+                        {"pattern": r"\d+", "replacement": "[NUM]"},
+                    ],
+                },
+            },
+        ],
+    }
+    cfg = AppConfig()
+    cfg.init_from_dict(config_dict)
+
+    assert len(cfg.shields) == 3
+    assert cfg.shields[0].name == "topic-guard-a"
+    assert cfg.shields[0].type == "question_validity"
+    assert cfg.shields[0].config.model_id == "test-model"  # type: ignore[union-attr]
+    assert cfg.shields[1].name == "topic-guard-b"
+    assert cfg.shields[1].config.model_id == "test-model-2"  # type: ignore[union-attr]
+    assert cfg.shields[2].name == "pii-guard"
+    assert cfg.shields[2].type == "redaction"
+    assert len(cfg.shields[2].config.compiled_patterns) == 1  # type: ignore[union-attr]
 
 
 def test_init_from_dict_with_mcp_servers() -> None:


### PR DESCRIPTION
## Description

Adds a `shields` configuration section to `lightspeed-stack.yaml` for configuring the pydantic-ai-lightspeed agent guardrail capabilities: question validity filtering (`src/pydantic_ai_lightspeed/capabilities/question_validity/`) and PII redaction (`src/pydantic_ai_lightspeed/capabilities/redaction/`). Previously these capabilities' config models (`QuestionValidityConfig`, `RedactionConfig`) existed but had no way to be populated from the service configuration file.

`shields` is a list of named, typed entries so that multiple shields — including multiple of the same type (e.g. several question-validity checks against different topics, or several independent redaction rule sets) — can be configured at once. Each entry has a `name`, a `type` (`redaction` or `question_validity`), and a type-specific `config` block.

Each entry's `config` is parsed into the concrete model matching `type` (`QuestionValidityConfig` for `question_validity`, `RedactionConfig` for `redaction`) via a `model_validator(mode="before")` on the new `ShieldConfiguration` model, with a clear error message when `config` doesn't match the declared `type`. Shield `name`s must be unique across the list; a new validator on `Configuration` enforces this and raises a `ValueError` on duplicates.

This PR only introduces the configuration schema (model + `AppConfig.shields` accessor property) — wiring these shields into the actual agent-building flow (`utils/pydantic_ai_helpers.py`) is intentionally left for follow-up work.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue LCORE-3198
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Added `tests/unit/models/config/test_shields_configuration.py` covering: parsing `config` by `type` for both shield types, accepting an already-constructed config instance, rejecting mismatched `type`/`config` pairs and unknown types/fields, empty-by-default `shields`, mixing multiple shields (including multiple of the same type), and duplicate-name rejection.
- Updated `tests/unit/test_configuration.py` (`AppConfig.shields` accessor: not-loaded error, default empty list, and `init_from_dict` with a 3-entry `shields` list spanning both types) and `tests/unit/models/config/test_dump_configuration.py` (snapshot dumps now include `"shields": []`).
- Ran `uv run make format` and `uv run make verify` (black, ruff, pylint 10.00/10, pyright, mypy) — all clean for the changed files.
- Ran the full relevant unit test suite (`tests/unit/models`, `tests/unit/test_configuration.py`, `tests/unit/utils/test_models_dumper.py`) — 762 passed.