### PR TITLE
LCORE-1801: Fix Otel intrumentation to respect OTEL_SDK_DISABLED flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,11 @@ CONTAINER_RUNTIME ?= $(shell command -v podman 2>/dev/null || command -v docker 
 	docs/models/database.svg
 
 run-stack: ## Run lightspeed-stack directly, without building dependent service/s
-	uv run opentelemetry-instrument python3.12 src/lightspeed_stack.py -c $(CONFIG)
+	@if [ "$${OTEL_SDK_DISABLED:-true}" = "false" ]; then \
+		uv run opentelemetry-instrument python3.12 src/lightspeed_stack.py -c $(CONFIG); \
+	else \
+		uv run python3.12 src/lightspeed_stack.py -c $(CONFIG); \
+	fi
 
 run: start-llama-stack-container ## Run the service locally with dependent services
 	@echo "Starting Lightspeed Core Stack..."

--- a/deploy/lightspeed-stack/Containerfile
+++ b/deploy/lightspeed-stack/Containerfile
@@ -133,9 +133,13 @@ ENV PATH="/app-root/.venv/bin:$PATH"
 # We place them at /app-root/providers.d. YAMLs there reference lightspeed_stack_providers.*, so that package must be on PYTHONPATH.
 ENV PYTHONPATH="/app-root"
 
+# Copy entrypoint script
+COPY ${LSC_SOURCE_DIR}/scripts/entrypoint.sh /app-root/entrypoint.sh
+RUN chmod +x /app-root/entrypoint.sh
+
 # Run the application
 EXPOSE 8080
-ENTRYPOINT ["opentelemetry-instrument", "python3.12", "src/lightspeed_stack.py"]
+ENTRYPOINT ["/app-root/entrypoint.sh"]
 
 LABEL vendor="Red Hat, Inc." \
     name="lightspeed-core/lightspeed-stack-rhel9" \

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Only use OpenTelemetry instrumentation if explicitly enabled
+# Use explicit venv paths to ensure dependencies are found
+if [ "${OTEL_SDK_DISABLED:-true}" = "false" ]; then
+    exec /app-root/.venv/bin/opentelemetry-instrument /app-root/.venv/bin/python src/lightspeed_stack.py "$@"
+else
+    exec /app-root/.venv/bin/python src/lightspeed_stack.py "$@"
+fi

--- a/tests/e2e-prow/rhoai/manifests/lightspeed/lightspeed-stack.yaml
+++ b/tests/e2e-prow/rhoai/manifests/lightspeed/lightspeed-stack.yaml
@@ -63,7 +63,7 @@ spec:
               key: key
               optional: true
       image: ${LIGHTSPEED_STACK_IMAGE}
-      command: ["/bin/sh", "-c", "mkdir -p /tmp/data && exec opentelemetry-instrument python3.12 src/lightspeed_stack.py"]
+      command: ["/bin/sh", "-c", "mkdir -p /tmp/data && exec /app-root/entrypoint.sh"]
       ports:
         - containerPort: 8080
       # TCP probes avoid HTTP/auth. LCS + Llama handshake and large images can take 60–120s before :8080 listens;


### PR DESCRIPTION


## Description

Fix OpenTelemetry instrumentation to only initialize when explicitly enabled, preventing connection errors when tracing is disabled.

**Problem**

After adding `opentelemetry-instrument` wrapper to the application startup, the OpenTelemetry SDK was attempting to connect to the default OTLP endpoint (`localhost:4317`) even when `OTEL_SDK_DISABLED=true`. This caused errors in CI/E2E tests:

```
ERROR:opentelemetry.exporter.otlp.proto.grpc.exporter:Failed to export traces to localhost:4317,
error code: StatusCode.UNAVAILABLE WARNING:opentelemetry.exporter.otlp.proto.grpc.exporter:Transient error
StatusCode.UNAVAILABLE encountered while exporting metrics to localhost:4317
```

The `opentelemetry-instrument` CLI was initializing the SDK regardless of the `OTEL_SDK_DISABLED` environment variable, causing unnecessary connection attempts.

**Solution**

Make OpenTelemetry instrumentation **conditional** based on the `OTEL_SDK_DISABLED` environment variable.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry instrumentation can now be enabled or disabled through the `OTEL_SDK_DISABLED` setting.
  * Application startup consistently respects the instrumentation setting across local and containerized runs.

* **Bug Fixes**
  * Improved startup handling for end-to-end deployments by using a shared entrypoint script.
  * Preserved command-line arguments when launching the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->