### PR TITLE
LCORE-3285: redefined-outer-name fix (trivial)

### DIFF
--- a/scripts/generate_openapi_schema.py
+++ b/scripts/generate_openapi_schema.py
@@ -23,7 +23,7 @@ asyncio.run(AsyncLlamaStackClientHolder().load(configuration.configuration.llama
 from app.main import app  # noqa: E402  pylint: disable=C0413
 
 
-def read_version_from_openapi(filename: str) -> str:
+def read_version_from_openapi(openapi_filename: str) -> str:
     """
     Extract the OpenAPI document's version from a generated OpenAPI JSON file.
 
@@ -31,7 +31,7 @@ def read_version_from_openapi(filename: str) -> str:
         str: The value of the OpenAPI document's `info.version`.
     """
     # retrieve pre-generated OpenAPI schema
-    with open(filename, encoding="utf-8") as fin:
+    with open(openapi_filename, encoding="utf-8") as fin:
         pre_generated_schema = json.load(fin)
         assert pre_generated_schema is not None
         assert "info" in pre_generated_schema, "node 'info' not found in openapi.json"


### PR DESCRIPTION
## Description

LCORE-3285: redefined-outer-name fix (trivial)

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3285


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified the OpenAPI schema version-reading parameter name without changing functionality.
  * Existing version extraction behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->