### PR TITLE
LCORE-3307: Bump OGX version to 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ dependencies = [
     # Used by authentication/k8s integration
     "kubernetes>=30.1.0",
     # Used to call Llama Stack APIs
-    "ogx==1.0.2",
-    "ogx-client==1.0.2",
-    "ogx-api==1.0.2",
+    "ogx==1.2.2",
+    "ogx-client==1.2.2",
+    "ogx-api==1.2.2",
     # Used by Logger
     "rich>=14.0.0",
     # Used by JWK token auth handler

--- a/src/constants.py
+++ b/src/constants.py
@@ -7,7 +7,7 @@ from typing import Final, Literal
 
 # Minimal and maximal supported Llama Stack version
 MINIMAL_SUPPORTED_LLAMA_STACK_VERSION: Final[str] = "0.2.17"
-MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION: Final[str] = "1.0.2"
+MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION: Final[str] = "1.2.2"
 
 # Path to the lightspeed-stack.yaml, exported so uvicorn workers (separate
 # processes) can reload the configuration that the parent process selected.

--- a/tests/e2e/features/info.feature
+++ b/tests/e2e/features/info.feature
@@ -19,7 +19,7 @@ Feature: Info tests
      When I access REST API endpoint "info" using HTTP GET method
      Then The status code of the response is 200
       And The body of the response has proper name Lightspeed Core Service (LCS) and version 0.6.0rc2
-      And The body of the response has llama-stack version 1.0.2
+      And The body of the response has llama-stack version 1.2.2
 
   Scenario: Check if shields endpoint is working
      When I access REST API endpoint "shields" using HTTP GET method

--- a/uv.lock
+++ b/uv.lock
@@ -1836,9 +1836,9 @@ requires-dist = [
     { name = "jsonpath-ng", specifier = ">=1.6.1" },
     { name = "kubernetes", specifier = ">=30.1.0" },
     { name = "litellm", specifier = ">=1.83.7" },
-    { name = "ogx", specifier = "==1.0.2" },
-    { name = "ogx-api", specifier = "==1.0.2" },
-    { name = "ogx-client", specifier = "==1.0.2" },
+    { name = "ogx", specifier = "==1.2.2" },
+    { name = "ogx-api", specifier = "==1.2.2" },
+    { name = "ogx-client", specifier = "==1.2.2" },
     { name = "openai", specifier = ">=1.99.9" },
     { name = "opentelemetry-distro", specifier = ">=0.49b0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.34.1" },
@@ -2083,6 +2083,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "models-dev"
+version = "1.0.398"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/c8/5702047a574dc8fcba1638bd6deb910910c57afea7e85bce176799566f4e/models_dev-1.0.398.tar.gz", hash = "sha256:6c087e8308e3be9f8e3b17ba96e00c2453504a5c674914220ef621f7fe53abd2", size = 193300, upload-time = "2026-05-21T13:55:58.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/0a/8cb8bb5e22a4f09565bfea38c8c280c791ae8d09303b8624a8c70fc3cedc/models_dev-1.0.398-py3-none-any.whl", hash = "sha256:86155586aed904094facaf1d19d87a0beeb9b0635804c831540892c97708263a", size = 178535, upload-time = "2026-05-21T13:55:57.017Z" },
 ]
 
 [[package]]
@@ -2366,7 +2375,7 @@ wheels = [
 
 [[package]]
 name = "ogx"
-version = "1.0.2"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2376,10 +2385,13 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "mcp" },
+    { name = "models-dev" },
     { name = "ogx-api" },
     { name = "openai" },
     { name = "opentelemetry-distro" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-exporter-prometheus" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -2391,54 +2403,47 @@ dependencies = [
     { name = "termcolor" },
     { name = "tiktoken" },
     { name = "uvicorn" },
+    { name = "websockets" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/a0/c8f0c17c7297f8f989d8246ebd30312b08a0e707c83a6bd433e9954dbbb4/ogx-1.0.2.tar.gz", hash = "sha256:b4978ed93f89d7b4f91c70610e338a53265cb3c4c6a00dd5e6b572ba38ed8ccd", size = 16911718, upload-time = "2026-05-13T22:53:53.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/a2/645000263e2f1dc1598dfdded9dda4a82280fda2e4b0d2b431aa5d0e128d/ogx-1.2.2.tar.gz", hash = "sha256:4ac77235ea884da00afca5209df8727dd876e671466f1525d7168db4ff5e3860", size = 18175152, upload-time = "2026-07-27T14:55:42.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/ca/8681d636307f13a7af201a8544bb903f14de2359080612db1c748ee3a5f5/ogx-1.0.2-py3-none-any.whl", hash = "sha256:6904b34c0c8300dab84e581bf7fbb5b612eac1759c5c389f7a5f31db9a6ca522", size = 696448, upload-time = "2026-05-13T22:53:50.461Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/1e/17e6c2b0d6e00f66f5e9ff0dfe7e67e3076fa15f59a6f1c54c6495232e21/ogx-1.2.2-py3-none-any.whl", hash = "sha256:d47da083cb86452491d0d6b714733e7ef94df20f38a73a3c363b463faf03d02d", size = 778976, upload-time = "2026-07-27T14:55:39.874Z" },
 ]
 
 [[package]]
 name = "ogx-api"
-version = "1.0.2"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "jsonschema" },
     { name = "openai" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/4e/9e8919d50328f182ea5066751c80daaaab745da70fb3b1b8b13c6a72f3cb/ogx_api-1.0.2.tar.gz", hash = "sha256:33a5ef09761eea649415c0b581395f0638e98f2a45ea03461594fbdbfed439e4", size = 145638, upload-time = "2026-05-13T22:53:01.679Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/7f/e9c890ea8aac593e16d13800854d7855dc61d34761c84ae826b37982e643/ogx_api-1.2.2.tar.gz", hash = "sha256:9ff962c0550c6bdd310f3b4cac7be1b82ed8009126036dcc680f198afadc236f", size = 166463, upload-time = "2026-07-27T14:55:01.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/99/e25be35713869b730d4a1d47a3d3b2ae5705fb044279f95c1c83b773cdef/ogx_api-1.0.2-py3-none-any.whl", hash = "sha256:e88817c97e00b1e6ddd604d87dfb0c1c32f6c4ab4a9539fed9063f7339ef672a", size = 145201, upload-time = "2026-05-13T22:52:59.773Z" },
+    { url = "https://files.pythonhosted.org/packages/25/2f/4e1e2b44c67737d49d943144a2ceccac6a1c4f0bf6462ca404a941c290b4/ogx_api-1.2.2-py3-none-any.whl", hash = "sha256:cbebca0520334f9e4d01ca57fc3fa39d3f155ea3467612e8781641724ea61361", size = 166522, upload-time = "2026-07-27T14:54:59.925Z" },
 ]
 
 [[package]]
 name = "ogx-client"
-version = "1.0.2"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "click" },
-    { name = "distro" },
     { name = "fire" },
     { name = "httpx" },
