### PR TITLE
LCORE-3141: model dumper for conversation summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,7 +860,7 @@ options:
                         dump actual configuration into JSON file and quit
   -s, --dump-schema     dump configuration schema into OpenAPI-compatible file and quit
   -m, --dump-models     dump schemas for all models into OpenAPI-compatible file and quit
-  -gr, --dump-models-group {requests,successful_responses,error_responses,common,agents,common_responses}
+  -gr, --dump-models-group {conversation_summary,requests,successful_responses,error_responses,common,agents,common_responses}
                         dump schemas for selected models group into OpenAPI-compatible file and quit
   -c, --config CONFIG_FILE
                         path to configuration file (default: lightspeed-stack.yaml)

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -28,8 +28,8 @@ def create_argument_parser() -> ArgumentParser:
     - -d / --dump-configuration: dump the loaded configuration to JSON and exit
     - -s / --dump-schema: dump the configuration schema to OpenAPI JSON and exit
     - -m / --dump-models: dump schemas for all models into OpenAPI-compatible file and quit
-    - -gr / --dump-models-group {requests,successful_responses,error_responses,common,agents,
-                      common_responses}
+    - -gr / --dump-models-group {conversation_summary,requests,successful_responses,
+                      error_responses,common,agents,common_responses}
                       dump schemas for selected models group into OpenAPI-compatible file and quit
     - -c / --config: path to the configuration file (default "lightspeed-stack.yaml")
     - -g / --generate-llama-stack-configuration: generate a Llama Stack
@@ -80,6 +80,7 @@ def create_argument_parser() -> ArgumentParser:
         help="dump schemas for selected models group into OpenAPI-compatible file and quit",
         action="store",
         choices=[
+            "conversation_summary",
             "requests",
             "successful_responses",
             "error_responses",

--- a/src/utils/models_dumper.py
+++ b/src/utils/models_dumper.py
@@ -182,6 +182,7 @@ def get_models_for_group(model_group: str) -> list[type[BaseModel]]:
     """Return the list of Pydantic model classes for the given model group.
 
     Supported groups:
+    - "conversation_summary"
     - "requests"
     - "successful_responses"
     - "error_responses"
@@ -202,6 +203,8 @@ def get_models_for_group(model_group: str) -> list[type[BaseModel]]:
         Exception: If model_group is not a recognized group name.
     """
     match model_group:
+        case "conversation_summary":
+            return conversation_summary_models
         case "requests":
             return requests_models
         case "successful_responses":

--- a/src/utils/models_dumper.py
+++ b/src/utils/models_dumper.py
@@ -202,6 +202,7 @@ def get_models_for_group(model_group: str) -> list[type[BaseModel]]:
     ------
         Exception: If model_group is not a recognized group name.
     """
+    # pylint: disable=too-many-return-statements
     match model_group:
         case "conversation_summary":
             return conversation_summary_models

--- a/tests/unit/utils/test_models_dumper.py
+++ b/tests/unit/utils/test_models_dumper.py
@@ -9506,7 +9506,7 @@ def test_dump_models_group_error_responses(tmpdir: Path) -> None:
     check_json_file_content(filename, expected_schemas)
 
 
-def test_dump_models_group_common_models(tmpdir: Path) -> None:
+def test_dump_models_group_common(tmpdir: Path) -> None:
     """Test that selected models can be dump into a JSON file."""
     group = "common"
     filename = tmpdir / "foo.json"
@@ -9539,7 +9539,7 @@ def test_dump_models_group_common_models(tmpdir: Path) -> None:
     check_json_file_content(filename, expected_schemas)
 
 
-def test_dump_models_group_agent_models(tmpdir: Path) -> None:
+def test_dump_models_group_agent(tmpdir: Path) -> None:
     """Test that selected models can be dump into a JSON file."""
     group = "agents"
     filename = tmpdir / "foo.json"
@@ -9565,7 +9565,7 @@ def test_dump_models_group_agent_models(tmpdir: Path) -> None:
     check_json_file_content(filename, expected_schemas)
 
 
-def test_dump_models_common_responses_models(tmpdir: Path) -> None:
+def test_dump_models_common_responses(tmpdir: Path) -> None:
     """Test that selected models can be dump into a JSON file."""
     group = "common_responses"
     filename = tmpdir / "foo.json"
@@ -9576,6 +9576,17 @@ def test_dump_models_common_responses_models(tmpdir: Path) -> None:
         "InputToolMCP",
         "ResponsesApiParams",
     )
+    check_json_file_content(filename, expected_schemas)
+
+
+def test_dump_models_conversation_summary(tmpdir: Path) -> None:
+    """Test that selected models can be dump into a JSON file."""
+    group = "conversation_summary"
+    filename = tmpdir / "foo.json"
+    dump_models_group(group, filename)
+
+    # list of schemas expected in a dump
+    expected_schemas = ("ConversationSummary",)
     check_json_file_content(filename, expected_schemas)
 
 


### PR DESCRIPTION
## Description

LCORE-3141: model dumper for conversation summary

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3141


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting the `conversation_summary` model group when dumping models.
  - The new group outputs the Conversation Summary model schema.

- **Documentation**
  - Updated CLI help documentation to include `conversation_summary` as an available model group.

- **Tests**
  - Added coverage verifying model dumping for the new conversation summary group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->