### PR TITLE
LCORE- Fix accidental namspace package

### DIFF
--- a/src/utils/agents/__init__.py
+++ b/src/utils/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Agent helpers."""

--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -1,5 +1,7 @@
 """Agent streaming helpers for the streaming_query flow."""
 
+# pylint: disable=R0913,R0914, R0917
+
 from __future__ import annotations
 
 import asyncio
@@ -403,7 +405,7 @@ def _process_token(
 
 
 @singledispatch
-def dispatch_stream_event(
+def dispatch_stream_event(  # pylint: disable=useless-return
     event: AgentDispatchEvent,
     _state: AgentTurnAccumulator,
 ) -> Optional[StreamEventPayload]:
@@ -417,6 +419,7 @@ def dispatch_stream_event(
         None when the event does not map to an SSE payload.
     """
     logger.debug("Ignoring event kind=%s", event.event_kind)
+
     return None
 
 

--- a/src/utils/agents/tool_processor.py
+++ b/src/utils/agents/tool_processor.py
@@ -101,7 +101,7 @@ def summarize_native_tool_call(
                 type="mcp_call",
             )
         case _:
-            logger.warning(f"Unknown tool name: {part.tool_name}")
+            logger.warning("Unknown tool name: %s", part.tool_name)
             return None
 
 
@@ -184,7 +184,7 @@ def process_native_tool_result(
         case tool_name if tool_name.startswith(_MCP_SERVER_TOOL_PREFIX):
             tool_result = summarize_mcp_tool_result(part, state.tool_round)
         case _:
-            logger.warning(f"Unknown tool name: {part.tool_name}")
+            logger.warning("Unknown tool name: %s", part.tool_name)
             return None
 
     state.emitted_tool_result_ids.add(tool_result.id)


### PR DESCRIPTION
## Description

`src/utils/agents was missing` an `__init__.py`, making it a [namepsace package](https://docs.python.org/3/reference/import.html#reference-namespace-package). A side effect of this was it was being skipped by `pylint`.

Change the namespace package to a package and address `pylint` failures.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: crush using opus-4.6

## Related Tickets & Documents
 
Found when doing work on #2167.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
To duplicate the failure:

1. Checkout `main`
2. Run `pylint src`. Errors will be reported.
3. Run `pylint src tests`. No errors will be reported.

With the changes in this PR, running `pylint src tests` correctly inspects modules in the `utils.agents` package.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality and consistency in agent processing and streaming components.
  * Enhanced handling and logging of unrecognized tool events without changing user-facing behavior.
* **Documentation**
  * Added documentation for agent helper utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->