### PR TITLE
LCORE-3209: Wire shields into RLSAPI

### DIFF
--- a/src/app/endpoints/rlsapi_v1.py
+++ b/src/app/endpoints/rlsapi_v1.py
@@ -42,8 +42,9 @@ from models.api.responses.successful.rlsapi import (
     RlsapiV1InferData,
     RlsapiV1InferResponse,
 )
-from models.config import Action
+from models.config import Action, RedactionConfig
 from observability import InferenceEventData, build_inference_event, send_splunk_event
+from pydantic_ai_lightspeed.capabilities.redaction.core import redact_text
 from utils.endpoints import check_configuration_loaded
 from utils.model_list import parse_model_list_response
 from utils.query import (
@@ -62,7 +63,7 @@ from utils.responses import (
     get_mcp_tools,
 )
 from utils.rh_identity import AUTH_DISABLED, get_rh_identity_context
-from utils.shields import run_shield_moderation
+from utils.shields import run_shield_moderation_v2
 from utils.suid import get_suid
 
 logger = get_logger(__name__)
@@ -351,12 +352,14 @@ async def _check_shield_moderation(  # pylint: disable=too-many-arguments,too-ma
     background_tasks: BackgroundTasks,
     infer_request: RlsapiV1InferRequest,
     request: Request,
-    endpoint_path: str,
-) -> Optional[RlsapiV1InferResponse]:
-    """Run shield moderation and return a refusal response if blocked.
+) -> tuple[Optional[RlsapiV1InferResponse], str]:
+    """Run shield moderation and return the moderation outcome.
 
-    Uses all configured shields in Llama Stack. When no shields are
-    registered, moderation is a no-op and returns None immediately.
+    Iterates ``configuration.shields`` in order. Redaction shields apply
+    PII substitution to the input text (the redacted text is forwarded
+    to inference). All other shields (e.g. question validity) are run
+    via ``run_shield_moderation_v2``; the first block short-circuits
+    with a refusal response and Splunk telemetry event.
 
     Args:
         input_text: The combined user input to moderate.
@@ -364,19 +367,39 @@ async def _check_shield_moderation(  # pylint: disable=too-many-arguments,too-ma
         background_tasks: FastAPI background tasks for async Splunk event sending.
         infer_request: The original inference request (for Splunk event context).
         request: The FastAPI request object (for Splunk event context).
-        endpoint_path: The API endpoint path for metric labeling.
 
     Returns:
-        An RlsapiV1InferResponse containing the refusal message if the input
-        was blocked, or None if moderation passed.
+        A tuple of (refusal_response, moderated_input). refusal_response is
+        None when moderation passed; moderated_input is the (possibly
+        redacted) text to forward to inference.
     """
-    client = AsyncOgxClientHolder().get_client()
     logger.info("Running shield moderation for rlsapi v1 request %s", request_id)
-    moderation_result = await run_shield_moderation(client, input_text, endpoint_path)
+
+    moderated_input = input_text
+    non_redaction_shields = []
+
+    for shield_config in configuration.shields:
+        if isinstance(shield_config.config, RedactionConfig):
+            result = redact_text(
+                moderated_input, shield_config.config.compiled_patterns
+            )
+            if result.redacted:
+                logger.info(
+                    "PII redaction applied for rlsapi v1 request %s (%d substitutions)",
+                    request_id,
+                    result.redaction_count,
+                )
+                moderated_input = result.content
+        else:
+            non_redaction_shields.append(shield_config)
+
+    moderation_result = await run_shield_moderation_v2(
+        moderated_input, non_redaction_shields
+    )
 
     if moderation_result.decision != "blocked":
         logger.info("Shield moderation passed for rlsapi v1 request %s", request_id)
-        return None
+        return None, moderated_input
 
     logger.info("Shield moderation blocked rlsapi v1 request %s", request_id)
     _queue_splunk_event(
@@ -388,17 +411,20 @@ async def _check_shield_moderation(  # pylint: disable=too-many-arguments,too-ma
         0.0,
         "infer_shield_blocked",
     )
-    return RlsapiV1InferResponse(
-        data=RlsapiV1InferData(
-            text=moderation_result.message,
-            request_id=request_id,
-            tool_calls=None,
-            tool_results=None,
-            rag_chunks=None,
-            referenced_documents=None,
-            input_tokens=None,
-            output_tokens=None,
-        )
+    return (
+        RlsapiV1InferResponse(
+            data=RlsapiV1InferData(
+                text=moderation_result.message,
+                request_id=request_id,
+                tool_calls=None,
+                tool_results=None,
+                rag_chunks=None,
+                referenced_documents=None,
+                input_tokens=None,
+                output_tokens=None,
+            )
+        ),
+        moderated_input,
     )
 
 
@@ -683,13 +709,12 @@ async def infer_endpoint(  # pylint: disable=R0914,R0915
     # Uses all configured shields; no-op when no shields are registered.
     # Runs before model/tool discovery so blocked requests short-circuit
     # without incurring external I/O.
-    blocked_response = await _check_shield_moderation(
+    blocked_response, moderated_input = await _check_shield_moderation(
         input_source,
         request_id,
         background_tasks,
         infer_request,
         request,
-        endpoint_path,
     )
     if blocked_response is not None:
         return blocked_response
@@ -724,7 +749,7 @@ async def infer_endpoint(  # pylint: disable=R0914,R0915
         logger.info("Building instructions for rlsapi v1 request %s", request_id)
         instructions = _build_instructions(infer_request.context.systeminfo)
         response = await _call_llm(
-            input_source,
+            moderated_input,
             instructions,
             tools=cast(list[Any], mcp_tools),
             model_id=model_id,

--- a/tests/integration/endpoints/test_rlsapi_v1_integration.py
+++ b/tests/integration/endpoints/test_rlsapi_v1_integration.py
@@ -85,7 +85,7 @@ def mock_authorization_fixture(mocker: MockerFixture) -> None:
 def mock_shield_passed_fixture(mocker: MockerFixture) -> None:
     """Mock shield moderation to pass for all integration tests."""
     mocker.patch(
-        "app.endpoints.rlsapi_v1.run_shield_moderation",
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
         new=mocker.AsyncMock(return_value=ShieldModerationPassed()),
     )
 

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -25,6 +25,7 @@ from app.endpoints.rlsapi_v1 import (
     TemplateRenderError,
     _build_instructions,
     _call_llm,
+    _check_shield_moderation,
     _compile_prompt_template,
     _get_default_model_id,
     _resolve_quota_subject,
@@ -43,6 +44,13 @@ from models.api.requests.rlsapi import (
 from models.api.responses.error import ServiceUnavailableResponse
 from models.api.responses.successful.rlsapi import RlsapiV1InferResponse
 from models.common.moderation import ShieldModerationBlocked, ShieldModerationPassed
+from models.config import (
+    QuestionValidityConfig,
+    QuestionValidityShieldConfiguration,
+    RedactionConfig,
+    RedactionRule,
+    RedactionShieldConfiguration,
+)
 from tests.unit.utils.auth_helpers import mock_authorization_resolvers
 from utils.rh_identity import get_rh_identity_context
 from utils.suid import check_suid
@@ -70,6 +78,7 @@ def mock_custom_prompt_fixture(mocker: MockerFixture) -> Callable[[str], None]:
         mock_config.customization = mock_customization
         mock_config.rlsapi_v1 = mock_rlsapi_v1
         mock_config.quota_limiters = []
+        mock_config.shields = []
         mocker.patch("app.endpoints.rlsapi_v1.configuration", mock_config)
 
     return _set
@@ -151,7 +160,7 @@ def mock_shield_passed_fixture(mocker: MockerFixture) -> None:
     with a different return value.
     """
     mocker.patch(
-        "app.endpoints.rlsapi_v1.run_shield_moderation",
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
         new=mocker.AsyncMock(return_value=ShieldModerationPassed()),
     )
 
@@ -851,6 +860,7 @@ async def test_infer_include_metadata_respects_verbose_config(
     config_mock.customization = mock_configuration.customization
     config_mock.rlsapi_v1 = rlsapi_v1_mock
     config_mock.quota_limiters = []
+    config_mock.shields = []
     mocker.patch("app.endpoints.rlsapi_v1.configuration", config_mock)
 
     mock_response = mocker.Mock()
@@ -907,6 +917,7 @@ def _setup_config_mock(
     config_mock.customization = mock_configuration.customization
     config_mock.rlsapi_v1 = rlsapi_v1_mock
     config_mock.quota_limiters = []
+    config_mock.shields = []
     mocker.patch("app.endpoints.rlsapi_v1.configuration", config_mock)
 
 
@@ -1105,6 +1116,7 @@ def mock_quota_config_fixture(
         config_mock.customization = mock_configuration.customization
         config_mock.rlsapi_v1 = rlsapi_v1_mock
         config_mock.quota_limiters = []
+        config_mock.shields = []
         mocker.patch("app.endpoints.rlsapi_v1.configuration", config_mock)
 
     return _set
@@ -1255,7 +1267,7 @@ async def test_infer_quota_shield_blocked_does_not_consume_tokens(
         moderation_id="modr-test",
     )
     mocker.patch(
-        "app.endpoints.rlsapi_v1.run_shield_moderation",
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
         new=mocker.AsyncMock(return_value=blocked),
     )
 
@@ -1297,7 +1309,7 @@ async def test_infer_shield_blocked_returns_refusal(
     """Test that blocked shield moderation returns refusal text without calling LLM."""
     blocked = _create_blocked_moderation_result()
     mocker.patch(
-        "app.endpoints.rlsapi_v1.run_shield_moderation",
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
         new=mocker.AsyncMock(return_value=blocked),
     )
 
@@ -1336,7 +1348,7 @@ async def test_infer_shield_blocked_skips_llm_call(
     """Test that blocked shield moderation prevents any LLM call."""
     blocked = _create_blocked_moderation_result()
     mocker.patch(
-        "app.endpoints.rlsapi_v1.run_shield_moderation",
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
         new=mocker.AsyncMock(return_value=blocked),
     )
     mock_call_llm = mocker.patch(
@@ -1368,7 +1380,7 @@ async def test_infer_shield_blocked_queues_splunk_event(
     """Test that blocked shield moderation queues a Splunk event with correct sourcetype."""
     blocked = _create_blocked_moderation_result()
     mocker.patch(
-        "app.endpoints.rlsapi_v1.run_shield_moderation",
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
         new=mocker.AsyncMock(return_value=blocked),
     )
 
@@ -1424,7 +1436,7 @@ async def test_infer_shield_moderation_receives_combined_input(
     """Test that shield moderation receives the full combined input source."""
     mock_moderation = mocker.AsyncMock(return_value=ShieldModerationPassed())
     mocker.patch(
-        "app.endpoints.rlsapi_v1.run_shield_moderation",
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
         new=mock_moderation,
     )
 
@@ -1444,11 +1456,157 @@ async def test_infer_shield_moderation_receives_combined_input(
     )
 
     mock_moderation.assert_called_once()
-    # The input_text argument should be the combined input source
-    input_text = mock_moderation.call_args[0][1]
+    # The input_text argument is the first positional arg to run_shield_moderation_v2
+    input_text = mock_moderation.call_args[0][0]
     assert "Why did this fail?" in input_text
     assert "piped input" in input_text
     assert "permission denied" in input_text
+
+
+# --- Test PII redaction behavior via _check_shield_moderation ---
+
+
+def _redaction_shield() -> RedactionShieldConfiguration:
+    """Build a redaction shield that replaces email addresses."""
+    return RedactionShieldConfiguration(
+        name="pii-redaction",
+        provider_id="redaction",
+        config=RedactionConfig(
+            rules=[
+                RedactionRule(
+                    pattern=r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}",
+                    replacement="[REDACTED_EMAIL]",
+                )
+            ],
+        ),
+    )
+
+
+def _question_validity_shield() -> QuestionValidityShieldConfiguration:
+    """Build a question-validity shield configuration."""
+    return QuestionValidityShieldConfiguration(
+        name="question-validity",
+        provider_id="question_validity",
+        config=QuestionValidityConfig(model_id="test-model"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_shield_redaction_modifies_input(
+    mocker: MockerFixture,
+) -> None:
+    """Test that PII redaction returns redacted text as moderated_input."""
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.configuration",
+        mocker.Mock(shields=[_redaction_shield()]),
+    )
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
+        new=mocker.AsyncMock(return_value=ShieldModerationPassed()),
+    )
+
+    refusal, moderated = await _check_shield_moderation(
+        "Contact user@example.com for details",
+        "req-1",
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    assert refusal is None
+    assert "[REDACTED_EMAIL]" in moderated
+    assert "user@example.com" not in moderated
+
+
+@pytest.mark.asyncio
+async def test_check_shield_no_pii_passes_original(
+    mocker: MockerFixture,
+) -> None:
+    """Test that clean input passes through redaction unchanged."""
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.configuration",
+        mocker.Mock(shields=[_redaction_shield()]),
+    )
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
+        new=mocker.AsyncMock(return_value=ShieldModerationPassed()),
+    )
+
+    refusal, moderated = await _check_shield_moderation(
+        "How do I list files?",
+        "req-2",
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    assert refusal is None
+    assert moderated == "How do I list files?"
+
+
+@pytest.mark.asyncio
+async def test_check_shield_redaction_then_validity_passes_redacted_to_v2(
+    mocker: MockerFixture,
+) -> None:
+    """Test that redacted text is forwarded to run_shield_moderation_v2."""
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.configuration",
+        mocker.Mock(
+            shields=[_redaction_shield(), _question_validity_shield()],
+        ),
+    )
+    mock_v2 = mocker.AsyncMock(return_value=ShieldModerationPassed())
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
+        new=mock_v2,
+    )
+
+    refusal, moderated = await _check_shield_moderation(
+        "Contact user@example.com for help",
+        "req-3",
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    assert refusal is None
+    assert "[REDACTED_EMAIL]" in moderated
+    v2_input = mock_v2.call_args[0][0]
+    assert "[REDACTED_EMAIL]" in v2_input
+    assert "user@example.com" not in v2_input
+
+
+@pytest.mark.asyncio
+async def test_check_shield_validity_blocks_returns_refusal(
+    mocker: MockerFixture,
+) -> None:
+    """Test that question validity block returns a refusal response."""
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.configuration",
+        mocker.Mock(
+            shields=[_redaction_shield(), _question_validity_shield()],
+        ),
+    )
+    blocked = ShieldModerationBlocked(
+        message="Off-topic question.",
+        moderation_id="modr-block-123",
+    )
+    mocker.patch(
+        "app.endpoints.rlsapi_v1.run_shield_moderation_v2",
+        new=mocker.AsyncMock(return_value=blocked),
+    )
+
+    refusal, _ = await _check_shield_moderation(
+        "What is the meaning of life?",
+        "req-4",
+        mocker.Mock(),
+        mocker.Mock(),
+        mocker.Mock(),
+    )
+
+    assert refusal is not None
+    assert isinstance(refusal, RlsapiV1InferResponse)
+    assert refusal.data.text == "Off-topic question."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

 Wire shield moderation (redaction + question validity) into the RLSAPI v1 `infer` endpoint.

  ### What changed

  - **`_check_shield_moderation`** now iterates `configuration.shields` directly instead of delegating to the legacy `run_shield_moderation` helper:
    - **Redaction shields** (`RedactionConfig`) apply PII substitution inline via `redact_text`. The redacted text is forwarded to inference so the LLM never sees raw PII.
    - **All other shields** (e.g. question validity) are collected and passed to `run_shield_moderation_v2`; the first block short-circuits with a refusal response and Splunk telemetry event.
  - The function now returns a `(refusal_response, moderated_input)` tuple so the caller can forward the potentially-redacted text to `_call_llm`.
  - Removed the unused `endpoint_path` parameter and the direct `AsyncOgxClientHolder` dependency from `_check_shield_moderation`.

  ### Scoping decision

PII redaction passthrough is intentionally limited to the RLSAPI endpoint scope rather than being embedded in
`run_shield_moderation_v2`. This avoids breaking changes to the shared moderation path until we confirm other consumers (Responses API, streaming query) should also receive redacted input.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus

## Related Tickets & Documents

- Closes LCORE-3209

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [X] If it is a core feature, I have added thorough tests.

## Testing
1. Run unit tests: `uv run pytest tests/unit/app/endpoints/test_rlsapi_v1.py -v`
2. Verify PII redaction tests pass:
     - `test_check_shield_redaction_modifies_input` — confirms email addresses are replaced with `[REDACTED_EMAIL]`
     - `test_check_shield_no_pii_passes_original` — confirms clean input is unchanged
     - `test_check_shield_redaction_then_validity_passes_redacted_to_v2` — confirms redacted text is forwarded to
  downstream shields
     - `test_check_shield_validity_blocks_returns_refusal` — confirms question validity blocks return refusal response
3. Verify existing shield moderation tests still pass (mock target updated to `run_shield_moderation_v2`)
