### PR TITLE
LCORE-1826: Expose OpenTelemetry configuration in v1/config endpoint

### DIFF
--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -6753,6 +6753,15 @@
                                             }
                                         ],
                                         "name": "lightspeed-stack",
+                                        "observability": {
+                                            "otel": {
+                                                "OTEL_EXPORTER_OTLP_ENDPOINT": "",
+                                                "OTEL_EXPORTER_OTLP_HEADERS": "api-key=[REDACTED]",
+                                                "OTEL_EXPORTER_OTLP_PROTOCOL": "",
+                                                "OTEL_SDK_DISABLED": "true",
+                                                "OTEL_SERVICE_NAME": ""
+                                            }
+                                        },
                                         "quota_handlers": {
                                             "enable_token_history": false,
                                             "limiters": [],
@@ -12367,6 +12376,11 @@
                         "title": "Splunk configuration",
                         "description": "Splunk HEC configuration for sending telemetry events."
                     },
+                    "observability": {
+                        "$ref": "#/components/schemas/ObservabilityConfiguration",
+                        "title": "Observability configuration",
+                        "description": "OpenTelemetry and observability configuration collected from OTEL_* environment variables."
+                    },
                     "deployment_environment": {
                         "type": "string",
                         "title": "Deployment environment",
@@ -12463,6 +12477,15 @@
                                 }
                             ],
                             "name": "lightspeed-stack",
+                            "observability": {
+                                "otel": {
+                                    "OTEL_EXPORTER_OTLP_ENDPOINT": "",
+                                    "OTEL_EXPORTER_OTLP_HEADERS": "api-key=[REDACTED]",
+                                    "OTEL_EXPORTER_OTLP_PROTOCOL": "",
+                                    "OTEL_SDK_DISABLED": "true",
+                                    "OTEL_SERVICE_NAME": ""
+                                }
+                            },
                             "quota_handlers": {
                                 "enable_token_history": false,
                                 "limiters": [],
@@ -15106,6 +15129,22 @@
                 "type": "object",
                 "title": "OAuthFlows",
                 "description": "Defines the configuration for the supported OAuth 2.0 flows."
+            },
+            "ObservabilityConfiguration": {
+                "properties": {
+                    "otel": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "type": "object",
+                        "title": "OpenTelemetry configuration",
+                        "description": "Active OpenTelemetry configuration from OTEL_* environment variables"
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "ObservabilityConfiguration",
+                "description": "OpenTelemetry observability configuration.\n\nThis configuration is automatically populated from OTEL_* environment variables\nto provide visibility into the active tracing setup.\n\nAttributes:\n    otel: Dictionary of OTEL_* environment variables with secrets redacted."
             },
             "OkpConfiguration": {
                 "properties": {

--- a/src/models/api/responses/successful/configuration.py
+++ b/src/models/api/responses/successful/configuration.py
@@ -87,6 +87,15 @@ class ConfigurationResponse(AbstractSuccessfulResponse):
                             "scheduler": {"period": 1},
                             "enable_token_history": False,
                         },
+                        "observability": {
+                            "otel": {
+                                "OTEL_SDK_DISABLED": "true",
+                                "OTEL_EXPORTER_OTLP_ENDPOINT": "",
+                                "OTEL_EXPORTER_OTLP_PROTOCOL": "",
+                                "OTEL_SERVICE_NAME": "",
+                                "OTEL_EXPORTER_OTLP_HEADERS": "api-key=[REDACTED]",
+                            }
+                        },
                     }
                 }
             ]

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=too-many-lines
 
+import os
 import re
 from enum import Enum
 from functools import cached_property
@@ -2830,6 +2831,118 @@ class RedactionConfig(ConfigurationBase):
         return list(self._compiled_patterns)
 
 
