### PR TITLE
LCORE-3141: models group schema export ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,8 @@ options:
                         dump actual configuration into JSON file and quit
   -s, --dump-schema     dump configuration schema into OpenAPI-compatible file and quit
   -m, --dump-models     dump schemas for all models into OpenAPI-compatible file and quit
+  -gr, --dump-models-group DUMP_MODELS_GROUP
+                        dump schemas for selected models group into OpenAPI-compatible file and quit
   -c, --config CONFIG_FILE
                         path to configuration file (default: lightspeed-stack.yaml)
   --synthesized-config-output SYNTHESIZED_CONFIG_OUTPUT

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -78,7 +78,7 @@ def create_argument_parser() -> ArgumentParser:
         dest="dump_models_group",
         help="dump schemas for selected models group into OpenAPI-compatible file and quit",
         action="store",
-        default=False,
+        default=None,
     )
     parser.add_argument(
         "-c",

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -27,6 +27,9 @@ def create_argument_parser() -> ArgumentParser:
     - -v / --verbose: enable verbose output
     - -d / --dump-configuration: dump the loaded configuration to JSON and exit
     - -s / --dump-schema: dump the configuration schema to OpenAPI JSON and exit
+    - -m / --dump-models: dump schemas for all models into OpenAPI-compatible file and quit
+    - -gr / --dump-models-group DUMP_MODELS_GROUP
+                        dump schemas for selected models group into OpenAPI-compatible file and quit
     - -c / --config: path to the configuration file (default "lightspeed-stack.yaml")
     - -g / --generate-llama-stack-configuration: generate a Llama Stack
                                                  configuration from the service configuration
@@ -67,6 +70,14 @@ def create_argument_parser() -> ArgumentParser:
         dest="dump_models",
         help="dump schemas for all models into OpenAPI-compatible file and quit",
         action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "-gr",
+        "--dump-models-group",
+        dest="dump_models_group",
+        help="dump schemas for selected models group into OpenAPI-compatible file and quit",
+        action="store",
         default=False,
     )
     parser.add_argument(
@@ -208,6 +219,18 @@ def main() -> None:
         try:
             models_dumper.dump_models("models.json")
             logger.info("Schema for all models dumped to models.json")
+        except Exception as e:
+            logger.error("Failed to dump schema for models: %s", e)
+            raise SystemExit(1) from e
+        return
+
+    # -gr or --dump-models-group CLI parameter is used to dump schema for
+    # selected models into a JSON file that is compatible with OpenAPI schema
+    # specification
+    if args.dump_models_group is not None:
+        try:
+            models_dumper.dump_models_group(args.dump_models_group)
+            logger.info("Schema for group %s of models dumped", args.dump_models_group)
         except Exception as e:
             logger.error("Failed to dump schema for models: %s", e)
             raise SystemExit(1) from e


### PR DESCRIPTION
## Description

LCORE-3141: models group schema export ability

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--dump-models-group` command-line option to export OpenAPI-compatible schemas for selected model groups.
  * The command exits after successfully generating the schema file and reports errors if generation fails.

* **Documentation**
  * Updated CLI usage documentation to include the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->