### PR TITLE
LCORE-3201: Expand Shield Interface for direct running

### DIFF
--- a/src/models/common/moderation.py
+++ b/src/models/common/moderation.py
@@ -20,7 +20,14 @@ class ShieldModerationBlocked(BaseModel):
     decision: Literal["blocked"] = "blocked"
     message: str
     moderation_id: str
-    refusal_response: ResponseMessage
+
+    @property
+    def refusal_response(self) -> ResponseMessage:
+
+        return ResponseMessage(
+            role="assistant",
+            content=self.message,
+        )
 
 
 ShieldModerationResult = Annotated[

--- a/src/models/common/moderation.py
+++ b/src/models/common/moderation.py
@@ -23,7 +23,7 @@ class ShieldModerationBlocked(BaseModel):
 
     @property
     def refusal_response(self) -> ResponseMessage:
-
+        """Build a ResponseMessage carrying the shield's refusal text."""
         return ResponseMessage(
             role="assistant",
             content=self.message,

--- a/src/pydantic_ai_lightspeed/capabilities/base.py
+++ b/src/pydantic_ai_lightspeed/capabilities/base.py
@@ -1,0 +1,18 @@
+"""Abstract base for safety capabilities with a standalone run interface."""
+
+from abc import abstractmethod
+
+from pydantic_ai.capabilities import AbstractCapability
+from typing_extensions import TypeVar
+
+from models.common.moderation import ShieldModerationResult
+
+T = TypeVar("T", default=object)
+
+
+class AbstractSafetyCapability(AbstractCapability[T]):
+    """Interface for safety/moderation that can be called directly."""
+
+    @abstractmethod
+    async def run(self, input_text: str) -> ShieldModerationResult:
+        """Run moderation on input text."""

--- a/src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py
+++ b/src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py
@@ -13,10 +13,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from string import Template
 from typing import Optional
+from uuid import uuid4
 
 from pydantic_ai import AgentRunResult, RunContext
 from pydantic_ai._agent_graph import GraphAgentState
-from pydantic_ai.capabilities import AbstractCapability, WrapRunHandler
+from pydantic_ai.capabilities import WrapRunHandler
 from pydantic_ai.direct import model_request
 from pydantic_ai.messages import ModelRequest, TextContent, UserContent
 from pydantic_ai.models import Model
@@ -24,9 +25,15 @@ from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 
 from client import AsyncOgxClientHolder
 from log import get_logger
+from models.common.moderation import (
+    ShieldModerationBlocked,
+    ShieldModerationPassed,
+    ShieldModerationResult,
+)
 from models.config import (
     QuestionValidityConfig,
 )
+from pydantic_ai_lightspeed.capabilities.base import AbstractSafetyCapability
 from pydantic_ai_lightspeed.llamastack import OgxResponsesModel
 
 logger = get_logger(__name__)
@@ -56,7 +63,7 @@ def _extract_message_str_from_user_content(user_content: Sequence[UserContent]) 
 
 
 @dataclass
-class QuestionValidity(AbstractCapability[None]):
+class QuestionValidity(AbstractSafetyCapability):
     """Block or modify user input based on a guardrail check.
 
     The guard function receives the user prompt and returns True if safe.
@@ -139,4 +146,18 @@ class QuestionValidity(AbstractCapability[None]):
         state = GraphAgentState(usage=ctx.usage)
         return AgentRunResult(
             output=self.config.invalid_question_response, _state=state
+        )
+
+    async def run(self, input_text: str) -> ShieldModerationResult:
+        """Run question-validity check and return a moderation result."""
+        result = await model_request(
+            model=self._model, messages=[ModelRequest.user_text_prompt(input_text)]
+        )
+
+        if result.text is not None and result.text.strip() == SUBJECT_ALLOWED:
+            return ShieldModerationPassed()
+
+        return ShieldModerationBlocked(
+            message=self.config.invalid_question_response,
+            moderation_id=f"modr-{uuid4()}",
         )

--- a/src/pydantic_ai_lightspeed/capabilities/redaction/_capability.py
+++ b/src/pydantic_ai_lightspeed/capabilities/redaction/_capability.py
@@ -3,9 +3,9 @@
 from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import Any, Optional
+from uuid import uuid4
 
 from pydantic_ai import RunContext
-from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.messages import (
     ModelMessage,
     ModelRequest,
@@ -19,7 +19,13 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import ModelRequestContext
 
+from models.common.moderation import (
+    ShieldModerationBlocked,
+    ShieldModerationPassed,
+    ShieldModerationResult,
+)
 from models.config import RedactionConfig
+from pydantic_ai_lightspeed.capabilities.base import AbstractSafetyCapability
 from pydantic_ai_lightspeed.capabilities.redaction.core import (
     CompiledPatterns,
     redact_text,
@@ -257,7 +263,7 @@ def _redact_response(
 
 
 @dataclass
-class PiiRedactionCapability(AbstractCapability[Any]):
+class PiiRedactionCapability(AbstractSafetyCapability):
     """Pydantic AI capability that redacts PII from agent messages.
 
     Applies configurable regex-based redaction rules to user prompt
@@ -321,3 +327,14 @@ class PiiRedactionCapability(AbstractCapability[Any]):
         )
 
         return new_response
+
+    async def run(self, input_text: str) -> ShieldModerationResult:
+        """Run PII redaction on input text and return a moderation result."""
+        result = redact_text(input_text, self.config.compiled_patterns)
+
+        if result.redacted:
+            return ShieldModerationBlocked(
+                message="Sensitive content detected.", moderation_id=f"modr-{uuid4()}"
+            )
+
+        return ShieldModerationPassed()

--- a/src/utils/shields.py
+++ b/src/utils/shields.py
@@ -3,7 +3,6 @@
 from typing import Optional
 
 from fastapi import HTTPException
-from ogx_api import OpenAIResponseMessage
 from ogx_client import (
     APIConnectionError,
     AsyncOgxClient,
@@ -128,21 +127,6 @@ async def append_turn_to_conversation(
     except LLSApiStatusError as e:
         error_response = InternalServerErrorResponse.generic()
         raise HTTPException(**error_response.model_dump()) from e
-
-
-def create_refusal_response(refusal_message: str) -> OpenAIResponseMessage:
-    """Create a refusal response message object.
-
-    Args:
-        refusal_message: The refusal message text.
-
-    Returns:
-        OpenAIResponseMessage with refusal message.
-    """
-    return OpenAIResponseMessage(
-        role="assistant",
-        content=refusal_message,
-    )
 
 
 def get_shields_for_request(

--- a/tests/integration/endpoints/test_responses_integration.py
+++ b/tests/integration/endpoints/test_responses_integration.py
@@ -11,7 +11,6 @@ from typing import Any
 import pytest
 from fastapi import Request
 from fastapi.responses import StreamingResponse
-from ogx_api.openai_responses import OpenAIResponseMessage
 from ogx_client.types import ListModelsResponse
 from ogx_client.types.model import Model
 from pytest_mock import MockerFixture
@@ -172,10 +171,6 @@ def _configure_shield_blocked(
     blocked = ShieldModerationBlocked(
         message="Content blocked by safety shield",
         moderation_id=moderation_id,
-        refusal_response=OpenAIResponseMessage(
-            role="assistant",
-            content="Content blocked by safety shield",
-        ),
     )
     mocker.patch(
         "app.endpoints.responses.run_shield_moderation",

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -189,11 +189,6 @@ def _patch_moderation(mocker: MockerFixture, decision: str = "passed") -> Any:
         moderation_result = ShieldModerationBlocked(
             message="Content blocked",
             moderation_id="mod_blocked",
-            refusal_response=OpenAIResponseMessage(
-                role="assistant",
-                content="Content blocked",
-                type="message",
-            ),
         )
     else:
         moderation_result = ShieldModerationPassed()

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -623,9 +623,6 @@ class TestResponsesEndpointHandler:
         mock_moderation = _patch_moderation(mocker, decision="blocked")
         mock_moderation.message = "Blocked"
         mock_moderation.moderation_id = "resp_blocked_123"
-        mock_moderation.refusal_response = OpenAIResponseMessage(
-            type="message", role="assistant", content="Blocked"
-        )
         mock_append = mocker.patch(
             f"{MODULE}.append_turn_items_to_conversation",
             new=mocker.AsyncMock(),

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -13,7 +13,6 @@ from typing import Any, Optional
 
 import pytest
 from fastapi import HTTPException, status
-from ogx_api import OpenAIResponseMessage
 from ogx_client import APIConnectionError, APIStatusError
 from ogx_client.types import ListModelsResponse
 from ogx_client.types.model import Model
@@ -1254,10 +1253,6 @@ async def test_infer_quota_shield_blocked_does_not_consume_tokens(
     blocked = ShieldModerationBlocked(
         message="Blocked by moderation",
         moderation_id="modr-test",
-        refusal_response=OpenAIResponseMessage(
-            role="assistant",
-            content="Blocked by moderation",
-        ),
     )
     mocker.patch(
         "app.endpoints.rlsapi_v1.run_shield_moderation",
@@ -1287,10 +1282,6 @@ def _create_blocked_moderation_result() -> ShieldModerationBlocked:
     return ShieldModerationBlocked(
         message="I can't answer that. Can I help with something else?",
         moderation_id="modr-test-123",
-        refusal_response=OpenAIResponseMessage(
-            role="assistant",
-            content="I can't answer that. Can I help with something else?",
-        ),
     )
 
 

--- a/tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
+++ b/tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
@@ -14,6 +14,7 @@ from constants import (
     DEFAULT_INVALID_QUESTION_RESPONSE,
     DEFAULT_MODEL_PROMPT,
 )
+from models.common.moderation import ShieldModerationBlocked, ShieldModerationPassed
 from models.config import (
     QuestionValidityConfig,
 )
@@ -532,3 +533,108 @@ class TestWrapRun:
         prompt_str = str(messages[0])
         assert "How to" in prompt_str
         assert "scale a deployment?" in prompt_str
+
+
+class TestQuestionValidityRun:
+    """Tests for QuestionValidity.run method."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_create_model(self, mocker: MockerFixture) -> None:
+        """Mock model creation for all tests."""
+        mocker.patch(f"{_MODULE}.AsyncOgxClientHolder")
+        mocker.patch(f"{_MODULE}.OgxResponsesModel.from_ogx_client")
+
+    @pytest.mark.asyncio
+    async def test_allowed_returns_passed(self, mocker: MockerFixture) -> None:
+        """Test that an allowed response returns ShieldModerationPassed."""
+        mock_response = ModelResponse(
+            parts=[TextPart(content=SUBJECT_ALLOWED)],
+            usage=RequestUsage(input_tokens=10, output_tokens=1),
+        )
+        mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
+
+        config = QuestionValidityConfig(model_id="test")
+        qv = QuestionValidity(config=config)
+        result = await qv.run("How do I create a pod?")
+
+        assert isinstance(result, ShieldModerationPassed)
+        assert result.decision == "passed"
+
+    @pytest.mark.asyncio
+    async def test_rejected_returns_blocked(self, mocker: MockerFixture) -> None:
+        """Test that a rejected response returns ShieldModerationBlocked."""
+        mock_response = ModelResponse(
+            parts=[TextPart(content=SUBJECT_REJECTED)],
+            usage=RequestUsage(input_tokens=10, output_tokens=1),
+        )
+        mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
+
+        config = QuestionValidityConfig(model_id="test")
+        qv = QuestionValidity(config=config)
+        result = await qv.run("What is the meaning of life?")
+
+        assert isinstance(result, ShieldModerationBlocked)
+        assert result.message == DEFAULT_INVALID_QUESTION_RESPONSE
+        assert result.moderation_id.startswith("modr-")
+        assert result.refusal_response.role == "assistant"
+        assert result.refusal_response.content == DEFAULT_INVALID_QUESTION_RESPONSE
+
+    @pytest.mark.asyncio
+    async def test_unexpected_response_returns_blocked(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that an unexpected model response is treated as blocked."""
+        mock_response = ModelResponse(
+            parts=[TextPart(content="I don't understand")],
+            usage=RequestUsage(input_tokens=10, output_tokens=5),
+        )
+        mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
+
+        config = QuestionValidityConfig(model_id="test")
+        qv = QuestionValidity(config=config)
+        result = await qv.run("some input")
+
+        assert isinstance(result, ShieldModerationBlocked)
+        assert result.message == DEFAULT_INVALID_QUESTION_RESPONSE
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "response_text",
+        [" ALLOWED", "ALLOWED ", " ALLOWED ", "ALLOWED\n"],
+        ids=["leading-space", "trailing-space", "both-spaces", "trailing-newline"],
+    )
+    async def test_allowed_with_whitespace_returns_passed(
+        self, mocker: MockerFixture, response_text: str
+    ) -> None:
+        """Test that ALLOWED with surrounding whitespace still returns passed."""
+        mock_response = ModelResponse(
+            parts=[TextPart(content=response_text)],
+            usage=RequestUsage(input_tokens=10, output_tokens=1),
+        )
+        mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
+
+        config = QuestionValidityConfig(model_id="test")
+        qv = QuestionValidity(config=config)
+        result = await qv.run("How do I scale pods?")
+
+        assert isinstance(result, ShieldModerationPassed)
+
+    @pytest.mark.asyncio
+    async def test_custom_invalid_response_message(self, mocker: MockerFixture) -> None:
+        """Test that a custom rejection message is used in the blocked result."""
+        mock_response = ModelResponse(
+            parts=[TextPart(content=SUBJECT_REJECTED)],
+            usage=RequestUsage(),
+        )
+        mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
+
+        config = QuestionValidityConfig(
+            model_id="test", invalid_question_response="Custom rejection."
+        )
+        qv = QuestionValidity(config=config)
+        result = await qv.run("off-topic question")
+
+        assert isinstance(result, ShieldModerationBlocked)
+        assert result.message == "Custom rejection."
+        assert result.refusal_response.role == "assistant"
+        assert result.refusal_response.content == "Custom rejection."

--- a/tests/unit/pydantic_ai_lightspeed/capabilities/redaction/test_capability.py
+++ b/tests/unit/pydantic_ai_lightspeed/capabilities/redaction/test_capability.py
@@ -13,6 +13,7 @@ from pydantic_ai.messages import (
 from pydantic_ai.models import ModelRequestContext
 from pytest_mock import MockerFixture
 
+from models.common.moderation import ShieldModerationBlocked, ShieldModerationPassed
 from models.config import (
     RedactionConfig,
     RedactionRule,
@@ -314,3 +315,46 @@ class TestPiiRedactionCapability:
         )
         assert result is resp
         assert resp.parts[0].content == "clean response"
+
+
+class TestPiiRedactionCapabilityRun:
+    """Tests for PiiRedactionCapability.run method."""
+
+    @pytest.fixture(name="capability")
+    def capability_fixture(self) -> PiiRedactionCapability:
+        """Create a PiiRedactionCapability with an email redaction rule.
+
+        Returns:
+            A configured PiiRedactionCapability instance.
+        """
+        config = RedactionConfig(
+            rules=[
+                RedactionRule(
+                    pattern=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+                    replacement="[REDACTED_EMAIL]",
+                )
+            ],
+            case_sensitive=True,
+        )
+        return PiiRedactionCapability(config=config)
+
+    @pytest.mark.asyncio()
+    async def test_clean_text_returns_passed(
+        self, capability: PiiRedactionCapability
+    ) -> None:
+        """Test that clean text returns ShieldModerationPassed."""
+        result = await capability.run("no sensitive content here")
+
+        assert isinstance(result, ShieldModerationPassed)
+        assert result.decision == "passed"
+
+    @pytest.mark.asyncio()
+    async def test_pii_text_returns_blocked(
+        self, capability: PiiRedactionCapability
+    ) -> None:
+        """Test that text with PII returns ShieldModerationBlocked."""
+        result = await capability.run("contact user@example.com for details")
+
+        assert isinstance(result, ShieldModerationBlocked)
+        assert result.message == "Sensitive content detected."
+        assert result.moderation_id.startswith("modr-")

--- a/tests/unit/utils/agents/test_query.py
+++ b/tests/unit/utils/agents/test_query.py
@@ -5,9 +5,6 @@ from typing import Any, Optional
 
 import pytest
 from fastapi import HTTPException
-from ogx_api.openai_responses import (
-    OpenAIResponseMessage as ResponseMessage,
-)
 from ogx_client import APIConnectionError, APIStatusError
 from pydantic_ai.messages import (
     FinishReason,
@@ -109,10 +106,6 @@ def blocked_moderation_fixture() -> ShieldModerationBlocked:
     return ShieldModerationBlocked(
         message="Content blocked by shield.",
         moderation_id="modr-test-456",
-        refusal_response=ResponseMessage(
-            role="assistant",
-            content="Content blocked by shield.",
-        ),
     )
 
 

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -1048,9 +1048,9 @@ class TestInterruptPartialTokenAccumulation:
         num_chunks = len(chunk_ids)
         assert chunk_ids == sorted(chunk_ids), "chunk_ids must be monotonically ordered"
         assert all(cid >= 0 for cid in chunk_ids), "all chunk_ids must be non-negative"
-        assert num_chunks == len(set(chunk_ids)), (
-            "chunk_ids must not contain duplicates"
-        )
+        assert num_chunks == len(
+            set(chunk_ids)
+        ), "chunk_ids must not contain duplicates"
         assert chunk_ids[-1] == num_chunks - 1
 
     @pytest.mark.asyncio

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -9,9 +9,6 @@ from typing import Any, Optional
 
 import pytest
 from fastapi import HTTPException
-from ogx_api.openai_responses import (
-    OpenAIResponseMessage as ResponseMessage,
-)
 from ogx_client import APIStatusError
 from pydantic_ai import AgentRunResultEvent
 from pydantic_ai.exceptions import AgentRunError
@@ -118,10 +115,6 @@ def blocked_moderation_fixture() -> ShieldModerationBlocked:
     return ShieldModerationBlocked(
         message="Content blocked by shield.",
         moderation_id="modr-test-456",
-        refusal_response=ResponseMessage(
-            role="assistant",
-            content="Content blocked by shield.",
-        ),
     )
 
 
@@ -1055,9 +1048,9 @@ class TestInterruptPartialTokenAccumulation:
         num_chunks = len(chunk_ids)
         assert chunk_ids == sorted(chunk_ids), "chunk_ids must be monotonically ordered"
         assert all(cid >= 0 for cid in chunk_ids), "all chunk_ids must be non-negative"
-        assert num_chunks == len(
-            set(chunk_ids)
-        ), "chunk_ids must not contain duplicates"
+        assert num_chunks == len(set(chunk_ids)), (
+            "chunk_ids must not contain duplicates"
+        )
         assert chunk_ids[-1] == num_chunks - 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description
Introduce simplified V2 shield moderation models (ShieldModerationPassedV2, ShieldModerationBlockedV2, ShieldModerationResultV2) alongside the existing types to avoid breaking the responses pipeline. Add AbstractSafetyCapability in capabilities/base.py, consolidating the old safety module interface with pydantic-ai's AbstractCapability. Migrate QuestionValidity and PiiRedactionCapability to use V2 types and the new base class.

Follow-up PR will clean up the old moderation logic and rename V2 to the standard names.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
