### PR TITLE
LCORE-1801: Fix hardcoded Python version in Makefile run-stack target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ CONTAINER_RUNTIME ?= $(shell command -v podman 2>/dev/null || command -v docker 
 
 run-stack: ## Run lightspeed-stack directly, without building dependent service/s
 	@if [ "$${OTEL_SDK_DISABLED:-true}" = "false" ]; then \
-		uv run opentelemetry-instrument python3.12 src/lightspeed_stack.py -c $(CONFIG); \
+		uv run opentelemetry-instrument python src/lightspeed_stack.py -c $(CONFIG); \
 	else \
-		uv run python3.12 src/lightspeed_stack.py -c $(CONFIG); \
+		uv run python src/lightspeed_stack.py -c $(CONFIG); \
 	fi
 
 run: start-llama-stack-container ## Run the service locally with dependent services


### PR DESCRIPTION
## Description

Fixed hardcoded python3.12 reference in Makefile

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the stack runner to use the project’s managed Python environment.
  * Applies consistently whether OpenTelemetry instrumentation is enabled or disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->