### PR TITLE
LCORE-3269: Restructure LCORE shield configuration

### DIFF
--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -1443,7 +1443,8 @@
                                                 "model_prompt": "Is this question valid?"
                                             },
                                             "name": "question-validity",
-                                            "type": "question_validity"
+                                            "provider_id": "question_validity",
+                                            "type": "shield"
                                         },
                                         {
                                             "config": {
@@ -1456,7 +1457,8 @@
                                                 ]
                                             },
                                             "name": "pii-redaction",
-                                            "type": "redaction"
+                                            "provider_id": "redaction",
+                                            "type": "shield"
                                         }
                                     ]
                                 }
@@ -12122,14 +12124,21 @@
                         "title": "Name",
                         "description": "Unique, user-facing name of the shield instance"
                     },
-                    "type": {
+                    "provider_id": {
                         "type": "string",
                         "enum": [
                             "question_validity",
                             "redaction"
                         ],
+                        "title": "Provider Id",
+                        "description": "Shield provider / type discriminator"
+                    },
+                    "type": {
+                        "type": "string",
+                        "const": "shield",
                         "title": "Type",
-                        "description": "Shield type discriminator"
+                        "description": "Catalog entry type; always shield",
+                        "default": "shield"
                     },
                     "config": {
                         "additionalProperties": true,
@@ -12141,11 +12150,11 @@
                 "type": "object",
                 "required": [
                     "name",
-                    "type",
+                    "provider_id",
                     "config"
                 ],
                 "title": "CatalogShield",
-                "description": "Shield entry in the ``/shields`` catalog response.\n\nMirrors the LCS-owned ``ShieldConfiguration`` shape (name / type / config)."
+                "description": "Shield entry in the ``/shields`` catalog response.\n\nAttributes:\n    name: Unique, user-facing name identifying this shield instance.\n    provider_id: Shield provider / type discriminator.\n    type: Catalog entry type; always shield.\n    config: Type-specific shield configuration."
             },
             "CatalogTool": {
                 "properties": {
@@ -12482,7 +12491,7 @@
                                 }
                             ],
                             "discriminator": {
-                                "propertyName": "type",
+                                "propertyName": "provider_id",
                                 "mapping": {
                                     "question_validity": "#/components/schemas/QuestionValidityShieldConfiguration",
                                     "redaction": "#/components/schemas/RedactionShieldConfiguration"
@@ -12491,7 +12500,7 @@
                         },
                         "type": "array",
                         "title": "Shields configuration",
-                        "description": "List of pydantic-ai-lightspeed agent guardrail shields (question validity and PII redaction). Each entry has a unique 'name', a 'type' ('question_validity' or 'redaction'), and a type-specific 'config'."
+                        "description": "List of pydantic-ai-lightspeed agent guardrail shields (question validity and PII redaction). Each entry has a unique 'name', a 'provider_id' ('question_validity' or 'redaction'), and a type-specific 'config'."
                     }
                 },
                 "additionalProperties": false,
@@ -17660,10 +17669,10 @@
                             }
                         ],
                         "title": "Shield Ids",
-                        "description": "Optional list of safety shield IDs to apply. If None, all configured shields are used. ",
+                        "description": "Optional list of configured shield names to apply. If None, all configured shields are used.",
                         "examples": [
-                            "llama-guard",
-                            "custom-shield"
+                            "topic-guard",
+                            "pii-redaction"
                         ]
                     },
                     "solr": {
@@ -17702,7 +17711,7 @@
                     "query"
                 ],
                 "title": "QueryRequest",