-    { name = "pandas" },
-    { name = "prompt-toolkit" },
-    { name = "pyaml" },
     { name = "pydantic" },
+    { name = "python-dateutil" },
     { name = "requests" },
-    { name = "rich" },
-    { name = "sniffio" },
-    { name = "termcolor" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/74/3edc7a8f396137741d9b29a728bcf45afd4a8266b40f1080ec0118c52065/ogx_client-1.0.2.tar.gz", hash = "sha256:4f5d0a5285fdbfcd3c260c291d70d325cf44b743a67c51e65d8a0c5f5cd76177", size = 435217, upload-time = "2026-05-13T22:52:04.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/c5/a99d4d23447ddd2205e034f58e445252074a049ae2000c25b15d1c1b5b08/ogx_client-1.2.2.tar.gz", hash = "sha256:64ab1ada323acfb746bc99631f56b0470006d4fc59e05c89b83ddf7330718d6a", size = 588153, upload-time = "2026-07-27T14:54:17.411Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/fc/4bf0216fd6e13943837f30164937d6db78dd8743424984ce22c763491c22/ogx_client-1.0.2-py3-none-any.whl", hash = "sha256:167ad9f36ec632cd579bb6451dc8137d90d755d78cd7073d8fc9dcc9bf622fa5", size = 309278, upload-time = "2026-05-13T22:52:03.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2a/cc814caacc68dd1fa68b40fab6c3f31fc50aaa0bda357c802a940f1c4bf7/ogx_client-1.2.2-py3-none-any.whl", hash = "sha256:423e06b79508d86a2d9f0c4702c8cf564582106f8fd0853576092e1e12929590", size = 1544657, upload-time = "2026-07-27T14:54:15.536Z" },
 ]
 
 [[package]]
@@ -2559,6 +2564,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-prometheus"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/85/3a1af7b90a76d6c069bcbbc86cc641c93d15057f2674cc8226f47c5260e8/opentelemetry_exporter_prometheus-0.65b0.tar.gz", hash = "sha256:2777cbf41c403c119e10f418fce5d645c956b47f673a2ee120285d1d0c6df2d5", size = 16411, upload-time = "2026-07-16T15:25:39.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/0d/d7cdc030edeed0fea03448446b88f1a1f8c4a565bad30dac0f5477ebe290/opentelemetry_exporter_prometheus-0.65b0-py3-none-any.whl", hash = "sha256:3b3d24b586d0ad9712c7b52b7d19c8a9dfbb318b9b284121b5f95e90ed019367", size = 13031, upload-time = "2026-07-16T15:25:20.906Z" },
 ]
 
 [[package]]
@@ -3026,18 +3045,6 @@ keyring = [
 ]
 memory = [
     { name = "cachetools" },
-]
-
-[[package]]
-name = "pyaml"
-version = "26.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/15/6a/acfdf17de0d6947b419da8696e02b781b18de2cf49e0472298b50e1f0711/pyaml-26.7.0.tar.gz", hash = "sha256:11cda3a796efc6dbce0d56836be56cfd26289dad07bcd78e9904086729929c93", size = 30669, upload-time = "2026-07-04T00:34:38.532Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/26/3f05f9e3692853dff663913d5d62fb8df3f5640c8d70b06588c0b51ed953/pyaml-26.7.0-py3-none-any.whl", hash = "sha256:cfa382780c43ae660669b87d394d550a41856ef175f5749f51f753e12d7077ac", size = 27226, upload-time = "2026-07-04T00:34:37.198Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Bump OGX version to 1.2.2

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [x] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-3307
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
