### PR TITLE
LCORE-3192: Adapted models listing to OGX API

### DIFF
--- a/src/app/endpoints/models.py
+++ b/src/app/endpoints/models.py
@@ -23,42 +23,10 @@ from models.api.responses.error import (
 from models.api.responses.successful import ModelsResponse
 from models.config import Action
 from utils.endpoints import check_configuration_loaded
+from utils.model_list import parse_model_list_response
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["models"])
-
-
-def parse_llama_stack_model(model: Any) -> dict[str, Any]:
-    """
-    Parse llama-stack model.
-
-    Converting the new llama-stack model format (0.4.x) with custom_metadata.
-
-    Parameters:
-        model: Model object from llama-stack (has id, custom_metadata, object fields)
-
-    Returns:
-        dict: Model in legacy format with identifier, provider_id, model_type, etc.
-    """
-    custom_metadata = getattr(model, "custom_metadata", {}) or {}
-
-    model_type = str(custom_metadata.get("model_type", "unknown"))
-
-    metadata = {
-        k: v
-        for k, v in custom_metadata.items()
-        if k not in ("provider_id", "provider_resource_id", "model_type")
-    }
-
-    return {
-        "identifier": getattr(model, "id", ""),
-        "metadata": metadata,
-        "api_model_type": model_type,
-        "provider_id": str(custom_metadata.get("provider_id", "")),
-        "type": getattr(model, "object", "model"),
-        "provider_resource_id": str(custom_metadata.get("provider_resource_id", "")),
-        "model_type": model_type,
-    }
 
 
 models_responses: dict[int | str, dict[str, Any]] = {
@@ -124,18 +92,15 @@ async def models_endpoint_handler(
     try:
         # try to get Llama Stack client
         client = AsyncOgxClientHolder().get_client()
-        # retrieve models
-        models = await client.models.list()
-
-        # parse models to legacy format
-        parsed_models = [parse_llama_stack_model(model) for model in models]
+        # retrieve and normalize models across OpenAI/Anthropic/Google list shapes
+        parsed_models = parse_model_list_response(await client.models.list())
 
         # optional filtering by model type
         if model_type.model_type is not None:
             parsed_models = [
                 model
                 for model in parsed_models
-                if model["model_type"] == model_type.model_type
+                if model.model_type == model_type.model_type
             ]
 
         return ModelsResponse(models=parsed_models)

--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -45,6 +45,7 @@ from models.api.responses.successful.rlsapi import (
 from models.config import Action
 from observability import InferenceEventData, build_inference_event, send_splunk_event
 from utils.endpoints import check_configuration_loaded
+from utils.model_list import parse_model_list_response
 from utils.query import (
     consume_query_tokens,
     extract_provider_and_model_from_model_id,
@@ -186,7 +187,7 @@ async def _get_default_model_id() -> str:
     )
     client = AsyncOgxClientHolder().get_client()
     try:
-        models = await client.models.list()
+        models = parse_model_list_response(await client.models.list())
     except APIConnectionError as e:
         error_response = ServiceUnavailableResponse(
             backend_name="OGX",
@@ -197,11 +198,7 @@ async def _get_default_model_id() -> str:
         error_response = InternalServerErrorResponse.generic()
         raise HTTPException(**error_response.model_dump()) from e
 
-    llm_models = [
-        m
-        for m in models
-        if m.custom_metadata and m.custom_metadata.get("model_type") == "llm"
-    ]
+    llm_models = [m for m in models if m.model_type == "llm"]
     if not llm_models:
         msg = "No LLM model found in available models"
         logger.error(msg)
@@ -212,8 +209,8 @@ async def _get_default_model_id() -> str:
         raise HTTPException(**error_response.model_dump())
 
     model = llm_models[0]
-    logger.info("Auto-discovered LLM model for rlsapi v1: %s", model.id)
-    return model.id
+    logger.info("Auto-discovered LLM model for rlsapi v1: %s", model.identifier)
+    return model.identifier
 
 
 async def _resolve_validated_model_id() -> str:

--- a/src/client.py
+++ b/src/client.py
@@ -23,6 +23,7 @@ from llama_stack_configuration import (
 from log import get_logger, setup_logging
 from models.api.responses.error import ServiceUnavailableResponse
 from models.config import LlamaStackConfiguration
+from utils.model_list import parse_model_list_response
 from utils.types import Singleton
 
 logger = get_logger(__name__)
@@ -234,7 +235,7 @@ class AsyncOgxClientHolder(metaclass=Singleton):
         """
         try:
             client = self.get_client()
-            models = await client.models.list()
+            models = parse_model_list_response(await client.models.list())
         except RuntimeError as e:
             logger.warning("Client not initialized, skipping model check: %s", e)
             return False, f"Client not initialized: {e!s}"
@@ -242,7 +243,7 @@ class AsyncOgxClientHolder(metaclass=Singleton):
             logger.error("Error checking model availability: %s", e)
             return False, f"Error checking model availability: {e!s}"
 
-        if any(m.id == model_id for m in models):
+        if any(m.identifier == model_id for m in models):
             return True, f"Model {model_id} is available"
 
         # Model not found - attempt self-healing reload for library clients.
@@ -256,8 +257,8 @@ class AsyncOgxClientHolder(metaclass=Singleton):
             try:
                 await self.reload_library_client()
                 client = self.get_client()
-                reloaded_models = await client.models.list()
-                if any(m.id == model_id for m in reloaded_models):
+                reloaded_models = parse_model_list_response(await client.models.list())
+                if any(m.identifier == model_id for m in reloaded_models):
                     logger.info(
                         "Model %s found after client reload",
                         model_id,
@@ -271,7 +272,7 @@ class AsyncOgxClientHolder(metaclass=Singleton):
             ) as err:
                 logger.error("Client reload failed: %s", err)
 
-        registered_ids = [m.id for m in models]
+        registered_ids = [m.identifier for m in models]
         logger.error(
             "Model %s not found in registry. Registered models: %s",
             model_id,

--- a/src/metrics/utils.py
+++ b/src/metrics/utils.py
@@ -5,6 +5,7 @@ from client import AsyncOgxClientHolder
 from configuration import configuration
 from log import get_logger
 from utils.endpoints import check_configuration_loaded
+from utils.model_list import parse_model_list_response
 
 logger = get_logger(__name__)
 
@@ -17,13 +18,11 @@ async def setup_model_metrics() -> None:
     """
     logger.info("Setting up model metrics")
     check_configuration_loaded(configuration)
-    model_list = await AsyncOgxClientHolder().get_client().models.list()
+    model_list = parse_model_list_response(
+        await AsyncOgxClientHolder().get_client().models.list()
+    )
 
-    models = [
-        model
-        for model in model_list
-        if model.custom_metadata and model.custom_metadata.get("model_type") == "llm"
-    ]
+    models = [model for model in model_list if model.model_type == "llm"]
 
     default_model_label = (
         configuration.inference.default_provider,
@@ -31,12 +30,8 @@ async def setup_model_metrics() -> None:
     )
 
     for model in models:
-        provider = (
-            str(model.custom_metadata.get("provider_id", ""))
-            if model.custom_metadata
-            else ""
-        )
-        model_name = model.id
+        provider = str(model.provider_id or "")
+        model_name = model.identifier
         if provider and model_name:
             # If the model/provider combination is the default, set the metric value to 1
             # Otherwise, set it to 0

--- a/src/models/api/responses/successful/catalog.py
+++ b/src/models/api/responses/successful/catalog.py
@@ -5,13 +5,14 @@ from typing import Any, Optional
 from pydantic import Field
 
 from models.api.responses.successful.bases import AbstractSuccessfulResponse
+from models.common.models import CatalogModel
 from models.common.tools import CatalogTool
 
 
 class ModelsResponse(AbstractSuccessfulResponse):
     """Model representing a response to models request."""
 
-    models: list[dict[str, Any]] = Field(
+    models: list[CatalogModel] = Field(
         ...,
         description="List of models available",
     )

--- a/src/models/common/models.py
+++ b/src/models/common/models.py
@@ -1,0 +1,31 @@
+"""Backend-agnostic model catalog types."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CatalogModel(BaseModel):
+    """Normalized model entry used by ``/models`` and internal model resolution.
+
+    Unifies OpenAI-style, Anthropic, and Google ``models.list()`` payloads into
+    one catalog shape.
+    """
+
+    identifier: str = Field(description="Model identifier")
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Provider-specific metadata excluding core catalog fields",
+    )
+    api_model_type: str = Field(
+        description="API model type (typically mirrors model_type)"
+    )
+    provider_id: str = Field(description="Provider identifier")
+    type: str = Field(default="model", description="Object type, always 'model'")
+    provider_resource_id: str = Field(
+        default="",
+        description="Provider-native resource identifier for the model",
+    )
+    model_type: str = Field(description="Model type such as 'llm' or 'embedding'")

--- a/src/utils/model_list.py
+++ b/src/utils/model_list.py
@@ -1,0 +1,120 @@
+"""Helpers for normalizing OGX ``models.list()`` union responses."""
+
+from typing import Any
+
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
+from ogx_client.types.model_list_response import (
+    AnthropicListModelsResponse,
+    AnthropicListModelsResponseData,
+    GoogleListModelsResponse,
+    GoogleListModelsResponseModel,
+    ModelListResponse,
+)
+
+from models.common.models import CatalogModel
+
+
+def parse_openai_style_model(model: Model) -> CatalogModel:
+    """
+    Parse an OpenAI-style OGX ``Model`` into a unified catalog model.
+
+    Uses the OGX ``Model`` properties for identifier, model_type, provider
+    fields, and filtered metadata.
+
+    Parameters:
+        model: Model object from ``ListModelsResponse.data``.
+
+    Returns:
+        CatalogModel: Normalized catalog entry.
+    """
+    model_type = model.model_type or "unknown"
+
+    return CatalogModel(
+        identifier=model.identifier,
+        metadata=model.metadata or {},
+        api_model_type=model_type,
+        provider_id=model.provider_id or "",
+        type=model.object or "model",
+        provider_resource_id=model.provider_resource_id or "",
+        model_type=model_type,
+    )
+
+
+def parse_anthropic_model(model: AnthropicListModelsResponseData) -> CatalogModel:
+    """Parse an Anthropic model list entry into a unified catalog model.
+
+    Parameters:
+        model: Anthropic model object from ``AnthropicListModelsResponse.data``.
+
+    Returns:
+        CatalogModel: Normalized catalog entry. Treated as an LLM.
+    """
+    metadata: dict[str, Any] = {
+        "display_name": model.display_name,
+        "created_at": model.created_at,
+    }
+    if model.max_input_tokens is not None:
+        metadata["max_input_tokens"] = model.max_input_tokens
+    if model.max_tokens is not None:
+        metadata["max_tokens"] = model.max_tokens
+
+    return CatalogModel(
+        identifier=model.id,
+        metadata=metadata,
+        api_model_type="llm",
+        provider_id="anthropic",
+        type=model.type or "model",
+        provider_resource_id=model.id,
+        model_type="llm",
+    )
+
+
+def parse_google_model(model: GoogleListModelsResponseModel) -> CatalogModel:
+    """Parse a Google model list entry into a unified catalog model.
+
+    Parameters:
+        model: Google model object from ``GoogleListModelsResponse.models``.
+
+    Returns:
+        CatalogModel: Normalized catalog entry. Treated as an LLM.
+    """
+    metadata: dict[str, Any] = {
+        "display_name": model.display_name,
+    }
+    if model.description is not None:
+        metadata["description"] = model.description
+
+    return CatalogModel(
+        identifier=model.name,
+        metadata=metadata,
+        api_model_type="llm",
+        provider_id="google",
+        type="model",
+        provider_resource_id=model.name,
+        model_type="llm",
+    )
+
+
+def parse_model_list_response(response: ModelListResponse) -> list[CatalogModel]:
+    """Normalize an OGX ``models.list()`` union response into catalog models.
+
+    OGX returns one of ``ListModelsResponse``, ``AnthropicListModelsResponse``,
+    or ``GoogleListModelsResponse``. This helper matches on the concrete type
+    and parses every entry into :class:`CatalogModel`.
+
+    Parameters:
+        response: The union response returned by ``client.models.list()``.
+
+    Returns:
+        list[CatalogModel]: Parsed models in the unified catalog shape.
+    """
+    match response:
+        case ListModelsResponse(data=data):
+            return [parse_openai_style_model(model) for model in data]
+        case AnthropicListModelsResponse(data=data):
+            return [parse_anthropic_model(model) for model in data]
+        case GoogleListModelsResponse(models=models):
+            return [parse_google_model(model) for model in models]
+        case _:
+            return []

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -114,6 +114,7 @@ from utils.mcp_headers import (
     build_mcp_headers,
     find_unresolved_auth_headers,
 )
+from utils.model_list import parse_model_list_response
 from utils.prompts import get_system_prompt, get_topic_summary_system_prompt
 from utils.query import (
     extract_provider_and_model_from_model_id,
@@ -1338,15 +1339,15 @@ async def check_model_configured(
         HTTPException: If there's a connection error or other API error
     """
     try:
-        models = await client.models.list()
+        models = parse_model_list_response(await client.models.list())
         for model in models:
-            if model.id == model_id:
+            if model.identifier == model_id:
                 return True
 
             # Workaround to llama-stack watsonx bug
-            if model_id.startswith("watsonx/") and model.id == model_id.removeprefix(
+            if model_id.startswith(
                 "watsonx/"
-            ):
+            ) and model.identifier == model_id.removeprefix("watsonx/"):
                 return True
         return False
     except APIStatusError as e:
@@ -1404,7 +1405,7 @@ async def select_model_for_responses(
 
     # 3. Fetch models list and select the first LLM model (model_type="llm")
     try:
-        models = await client.models.list()
+        models = parse_model_list_response(await client.models.list())
     except APIConnectionError as e:
         error_response = ServiceUnavailableResponse(
             backend_name="OGX",
@@ -1415,27 +1416,20 @@ async def select_model_for_responses(
         error_response = InternalServerErrorResponse.generic()
         raise HTTPException(**error_response.model_dump()) from e
 
-    llm_models = [
-        m
-        for m in models
-        if m.custom_metadata and m.custom_metadata.get("model_type") == "llm"
-    ]
+    llm_models = [m for m in models if m.model_type == "llm"]
     if not llm_models:
         logger.error("No LLM model found in available models")
         response = NotFoundResponse(resource="model", resource_id=None)
         raise HTTPException(**response.model_dump())
 
     model = llm_models[0]
-    logger.info("Selected first LLM model: %s", model.id)
+    logger.info("Selected first LLM model: %s", model.identifier)
 
     # Workaround to llama-stack bug for watsonx
     # model needs to be "watsonx/<model_id>" in the response request
-    metadata = model.custom_metadata or {}
-    if metadata.get("provider_id") == "watsonx":
-        provider_resource_id = metadata.get("provider_resource_id")
-        if isinstance(provider_resource_id, str):
-            return provider_resource_id
-    return model.id
+    if model.provider_id == "watsonx" and model.provider_resource_id:
+        return model.provider_resource_id
+    return model.identifier
 
 
 def is_server_deployed_output(output_item: ResponseOutput) -> bool:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,8 @@ import pytest
 from fastapi import Request, Response
 from fastapi.testclient import TestClient
 from ogx_api.openai_responses import OpenAIResponseObject
-from ogx_client.types import VersionInfo
+from ogx_client.types import ListModelsResponse, VersionInfo
+from ogx_client.types.model import Model
 from pydantic_ai import AgentRunResultEvent
 from pydantic_ai.messages import (
     ModelMessage,
@@ -767,13 +768,20 @@ def mock_ogx_client_fixture(
     mock_client.responses.create.return_value = mock_response
 
     # Mock models.list
-    mock_model = mocker.MagicMock()
-    mock_model.id = "test-provider/test-model"
-    mock_model.custom_metadata = {
-        "provider_id": "test-provider",
-        "model_type": "llm",
-    }
-    mock_client.models.list.return_value = [mock_model]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            Model.model_construct(
+                id="test-provider/test-model",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={
+                    "provider_id": "test-provider",
+                    "model_type": "llm",
+                },
+            )
+        ]
+    )
 
     # Mock shields.list (empty by default)
     mock_client.shields.list.return_value = []

--- a/tests/integration/endpoints/test_model_list.py
+++ b/tests/integration/endpoints/test_model_list.py
@@ -7,6 +7,8 @@ import pytest
 from fastapi import Request
 from fastapi.exceptions import HTTPException
 from ogx_client import APIConnectionError
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pytest_mock import AsyncMockType, MockerFixture
 
 from app.endpoints.models import models_endpoint_handler
@@ -38,19 +40,30 @@ def mock_ogx_client_fixture(
     mock_client = mocker.AsyncMock()
 
     # Mock models list (required for model selection)
-    mock_model1 = mocker.MagicMock()
-    mock_model1.id = "test-provider/test-model-1"
-    mock_model1.custom_metadata = {
-        "provider_id": "test-provider",
-        "model_type": "llm",
-    }
-    mock_model2 = mocker.MagicMock()
-    mock_model2.id = "test-provider/test-model-2"
-    mock_model2.custom_metadata = {
-        "provider_id": "test-provider",
-        "model_type": "embedding",
-    }
-    mock_client.models.list.return_value = [mock_model1, mock_model2]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            Model.model_construct(
+                id="test-provider/test-model-1",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={
+                    "provider_id": "test-provider",
+                    "model_type": "llm",
+                },
+            ),
+            Model.model_construct(
+                id="test-provider/test-model-2",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={
+                    "provider_id": "test-provider",
+                    "model_type": "embedding",
+                },
+            ),
+        ]
+    )
 
     # Create a mock holder instance
     mock_holder_instance = mock_holder_class.return_value
@@ -170,8 +183,8 @@ async def test_models_list_with_filter(
 
     # Verify each expected model
     for i, expected_model in enumerate(expected_models):
-        assert response.models[i]["identifier"] == expected_model["identifier"]
-        assert response.models[i]["api_model_type"] == expected_model["api_model_type"]
+        assert response.models[i].identifier == expected_model["identifier"]
+        assert response.models[i].api_model_type == expected_model["api_model_type"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/endpoints/test_query_byok_integration.py
+++ b/tests/integration/endpoints/test_query_byok_integration.py
@@ -7,7 +7,8 @@ from typing import Any
 
 import pytest
 from fastapi import Request
-from ogx_client.types import VersionInfo
+from ogx_client.types import ListModelsResponse, VersionInfo
+from ogx_client.types.model import Model
 from pytest_mock import AsyncMockType, MockerFixture
 
 import constants
@@ -98,13 +99,20 @@ def _build_base_mock_client(mocker: MockerFixture) -> Any:
     mock_client = mocker.AsyncMock()
 
     # Model list
-    mock_model = mocker.MagicMock()
-    mock_model.id = "test-provider/test-model"
-    mock_model.custom_metadata = {
-        "provider_id": "test-provider",
-        "model_type": "llm",
-    }
-    mock_client.models.list.return_value = [mock_model]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            Model.model_construct(
+                id="test-provider/test-model",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={
+                    "provider_id": "test-provider",
+                    "model_type": "llm",
+                },
+            )
+        ]
+    )
 
     # Shields (empty)
     mock_client.shields.list.return_value = []

--- a/tests/integration/endpoints/test_responses_integration.py
+++ b/tests/integration/endpoints/test_responses_integration.py
@@ -11,6 +11,8 @@ from typing import Any
 import pytest
 from fastapi import Request
 from fastapi.responses import StreamingResponse
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import Session
 
@@ -88,13 +90,20 @@ def _build_mock_client(mocker: MockerFixture) -> Any:
     mock_response.model_dump.return_value = _RESPONSE_DUMP.copy()
     mock_client.responses.create = mocker.AsyncMock(return_value=mock_response)
 
-    mock_model = mocker.MagicMock()
-    mock_model.id = "test-provider/test-model"
-    mock_model.custom_metadata = {
-        "provider_id": "test-provider",
-        "model_type": "llm",
-    }
-    mock_client.models.list.return_value = [mock_model]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            Model.model_construct(
+                id="test-provider/test-model",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={
+                    "provider_id": "test-provider",
+                    "model_type": "llm",
+                },
+            )
+        ]
+    )
 
     mock_client.shields.list.return_value = []
 

--- a/tests/integration/endpoints/test_streaming_query_integration.py
+++ b/tests/integration/endpoints/test_streaming_query_integration.py
@@ -7,6 +7,8 @@ import pytest
 from fastapi import HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pytest_mock import AsyncMockType, MockerFixture
 
 from app.endpoints.streaming_query import streaming_query_endpoint_handler
@@ -33,13 +35,20 @@ def mock_llama_stack_streaming_fixture(
     )
     mock_client = mocker.AsyncMock()
 
-    mock_model = mocker.MagicMock()
-    mock_model.id = "test-provider/test-model"
-    mock_model.custom_metadata = {
-        "provider_id": "test-provider",
-        "model_type": "llm",
-    }
-    mock_client.models.list.return_value = [mock_model]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            Model.model_construct(
+                id="test-provider/test-model",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={
+                    "provider_id": "test-provider",
+                    "model_type": "llm",
+                },
+            )
+        ]
+    )
 
     mock_vector_stores_response = mocker.MagicMock()
     mock_vector_stores_response.data = []

--- a/tests/unit/app/endpoints/test_a2a.py
+++ b/tests/unit/app/endpoints/test_a2a.py
@@ -23,6 +23,7 @@ from a2a.types import (
 from a2a.utils import new_agent_text_message
 from fastapi import HTTPException, Request
 from ogx_client import APIConnectionError
+from ogx_client.types import ListModelsResponse
 from pydantic_ai import AgentRunResultEvent
 from pydantic_ai.exceptions import AgentRunError
 from pydantic_ai.messages import (
@@ -776,7 +777,9 @@ class TestA2AAgentExecutor:
         # Mock the client
         mock_client = mocker.AsyncMock()
         mock_models = [mocker.MagicMock()]
-        mock_client.models.list = mocker.AsyncMock(return_value=mock_models)
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(data=mock_models)
+        )
         mocker.patch(
             "app.endpoints.a2a.AsyncOgxClientHolder"
         ).return_value.get_client.return_value = mock_client
@@ -860,7 +863,9 @@ class TestA2AAgentExecutor:
         )
 
         mock_client = mocker.AsyncMock()
-        mock_client.models.list = mocker.AsyncMock(return_value=[mocker.MagicMock()])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(data=[mocker.MagicMock()])
+        )
         mocker.patch(
             "app.endpoints.a2a.AsyncOgxClientHolder"
         ).return_value.get_client.return_value = mock_client
@@ -935,7 +940,9 @@ class TestA2AAgentExecutor:
         )
 
         mock_client = mocker.AsyncMock()
-        mock_client.models.list = mocker.AsyncMock(return_value=[mocker.MagicMock()])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(data=[mocker.MagicMock()])
+        )
         mocker.patch(
             "app.endpoints.a2a.AsyncOgxClientHolder"
         ).return_value.get_client.return_value = mock_client

--- a/tests/unit/app/endpoints/test_models.py
+++ b/tests/unit/app/endpoints/test_models.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 from fastapi import HTTPException, Request, status
 from ogx_client import APIConnectionError
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pytest_mock import MockerFixture
 from pytest_subtests import SubTests
 
@@ -15,17 +17,18 @@ from models.api.requests import ModelFilter
 from tests.unit.utils.auth_helpers import mock_authorization_resolvers
 
 
-# pylint: disable=R0903
-class Model:
-    """Model information returned in response."""
-
-    def __init__(self, model_id: str, provider_id: str, model_type: str) -> None:
-        """Initialize model information."""
-        self.id = model_id
-        self.custom_metadata = {
+def _make_model(model_id: str, provider_id: str, model_type: str) -> Model:
+    """Build an OGX Model for models-endpoint tests."""
+    return Model.model_construct(
+        id=model_id,
+        created=0,
+        owned_by="test",
+        object="model",
+        custom_metadata={
             "model_type": model_type,
             "provider_id": provider_id,
-        }
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -159,7 +162,7 @@ async def test_models_endpoint_handler_unable_to_retrieve_models_list(
 
     # Mock the LlamaStack client
     mock_client = mocker.AsyncMock()
-    mock_client.models.list.return_value = []
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(data=[])
     mock_lsc = mocker.patch("app.endpoints.models.AsyncOgxClientHolder.get_client")
     mock_lsc.return_value = mock_client
     mock_config = mocker.Mock()
@@ -216,7 +219,7 @@ async def test_models_endpoint_handler_model_type_query_parameter(
 
     # Mock the LlamaStack client
     mock_client = mocker.AsyncMock()
-    mock_client.models.list.return_value = []
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(data=[])
     mock_lsc = mocker.patch("app.endpoints.models.AsyncOgxClientHolder.get_client")
     mock_lsc.return_value = mock_client
     mock_config = mocker.Mock()
@@ -272,12 +275,14 @@ async def test_models_endpoint_handler_model_list_retrieved(
 
     # Mock the LlamaStack client
     mock_client = mocker.AsyncMock()
-    mock_client.models.list.return_value = [
-        Model("model1", "provider1", "llm"),
-        Model("model2", "provider2", "embedding"),
-        Model("model3", "provider3", "llm"),
-        Model("model4", "provider4", "embedding"),
-    ]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            _make_model("model1", "provider1", "llm"),
+            _make_model("model2", "provider2", "embedding"),
+            _make_model("model3", "provider3", "llm"),
+            _make_model("model4", "provider4", "embedding"),
+        ]
+    )
     mock_lsc = mocker.patch("app.endpoints.models.AsyncOgxClientHolder.get_client")
     mock_lsc.return_value = mock_client
     mock_config = mocker.Mock()
@@ -298,14 +303,14 @@ async def test_models_endpoint_handler_model_list_retrieved(
     )
     assert response is not None
     assert len(response.models) == 4
-    assert response.models[0]["identifier"] == "model1"
-    assert response.models[0]["model_type"] == "llm"
-    assert response.models[1]["identifier"] == "model2"
-    assert response.models[1]["model_type"] == "embedding"
-    assert response.models[2]["identifier"] == "model3"
-    assert response.models[2]["model_type"] == "llm"
-    assert response.models[3]["identifier"] == "model4"
-    assert response.models[3]["model_type"] == "embedding"
+    assert response.models[0].identifier == "model1"
+    assert response.models[0].model_type == "llm"
+    assert response.models[1].identifier == "model2"
+    assert response.models[1].model_type == "embedding"
+    assert response.models[2].identifier == "model3"
+    assert response.models[2].model_type == "llm"
+    assert response.models[3].identifier == "model4"
+    assert response.models[3].model_type == "embedding"
 
 
 @pytest.mark.asyncio
@@ -344,12 +349,14 @@ async def test_models_endpoint_handler_model_list_retrieved_with_query_parameter
 
     # Mock the LlamaStack client
     mock_client = mocker.AsyncMock()
-    mock_client.models.list.return_value = [
-        Model("model1", "provider1", "llm"),
-        Model("model2", "provider2", "embedding"),
-        Model("model3", "provider3", "llm"),
-        Model("model4", "provider4", "embedding"),
-    ]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            _make_model("model1", "provider1", "llm"),
+            _make_model("model2", "provider2", "embedding"),
+            _make_model("model3", "provider3", "llm"),
+            _make_model("model4", "provider4", "embedding"),
+        ]
+    )
     mock_lsc = mocker.patch("app.endpoints.models.AsyncOgxClientHolder.get_client")
     mock_lsc.return_value = mock_client
     mock_config = mocker.Mock()
@@ -371,10 +378,10 @@ async def test_models_endpoint_handler_model_list_retrieved_with_query_parameter
         )
         assert response is not None
         assert len(response.models) == 2
-        assert response.models[0]["identifier"] == "model1"
-        assert response.models[0]["model_type"] == "llm"
-        assert response.models[1]["identifier"] == "model3"
-        assert response.models[1]["model_type"] == "llm"
+        assert response.models[0].identifier == "model1"
+        assert response.models[0].model_type == "llm"
+        assert response.models[1].identifier == "model3"
+        assert response.models[1].model_type == "llm"
 
     with subtests.test(msg="Model type = 'embedding'"):
         response = await models_endpoint_handler(
@@ -382,10 +389,10 @@ async def test_models_endpoint_handler_model_list_retrieved_with_query_parameter
         )
         assert response is not None
         assert len(response.models) == 2
-        assert response.models[0]["identifier"] == "model2"
-        assert response.models[0]["model_type"] == "embedding"
-        assert response.models[1]["identifier"] == "model4"
-        assert response.models[1]["model_type"] == "embedding"
+        assert response.models[0].identifier == "model2"
+        assert response.models[0].model_type == "embedding"
+        assert response.models[1].identifier == "model4"
+        assert response.models[1].model_type == "embedding"
 
     with subtests.test(msg="Model type = 'xyzzy'"):
         response = await models_endpoint_handler(

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -15,6 +15,8 @@ import pytest
 from fastapi import HTTPException, status
 from ogx_api import OpenAIResponseMessage
 from ogx_client import APIConnectionError, APIStatusError
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 
@@ -352,15 +354,21 @@ async def test_get_default_model_id_errors(
     """Test _get_default_model_id fallback failures raise 503 responses."""
     mocker.patch("app.endpoints.rlsapi_v1.configuration", minimal_config)
 
-    mock_embedding_model = mocker.Mock()
-    mock_embedding_model.custom_metadata = {"model_type": "embedding"}
-    mock_embedding_model.id = "sentence-transformers/all-mpnet-base-v2"
+    mock_embedding_model = Model.model_construct(
+        id="sentence-transformers/all-mpnet-base-v2",
+        created=0,
+        owned_by="test",
+        object="model",
+        custom_metadata={"model_type": "embedding"},
+    )
 
     mock_client = mocker.Mock()
     mock_client.models = mocker.Mock()
 
     if failure_mode == "no_llm_models":
-        mock_client.models.list = mocker.AsyncMock(return_value=[mock_embedding_model])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(data=[mock_embedding_model])
+        )
     else:
         mock_client.models.list = mocker.AsyncMock(
             side_effect=APIConnectionError(request=mocker.Mock())
@@ -394,13 +402,19 @@ async def test_config_error_503_matches_llm_error_503_shape(
     """
     mocker.patch("app.endpoints.rlsapi_v1.configuration", minimal_config)
 
-    mock_embedding_model = mocker.Mock()
-    mock_embedding_model.custom_metadata = {"model_type": "embedding"}
-    mock_embedding_model.id = "sentence-transformers/all-mpnet-base-v2"
+    mock_embedding_model = Model.model_construct(
+        id="sentence-transformers/all-mpnet-base-v2",
+        created=0,
+        owned_by="test",
+        object="model",
+        custom_metadata={"model_type": "embedding"},
+    )
 
     mock_client = mocker.Mock()
     mock_client.models = mocker.Mock()
-    mock_client.models.list = mocker.AsyncMock(return_value=[mock_embedding_model])
+    mock_client.models.list = mocker.AsyncMock(
+        return_value=ListModelsResponse.model_construct(data=[mock_embedding_model])
+    )
 
     mock_client_holder = mocker.Mock()
     mock_client_holder.get_client.return_value = mock_client
@@ -432,18 +446,28 @@ async def test_get_default_model_id_auto_discovery_success(
     """Test _get_default_model_id returns first discovered LLM model ID."""
     mocker.patch("app.endpoints.rlsapi_v1.configuration", minimal_config)
 
-    mock_llm_model = mocker.Mock()
-    mock_llm_model.custom_metadata = {"model_type": "llm"}
-    mock_llm_model.id = "openai/gpt-4o-mini"
+    mock_llm_model = Model.model_construct(
+        id="openai/gpt-4o-mini",
+        created=0,
+        owned_by="test",
+        object="model",
+        custom_metadata={"model_type": "llm"},
+    )
 
-    mock_embedding_model = mocker.Mock()
-    mock_embedding_model.custom_metadata = {"model_type": "embedding"}
-    mock_embedding_model.id = "sentence-transformers/all-mpnet-base-v2"
+    mock_embedding_model = Model.model_construct(
+        id="sentence-transformers/all-mpnet-base-v2",
+        created=0,
+        owned_by="test",
+        object="model",
+        custom_metadata={"model_type": "embedding"},
+    )
 
     mock_client = mocker.Mock()
     mock_client.models = mocker.Mock()
     mock_client.models.list = mocker.AsyncMock(
-        return_value=[mock_embedding_model, mock_llm_model]
+        return_value=ListModelsResponse.model_construct(
+            data=[mock_embedding_model, mock_llm_model]
+        )
     )
 
     mock_client_holder = mocker.Mock()

--- a/tests/unit/metrics/test_utis.py
+++ b/tests/unit/metrics/test_utis.py
@@ -1,9 +1,22 @@
 """Unit tests for functions defined in metrics/utils.py"""
 
 import pytest
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pytest_mock import MockerFixture
 
 from metrics.utils import setup_model_metrics
+
+
+def _make_model(model_id: str, provider_id: str, model_type: str) -> Model:
+    """Build an OGX Model for metrics tests."""
+    return Model.model_construct(
+        id=model_id,
+        created=0,
+        owned_by="test",
+        object="model",
+        custom_metadata={"provider_id": provider_id, "model_type": model_type},
+    )
 
 
 @pytest.mark.asyncio
@@ -24,34 +37,20 @@ async def test_setup_model_metrics(mocker: MockerFixture) -> None:
     )
 
     mock_metric = mocker.patch("metrics.provider_model_configuration")
-    # Mock a model that is the default
-    model_default = mocker.Mock(
-        id="default_model",
-        custom_metadata={"provider_id": "default_provider", "model_type": "llm"},
-    )
-    # Mock a model that is not the default
-    model_0 = mocker.Mock(
-        id="test_model-0",
-        custom_metadata={"provider_id": "test_provider-0", "model_type": "llm"},
-    )
-    # Mock a second model which is not default
-    model_1 = mocker.Mock(
-        id="test_model-1",
-        custom_metadata={"provider_id": "test_provider-1", "model_type": "llm"},
-    )
-    # Mock a model that is not an LLM type, should be ignored
-    not_llm_model = mocker.Mock(
-        id="not-llm-model",
-        custom_metadata={"provider_id": "not-llm-provider", "model_type": "not-llm"},
-    )
+    model_default = _make_model("default_model", "default_provider", "llm")
+    model_0 = _make_model("test_model-0", "test_provider-0", "llm")
+    model_1 = _make_model("test_model-1", "test_provider-1", "llm")
+    not_llm_model = _make_model("not-llm-model", "not-llm-provider", "not-llm")
 
     # Mock the list of models returned by the client
-    mock_client.models.list.return_value = [
-        model_0,
-        model_default,
-        not_llm_model,
-        model_1,
-    ]
+    mock_client.models.list.return_value = ListModelsResponse.model_construct(
+        data=[
+            model_0,
+            model_default,
+            not_llm_model,
+            model_1,
+        ]
+    )
 
     await setup_model_metrics()
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -10,6 +10,8 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 from ogx_client import APIConnectionError, APIStatusError
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pydantic import AnyHttpUrl, SecretStr
 from pytest_mock import MockerFixture
 
@@ -222,11 +224,16 @@ class TestCheckModelAvailable:
         holder._lsc = mock_client
         return holder, mock_client
 
-    def _make_model(self, mocker: MockerFixture, model_id: str) -> Any:
-        """Create a mock model with the given ID."""
-        model = mocker.Mock()
-        model.id = model_id
-        return model
+    def _make_model(self, mocker: MockerFixture, model_id: str) -> Model:
+        """Create an OGX Model with the given ID."""
+        _ = mocker
+        return Model.model_construct(
+            id=model_id,
+            created=0,
+            owned_by="test",
+            object="model",
+            custom_metadata={},
+        )
 
     @pytest.mark.asyncio
     async def test_model_available(
@@ -236,9 +243,9 @@ class TestCheckModelAvailable:
     ) -> None:
         """Test returns True when the model is found in the registry."""
         holder, mock_client = holder_with_mock_client
-        mock_client.models.list.return_value = [
-            self._make_model(mocker, self.EXPECTED_MODEL_ID)
-        ]
+        mock_client.models.list.return_value = ListModelsResponse.model_construct(
+            data=[self._make_model(mocker, self.EXPECTED_MODEL_ID)]
+        )
 
         available, reason = await holder.check_model_available(self.EXPECTED_MODEL_ID)
 
@@ -253,7 +260,9 @@ class TestCheckModelAvailable:
     ) -> None:
         """Test returns False and skips reload for non-library (service) clients."""
         holder, mock_client = holder_with_mock_client
-        mock_client.models.list.return_value = [self._make_model(mocker, "other/model")]
+        mock_client.models.list.return_value = ListModelsResponse.model_construct(
+            data=[self._make_model(mocker, "other/model")]
+        )
 
         available, reason = await holder.check_model_available(self.EXPECTED_MODEL_ID)
 
@@ -322,7 +331,10 @@ class TestCheckModelAvailable:
 
         wrong_model = self._make_model(mocker, "other/model")
         correct_model = self._make_model(mocker, self.EXPECTED_MODEL_ID)
-        mock_client.models.list.side_effect = [[wrong_model], [correct_model]]
+        mock_client.models.list.side_effect = [
+            ListModelsResponse.model_construct(data=[wrong_model]),
+            ListModelsResponse.model_construct(data=[correct_model]),
+        ]
 
         available, reason = await holder.check_model_available(self.EXPECTED_MODEL_ID)
 
@@ -347,7 +359,9 @@ class TestCheckModelAvailable:
         holder.reload_library_client = mocker.AsyncMock(
             side_effect=RuntimeError("Cannot reload: config path not set")
         )
-        mock_client.models.list.return_value = [self._make_model(mocker, "other/model")]
+        mock_client.models.list.return_value = ListModelsResponse.model_construct(
+            data=[self._make_model(mocker, "other/model")]
+        )
 
         available, reason = await holder.check_model_available(self.EXPECTED_MODEL_ID)
 
@@ -371,7 +385,9 @@ class TestCheckModelAvailable:
         holder.reload_library_client = mocker.AsyncMock(
             side_effect=HTTPException(status_code=503, detail="Llama Stack unavailable")
         )
-        mock_client.models.list.return_value = [self._make_model(mocker, "other/model")]
+        mock_client.models.list.return_value = ListModelsResponse.model_construct(
+            data=[self._make_model(mocker, "other/model")]
+        )
 
         available, reason = await holder.check_model_available(self.EXPECTED_MODEL_ID)
 

--- a/tests/unit/utils/test_model_list.py
+++ b/tests/unit/utils/test_model_list.py
@@ -1,0 +1,145 @@
+"""Unit tests for utils/model_list.py helpers."""
+
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
+from ogx_client.types.model_list_response import (
+    AnthropicListModelsResponse,
+    AnthropicListModelsResponseData,
+    GoogleListModelsResponse,
+    GoogleListModelsResponseModel,
+)
+
+from models.common.models import CatalogModel
+from utils.model_list import (
+    parse_anthropic_model,
+    parse_google_model,
+    parse_model_list_response,
+    parse_openai_style_model,
+)
+
+
+def test_parse_openai_style_model_with_custom_metadata() -> None:
+    """OpenAI-style models map custom_metadata into CatalogModel."""
+    model = Model.model_construct(
+        id="provider/model",
+        created=1,
+        owned_by="org",
+        object="model",
+        custom_metadata={
+            "model_type": "llm",
+            "provider_id": "provider",
+            "provider_resource_id": "model",
+            "extra": "value",
+        },
+    )
+
+    parsed = parse_openai_style_model(model)
+
+    assert isinstance(parsed, CatalogModel)
+    assert parsed.identifier == "provider/model"
+    assert parsed.model_type == "llm"
+    assert parsed.provider_id == "provider"
+    assert parsed.provider_resource_id == "model"
+    assert parsed.metadata == {"extra": "value"}
+    assert parsed.api_model_type == "llm"
+    assert parsed.type == "model"
+
+
+def test_parse_anthropic_model() -> None:
+    """Anthropic models are normalized as LLM CatalogModel entries."""
+    model = AnthropicListModelsResponseData.model_construct(
+        id="claude-sonnet",
+        created_at="2024-01-01T00:00:00Z",
+        display_name="Claude Sonnet",
+        max_input_tokens=200000,
+        max_tokens=8192,
+        type="model",
+    )
+
+    parsed = parse_anthropic_model(model)
+
+    assert parsed.identifier == "claude-sonnet"
+    assert parsed.model_type == "llm"
+    assert parsed.provider_id == "anthropic"
+    assert parsed.metadata["display_name"] == "Claude Sonnet"
+    assert parsed.metadata["max_input_tokens"] == 200000
+    assert parsed.metadata["max_tokens"] == 8192
+
+
+def test_parse_google_model() -> None:
+    """Google models are normalized as LLM CatalogModel entries."""
+    model = GoogleListModelsResponseModel.model_construct(
+        name="models/gemini-pro",
+        display_name="Gemini Pro",
+        description="A Gemini model",
+    )
+
+    parsed = parse_google_model(model)
+
+    assert parsed.identifier == "models/gemini-pro"
+    assert parsed.model_type == "llm"
+    assert parsed.provider_id == "google"
+    assert parsed.metadata["display_name"] == "Gemini Pro"
+    assert parsed.metadata["description"] == "A Gemini model"
+
+
+def test_parse_model_list_response_openai() -> None:
+    """ListModelsResponse branch returns CatalogModel entries."""
+    response = ListModelsResponse.model_construct(
+        data=[
+            Model.model_construct(
+                id="p/m",
+                created=1,
+                owned_by="x",
+                custom_metadata={"model_type": "embedding", "provider_id": "p"},
+            )
+        ]
+    )
+
+    parsed = parse_model_list_response(response)
+
+    assert len(parsed) == 1
+    assert parsed[0].identifier == "p/m"
+    assert parsed[0].model_type == "embedding"
+
+
+def test_parse_model_list_response_anthropic() -> None:
+    """AnthropicListModelsResponse branch returns CatalogModel entries."""
+    response = AnthropicListModelsResponse.model_construct(
+        data=[
+            AnthropicListModelsResponseData.model_construct(
+                id="claude",
+                created_at="2024-01-01T00:00:00Z",
+                display_name="Claude",
+            )
+        ]
+    )
+
+    parsed = parse_model_list_response(response)
+
+    assert len(parsed) == 1
+    assert parsed[0].identifier == "claude"
+    assert parsed[0].provider_id == "anthropic"
+
+
+def test_parse_model_list_response_google() -> None:
+    """GoogleListModelsResponse branch returns CatalogModel entries."""
+    response = GoogleListModelsResponse.model_construct(
+        models=[
+            GoogleListModelsResponseModel.model_construct(
+                name="models/gemini",
+                display_name="Gemini",
+            )
+        ]
+    )
+
+    parsed = parse_model_list_response(response)
+
+    assert len(parsed) == 1
+    assert parsed[0].identifier == "models/gemini"
+    assert parsed[0].provider_id == "google"
+
+
+def test_parse_model_list_response_unsupported_type() -> None:
+    """Unsupported response types yield an empty catalog list."""
+    assert parse_model_list_response(object()) == []  # type: ignore[arg-type]

--- a/tests/unit/utils/test_query.py
+++ b/tests/unit/utils/test_query.py
@@ -8,7 +8,8 @@ from typing import Any
 import psycopg2
 import pytest
 from fastapi import HTTPException
-from ogx_client.types import ModelListResponse
+from ogx_client.types import ListModelsResponse, ModelListResponse
+from ogx_client.types.model import Model
 from pytest_mock import MockerFixture
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -53,24 +54,25 @@ def mock_config_fixture() -> AppConfig:
 
 @pytest.fixture(name="mock_models")
 def mock_models_fixture() -> ModelListResponse:
-    """Create mock models list."""
-    model1 = type(
-        "Model",
-        (),
-        {
-            "id": "provider1/model1",
-            "custom_metadata": {"model_type": "llm", "provider_id": "provider1"},
-        },
-    )()
-    model2 = type(
-        "Model",
-        (),
-        {
-            "id": "provider2/model2",
-            "custom_metadata": {"model_type": "llm", "provider_id": "provider2"},
-        },
-    )()
-    return [model1, model2]
+    """Create an OpenAI-style OGX models list response."""
+    return ListModelsResponse.model_construct(
+        data=[
+            Model.model_construct(
+                id="provider1/model1",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={"model_type": "llm", "provider_id": "provider1"},
+            ),
+            Model.model_construct(
+                id="provider2/model2",
+                created=0,
+                owned_by="test",
+                object="model",
+                custom_metadata={"model_type": "llm", "provider_id": "provider2"},
+            ),
+        ]
+    )
 
 
 class TestStoreConversationIntoCache:

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -50,6 +50,8 @@ from ogx_api.openai_responses import (
     OpenAIResponseOutputMessageWebSearchToolCall as WebSearchCall,
 )
 from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
+from ogx_client.types import ListModelsResponse
+from ogx_client.types.model import Model
 from pydantic import AnyUrl, BaseModel
 from pytest_mock import MockerFixture
 
@@ -1971,10 +1973,22 @@ class TestPrepareResponsesParams:
     ) -> None:
         """Test prepare_responses_params with existing conversation ID."""
         mock_client = mocker.AsyncMock()
-        mock_model = mocker.Mock()
-        mock_model.id = "provider1/model1"
-        mock_model.custom_metadata = {"model_type": "llm", "provider_id": "provider1"}
-        mock_client.models.list = mocker.AsyncMock(return_value=[mock_model])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(
+                data=[
+                    Model.model_construct(
+                        id="provider1/model1",
+                        created=0,
+                        owned_by="test",
+                        object="model",
+                        custom_metadata={
+                            "model_type": "llm",
+                            "provider_id": "provider1",
+                        },
+                    )
+                ]
+            )
+        )
 
         query_request = QueryRequest(
             query="test", conversation_id="123e4567-e89b-12d3-a456-426614174000"
@@ -2003,10 +2017,22 @@ class TestPrepareResponsesParams:
     ) -> None:
         """Test prepare_responses_params creates new conversation when ID not provided."""
         mock_client = mocker.AsyncMock()
-        mock_model = mocker.Mock()
-        mock_model.id = "provider1/model1"
-        mock_model.custom_metadata = {"model_type": "llm", "provider_id": "provider1"}
-        mock_client.models.list = mocker.AsyncMock(return_value=[mock_model])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(
+                data=[
+                    Model.model_construct(
+                        id="provider1/model1",
+                        created=0,
+                        owned_by="test",
+                        object="model",
+                        custom_metadata={
+                            "model_type": "llm",
+                            "provider_id": "provider1",
+                        },
+                    )
+                ]
+            )
+        )
 
         mock_conversation = mocker.Mock()
         mock_conversation.id = "new_conv_id"
@@ -2056,10 +2082,22 @@ class TestPrepareResponsesParams:
     ) -> None:
         """Test prepare_responses_params raises HTTPException on connection error when creating conversation."""
         mock_client = mocker.AsyncMock()
-        mock_model = mocker.Mock()
-        mock_model.id = "provider1/model1"
-        mock_model.custom_metadata = {"model_type": "llm", "provider_id": "provider1"}
-        mock_client.models.list = mocker.AsyncMock(return_value=[mock_model])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(
+                data=[
+                    Model.model_construct(
+                        id="provider1/model1",
+                        created=0,
+                        owned_by="test",
+                        object="model",
+                        custom_metadata={
+                            "model_type": "llm",
+                            "provider_id": "provider1",
+                        },
+                    )
+                ]
+            )
+        )
         mock_client.conversations.create = mocker.AsyncMock(
             side_effect=APIConnectionError(
                 message="Connection failed", request=mocker.Mock()
@@ -2106,10 +2144,22 @@ class TestPrepareResponsesParams:
     ) -> None:
         """Test that extra_headers with x-llamastack-provider-data is set when MCP tools have headers."""
         mock_client = mocker.AsyncMock()
-        mock_model = mocker.Mock()
-        mock_model.id = "provider1/model1"
-        mock_model.custom_metadata = {"model_type": "llm", "provider_id": "provider1"}
-        mock_client.models.list = mocker.AsyncMock(return_value=[mock_model])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(
+                data=[
+                    Model.model_construct(
+                        id="provider1/model1",
+                        created=0,
+                        owned_by="test",
+                        object="model",
+                        custom_metadata={
+                            "model_type": "llm",
+                            "provider_id": "provider1",
+                        },
+                    )
+                ]
+            )
+        )
 
         mock_conversation = mocker.Mock()
         mock_conversation.id = "new_conv_id"
@@ -2170,10 +2220,22 @@ class TestPrepareResponsesParams:
     ) -> None:
         """Test that extra_headers is None when no MCP tools have headers."""
         mock_client = mocker.AsyncMock()
-        mock_model = mocker.Mock()
-        mock_model.id = "provider1/model1"
-        mock_model.custom_metadata = {"model_type": "llm", "provider_id": "provider1"}
-        mock_client.models.list = mocker.AsyncMock(return_value=[mock_model])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(
+                data=[
+                    Model.model_construct(
+                        id="provider1/model1",
+                        created=0,
+                        owned_by="test",
+                        object="model",
+                        custom_metadata={
+                            "model_type": "llm",
+                            "provider_id": "provider1",
+                        },
+                    )
+                ]
+            )
+        )
 
         mock_conversation = mocker.Mock()
         mock_conversation.id = "new_conv_id"
@@ -2203,10 +2265,22 @@ class TestPrepareResponsesParams:
     ) -> None:
         """Test prepare_responses_params raises HTTPException on API status error when creating conversation."""
         mock_client = mocker.AsyncMock()
-        mock_model = mocker.Mock()
-        mock_model.id = "provider1/model1"
-        mock_model.custom_metadata = {"model_type": "llm", "provider_id": "provider1"}
-        mock_client.models.list = mocker.AsyncMock(return_value=[mock_model])
+        mock_client.models.list = mocker.AsyncMock(
+            return_value=ListModelsResponse.model_construct(
+                data=[
+                    Model.model_construct(
+                        id="provider1/model1",
+                        created=0,
+                        owned_by="test",
+                        object="model",
+                        custom_metadata={
+                            "model_type": "llm",
+                            "provider_id": "provider1",
+                        },
+                    )
+                ]
+            )
+        )
         mock_client.conversations.create = mocker.AsyncMock(
             side_effect=APIStatusError(
                 message="API error", response=mocker.Mock(request=None), body=None


### PR DESCRIPTION
## Description

Adapt `models.list()` for OGX 1.0, where the client returns a `ModelListResponse` union (OpenAI, Anthropic, or Google) instead of a bare list. Call sites now go through a shared helper that matches on the response type and normalizes entries into a unified `CatalogModel`, so `/models`, client availability checks, responses model selection, metrics, and rlsapi auto-discovery all share one typed catalog shape. Tests were updated to construct real OGX Model / list-response objects rather than ad-hoc mocks.

## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [x] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3192

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
