### PR TITLE
LCORE-2923: Propagate RHEL AI e2e test failures to Konflux

### DIFF
--- a/.tekton/integration-tests/pipeline/lightspeed-stack-rhelai-test.yaml
+++ b/.tekton/integration-tests/pipeline/lightspeed-stack-rhelai-test.yaml
@@ -362,7 +362,6 @@ spec:
               - name: credentials
                 value: credentials
           - name: run-e2e-tests
-            onError: continue
             resources:
               requests:
                 cpu: '1'


### PR DESCRIPTION
## Description

Removes `onError: continue` from the `run-e2e-tests` step in the RHEL AI Tekton pipeline. This was suppressing e2e test failures, causing the Konflux integration test to report success even when tests failed.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [x] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude Opus 4.6
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: LCORE-2923

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

1. Trigger a Konflux integration test run with a failing e2e test scenario
2. Verify the pipeline task now fails (instead of passing silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integration pipeline errors are now reported instead of being ignored, improving test reliability and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->