-                "description": "Model representing a request for the LLM (Language Model).\n\nAttributes:\n    query: The query string.\n    conversation_id: The optional conversation ID (UUID).\n    provider: The optional provider.\n    model: The optional model.\n    system_prompt: The optional system prompt.\n    attachments: The optional attachments.\n    no_tools: Whether to bypass all tools and MCP servers (default: False).\n    generate_topic_summary: Whether to generate topic summary for new conversations.\n    media_type: The optional media type for response format (application/json or text/plain).\n    vector_store_ids: The optional list of specific vector store IDs to query for RAG.\n    shield_ids: The optional list of safety shield IDs to apply.\n    solr: Optional Solr inline RAG options (mode, filters) or legacy filter-only dict.",
+                "description": "Model representing a request for the LLM (Language Model).\n\nAttributes:\n    query: The query string.\n    conversation_id: The optional conversation ID (UUID).\n    provider: The optional provider.\n    model: The optional model.\n    system_prompt: The optional system prompt.\n    attachments: The optional attachments.\n    no_tools: Whether to bypass all tools and MCP servers (default: False).\n    generate_topic_summary: Whether to generate topic summary for new conversations.\n    media_type: The optional media type for response format (application/json or text/plain).\n    vector_store_ids: The optional list of specific vector store IDs to query for RAG.\n    shield_ids: The optional list of configured shield names to apply.\n    solr: Optional Solr inline RAG options (mode, filters) or legacy filter-only dict.",
                 "examples": [
                     {
                         "attachments": [
@@ -17926,10 +17935,10 @@
                         "title": "Shield name",
                         "description": "Unique, user-facing name identifying this shield instance."
                     },
-                    "type": {
+                    "provider_id": {
                         "type": "string",
                         "const": "question_validity",
-                        "title": "Shield type",
+                        "title": "Shield provider id",
                         "description": "Discriminator identifying this as a question-validity shield."
                     },
                     "config": {
@@ -17942,11 +17951,11 @@
                 "type": "object",
                 "required": [
                     "name",
-                    "type",
+                    "provider_id",
                     "config"
                 ],
                 "title": "QuestionValidityShieldConfiguration",
-                "description": "Configuration for a named question-validity guardrail shield.\n\nAttributes:\n    name: Unique, user-facing name identifying this shield instance.\n    type: Discriminator identifying this as a question-validity shield.\n    config: Question-validity-specific configuration."
+                "description": "Configuration for a named question-validity guardrail shield.\n\nAttributes:\n    name: Unique, user-facing name identifying this shield instance.\n    provider_id: Discriminator identifying this as a question-validity shield.\n    config: Question-validity-specific configuration."
             },
             "QuotaExceededResponse": {
                 "properties": {
@@ -18544,10 +18553,10 @@
                         "title": "Shield name",
                         "description": "Unique, user-facing name identifying this shield instance."
                     },
-                    "type": {
+                    "provider_id": {
                         "type": "string",
                         "const": "redaction",
-                        "title": "Shield type",
+                        "title": "Shield provider id",
                         "description": "Discriminator identifying this as a redaction shield."
                     },
                     "config": {
@@ -18560,11 +18569,11 @@
                 "type": "object",
                 "required": [
                     "name",
-                    "type",
+                    "provider_id",
                     "config"
                 ],
                 "title": "RedactionShieldConfiguration",
-                "description": "Configuration for a named PII-redaction guardrail shield.\n\nAttributes:\n    name: Unique, user-facing name identifying this shield instance.\n    type: Discriminator identifying this as a redaction shield.\n    config: Redaction-specific configuration."
+                "description": "Configuration for a named PII-redaction guardrail shield.\n\nAttributes:\n    name: Unique, user-facing name identifying this shield instance.\n    provider_id: Discriminator identifying this as a redaction shield.\n    config: Redaction-specific configuration."
             },
             "ReferencedDocument": {
                 "properties": {
@@ -19002,7 +19011,7 @@
                     "input"
                 ],
                 "title": "ResponsesRequest",
-                "description": "Model representing a request for the Responses API following LCORE specification.\n\nAttributes:\n    input: Input text or structured input items containing the query.\n    model: Model identifier in format \"provider/model\". Auto-selected if not provided.\n    conversation: Conversation ID linking to an existing conversation. Accepts both\n        OpenAI and LCORE formats. Mutually exclusive with previous_response_id.\n    include: Explicitly specify output item types that are excluded by default but\n        should be included in the response.\n    instructions: System instructions or guidelines provided to the model (acts as\n        the system prompt).\n    max_infer_iters: Maximum number of inference iterations the model can perform.\n    max_output_tokens: Maximum number of tokens allowed in the response.\n    max_tool_calls: Maximum number of tool calls allowed in a single response.\n    metadata: Custom metadata dictionary with key-value pairs for tracking or logging.\n    parallel_tool_calls: Whether the model can make multiple tool calls in parallel.\n    previous_response_id: Identifier of the previous response in a multi-turn\n        conversation. Mutually exclusive with conversation.\n    prompt: Prompt object containing a template with variables for dynamic\n        substitution.\n    reasoning: Reasoning configuration for the response.\n    safety_identifier: Safety identifier for the response.\n    store: Whether to store the response in conversation history. Defaults to True.\n    stream: Whether to stream the response as it is generated. Defaults to False.\n    temperature: Sampling temperature controlling randomness (typically 0.0\u20132.0).\n    text: Text response configuration specifying output format constraints (JSON\n        schema, JSON object, or plain text).\n    tool_choice: Tool selection strategy (\"auto\", \"required\", \"none\", or specific\n        tool configuration).\n    tools: List of tools available to the model (file search, web search, function\n        calls, MCP tools). Defaults to all tools available to the model.\n    generate_topic_summary: LCORE-specific flag indicating whether to generate a\n        topic summary for new conversations. Defaults to True.\n    shield_ids: LCORE-specific list of safety shield IDs to apply. If None, all\n        configured shields are used.\n    solr: Optional Solr inline RAG options (mode, filters) or legacy filter-only dict.",
+                "description": "Model representing a request for the Responses API following LCORE specification.\n\nAttributes:\n    input: Input text or structured input items containing the query.\n    model: Model identifier in format \"provider/model\". Auto-selected if not provided.\n    conversation: Conversation ID linking to an existing conversation. Accepts both\n        OpenAI and LCORE formats. Mutually exclusive with previous_response_id.\n    include: Explicitly specify output item types that are excluded by default but\n        should be included in the response.\n    instructions: System instructions or guidelines provided to the model (acts as\n        the system prompt).\n    max_infer_iters: Maximum number of inference iterations the model can perform.\n    max_output_tokens: Maximum number of tokens allowed in the response.\n    max_tool_calls: Maximum number of tool calls allowed in a single response.\n    metadata: Custom metadata dictionary with key-value pairs for tracking or logging.\n    parallel_tool_calls: Whether the model can make multiple tool calls in parallel.\n    previous_response_id: Identifier of the previous response in a multi-turn\n        conversation. Mutually exclusive with conversation.\n    prompt: Prompt object containing a template with variables for dynamic\n        substitution.\n    reasoning: Reasoning configuration for the response.\n    safety_identifier: Safety identifier for the response.\n    store: Whether to store the response in conversation history. Defaults to True.\n    stream: Whether to stream the response as it is generated. Defaults to False.\n    temperature: Sampling temperature controlling randomness (typically 0.0\u20132.0).\n    text: Text response configuration specifying output format constraints (JSON\n        schema, JSON object, or plain text).\n    tool_choice: Tool selection strategy (\"auto\", \"required\", \"none\", or specific\n        tool configuration).\n    tools: List of tools available to the model (file search, web search, function\n        calls, MCP tools). Defaults to all tools available to the model.\n    generate_topic_summary: LCORE-specific flag indicating whether to generate a\n        topic summary for new conversations. Defaults to True.\n    shield_ids: LCORE-specific list of configured shield names to apply.\n        If None, all configured shields are used.\n    solr: Optional Solr inline RAG options (mode, filters) or legacy filter-only dict.",
                 "examples": [
                     {
                         "generate_topic_summary": true,
@@ -20158,7 +20167,8 @@
                                     "model_prompt": "Is this question valid?"
                                 },
                                 "name": "question-validity",
-                                "type": "question_validity"
+                                "provider_id": "question_validity",
+                                "type": "shield"
                             },
                             {
                                 "config": {
@@ -20171,7 +20181,8 @@
                                     ]
                                 },
                                 "name": "pii-redaction",
-                                "type": "redaction"
+                                "provider_id": "redaction",
+                                "type": "shield"
                             }
                         ]
                     }

--- a/src/models/api/requests/query.py
+++ b/src/models/api/requests/query.py
@@ -23,7 +23,7 @@ class QueryRequest(BaseModel):
         generate_topic_summary: Whether to generate topic summary for new conversations.
         media_type: The optional media type for response format (application/json or text/plain).
         vector_store_ids: The optional list of specific vector store IDs to query for RAG.
-        shield_ids: The optional list of safety shield IDs to apply.
+        shield_ids: The optional list of configured shield names to apply.
         solr: Optional Solr inline RAG options (mode, filters) or legacy filter-only dict.
     """
 
@@ -105,9 +105,9 @@ class QueryRequest(BaseModel):
 
     shield_ids: Optional[list[str]] = Field(
         None,
-        description="Optional list of safety shield IDs to apply. "
-        "If None, all configured shields are used. ",
-        examples=["llama-guard", "custom-shield"],
+        description="Optional list of configured shield names to apply. "
+        "If None, all configured shields are used.",
+        examples=["topic-guard", "pii-redaction"],
     )
 
     solr: Optional[SolrVectorSearchRequest] = Field(

--- a/src/models/api/requests/responses_openai.py
+++ b/src/models/api/requests/responses_openai.py
@@ -57,8 +57,8 @@ class ResponsesRequest(BaseModel):
             calls, MCP tools). Defaults to all tools available to the model.
         generate_topic_summary: LCORE-specific flag indicating whether to generate a
             topic summary for new conversations. Defaults to True.
-        shield_ids: LCORE-specific list of safety shield IDs to apply. If None, all
-            configured shields are used.
+        shield_ids: LCORE-specific list of configured shield names to apply.
+            If None, all configured shields are used.
         solr: Optional Solr inline RAG options (mode, filters) or legacy filter-only dict.
     """
 

--- a/src/models/api/responses/successful/catalog.py
+++ b/src/models/api/responses/successful/catalog.py
@@ -91,7 +91,8 @@ class ShieldsResponse(AbstractSuccessfulResponse):
                     "shields": [
                         {
                             "name": "question-validity",
-                            "type": "question_validity",
+                            "provider_id": "question_validity",
+                            "type": "shield",
                             "config": {
                                 "model_id": "openai/gpt-4o-mini",
                                 "model_prompt": "Is this question valid?",
@@ -102,7 +103,8 @@ class ShieldsResponse(AbstractSuccessfulResponse):
                         },
                         {
                             "name": "pii-redaction",
-                            "type": "redaction",
+                            "provider_id": "redaction",
+                            "type": "shield",
                             "config": {
                                 "rules": [
                                     {

--- a/src/models/common/shields.py
+++ b/src/models/common/shields.py
@@ -10,12 +10,20 @@ from pydantic import BaseModel, Field
 class CatalogShield(BaseModel):
     """Shield entry in the ``/shields`` catalog response.
 
-    Mirrors the LCS-owned ``ShieldConfiguration`` shape (name / type / config).
+    Attributes:
+        name: Unique, user-facing name identifying this shield instance.
+        provider_id: Shield provider / type discriminator.
+        type: Catalog entry type; always shield.
+        config: Type-specific shield configuration.
     """
 
     name: str = Field(description="Unique, user-facing name of the shield instance")
-    type: Literal["question_validity", "redaction"] = Field(
-        description="Shield type discriminator",
+    provider_id: Literal["question_validity", "redaction"] = Field(
+        description="Shield provider / type discriminator",
+    )
+    type: Literal["shield"] = Field(
+        default="shield",
+        description="Catalog entry type; always shield",
     )
     config: dict[str, Any] = Field(
         description="Type-specific shield configuration",

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2595,7 +2595,7 @@ class QuestionValidityShieldConfiguration(ConfigurationBase):
 
     Attributes:
         name: Unique, user-facing name identifying this shield instance.
-        type: Discriminator identifying this as a question-validity shield.
+        provider_id: Discriminator identifying this as a question-validity shield.
         config: Question-validity-specific configuration.
     """
 
@@ -2605,9 +2605,9 @@ class QuestionValidityShieldConfiguration(ConfigurationBase):
         description="Unique, user-facing name identifying this shield instance.",
     )
 
-    type: Literal["question_validity"] = Field(
+    provider_id: Literal["question_validity"] = Field(
         ...,
-        title="Shield type",
+        title="Shield provider id",
         description="Discriminator identifying this as a question-validity shield.",
     )
 
@@ -2623,7 +2623,7 @@ class RedactionShieldConfiguration(ConfigurationBase):
 
     Attributes:
         name: Unique, user-facing name identifying this shield instance.
-        type: Discriminator identifying this as a redaction shield.
+        provider_id: Discriminator identifying this as a redaction shield.
         config: Redaction-specific configuration.
     """
 
@@ -2633,9 +2633,9 @@ class RedactionShieldConfiguration(ConfigurationBase):
         description="Unique, user-facing name identifying this shield instance.",
     )
 
-    type: Literal["redaction"] = Field(
+    provider_id: Literal["redaction"] = Field(
         ...,
-        title="Shield type",
+        title="Shield provider id",
         description="Discriminator identifying this as a redaction shield.",
     )
 
@@ -2648,11 +2648,11 @@ class RedactionShieldConfiguration(ConfigurationBase):
 
 ShieldConfiguration = Annotated[
     QuestionValidityShieldConfiguration | RedactionShieldConfiguration,
-    Field(discriminator="type"),
+    Field(discriminator="provider_id"),
 ]
 """Configuration for a single named guardrail shield (question validity or redaction).
 
-A discriminated union on ``type``: Pydantic selects
+A discriminated union on ``provider_id``: Pydantic selects
 ``QuestionValidityShieldConfiguration`` or ``RedactionShieldConfiguration``
 and validates ``config`` against the matching model.
 """
@@ -2847,9 +2847,9 @@ class Configuration(ConfigurationBase):
         default_factory=list,
         title="Shields configuration",
         description="List of pydantic-ai-lightspeed agent guardrail shields "
-        "(question validity and PII redaction). Each entry has a unique 'name', "
-        "a 'type' ('question_validity' or 'redaction'), and a type-specific "
-        "'config'.",
+        "(question validity and PII redaction). Each entry has a unique "
+        "'name', a 'provider_id' ('question_validity' or 'redaction'), "
+        "and a type-specific 'config'.",
     )
 
     @model_validator(mode="after")

--- a/src/utils/shields.py
+++ b/src/utils/shields.py
@@ -149,22 +149,20 @@ def get_shields_for_request(
     shields: list[ShieldConfiguration],
     shield_ids: Optional[list[str]] = None,
 ) -> list[ShieldConfiguration]:
-    """Return configured shields, optionally filtered by request ``shield_ids``.
-
-    Shield identifiers in the request map to each shield's configured ``name``.
+    """Return configured shields, optionally filtered by request shield_ids.
 
     Args:
         shields: Configured LCS shields.
-        shield_ids: Optional list of shield names. If ``None``, all ``shields``
-            are returned. An empty list skips all shields. Otherwise only
-            shields whose ``name`` is in this list are returned.
+        shield_ids: Optional list of shield names. If None, all shields are
+            returned. An empty list skips all shields. Otherwise only shields
+            whose name is in this list are returned.
 
     Returns:
         list[ShieldConfiguration]: Shield configurations to run for this request.
 
     Raises:
-        HTTPException: 404 if ``shield_ids`` is provided and any requested
-            shield name is not present in ``shields``.
+        HTTPException: 404 if shield_ids is provided and any requested shield
+            name is not present in shields.
     """
     if shield_ids is None:
         return list(shields)
@@ -173,8 +171,8 @@ def get_shields_for_request(
         return []
 
     requested = set(shield_ids)
-    configured_ids = {shield.name for shield in shields}
-    missing = requested - configured_ids
+    configured_names = {shield.name for shield in shields}
+    missing = requested - configured_names
     if missing:
         response = NotFoundResponse(
             resource=f"Shield{'s' if len(missing) > 1 else ''}",

--- a/tests/e2e/configuration/library-mode/lightspeed-stack.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack.yaml
@@ -35,3 +35,12 @@ byok_rag:
 rag:
   tool:
     - e2e-test-docs
+
+shields:
+  - name: pii-redaction
+    provider_id: redaction
+    config:
+      rules:
+        - pattern: '\d+'
+          replacement: '[NUM]'
+

--- a/tests/e2e/configuration/server-mode/lightspeed-stack.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack.yaml
@@ -33,3 +33,11 @@ byok_rag:
 rag:
   tool:
     - e2e-test-docs
+
+shields:
+  - name: pii-redaction
+    provider_id: redaction
+    config:
+      rules:
+        - pattern: '\d+'
+          replacement: '[NUM]'

--- a/tests/e2e/features/info.feature
+++ b/tests/e2e/features/info.feature
@@ -21,7 +21,6 @@ Feature: Info tests
       And The body of the response has proper name Lightspeed Core Service (LCS) and version 0.6.0rc2
       And The body of the response has llama-stack version 1.0.2
 
-  @skip
   Scenario: Check if shields endpoint is working
      When I access REST API endpoint "shields" using HTTP GET method
      Then The status code of the response is 200

--- a/tests/e2e/features/steps/info.py
+++ b/tests/e2e/features/steps/info.py
@@ -58,15 +58,11 @@ def check_shield_structure(context: Context) -> None:
     # Validate structure and values
     assert found_shield["type"] == "shield", "type should be 'shield'"
     assert (
-        found_shield["provider_id"] == "llama-guard"
-    ), "provider_id should be 'llama-guard'"
-    assert found_shield["provider_resource_id"] == "openai/gpt-4o-mini", (
-        f"provider_resource_id should be 'openai/gpt-4o-mini', "
-        f"but is '{found_shield['provider_resource_id']}'"
+        found_shield["provider_id"] == "redaction"
+    ), "provider_id should be 'redaction'"
+    assert found_shield["name"] == "pii-redaction", (
+        f"name should be 'pii-redaction', " f"but is '{found_shield['name']}'"
     )
-    assert (
-        found_shield["identifier"] == "llama-guard"
-    ), f"identifier should be 'llama-guard', but is '{found_shield["identifier"]}'"
 
 
 @then("The response contains {count:d} tools listed for provider {provider_name}")

--- a/tests/unit/app/endpoints/test_shields.py
+++ b/tests/unit/app/endpoints/test_shields.py
@@ -100,7 +100,7 @@ async def test_shields_endpoint_handler_configured_shields(
     config_dict["shields"] = [
         {
             "name": "question-validity",
-            "type": "question_validity",
+            "provider_id": "question_validity",
             "config": {
                 "model_id": "openai/gpt-4o-mini",
                 "model_prompt": "Is this question valid?",
@@ -109,7 +109,7 @@ async def test_shields_endpoint_handler_configured_shields(
         },
         {
             "name": "pii-redaction",
-            "type": "redaction",
+            "provider_id": "redaction",
             "config": {
                 "rules": [
                     {
@@ -132,8 +132,10 @@ async def test_shields_endpoint_handler_configured_shields(
     assert isinstance(response, ShieldsResponse)
     assert len(response.shields) == 2
     assert response.shields[0].name == "question-validity"
-    assert response.shields[0].type == "question_validity"
+    assert response.shields[0].provider_id == "question_validity"
+    assert response.shields[0].type == "shield"
     assert response.shields[0].config["model_id"] == "openai/gpt-4o-mini"
     assert response.shields[1].name == "pii-redaction"
-    assert response.shields[1].type == "redaction"
+    assert response.shields[1].provider_id == "redaction"
+    assert response.shields[1].type == "shield"
     assert response.shields[1].config["rules"][0]["replacement"] == "[REDACTED]"

--- a/tests/unit/models/config/test_shields_configuration.py
+++ b/tests/unit/models/config/test_shields_configuration.py
@@ -27,12 +27,12 @@ class TestShieldConfiguration:
         shield = QuestionValidityShieldConfiguration.model_validate(
             {
                 "name": "topic-guard",
-                "type": "question_validity",
+                "provider_id": "question_validity",
                 "config": {"model_id": "test-model"},
             }
         )
         assert shield.name == "topic-guard"
-        assert shield.type == "question_validity"
+        assert shield.provider_id == "question_validity"
         assert isinstance(shield.config, QuestionValidityConfig)
         assert shield.config.model_id == "test-model"
 
@@ -41,12 +41,12 @@ class TestShieldConfiguration:
         shield = RedactionShieldConfiguration.model_validate(
             {
                 "name": "pii-guard",
-                "type": "redaction",
+                "provider_id": "redaction",
                 "config": {"rules": [{"pattern": r"\d+", "replacement": "[NUM]"}]},
             }
         )
         assert shield.name == "pii-guard"
-        assert shield.type == "redaction"
+        assert shield.provider_id == "redaction"
         assert isinstance(shield.config, RedactionConfig)
         assert len(shield.config.compiled_patterns) == 1
 
@@ -54,24 +54,24 @@ class TestShieldConfiguration:
         """config may be passed as an already-constructed model instance."""
         shield = QuestionValidityShieldConfiguration(
             name="topic-guard",
-            type="question_validity",
+            provider_id="question_validity",
             config=QuestionValidityConfig(model_id="test-model"),
         )
         assert isinstance(shield.config, QuestionValidityConfig)
 
-    def test_rejects_config_mismatched_with_type(self) -> None:
-        """A redaction type with question_validity-shaped config is rejected."""
+    def test_rejects_config_mismatched_with_provider_id(self) -> None:
+        """A redaction provider_id with question_validity-shaped config is rejected."""
         with pytest.raises(ValidationError, match="model_id"):
             RedactionShieldConfiguration.model_validate(
                 {
                     "name": "bad",
-                    "type": "redaction",
+                    "provider_id": "redaction",
                     "config": {"model_id": "oops"},
                 }
             )
 
-    def test_rejects_unknown_type(self) -> None:
-        """An unrecognized shield type is rejected by the root Configuration union."""
+    def test_rejects_unknown_provider_id(self) -> None:
+        """An unrecognized shield provider_id is rejected by the root Configuration."""
         with pytest.raises(ValidationError):
             Configuration.model_validate(
                 {
@@ -79,7 +79,7 @@ class TestShieldConfiguration:
                     "shields": [
                         {
                             "name": "bad",
-                            "type": "unknown_type",
+                            "provider_id": "unknown_type",
                             "config": {"model_id": "test-model"},
                         }
                     ],
@@ -92,7 +92,7 @@ class TestShieldConfiguration:
             QuestionValidityShieldConfiguration.model_validate(
                 {
                     "name": "topic-guard",
-                    "type": "question_validity",
+                    "provider_id": "question_validity",
                     "config": {"model_id": "test-model"},
                     "unknown_field": "value",
                 }
@@ -131,18 +131,18 @@ def test_root_configuration_default_shields_is_empty() -> None:
 
 
 def test_root_configuration_accepts_multiple_shields_of_same_type() -> None:
-    """Multiple shields of the same type may be configured with distinct names."""
+    """Multiple shields of the same provider may be configured with distinct ids."""
     cfg = Configuration(
         **_minimal_configuration_kwargs(),
         shields=[
             QuestionValidityShieldConfiguration(
                 name="topic-guard-a",
-                type="question_validity",
+                provider_id="question_validity",
                 config=QuestionValidityConfig(model_id="model-a"),
             ),
             QuestionValidityShieldConfiguration(
                 name="topic-guard-b",
-                type="question_validity",
+                provider_id="question_validity",
                 config=QuestionValidityConfig(model_id="model-b"),
             ),
         ],
@@ -153,18 +153,18 @@ def test_root_configuration_accepts_multiple_shields_of_same_type() -> None:
 
 
 def test_root_configuration_accepts_mixed_shield_types() -> None:
-    """Shields of different types may be mixed in the same list."""
+    """Shields of different providers may be mixed in the same list."""
     cfg = Configuration(
         **_minimal_configuration_kwargs(),
         shields=[
             QuestionValidityShieldConfiguration(
                 name="topic-guard",
-                type="question_validity",
+                provider_id="question_validity",
                 config=QuestionValidityConfig(model_id="test-model"),
             ),
             RedactionShieldConfiguration(
                 name="pii-guard",
-                type="redaction",
+                provider_id="redaction",
                 config=RedactionConfig(
                     rules=[RedactionRule(pattern=r"\d+", replacement="[NUM]")]
                 ),
@@ -172,8 +172,8 @@ def test_root_configuration_accepts_mixed_shield_types() -> None:
         ],
     )
     assert len(cfg.shields) == 2
-    assert cfg.shields[0].type == "question_validity"
-    assert cfg.shields[1].type == "redaction"
+    assert cfg.shields[0].provider_id == "question_validity"
+    assert cfg.shields[1].provider_id == "redaction"
 
 
 def test_root_configuration_rejects_duplicate_shield_names() -> None:
@@ -184,12 +184,12 @@ def test_root_configuration_rejects_duplicate_shield_names() -> None:
             shields=[
                 QuestionValidityShieldConfiguration(
                     name="dup",
-                    type="question_validity",
+                    provider_id="question_validity",
                     config=QuestionValidityConfig(model_id="model-a"),
                 ),
                 RedactionShieldConfiguration(
                     name="dup",
-                    type="redaction",
+                    provider_id="redaction",
                     config=RedactionConfig(),
                 ),
             ],

--- a/tests/unit/models/responses/test_successful_responses.py
+++ b/tests/unit/models/responses/test_successful_responses.py
@@ -189,7 +189,8 @@ class TestShieldsResponse:
         shields = [
             {
                 "name": "question-validity",
-                "type": "question_validity",
+                "provider_id": "question_validity",
+                "type": "shield",
                 "config": {
                     "model_id": "openai/gpt-4o-mini",
                     "model_prompt": "Is this question valid?",

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -278,17 +278,17 @@ def test_init_from_dict_with_shields() -> None:
         "shields": [
             {
                 "name": "topic-guard-a",
-                "type": "question_validity",
+                "provider_id": "question_validity",
                 "config": {"model_id": "test-model"},
             },
             {
                 "name": "topic-guard-b",
-                "type": "question_validity",
+                "provider_id": "question_validity",
                 "config": {"model_id": "test-model-2"},
             },
             {
                 "name": "pii-guard",
-                "type": "redaction",
+                "provider_id": "redaction",
                 "config": {
                     "rules": [
                         {"pattern": r"\d+", "replacement": "[NUM]"},
@@ -302,12 +302,12 @@ def test_init_from_dict_with_shields() -> None:
 
     assert len(cfg.shields) == 3
     assert cfg.shields[0].name == "topic-guard-a"
-    assert cfg.shields[0].type == "question_validity"
+    assert cfg.shields[0].provider_id == "question_validity"
     assert cfg.shields[0].config.model_id == "test-model"  # type: ignore[union-attr]
     assert cfg.shields[1].name == "topic-guard-b"
     assert cfg.shields[1].config.model_id == "test-model-2"  # type: ignore[union-attr]
     assert cfg.shields[2].name == "pii-guard"
-    assert cfg.shields[2].type == "redaction"
+    assert cfg.shields[2].provider_id == "redaction"
     assert len(cfg.shields[2].config.compiled_patterns) == 1  # type: ignore[union-attr]
 
 

--- a/tests/unit/utils/test_shields.py
+++ b/tests/unit/utils/test_shields.py
@@ -16,7 +16,7 @@ def _shield(name: str) -> QuestionValidityShieldConfiguration:
     """Build a minimal question-validity shield configuration for tests."""
     return QuestionValidityShieldConfiguration(
         name=name,
-        type="question_validity",
+        provider_id="question_validity",
         config=QuestionValidityConfig(model_id="test-model"),
     )
 


### PR DESCRIPTION
## Description

Rename shield config fields to name/provider_id, reshape CatalogShield to type=shield with params, and align listing/tests with the new shape.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3269

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
