### PR TITLE
LCORE-3141: Limit possible values on CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,7 +860,7 @@ options:
                         dump actual configuration into JSON file and quit
   -s, --dump-schema     dump configuration schema into OpenAPI-compatible file and quit
   -m, --dump-models     dump schemas for all models into OpenAPI-compatible file and quit
-  -gr, --dump-models-group DUMP_MODELS_GROUP
+  -gr, --dump-models-group {requests,successful_responses,error_responses,common,agents,common_responses}
                         dump schemas for selected models group into OpenAPI-compatible file and quit
   -c, --config CONFIG_FILE
                         path to configuration file (default: lightspeed-stack.yaml)

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -28,8 +28,9 @@ def create_argument_parser() -> ArgumentParser:
     - -d / --dump-configuration: dump the loaded configuration to JSON and exit
     - -s / --dump-schema: dump the configuration schema to OpenAPI JSON and exit
     - -m / --dump-models: dump schemas for all models into OpenAPI-compatible file and quit
-    - -gr / --dump-models-group DUMP_MODELS_GROUP
-                        dump schemas for selected models group into OpenAPI-compatible file and quit
+    - -gr / --dump-models-group {requests,successful_responses,error_responses,common,agents,
+                      common_responses}
+                      dump schemas for selected models group into OpenAPI-compatible file and quit
     - -c / --config: path to the configuration file (default "lightspeed-stack.yaml")
     - -g / --generate-llama-stack-configuration: generate a Llama Stack
                                                  configuration from the service configuration
@@ -78,6 +79,14 @@ def create_argument_parser() -> ArgumentParser:
         dest="dump_models_group",
         help="dump schemas for selected models group into OpenAPI-compatible file and quit",
         action="store",
+        choices=[
+            "requests",
+            "successful_responses",
+            "error_responses",
+            "common",
+            "agents",
+            "common_responses",
+        ],
         default=None,
     )
     parser.add_argument(


### PR DESCRIPTION
## Description

LCORE-3141: Limit possible values on CLI

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help text to list the available model groups for `--dump-models-group`.

* **Bug Fixes**
  * Improved validation for model group selection by restricting the option to supported values.
  * Invalid model group entries now provide clearer command-line feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->