### PR TITLE
LCORE-3141: Docs models are PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,23 @@ LLAMA_STACK_IMAGE ?= lightspeed-llama-stack:local
 LLAMA_STACK_PORT ?= 8321
 CONTAINER_RUNTIME ?= $(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null)
 
-.PHONY: run run-stack build-llama-stack-image remove-llama-stack-container stop-llama-stack-container start-llama-stack-container wait-for-llama-stack-health clean-llama-stack
+.PHONY: run \
+	run-stack \
+	build-llama-stack-image \
+	remove-llama-stack-container \
+	stop-llama-stack-container \
+	start-llama-stack-container \
+	wait-for-llama-stack-health \
+	clean-llama-stack \
+	docs/models \
+	docs/models/requests.puml \
+	docs/models/responses.puml \
+	docs/models/common.puml \
+	docs/models/database.puml \
+	docs/models/requests.svg \
+	docs/models/responses.svg \
+	docs/models/common.svg \
+	docs/models/database.svg
 
 run-stack: ## Run lightspeed-stack directly, without building dependent service/s
 	uv run src/lightspeed_stack.py -c $(CONFIG)
@@ -193,6 +209,7 @@ devel-doc:	## Generate documentation for developers
 	scripts/gen_doc.py
 
 docs/models:	docs/models/requests.puml docs/models/responses.puml docs/models/database.puml docs/models/common.puml	## Generate documentation about models
+	rm docs/models/packages.puml
 
 docs/models/requests.puml: ## Generate PlantUML class diagram for requests data models
 	uv run pyreverse src/models/api/requests/ --output puml --output-directory=docs/models/

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ devel-doc:	## Generate documentation for developers
 	scripts/gen_doc.py
 
 docs/models:	docs/models/requests.puml docs/models/responses.puml docs/models/database.puml docs/models/common.puml	## Generate documentation about models
-	rm docs/models/packages.puml
+	rm -f docs/models/packages.puml
 
 docs/models/requests.puml: ## Generate PlantUML class diagram for requests data models
 	uv run pyreverse src/models/api/requests/ --output puml --output-directory=docs/models/


### PR DESCRIPTION
## Description

LCORE-3141: Docs models are PHONY targets

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the model documentation generation workflow to include request, response, common, and database diagrams.
  * Ensured obsolete package diagram output is removed when regenerating model documentation.
  * Improved build target handling for documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->