### PR TITLE
LCORE-3211: Adapted OGX API changes

### DIFF
--- a/docs/devel_doc/responses.md
+++ b/docs/devel_doc/responses.md
@@ -154,7 +154,7 @@ All input item objects have a common `type` discriminator that determines the su
 
 Optional. List of output item types to include in the response that are excluded by default.
 
-Allowed values (literal strings): `web_search_call.action.sources`, `code_interpreter_call.outputs`, `computer_call_output.output.image_url`, `file_search_call.results`, `message.input_image.image_url`, `message.output_text.logprobs`, `reasoning.encrypted_content`.
+Allowed values (literal strings): `web_search_call.action.sources`, `code_interpreter_call.outputs`, `computer_call_output.output.image_url`, `file_search_call.results`, `message.input_image.image_url`, `message.output_text.logprobs`.
 
 **Examples:**
 

--- a/src/app/endpoints/conversations_v1.py
+++ b/src/app/endpoints/conversations_v1.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from ogx_api import ConversationNotFoundError
+from ogx_api import ConversationNotFoundError, InvalidParameterError
 from ogx_client import (
     APIConnectionError,
     APIStatusError,
@@ -388,7 +388,7 @@ async def delete_conversation_endpoint_handler(
         response = ServiceUnavailableResponse(backend_name="OGX", cause=str(e))
         raise HTTPException(**response.model_dump()) from e
 
-    except (APIStatusError, ConversationNotFoundError):
+    except (APIStatusError, ConversationNotFoundError, InvalidParameterError):
         # In library mode, ConversationNotFoundError is raised instead of APIStatusError
         logger.warning(
             "Conversation %s in LlamaStack not found. Treating as already deleted.",

--- a/src/models/common/responses/types.py
+++ b/src/models/common/responses/types.py
@@ -37,6 +37,9 @@ from ogx_api.openai_responses import (
     OpenAIResponseOutputMessageMCPListTools as McpListTools,
 )
 from ogx_api.openai_responses import (
+    OpenAIResponseOutputMessageReasoningItem as ReasoningItem,
+)
+from ogx_api.openai_responses import (
     OpenAIResponseOutputMessageWebSearchToolCall as WebSearchToolCall,
 )
 from pydantic import Field
@@ -60,7 +63,6 @@ type IncludeParameter = Literal[
     "file_search_call.results",
     "message.input_image.image_url",
     "message.output_text.logprobs",
-    "reasoning.encrypted_content",
 ]
 
 type ResponseItem = (
@@ -73,6 +75,7 @@ type ResponseItem = (
     | McpApprovalRequest
     | FunctionToolCall
     | McpApprovalResponse
+    | ReasoningItem
 )
 
 type ResponseInput = str | list[ResponseItem]

--- a/src/pydantic_ai_lightspeed/llamastack/_model.py
+++ b/src/pydantic_ai_lightspeed/llamastack/_model.py
@@ -12,6 +12,9 @@ streamed ``tool_args`` content to the correct part.
 
 This module provides ``OgxResponsesModel`` which wraps the event stream to
 buffer those early delta events and replay them correctly once the item is announced.
+
+Additionally overrides ``_responses_create`` to filter out ``reasoning.encrypted_content``
+from the include parameter, which llama-stack / OGX doesn't support.
 """
 
 from __future__ import annotations as _annotations
@@ -226,7 +229,49 @@ class OgxResponsesModel(OpenAIResponsesModel):
     Overrides the streaming response processing to buffer and replay
     ``ResponseFunctionCallArgumentsDeltaEvent`` events that Llama Stack emits
     before the corresponding ``McpCall`` or ``ResponseFunctionToolCall`` item.
+
+    Also filters ``reasoning.encrypted_content`` from the include parameter since
+    OGX doesn't support it.
     """
+
+    async def _responses_create(
+        self,
+        messages: list[ModelMessage],
+        stream: bool,
+        model_settings: OpenAIResponsesModelSettings,
+        model_request_parameters: ModelRequestParameters,
+    ) -> Any:
+        """Call parent's ``_responses_create``, filtering encrypted reasoning include.
+
+        OGX doesn't support ``reasoning.encrypted_content`` in the include
+        parameter. pydantic-ai adds it automatically based on the model profile, so we
+        disable that profile flag before sending.
+
+        Args:
+            messages: Model messages for the request.
+            stream: Whether this is a streaming request.
+            model_settings: Model-specific settings.
+            model_request_parameters: Request parameters for the model.
+
+        Returns:
+            Response from the Responses API.
+        """
+        # Parent gates include on this profile flag; disable it for OGX.
+        self.profile["openai_supports_encrypted_reasoning_content"] = False
+        # Branch on stream so mypy matches OpenAIResponsesModel overloads
+        if stream:
+            return await super()._responses_create(
+                messages,
+                True,
+                model_settings,
+                model_request_parameters,
+            )
+        return await super()._responses_create(
+            messages,
+            False,
+            model_settings,
+            model_request_parameters,
+        )
 
     async def request(  # pylint: disable=unused-argument
         self,

--- a/src/utils/conversations.py
+++ b/src/utils/conversations.py
@@ -31,6 +31,9 @@ from ogx_client.types.conversations.item_list_response import (
     OpenAIResponseInputFunctionToolCallOutput as FunctionToolCallOutput,
 )
 from ogx_client.types.conversations.item_list_response import (
+    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFile as FunctionCallOutputContentPart,  # pylint: disable=line-too-long
+)
+from ogx_client.types.conversations.item_list_response import (
     OpenAIResponseMcpApprovalRequest as MCPApprovalRequest,
 )
 from ogx_client.types.conversations.item_list_response import (
@@ -87,6 +90,29 @@ def _extract_text_from_content(content: str | list[Any]) -> str:
                     text_fragments.append(str(dict_text))
 
     return "".join(text_fragments)
+
+
+def _function_call_output_to_str(
+    output: str | list[FunctionCallOutputContentPart],
+) -> str:
+    """Convert function call output content into a string summary.
+
+    Parameters:
+        output: Raw function call output from the Conversations API.
+
+    Returns:
+        Plain string content for ``ToolResultSummary``.
+    """
+    if isinstance(output, str):
+        return output
+
+    fragments: list[str] = []
+    for part in output:
+        if part.type == "input_text":
+            fragments.append(part.text)
+        else:
+            fragments.append(part.model_dump_json(exclude_none=True))
+    return "\n\n".join(fragments)
 
 
 def _parse_message_item(item: MessageOutput) -> Message:
@@ -259,7 +285,7 @@ def _build_tool_call_summary_from_item(  # pylint: disable=too-many-return-state
             ToolResultSummary(
                 id=function_output.call_id,
                 status=function_output.status or "success",
-                content=function_output.output,
+                content=_function_call_output_to_str(function_output.output),
                 type="function_call_output",
                 round=1,
             ),

--- a/tests/unit/utils/test_conversations.py
+++ b/tests/unit/utils/test_conversations.py
@@ -7,6 +7,15 @@ import pytest
 from fastapi import HTTPException
 from ogx_api import OpenAIResponseMessage
 from ogx_client import APIConnectionError, APIStatusError
+from ogx_client.types.conversations.item_list_response import (
+    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFileOpenAIResponseInputMessageContentFile as FunctionCallOutputFile,  # pylint: disable=line-too-long
+)
+from ogx_client.types.conversations.item_list_response import (
+    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFileOpenAIResponseInputMessageContentImage as FunctionCallOutputImage,  # pylint: disable=line-too-long
+)
+from ogx_client.types.conversations.item_list_response import (
+    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFileOpenAIResponseInputMessageContentText as FunctionCallOutputText,  # pylint: disable=line-too-long
+)
 from pytest_mock import MockerFixture
 
 from constants import DEFAULT_RAG_TOOL
@@ -15,6 +24,7 @@ from models.database.conversations import UserTurn
 from utils.conversations import (
     _build_tool_call_summary_from_item,
     _extract_text_from_content,
+    _function_call_output_to_str,
     append_turn_items_to_conversation,
     build_conversation_turns_from_items,
     get_all_conversation_items,
@@ -353,6 +363,60 @@ class TestBuildToolCallSummaryFromItem:
 
         assert tool_result is not None
         assert tool_result.status == "success"  # Defaults to "success"
+
+    def test_function_call_output_with_structured_content(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test parsing function_call_output with mixed content parts."""
+        mock_item = mocker.Mock()
+        mock_item.type = "function_call_output"
+        mock_item.call_id = "call_456"
+        mock_item.status = "success"
+        mock_item.output = [
+            FunctionCallOutputText(type="input_text", text="result text"),
+            FunctionCallOutputImage(
+                type="input_image",
+                image_url="https://example.com/image.png",
+            ),
+            FunctionCallOutputFile(
+                type="input_file",
+                file_id="file_123",
+                filename="report.pdf",
+            ),
+        ]
+
+        _, tool_result = _build_tool_call_summary_from_item(mock_item)
+
+        assert tool_result is not None
+        content = tool_result.model_dump()["content"]
+        assert isinstance(content, str)
+        assert content.startswith("result text")
+        assert '"type":"input_image"' in content
+        assert '"file_id":"file_123"' in content
+
+
+class TestFunctionCallOutputToStr:
+    """Test cases for _function_call_output_to_str helper."""
+
+    def test_returns_string_output_unchanged(self) -> None:
+        """Return plain string output as-is."""
+        assert _function_call_output_to_str("plain result") == "plain result"
+
+    def test_extracts_text_and_serializes_other_parts(self) -> None:
+        """Extract text parts and JSON-serialize image/file parts."""
+        output = [
+            FunctionCallOutputText(type="input_text", text="hello"),
+            FunctionCallOutputImage(type="input_image", file_id="img_1"),
+            FunctionCallOutputFile(type="input_file", filename="data.csv"),
+        ]
+
+        content = _function_call_output_to_str(output)
+
+        assert content.startswith("hello")
+        assert '"type":"input_image"' in content
+        assert '"file_id":"img_1"' in content
+        assert '"type":"input_file"' in content
+        assert '"filename":"data.csv"' in content
 
     def test_unknown_item_type(self, mocker: MockerFixture) -> None:
         """Test parsing an unknown item type."""
@@ -837,7 +901,7 @@ class TestGetAllConversationItems:
             await get_all_conversation_items(mock_client, "conv_xyz")
 
         assert exc_info.value.status_code == 503
-        assert "Llama Stack" in str(exc_info.value.detail)
+        assert "OGX" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_handles_api_status_error(self, mocker: MockerFixture) -> None:

--- a/tests/unit/utils/test_models_dumper.py
+++ b/tests/unit/utils/test_models_dumper.py
@@ -2127,8 +2127,7 @@ def test_dump_models(tmpdir: Path) -> None:
                         "computer_call_output.output.image_url",
                         "file_search_call.results",
                         "message.input_image.image_url",
-                        "message.output_text.logprobs",
-                        "reasoning.encrypted_content"
+                        "message.output_text.logprobs"
                     ],
                     "type": "string"
                 },


### PR DESCRIPTION
## Description

Adapts to OGX API changes:
- Add ReasoningItem to ResponseItem; drop reasoning.encrypted_content from IncludeParameter (types + docs/dumper)
- Override OgxResponsesModel._responses_create so pydantic-ai does not request encrypted reasoning content
- Catch InvalidParameterError on conversations v1 delete (treat like not-found / already deleted)
- Normalize structured function_call_output content to a string in conversations utils (+ unit tests)

## Type of change

- [ ] Refactor
- [x] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3210 https://redhat.atlassian.net/browse/LCORE-3211

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
