### PR TITLE
LCORE-3411: Added explicit model registration for vertexai

### DIFF
--- a/examples/vertexai-run.yaml
+++ b/examples/vertexai-run.yaml
@@ -97,6 +97,10 @@ storage:
       backend: sql_default
 registered_resources:
   models:
+  - model_id: google/gemini-2.5-flash
+    provider_id: google-vertex
+    model_type: llm
+    provider_model_id: google/gemini-2.5-flash
   - model_id: all-mpnet-base-v2
     model_type: embedding
     provider_id: sentence-transformers

--- a/tests/e2e/configs/run-vertexai.yaml
+++ b/tests/e2e/configs/run-vertexai.yaml
@@ -98,6 +98,10 @@ storage:
       backend: sql_default
 registered_resources:
   models:
+  - model_id: google/gemini-2.5-flash
+    provider_id: google-vertex
+    model_type: llm
+    provider_model_id: google/gemini-2.5-flash
   - model_id: all-mpnet-base-v2
     model_type: embedding
     provider_id: sentence-transformers


### PR DESCRIPTION
## Description

VertexAI providers e2e fails the Quick connectivity test: GET /v1/models returns no matching LLM (often an empty/missing model list), so the check for provider_id=google-vertex + provider_resource_id=google/gemini-2.5-flash fails.

Cause: gemini is only under inference.allowed_models, not under registered_resources.models, so it is never registered.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3411

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini 2.5 Flash through the Google Vertex AI provider.
  * Included the model in Vertex AI example and end-to-end configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->