+class ObservabilityConfiguration(ConfigurationBase):
+    """OpenTelemetry observability configuration.
+
+    This configuration is automatically populated from OTEL_* environment variables
+    to provide visibility into the active tracing setup.
+
+    Attributes:
+        otel: Dictionary of OTEL_* environment variables with secrets redacted.
+    """
+
+    otel: dict[str, str] = Field(
+        default_factory=dict,
+        title="OpenTelemetry configuration",
+        description="Active OpenTelemetry configuration from OTEL_* environment variables",
+    )
+
+    @field_validator("otel", mode="before")
+    @classmethod
+    def redact_secrets(cls, value: dict[str, str]) -> dict[str, str]:
+        """Redact sensitive OTEL environment variables.
+
+        For headers (e.g., OTEL_EXPORTER_OTLP_HEADERS), redacts values while preserving
+        key names for debugging. For certificates and client keys, redacts the entire value.
+
+        Parameters:
+        ----------
+            value: Dictionary of OTEL environment variables
+
+        Returns:
+            New dictionary with sensitive values redacted
+        """
+        # Let Pydantic handle type validation for non-dict inputs
+        if not isinstance(value, dict):
+            return value
+
+        if not value:
+            return value
+
+        # Create a new dict to avoid mutating caller's data
+        redacted = {}
+
+        for key, val in value.items():
+            # Redact generic and signal-specific OTLP headers
+            # Matches: OTEL_EXPORTER_OTLP_HEADERS,
+            #          OTEL_EXPORTER_OTLP_TRACES_HEADERS,
+            #          OTEL_EXPORTER_OTLP_METRICS_HEADERS,
+            #          OTEL_EXPORTER_OTLP_LOGS_HEADERS
+            # Format: "api-key=secret,tenant-id=acme" -> "api-key=[REDACTED],tenant-id=[REDACTED]"
+            if "HEADERS" in key and "OTLP" in key:
+                redacted[key] = cls._redact_header_values(val)
+            # Redact generic and signal-specific certificates
+            # Matches: OTEL_EXPORTER_OTLP_CERTIFICATE,
+            #          OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE, etc.
+            elif "CERTIFICATE" in key and "OTLP" in key:
+                redacted[key] = "[REDACTED]"
+            # Redact generic and signal-specific client keys
+            # Matches: OTEL_EXPORTER_OTLP_CLIENT_KEY,
+            #          OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY, etc.
+            elif "CLIENT_KEY" in key and "OTLP" in key:
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = val
+
+        return redacted
+
+    @staticmethod
+    def _redact_header_values(header_string: str) -> str:
+        """Redact header values while preserving key names.
+
+        OTEL headers format: "key1=value1,key2=value2"
+        Result: "key1=[REDACTED],key2=[REDACTED]"
+
+        Parameters:
+        ----------
+            header_string: Comma-separated key=value pairs
+
+        Returns:
+            Header string with values redacted but keys preserved
+        """
+        if not header_string or "=" not in header_string:
+            # No key=value pairs found, redact entire string
+            return "[REDACTED]"
+
+        redacted_pairs = []
+        for pair in header_string.split(","):
+            pair = pair.strip()
+            if "=" in pair:
+                key_part = pair.split("=", 1)[0]
+                redacted_pairs.append(f"{key_part}=[REDACTED]")
+            else:
+                # Malformed pair without =, redact entirely
+                redacted_pairs.append("[REDACTED]")
+
+        return ",".join(redacted_pairs)
+
+    @classmethod
+    def from_environment(cls) -> "ObservabilityConfiguration":
+        """Collect all OTEL_* environment variables from the environment.
+
+        Sensitive variables (headers, certificates, keys) are automatically redacted
+        by the field validator.
+
+        Returns:
+            ObservabilityConfiguration with otel dict populated from environment.
+        """
+        otel_vars = {}
+        for key, value in os.environ.items():
+            if key.startswith("OTEL_"):
+                otel_vars[key] = value
+        return cls(otel=otel_vars)
+
+
 class Configuration(ConfigurationBase):
     """Global service configuration."""
 
@@ -2989,6 +3102,13 @@ class Configuration(ConfigurationBase):
         default=None,
         title="Splunk configuration",
         description="Splunk HEC configuration for sending telemetry events.",
