### PR TITLE
LCORE-3332: regenerated openapi schema

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -13,7 +13,7 @@
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
         },
-        "version": "0.6.0"
+        "version": "0.6.2"
     },
     "servers": [
         {


### PR DESCRIPTION
## Description

Updates the OpenAPI schema version in `docs/openapi.json` from `0.6.0` to `0.6.2` so the published API spec matches the 0.6.2 release. Regenerated via the OpenAPI schema make target.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [x] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue # LCORE-3332
- Closes # LCORE-3332

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Regenerated the OpenAPI schema using the project's make target (`make schema` / equivalent)
- Verified `docs/openapi.json` `info.version` is `0.6.2`