+    )
+
+    observability: ObservabilityConfiguration = Field(
+        default_factory=ObservabilityConfiguration.from_environment,
+        title="Observability configuration",
+        description="OpenTelemetry and observability configuration collected "
+        "from OTEL_* environment variables.",
     )
 
     deployment_environment: str = Field(

--- a/tests/integration/endpoints/test_config_integration.py
+++ b/tests/integration/endpoints/test_config_integration.py
@@ -88,3 +88,85 @@ async def test_config_endpoint_fails_without_configuration(
     assert "response" in exc_info.value.detail
     detail = cast(dict[str, str], exc_info.value.detail)
     assert "configuration is not loaded" in detail["response"].lower()
+
+
+@pytest.mark.asyncio
+async def test_config_endpoint_includes_observability(
+    current_config: AppConfig,  # pylint: disable=unused-argument
+    test_request: Request,
+    test_auth: AuthTuple,
+) -> None:
+    """Test that config endpoint includes observability configuration.
+
+    This integration test verifies:
+    - Observability field is present in the configuration response
+    - OTEL environment variables are correctly collected
+    - Response structure includes observability.otel block
+
+    Parameters:
+    ----------
+        current_config (AppConfig): Loads root configuration
+        test_request (Request): FastAPI request
+        test_auth (AuthTuple): noop authentication tuple
+    """
+    response = await config_endpoint_handler(auth=test_auth, request=test_request)
+
+    # Verify observability field exists
+    assert hasattr(response.configuration, "observability")
+    assert response.configuration.observability is not None
+
+    # Verify otel field exists
+    assert hasattr(response.configuration.observability, "otel")
+    assert isinstance(response.configuration.observability.otel, dict)
+
+
+@pytest.mark.asyncio
+async def test_config_endpoint_observability_collects_otel_vars(
+    current_config: AppConfig,
+    test_request: Request,
+    test_auth: AuthTuple,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that observability config collects OTEL_* environment variables.
+
+    This integration test verifies the full endpoint integration:
+    - OTEL_* environment variables are collected into observability.otel
+    - Configuration reload picks up new environment variables
+    - Endpoint response includes the updated observability configuration
+
+    Parameters:
+    ----------
+        current_config (AppConfig): Loads root configuration
+        test_request (Request): FastAPI request
+        test_auth (AuthTuple): noop authentication tuple
+        monkeypatch (pytest.MonkeyPatch): Fixture to modify environment variables
+    """
+    # pylint: disable=import-outside-toplevel
+    from pathlib import Path
+
+    # Set OTEL environment variables
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "test-service")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    # Reload configuration to pick up new env vars
+    # The observability field is populated via from_environment() during config load
+    config_path = Path(__file__).parent.parent.parent.parent / "lightspeed-stack.yaml"
+    current_config.load_configuration(str(config_path))
+
+    # Call the actual endpoint handler to test full integration
+    response = await config_endpoint_handler(auth=test_auth, request=test_request)
+
+    # Verify that the endpoint response includes observability configuration
+    assert hasattr(response.configuration, "observability")
+    assert response.configuration.observability is not None
+    assert hasattr(response.configuration.observability, "otel")
+
+    # Verify OTEL vars are present in the endpoint response
+    otel_config = response.configuration.observability.otel
+    assert "OTEL_SDK_DISABLED" in otel_config
+    assert otel_config["OTEL_SDK_DISABLED"] == "true"
+    assert "OTEL_SERVICE_NAME" in otel_config
+    assert otel_config["OTEL_SERVICE_NAME"] == "test-service"
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" in otel_config
+    assert otel_config["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -4,9 +4,11 @@
 # pyright: reportCallIssue=false
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
+import pytest
 from pydantic import SecretStr
 
 import constants
@@ -50,6 +52,26 @@ _MCP_SERVER_DUMP_DEFAULTS: dict[str, Any] = {
     "require_approval": "never",
     "timeout": None,
 }
+
+
+@pytest.fixture(name="clear_otel_env", autouse=True)
+def clear_otel_env_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear OTEL_* environment variables to prevent ambient leakage in tests.
+
+    This fixture ensures dump configuration tests have stable expectations
+    regardless of whether they run on instrumented CI runners.
+    """
+    for key in list(os.environ.keys()):
+        if key.startswith("OTEL_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _get_expected_observability_dump() -> dict[str, dict[str, str]]:
+    """Get expected observability dump based on current environment.
+
+    Returns empty otel dict when OTEL_* vars are cleared by fixture.
+    """
+    return {"otel": {}}
 
 
 def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
@@ -232,6 +254,7 @@ def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -459,6 +482,7 @@ def test_dump_configuration_valid_values(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -837,6 +861,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -1099,6 +1124,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -1394,6 +1420,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -1616,6 +1643,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -1998,6 +2026,7 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -2226,6 +2255,7 @@ def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -2454,6 +2484,7 @@ def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,
@@ -2689,6 +2720,7 @@ def test_dump_configuration_specific_compaction_values(tmp_path: Path) -> None:
                 "quota_subject": None,
             },
             "splunk": None,
+            "observability": _get_expected_observability_dump(),
             "deployment_environment": "development",
             "reranker": {
                 "enabled": False,

--- a/tests/unit/models/config/test_observability_configuration.py
+++ b/tests/unit/models/config/test_observability_configuration.py
@@ -1,0 +1,366 @@
+"""Unit tests for ObservabilityConfiguration model."""
+
+import os
+
+import pytest
+
+from models.config import ObservabilityConfiguration
+
+
+def test_default_values() -> None:
+    """Test default ObservabilityConfiguration has expected values."""
+    cfg = ObservabilityConfiguration()
+    assert cfg.otel == {}
+
+
+def test_from_environment_no_otel_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test from_environment with no OTEL_* environment variables.
+
+    Parameters:
+    ----------
+        monkeypatch (pytest.MonkeyPatch): Pytest fixture for environment manipulation.
+    """
+    # Clear any existing OTEL_ variables
+    for key in list(os.environ.keys()):
+        if key.startswith("OTEL_"):
+            monkeypatch.delenv(key, raising=False)
+
+    cfg = ObservabilityConfiguration.from_environment()
+    assert cfg.otel == {}
+
+
+def test_from_environment_with_otel_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test from_environment collects OTEL_* environment variables.
+
+    Parameters:
+    ----------
+        monkeypatch (pytest.MonkeyPatch): Pytest fixture for environment manipulation.
+    """
+    # Set OTEL_ environment variables
+    otel_vars = {
+        "OTEL_SDK_DISABLED": "true",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
+        "OTEL_SERVICE_NAME": "lightspeed-stack",
+    }
+
+    for key, value in otel_vars.items():
+        monkeypatch.setenv(key, value)
+
+    cfg = ObservabilityConfiguration.from_environment()
+
+    # Verify all OTEL_ vars are collected
+    for key, value in otel_vars.items():
+        assert key in cfg.otel
+        assert cfg.otel[key] == value
+
+
+def test_from_environment_ignores_non_otel_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test from_environment only collects OTEL_* variables.
+
+    Parameters:
+    ----------
+        monkeypatch (pytest.MonkeyPatch): Pytest fixture for environment manipulation.
+    """
+    # Set some non-OTEL variables
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("HOME", "/home/user")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+    cfg = ObservabilityConfiguration.from_environment()
+
+    # Only OTEL_ vars should be collected
+    assert "PATH" not in cfg.otel
+    assert "HOME" not in cfg.otel
+    assert "OTEL_SDK_DISABLED" in cfg.otel
+    assert cfg.otel["OTEL_SDK_DISABLED"] == "true"
+
+
+def test_manual_construction() -> None:
+    """Test manual construction of ObservabilityConfiguration."""
+    otel_dict = {
+        "OTEL_SDK_DISABLED": "false",
+        "OTEL_SERVICE_NAME": "test-service",
+    }
+
+    cfg = ObservabilityConfiguration(otel=otel_dict)
+
+    assert cfg.otel == otel_dict
+    assert cfg.otel["OTEL_SDK_DISABLED"] == "false"
+    assert cfg.otel["OTEL_SERVICE_NAME"] == "test-service"
+
+
+@pytest.mark.parametrize(
+    ("otel_dict", "expected_count"),
+    [
+        ({}, 0),
+        ({"OTEL_SDK_DISABLED": "true"}, 1),
+        (
+            {
+                "OTEL_SDK_DISABLED": "true",
+                "OTEL_SERVICE_NAME": "test",
+                "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+            },
+            3,
+        ),
+    ],
+    ids=[
+        "empty",
+        "single_var",
+        "multiple_vars",
+    ],
+)
+def test_otel_dict_sizes(otel_dict: dict[str, str], expected_count: int) -> None:
+    """Test ObservabilityConfiguration with various otel dict sizes.
+
+    Parameters:
+    ----------
+        otel_dict (dict[str, str]): Dictionary of OTEL environment variables to test.
+        expected_count (int): Expected number of items in the resulting otel dict.
+    """
+    cfg = ObservabilityConfiguration(otel=otel_dict)
+    assert len(cfg.otel) == expected_count
+
+
+def test_otel_empty_string_values() -> None:
+    """Test ObservabilityConfiguration handles empty string values."""
+    otel_dict = {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "",
+        "OTEL_SERVICE_NAME": "",
+    }
+
+    cfg = ObservabilityConfiguration(otel=otel_dict)
+
+    assert cfg.otel["OTEL_EXPORTER_OTLP_ENDPOINT"] == ""
+    assert cfg.otel["OTEL_SERVICE_NAME"] == ""
+
+
+def test_model_config_extra_forbid() -> None:
+    """Test that extra fields are forbidden (inherited from ConfigurationBase)."""
+    with pytest.raises(ValueError, match="Extra inputs are not permitted"):
+        ObservabilityConfiguration(
+            otel={},
+            unexpected_field="value",  # type: ignore[call-arg]
+        )
+
+
+def test_from_environment_redacts_secret_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that OTEL_EXPORTER_OTLP_HEADERS values are redacted.
+
+    Parameters:
+    ----------
+        monkeypatch (pytest.MonkeyPatch): Pytest fixture for environment manipulation.
+    """
+    monkeypatch.setenv(
+        "OTEL_EXPORTER_OTLP_HEADERS", "api-key=secret_token,tenant-id=acme"
+    )
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "test-service")
+
+    cfg = ObservabilityConfiguration.from_environment()
+
+    # Header values should be redacted but keys preserved
+    assert "OTEL_EXPORTER_OTLP_HEADERS" in cfg.otel
+    assert (
+        cfg.otel["OTEL_EXPORTER_OTLP_HEADERS"]
+        == "api-key=[REDACTED],tenant-id=[REDACTED]"
+    )
+
+    # Non-secret vars should not be redacted
+    assert "OTEL_SERVICE_NAME" in cfg.otel
+    assert cfg.otel["OTEL_SERVICE_NAME"] == "test-service"
+
+
+def test_from_environment_redacts_mtls_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that mTLS certificate and key paths are redacted.
+
+    Parameters:
+    ----------
+        monkeypatch (pytest.MonkeyPatch): Pytest fixture for environment manipulation.
+    """
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", "/path/to/cert.pem")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_CLIENT_KEY", "/path/to/key.pem")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+
+    cfg = ObservabilityConfiguration.from_environment()
+
+    # All mTLS-related vars should be redacted
+    assert cfg.otel["OTEL_EXPORTER_OTLP_CERTIFICATE"] == "[REDACTED]"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_CLIENT_KEY"] == "[REDACTED]"
+
+    # Non-secret var should not be redacted
+    assert cfg.otel["OTEL_SDK_DISABLED"] == "false"
+
+
+def test_from_environment_redacts_all_secret_vars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that generic and signal-specific secret OTEL variables are redacted.
+
+    Parameters:
+    ----------
+        monkeypatch (pytest.MonkeyPatch): Pytest fixture for environment manipulation.
+    """
+    # Set headers with key=value format
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "api-key=secret")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "trace-key=secret")
+
+    # Set certificates and keys
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", "/secret/cert.pem")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_CLIENT_KEY", "/secret/key.pem")
+
+    # Also set some non-secret vars
+    monkeypatch.setenv("OTEL_SERVICE_NAME", "test-service")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    cfg = ObservabilityConfiguration.from_environment()
+
+    # Headers should have values redacted but keys preserved
+    assert cfg.otel["OTEL_EXPORTER_OTLP_HEADERS"] == "api-key=[REDACTED]"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] == "trace-key=[REDACTED]"
+
+    # Certificates and keys should be fully redacted
+    assert cfg.otel["OTEL_EXPORTER_OTLP_CERTIFICATE"] == "[REDACTED]"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_CLIENT_KEY"] == "[REDACTED]"
+
+    # Non-secret vars should not be redacted
+    assert cfg.otel["OTEL_SERVICE_NAME"] == "test-service"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+
+
+def test_direct_construction_redacts_secrets() -> None:
+    """Test that direct construction also redacts secrets via validator."""
+    otel_dict = {
+        "OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer secret,x-api-key=12345",
+        "OTEL_EXPORTER_OTLP_CERTIFICATE": "/path/to/cert.pem",
+        "OTEL_EXPORTER_OTLP_CLIENT_KEY": "/path/to/key.pem",
+        "OTEL_SERVICE_NAME": "my-service",
+        "OTEL_SDK_DISABLED": "false",
+    }
+
+    cfg = ObservabilityConfiguration(otel=otel_dict)
+
+    # Header values should be redacted but keys preserved
+    assert (
+        cfg.otel["OTEL_EXPORTER_OTLP_HEADERS"]
+        == "Authorization=[REDACTED],x-api-key=[REDACTED]"
+    )
+
+    # Certificates and keys should be fully redacted
+    assert cfg.otel["OTEL_EXPORTER_OTLP_CERTIFICATE"] == "[REDACTED]"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_CLIENT_KEY"] == "[REDACTED]"
+
+    # Non-secrets should not be redacted
+    assert cfg.otel["OTEL_SERVICE_NAME"] == "my-service"
+    assert cfg.otel["OTEL_SDK_DISABLED"] == "false"
+
+
+def test_signal_specific_headers_redacted() -> None:
+    """Test that signal-specific OTLP headers have values redacted."""
+    otel_dict = {
+        "OTEL_EXPORTER_OTLP_TRACES_HEADERS": "Authorization=Bearer trace-token",
+        "OTEL_EXPORTER_OTLP_METRICS_HEADERS": "x-api-key=metrics-key,tenant=prod",
+        "OTEL_EXPORTER_OTLP_LOGS_HEADERS": "api-key=logs-token",
+        "OTEL_EXPORTER_OTLP_ENDPOINT": "http://collector:4317",
+    }
+
+    cfg = ObservabilityConfiguration(otel=otel_dict)
+
+    # All signal-specific header values should be redacted but keys preserved
+    assert cfg.otel["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] == "Authorization=[REDACTED]"
+    assert (
+        cfg.otel["OTEL_EXPORTER_OTLP_METRICS_HEADERS"]
+        == "x-api-key=[REDACTED],tenant=[REDACTED]"
+    )
+    assert cfg.otel["OTEL_EXPORTER_OTLP_LOGS_HEADERS"] == "api-key=[REDACTED]"
+
+    # Non-secret should not be redacted
+    assert cfg.otel["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://collector:4317"
+
+
+def test_signal_specific_certificates_redacted() -> None:
+    """Test that signal-specific OTLP certificates and keys are redacted."""
+    otel_dict = {
+        "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE": "/path/to/traces-cert.pem",
+        "OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE": "/path/to/metrics-cert.pem",
+        "OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY": "/path/to/traces-key.pem",
+        "OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY": "/path/to/metrics-key.pem",
+        "OTEL_SERVICE_NAME": "test-service",
+    }
+
+    cfg = ObservabilityConfiguration(otel=otel_dict)
+
+    # All signal-specific certificates and keys should be redacted
+    assert cfg.otel["OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE"] == "[REDACTED]"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE"] == "[REDACTED]"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY"] == "[REDACTED]"
+    assert cfg.otel["OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY"] == "[REDACTED]"
+
+    # Non-secret should not be redacted
+    assert cfg.otel["OTEL_SERVICE_NAME"] == "test-service"
+
+
+def test_validator_does_not_mutate_input() -> None:
+    """Test that the validator returns a new dict without mutating input."""
+    original_dict = {
+        "OTEL_EXPORTER_OTLP_HEADERS": "api-key=secret-token",
+        "OTEL_SERVICE_NAME": "test-service",
+    }
+
+    # Create a copy to verify original isn't mutated
+    original_copy = original_dict.copy()
+
+    cfg = ObservabilityConfiguration(otel=original_dict)
+
+    # Original dict should be unchanged
+    assert original_dict == original_copy
+    assert original_dict["OTEL_EXPORTER_OTLP_HEADERS"] == "api-key=secret-token"
+
+    # But the config should have redacted value
+    assert cfg.otel["OTEL_EXPORTER_OTLP_HEADERS"] == "api-key=[REDACTED]"
+
+
+def test_header_redaction_edge_cases() -> None:
+    """Test header value redaction handles various formats correctly."""
+    # Multiple key=value pairs
+    otel_dict = {
+        "OTEL_EXPORTER_OTLP_HEADERS": "api-key=secret1,tenant-id=acme,x-trace-id=12345",
+    }
+    cfg = ObservabilityConfiguration(otel=otel_dict)
+    assert (
+        cfg.otel["OTEL_EXPORTER_OTLP_HEADERS"]
+        == "api-key=[REDACTED],tenant-id=[REDACTED],x-trace-id=[REDACTED]"
+    )
+
+    # Single key=value pair
+    otel_dict2 = {"OTEL_EXPORTER_OTLP_HEADERS": "Authorization=Bearer token123"}
+    cfg2 = ObservabilityConfiguration(otel=otel_dict2)
+    assert cfg2.otel["OTEL_EXPORTER_OTLP_HEADERS"] == "Authorization=[REDACTED]"
+
+    # No equals sign (malformed, redact entirely)
+    otel_dict3 = {"OTEL_EXPORTER_OTLP_HEADERS": "just-a-token"}
+    cfg3 = ObservabilityConfiguration(otel=otel_dict3)
+    assert cfg3.otel["OTEL_EXPORTER_OTLP_HEADERS"] == "[REDACTED]"
+
+    # Empty string
+    otel_dict4 = {"OTEL_EXPORTER_OTLP_HEADERS": ""}
+    cfg4 = ObservabilityConfiguration(otel=otel_dict4)
+    assert cfg4.otel["OTEL_EXPORTER_OTLP_HEADERS"] == "[REDACTED]"
+
+
+def test_validator_handles_invalid_input_types() -> None:
+    """Test that validator allows Pydantic to handle non-dict inputs."""
+    # Non-dict inputs should raise Pydantic validation errors, not AttributeError
+    with pytest.raises(ValueError, match="Input should be a valid dictionary"):
+        ObservabilityConfiguration(otel="not-a-dict")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Input should be a valid dictionary"):
+        ObservabilityConfiguration(otel=123)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Input should be a valid dictionary"):
+        ObservabilityConfiguration(otel=["list", "of", "values"])  # type: ignore[arg-type]


### PR DESCRIPTION
## Description

Add observability configuration to the v1/config endpoint, exposing all OTEL_* environment variables to provide visibility into the active OpenTelemetry tracing setup.


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `observability` section to the configuration response.
  * Automatically surfaces OpenTelemetry settings from `OTEL_*` environment variables.
  * Redacts sensitive OpenTelemetry values (headers and certificate/key-related fields) before exposing them.
  * Updated the published API documentation with the new observability configuration schema.

* **Tests**
  * Added integration tests validating `/config` includes observability and correctly collects `OTEL_*` values.
  * Added unit tests covering defaults, parsing, validation, and secret redaction edge cases.
  * Updated configuration dump expectations to include `observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->