### PR TITLE
LCORE-3309: Migrated types imports to models

### DIFF
--- a/src/app/endpoints/providers.py
+++ b/src/app/endpoints/providers.py
@@ -5,7 +5,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.params import Depends
 from ogx_client import APIConnectionError, BadRequestError
-from ogx_client.types import ProviderListResponse
+from ogx_client.models.list_providers_response import ListProvidersResponse
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -91,7 +91,7 @@ async def providers_endpoint_handler(
 
     try:
         client = AsyncOgxClientHolder().get_client()
-        providers: ProviderListResponse = await client.providers.list()
+        providers: ListProvidersResponse = await client.providers.list()
     except APIConnectionError as e:
         logger.error("Unable to connect to Llama Stack: %s", e)
         response = ServiceUnavailableResponse(backend_name="OGX", cause=str(e))
@@ -100,7 +100,7 @@ async def providers_endpoint_handler(
     return ProvidersListResponse(providers=group_providers(providers))
 
 
-def group_providers(providers: ProviderListResponse) -> dict[str, list[dict[str, Any]]]:
+def group_providers(providers: ListProvidersResponse) -> dict[str, list[dict[str, Any]]]:
     """Group a list of ProviderInfo objects by their API type.
 
     Args:

--- a/src/utils/builtin_tools.py
+++ b/src/utils/builtin_tools.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from fastapi import HTTPException
 from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
-from ogx_client.types.shared.provider_info import ProviderInfo
+from ogx_client.models.provider_info import ProviderInfo
 
 from log import get_logger
 from models.api.responses.error import ServiceUnavailableResponse

--- a/src/utils/conversation_compaction.py
+++ b/src/utils/conversation_compaction.py
@@ -49,7 +49,6 @@ from typing import Any, Optional, cast
 
 from ogx_api.openai_responses import OpenAIResponseMessage
 from ogx_client import AsyncOgxClient
-from ogx_client.types.conversations.item_create_params import Item
 
 from cache.cache import Cache
 from cache.cache_error import CacheError
@@ -285,7 +284,7 @@ async def _write_summary_marker(
     }
     await client.conversations.items.create(
         conversation_id,
-        items=cast(list[Item], [marker_item]),
+        items=[marker_item],
     )
 
 

--- a/src/utils/conversations.py
+++ b/src/utils/conversations.py
@@ -3,44 +3,49 @@
 import json
 from collections.abc import Sequence
 from datetime import UTC, datetime
-from typing import Any, Optional, cast
+from typing import Any, Literal, Optional, cast
 
 from fastapi import HTTPException
 from ogx_api import OpenAIResponseMessage, OpenAIResponseOutput
-from ogx_api.openai_responses import (
+from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
+from ogx_client.models.open_ai_response_input_function_tool_call_output import (
+    OpenAIResponseInputFunctionToolCallOutput as FunctionCallOutput,
+)
+from ogx_client.models.open_ai_response_input_message_content_file import (
+    OpenAIResponseInputMessageContentFile as InputFileContent,
+)
+from ogx_client.models.open_ai_response_input_message_content_image import (
+    OpenAIResponseInputMessageContentImage as InputImageContent,
+)
+from ogx_client.models.open_ai_response_input_message_content_text import (
+    OpenAIResponseInputMessageContentText as InputTextContent,
+)
+from ogx_client.models.open_ai_response_mcp_approval_request import (
+    OpenAIResponseMCPApprovalRequest as MCPApprovalRequest,
+)
+from ogx_client.models.open_ai_response_mcp_approval_response import (
+    OpenAIResponseMCPApprovalResponse as MCPApprovalResponse,
+)
+from ogx_client.models.open_ai_response_message import (
+    OpenAIResponseMessage as ConversationMessage,
+)
+from ogx_client.models.open_ai_response_message11_variants import (
+    OpenAIResponseMessage11Variants as ConversationItem,
+)
+from ogx_client.models.open_ai_response_output_message_file_search_tool_call import (
     OpenAIResponseOutputMessageFileSearchToolCall as FileSearchCall,
 )
-from ogx_api.openai_responses import (
+from ogx_client.models.open_ai_response_output_message_function_tool_call import (
     OpenAIResponseOutputMessageFunctionToolCall as FunctionCall,
 )
-from ogx_api.openai_responses import (
+from ogx_client.models.open_ai_response_output_message_mcp_call import (
     OpenAIResponseOutputMessageMCPCall as MCPCall,
 )
-from ogx_api.openai_responses import (
+from ogx_client.models.open_ai_response_output_message_mcp_list_tools import (
     OpenAIResponseOutputMessageMCPListTools as MCPListTools,
 )
-from ogx_api.openai_responses import (
+from ogx_client.models.open_ai_response_output_message_web_search_tool_call import (
     OpenAIResponseOutputMessageWebSearchToolCall as WebSearchCall,
-)
-from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
-from ogx_client.types.conversations.item_create_params import Item
-from ogx_client.types.conversations.item_list_response import (
-    ItemListResponse,
-)
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseInputFunctionToolCallOutput as FunctionToolCallOutput,
-)
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFile as FunctionCallOutputContentPart,  # pylint: disable=line-too-long
-)
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseMcpApprovalRequest as MCPApprovalRequest,
-)
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseMcpApprovalResponse as MCPApprovalResponse,
-)
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseMessageOutput as MessageOutput,
 )
 
 from constants import DEFAULT_RAG_TOOL
@@ -57,8 +62,11 @@ from models.common.turn_summary import ToolCallSummary, ToolResultSummary
 from models.database.conversations import UserTurn
 from utils.responses import parse_arguments_string
 
+type FunctionCallOutputPart = InputTextContent | InputImageContent | InputFileContent
+type FunctionCallOutputContent = str | list[FunctionCallOutputPart]
 
-def _extract_text_from_content(content: str | list[Any]) -> str:
+
+def _extract_text_from_content(content: Any) -> str:
     """Extract text content from message content.
 
     Args:
@@ -92,9 +100,7 @@ def _extract_text_from_content(content: str | list[Any]) -> str:
     return "".join(text_fragments)
 
 
-def _function_call_output_to_str(
-    output: str | list[FunctionCallOutputContentPart],
-) -> str:
+def _function_call_output_to_str(output: FunctionCallOutputContent) -> str:
     """Convert function call output content into a string summary.
 
     Parameters:
@@ -108,14 +114,15 @@ def _function_call_output_to_str(
 
     fragments: list[str] = []
     for part in output:
-        if part.type == "input_text":
-            fragments.append(part.text)
+        if getattr(part, "type", None) == "input_text":
+            text_part = cast(InputTextContent, part)
+            fragments.append(text_part.text)
         else:
             fragments.append(part.model_dump_json(exclude_none=True))
     return "\n\n".join(fragments)
 
 
-def _parse_message_item(item: MessageOutput) -> Message:
+def _parse_message_item(item: ConversationMessage) -> Message:
     """Parse a message item into a Message object.
 
     Args:
@@ -124,13 +131,15 @@ def _parse_message_item(item: MessageOutput) -> Message:
     Returns:
         Message object with extracted content and type (user or assistant)
     """
-    content_text = _extract_text_from_content(item.content)
-    message_type = item.role
-    return Message(content=content_text, type=message_type, referenced_documents=None)
+    return Message(
+        content=_extract_text_from_content(item.content),
+        type=cast(Literal["user", "assistant", "system", "developer"], item.role),
+        referenced_documents=None,
+    )
 
 
 def _build_tool_call_summary_from_item(  # pylint: disable=too-many-return-statements
-    item: ItemListResponse,
+    item: ConversationItem,
 ) -> tuple[Optional[ToolCallSummary], Optional[ToolResultSummary]]:
     """Translate Conversations API tool items into ToolCallSummary and ToolResultSummary records.
 
@@ -279,13 +288,15 @@ def _build_tool_call_summary_from_item(  # pylint: disable=too-many-return-state
         )
 
     if item_type == "function_call_output":
-        function_output = cast(FunctionToolCallOutput, item)
+        function_output = cast(FunctionCallOutput, item)
         return (
             None,
             ToolResultSummary(
                 id=function_output.call_id,
                 status=function_output.status or "success",
-                content=_function_call_output_to_str(function_output.output),
+                content=_function_call_output_to_str(
+                    cast(FunctionCallOutputContent, function_output.output)
+                ),
                 type="function_call_output",
                 round=1,
             ),
@@ -349,8 +360,8 @@ def _create_turn_from_db_metadata(
 
 
 def _group_items_into_turns(
-    items: list[ItemListResponse],
-) -> list[list[ItemListResponse]]:
+    items: list[ConversationItem],
+) -> list[list[ConversationItem]]:
     """Group conversation items into turns.
 
     Each turn starts with a user message. All subsequent messages and tool items
@@ -362,15 +373,15 @@ def _group_items_into_turns(
     Returns:
         List of turns, where each turn is a list of items belonging to that turn
     """
-    turns: list[list[ItemListResponse]] = []
-    current_turn_items: list[ItemListResponse] = []
+    turns: list[list[ConversationItem]] = []
+    current_turn_items: list[ConversationItem] = []
 
     for item in items:
         item_type = getattr(item, "type", None)
 
         # User message marks the beginning of a new turn
         if item_type == "message":
-            message_item = cast(MessageOutput, item)
+            message_item = cast(ConversationMessage, item)
             if message_item.role == "user":
                 # If we have accumulated items, finish the previous turn
                 if current_turn_items:
@@ -394,7 +405,7 @@ def _group_items_into_turns(
 
 
 def _process_turn_items(
-    turn_items: list[ItemListResponse],
+    turn_items: list[ConversationItem],
 ) -> tuple[list[Message], list[ToolCallSummary], list[ToolResultSummary]]:
     """Process items from a single turn into messages, tool calls, and tool results.
 
@@ -412,7 +423,7 @@ def _process_turn_items(
         item_type = getattr(item, "type", None)
 
         if item_type == "message":
-            message_item = cast(MessageOutput, item)
+            message_item = cast(ConversationMessage, item)
             message = _parse_message_item(message_item)
             messages.append(message)
         else:
@@ -426,7 +437,7 @@ def _process_turn_items(
 
 
 def build_conversation_turns_from_items(
-    items: list[ItemListResponse],
+    items: list[ConversationItem],
     turns_metadata: list[UserTurn],
     conversation_start_time: datetime,
 ) -> list[ConversationTurn]:
@@ -506,7 +517,7 @@ async def append_turn_items_to_conversation(
     try:
         await client.conversations.items.create(
             conversation_id,
-            items=cast(list[Item], items),
+            items=items,
         )
     except APIConnectionError as e:
         error_response = ServiceUnavailableResponse(
@@ -522,7 +533,7 @@ async def append_turn_items_to_conversation(
 async def get_all_conversation_items(
     client: AsyncOgxClient,
     conversation_id_llama_stack: str,
-) -> list[ItemListResponse]:
+) -> list[ConversationItem]:
     """Fetch all items for a conversation (Conversations API), paginating as needed.
 
     Args:
@@ -538,7 +549,7 @@ async def get_all_conversation_items(
             order="asc",
         )
         first_page = await paginator
-        items: list[ItemListResponse] = list(first_page.data or [])
+        items: list[ConversationItem] = list(first_page.data or [])
         page = first_page
         while page.has_next_page():
             page = await page.get_next_page()

--- a/src/utils/model_list.py
+++ b/src/utils/model_list.py
@@ -2,46 +2,50 @@
 
 from typing import Any
 
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
-from ogx_client.types.model_list_response import (
-    AnthropicListModelsResponse,
-    AnthropicListModelsResponseData,
-    GoogleListModelsResponse,
-    GoogleListModelsResponseModel,
-    ModelListResponse,
+from ogx_client.models.anthropic_list_models_response import AnthropicListModelsResponse
+from ogx_client.models.anthropic_model_info import AnthropicModelInfo
+from ogx_client.models.google_list_models_response import GoogleListModelsResponse
+from ogx_client.models.google_model_info import GoogleModelInfo
+from ogx_client.models.list_models_v1_models_get200_response import (
+    ListModelsV1ModelsGet200Response,
 )
+from ogx_client.models.open_ai_list_models_response import OpenAIListModelsResponse
+from ogx_client.models.open_ai_model import OpenAIModel
 
 from models.common.models import CatalogModel
 
 
-def parse_openai_style_model(model: Model) -> CatalogModel:
+def parse_openai_style_model(model: OpenAIModel) -> CatalogModel:
     """
-    Parse an OpenAI-style OGX ``Model`` into a unified catalog model.
+    Parse an OpenAI-style OGX ``OpenAIModel`` into a unified catalog model.
 
-    Uses the OGX ``Model`` properties for identifier, model_type, provider
-    fields, and filtered metadata.
+    Reads ``id`` / ``object`` from the model and pulls ``model_type``,
+    ``provider_id``, and ``provider_resource_id`` from ``custom_metadata``.
+    Remaining custom metadata becomes ``CatalogModel.metadata``.
 
     Parameters:
-        model: Model object from ``ListModelsResponse.data``.
+        model: Model object from ``OpenAIListModelsResponse.data``.
 
     Returns:
         CatalogModel: Normalized catalog entry.
     """
-    model_type = model.model_type or "unknown"
+    custom_metadata = dict(model.custom_metadata or {})
+    model_type = custom_metadata.pop("model_type", None) or "unknown"
+    provider_id = custom_metadata.pop("provider_id", "") or ""
+    provider_resource_id = custom_metadata.pop("provider_resource_id", "") or ""
 
     return CatalogModel(
-        identifier=model.identifier,
-        metadata=model.metadata or {},
+        identifier=model.id,
+        metadata=custom_metadata,
         api_model_type=model_type,
-        provider_id=model.provider_id or "",
+        provider_id=provider_id,
         type=model.object or "model",
-        provider_resource_id=model.provider_resource_id or "",
+        provider_resource_id=provider_resource_id,
         model_type=model_type,
     )
 
 
-def parse_anthropic_model(model: AnthropicListModelsResponseData) -> CatalogModel:
+def parse_anthropic_model(model: AnthropicModelInfo) -> CatalogModel:
     """Parse an Anthropic model list entry into a unified catalog model.
 
     Parameters:
@@ -70,7 +74,7 @@ def parse_anthropic_model(model: AnthropicListModelsResponseData) -> CatalogMode
     )
 
 
-def parse_google_model(model: GoogleListModelsResponseModel) -> CatalogModel:
+def parse_google_model(model: GoogleModelInfo) -> CatalogModel:
     """Parse a Google model list entry into a unified catalog model.
 
     Parameters:
@@ -96,21 +100,19 @@ def parse_google_model(model: GoogleListModelsResponseModel) -> CatalogModel:
     )
 
 
-def parse_model_list_response(response: ModelListResponse) -> list[CatalogModel]:
-    """Normalize an OGX ``models.list()`` union response into catalog models.
-
-    OGX returns one of ``ListModelsResponse``, ``AnthropicListModelsResponse``,
-    or ``GoogleListModelsResponse``. This helper matches on the concrete type
-    and parses every entry into :class:`CatalogModel`.
+def parse_model_list_response(
+    response: ListModelsV1ModelsGet200Response,
+) -> list[CatalogModel]:
+    """Normalize an OGX ``models.list()`` response into catalog models.
 
     Parameters:
-        response: The union response returned by ``client.models.list()``.
+        response: The response returned by ``client.models.list()``.
 
     Returns:
         list[CatalogModel]: Parsed models in the unified catalog shape.
     """
-    match response:
-        case ListModelsResponse(data=data):
+    match response.actual_instance:
+        case OpenAIListModelsResponse(data=data):
             return [parse_openai_style_model(model) for model in data]
         case AnthropicListModelsResponse(data=data):
             return [parse_anthropic_model(model) for model in data]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,8 +9,12 @@ import pytest
 from fastapi import Request, Response
 from fastapi.testclient import TestClient
 from ogx_api.openai_responses import OpenAIResponseObject
-from ogx_client.types import ListModelsResponse, VersionInfo
-from ogx_client.types.model import Model
+from ogx_client.models.list_models_v1_models_get200_response import (
+    ListModelsV1ModelsGet200Response,
+)
+from ogx_client.models.open_ai_list_models_response import OpenAIListModelsResponse
+from ogx_client.models.open_ai_model import OpenAIModel
+from ogx_client.models.version_info import VersionInfo
 from pydantic_ai import AgentRunResultEvent
 from pydantic_ai.messages import (
     ModelMessage,
@@ -62,6 +66,50 @@ TEST_MODEL_NAME = "test-model"
 # ==========================================
 # Helper Functions
 # ==========================================
+
+
+def make_openai_models_list_response(
+    *models: OpenAIModel,
+) -> ListModelsV1ModelsGet200Response:
+    """Build a ``client.models.list()`` response in the OpenAI OneOf shape.
+
+    Parameters:
+        *models: OpenAI-style model entries for ``data``.
+
+    Returns:
+        ``ListModelsV1ModelsGet200Response`` wrapping ``OpenAIListModelsResponse``.
+    """
+    return ListModelsV1ModelsGet200Response(
+        OpenAIListModelsResponse.model_construct(data=list(models))
+    )
+
+
+def make_openai_model(
+    *,
+    model_id: str = TEST_MODEL,
+    provider_id: str = TEST_PROVIDER,
+    model_type: str = "llm",
+) -> OpenAIModel:
+    """Build an ``OpenAIModel`` for integration ``models.list`` mocks.
+
+    Parameters:
+        model_id: Full model identifier (provider/name).
+        provider_id: Value stored in ``custom_metadata.provider_id``.
+        model_type: Value stored in ``custom_metadata.model_type``.
+
+    Returns:
+        Constructed ``OpenAIModel`` instance.
+    """
+    return OpenAIModel.model_construct(
+        id=model_id,
+        created=0,
+        owned_by="test",
+        object="model",
+        custom_metadata={
+            "provider_id": provider_id,
+            "model_type": model_type,
+        },
+    )
 
 
 def create_mock_llm_response(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -768,19 +816,8 @@ def mock_ogx_client_fixture(
     mock_client.responses.create.return_value = mock_response
 
     # Mock models.list
-    mock_client.models.list.return_value = ListModelsResponse.model_construct(
-        data=[
-            Model.model_construct(
-                id="test-provider/test-model",
-                created=0,
-                owned_by="test",
-                object="model",
-                custom_metadata={
-                    "provider_id": "test-provider",
-                    "model_type": "llm",
-                },
-            )
-        ]
+    mock_client.models.list.return_value = make_openai_models_list_response(
+        make_openai_model()
     )
 
     # Mock shields.list (empty by default)

--- a/tests/integration/endpoints/test_info_integration.py
+++ b/tests/integration/endpoints/test_info_integration.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from fastapi import HTTPException, Request, status
 from ogx_client import APIConnectionError
-from ogx_client.types import VersionInfo
+from ogx_client.models.version_info import VersionInfo
 from pytest_mock import AsyncMockType, MockerFixture
 
 from app.endpoints.info import info_endpoint_handler

--- a/tests/integration/endpoints/test_model_list.py
+++ b/tests/integration/endpoints/test_model_list.py
@@ -7,14 +7,13 @@ import pytest
 from fastapi import Request
 from fastapi.exceptions import HTTPException
 from ogx_client import APIConnectionError
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
 from pytest_mock import AsyncMockType, MockerFixture
 
 from app.endpoints.models import models_endpoint_handler
 from authentication.interface import AuthTuple
 from configuration import AppConfig
 from models.api.requests import ModelFilter
+from tests.integration.conftest import make_openai_model, make_openai_models_list_response
 
 
 @pytest.fixture(name="mock_ogx_client")
@@ -40,29 +39,11 @@ def mock_ogx_client_fixture(
     mock_client = mocker.AsyncMock()
 
     # Mock models list (required for model selection)
-    mock_client.models.list.return_value = ListModelsResponse.model_construct(
-        data=[
-            Model.model_construct(
-                id="test-provider/test-model-1",
-                created=0,
-                owned_by="test",
-                object="model",
-                custom_metadata={
-                    "provider_id": "test-provider",
-                    "model_type": "llm",
-                },
-            ),
-            Model.model_construct(
-                id="test-provider/test-model-2",
-                created=0,
-                owned_by="test",
-                object="model",
-                custom_metadata={
-                    "provider_id": "test-provider",
-                    "model_type": "embedding",
-                },
-            ),
-        ]
+    mock_client.models.list.return_value = make_openai_models_list_response(
+        make_openai_model(model_id="test-provider/test-model-1"),
+        make_openai_model(
+            model_id="test-provider/test-model-2", model_type="embedding"
+        ),
     )
 
     # Create a mock holder instance

--- a/tests/integration/endpoints/test_query_byok_integration.py
+++ b/tests/integration/endpoints/test_query_byok_integration.py
@@ -7,8 +7,7 @@ from typing import Any
 
 import pytest
 from fastapi import Request
-from ogx_client.types import ListModelsResponse, VersionInfo
-from ogx_client.types.model import Model
+from ogx_client.models.version_info import VersionInfo
 from pytest_mock import AsyncMockType, MockerFixture
 
 import constants
@@ -21,6 +20,8 @@ from tests.integration.conftest import (
     create_agent_run_result,
     create_file_search_agent_run_result,
     create_mock_llm_response,
+    make_openai_model,
+    make_openai_models_list_response,
 )
 
 # ---------------------------------------------------------------------------
@@ -99,19 +100,8 @@ def _build_base_mock_client(mocker: MockerFixture) -> Any:
     mock_client = mocker.AsyncMock()
 
     # Model list
-    mock_client.models.list.return_value = ListModelsResponse.model_construct(
-        data=[
-            Model.model_construct(
-                id="test-provider/test-model",
-                created=0,
-                owned_by="test",
-                object="model",
-                custom_metadata={
-                    "provider_id": "test-provider",
-                    "model_type": "llm",
-                },
-            )
-        ]
+    mock_client.models.list.return_value = make_openai_models_list_response(
+        make_openai_model()
     )
 
     # Shields (empty)

--- a/tests/integration/endpoints/test_responses_integration.py
+++ b/tests/integration/endpoints/test_responses_integration.py
@@ -11,8 +11,6 @@ from typing import Any
 import pytest
 from fastapi import Request
 from fastapi.responses import StreamingResponse
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
 from pytest_mock import MockerFixture
 from sqlalchemy.orm import Session
 
@@ -23,6 +21,7 @@ from models.api.requests import ResponsesRequest
 from models.api.responses.successful import ResponsesResponse
 from models.common.moderation import ShieldModerationBlocked
 from models.common.responses.contexts import ResponsesContext
+from tests.integration.conftest import make_openai_model, make_openai_models_list_response
 from models.database.conversations import UserConversation, UserTurn
 
 MOCK_AUTH: AuthTuple = (
@@ -91,19 +90,8 @@ def _build_mock_client(mocker: MockerFixture) -> Any:
     mock_response.model_dump.return_value = _RESPONSE_DUMP.copy()
     mock_client.responses.create = mocker.AsyncMock(return_value=mock_response)
 
-    mock_client.models.list.return_value = ListModelsResponse.model_construct(
-        data=[
-            Model.model_construct(
-                id="test-provider/test-model",
-                created=0,
-                owned_by="test",
-                object="model",
-                custom_metadata={
-                    "provider_id": "test-provider",
-                    "model_type": "llm",
-                },
-            )
-        ]
+    mock_client.models.list.return_value = make_openai_models_list_response(
+        make_openai_model()
     )
 
     mock_client.shields.list.return_value = []

--- a/tests/integration/endpoints/test_root_endpoint.py
+++ b/tests/integration/endpoints/test_root_endpoint.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 from fastapi import Request, status
-from ogx_client.types import VersionInfo
+from ogx_client.models.version_info import VersionInfo
 from pytest_mock import MockerFixture
 
 from app.endpoints.root import root_endpoint_handler

--- a/tests/integration/endpoints/test_streaming_query_integration.py
+++ b/tests/integration/endpoints/test_streaming_query_integration.py
@@ -7,8 +7,6 @@ import pytest
 from fastapi import HTTPException, Request, status
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
 from pytest_mock import AsyncMockType, MockerFixture
 
 from app.endpoints.streaming_query import streaming_query_endpoint_handler
@@ -16,6 +14,7 @@ from authentication.interface import AuthTuple
 from configuration import AppConfig
 from models.api.requests import QueryRequest
 from models.common.query import Attachment
+from tests.integration.conftest import make_openai_model, make_openai_models_list_response
 
 
 @pytest.fixture(name="mock_streaming_ogx_client")
@@ -35,19 +34,8 @@ def mock_llama_stack_streaming_fixture(
     )
     mock_client = mocker.AsyncMock()
 
-    mock_client.models.list.return_value = ListModelsResponse.model_construct(
-        data=[
-            Model.model_construct(
-                id="test-provider/test-model",
-                created=0,
-                owned_by="test",
-                object="model",
-                custom_metadata={
-                    "provider_id": "test-provider",
-                    "model_type": "llm",
-                },
-            )
-        ]
+    mock_client.models.list.return_value = make_openai_models_list_response(
+        make_openai_model()
     )
 
     mock_vector_stores_response = mocker.MagicMock()

--- a/tests/unit/app/endpoints/test_a2a.py
+++ b/tests/unit/app/endpoints/test_a2a.py
@@ -23,7 +23,7 @@ from a2a.types import (
 from a2a.utils import new_agent_text_message
 from fastapi import HTTPException, Request
 from ogx_client import APIConnectionError
-from ogx_client.types import ListModelsResponse
+from ogx_client.models.list_models_response import ListModelsResponse
 from pydantic_ai import AgentRunResultEvent
 from pydantic_ai.exceptions import AgentRunError
 from pydantic_ai.messages import (

--- a/tests/unit/app/endpoints/test_info.py
+++ b/tests/unit/app/endpoints/test_info.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from fastapi import HTTPException, Request, status
 from ogx_client import APIConnectionError
-from ogx_client.types import VersionInfo
+from ogx_client.models.version_info import VersionInfo
 from pytest_mock import MockerFixture
 
 from app.endpoints.info import info_endpoint_handler

--- a/tests/unit/app/endpoints/test_models.py
+++ b/tests/unit/app/endpoints/test_models.py
@@ -5,8 +5,8 @@ from typing import Any
 import pytest
 from fastapi import HTTPException, Request, status
 from ogx_client import APIConnectionError
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
+from ogx_client.models.list_models_response import ListModelsResponse
+from ogx_client.models.model import Model
 from pytest_mock import MockerFixture
 from pytest_subtests import SubTests
 

--- a/tests/unit/app/endpoints/test_prompts.py
+++ b/tests/unit/app/endpoints/test_prompts.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import pytest
 from fastapi import HTTPException, Request, status
 from ogx_client import APIConnectionError, BadRequestError
-from ogx_client.types.prompt import Prompt
+from ogx_client.models.prompt import Prompt
 from pytest_mock import MockerFixture
 
 from app.endpoints.prompts import (

--- a/tests/unit/app/endpoints/test_providers.py
+++ b/tests/unit/app/endpoints/test_providers.py
@@ -3,7 +3,7 @@
 import pytest
 from fastapi import HTTPException, Request, status
 from ogx_client import APIConnectionError, BadRequestError
-from ogx_client.types import ProviderInfo
+from ogx_client.models.provider_info import ProviderInfo
 from pytest_mock import MockerFixture
 
 from app.endpoints.providers import (

--- a/tests/unit/app/endpoints/test_rlsapi_v1.py
+++ b/tests/unit/app/endpoints/test_rlsapi_v1.py
@@ -14,8 +14,8 @@ from typing import Any, Optional
 import pytest
 from fastapi import HTTPException, status
 from ogx_client import APIConnectionError, APIStatusError
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
+from ogx_client.models.list_models_response import ListModelsResponse
+from ogx_client.models.model import Model
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
 

--- a/tests/unit/metrics/test_utis.py
+++ b/tests/unit/metrics/test_utis.py
@@ -1,8 +1,8 @@
 """Unit tests for functions defined in metrics/utils.py"""
 
 import pytest
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
+from ogx_client.models.list_models_response import ListModelsResponse
+from ogx_client.models.model import Model
 from pytest_mock import MockerFixture
 
 from metrics.utils import setup_model_metrics

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -10,8 +10,8 @@ from typing import Any
 import pytest
 from fastapi import HTTPException
 from ogx_client import APIConnectionError, APIStatusError
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
+from ogx_client.models.list_models_response import ListModelsResponse
+from ogx_client.models.model import Model
 from pydantic import AnyHttpUrl, SecretStr
 from pytest_mock import MockerFixture
 

--- a/tests/unit/utils/test_builtin_tools.py
+++ b/tests/unit/utils/test_builtin_tools.py
@@ -5,7 +5,7 @@
 import pytest
 from fastapi import HTTPException
 from ogx_client import APIConnectionError
-from ogx_client.types.shared.provider_info import ProviderInfo
+from ogx_client.models.provider_info import ProviderInfo
 from pytest_mock import MockerFixture
 
 from utils.builtin_tools import get_file_search_tools

--- a/tests/unit/utils/test_conversations.py
+++ b/tests/unit/utils/test_conversations.py
@@ -7,14 +7,17 @@ import pytest
 from fastapi import HTTPException
 from ogx_api import OpenAIResponseMessage
 from ogx_client import APIConnectionError, APIStatusError
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFileOpenAIResponseInputMessageContentFile as FunctionCallOutputFile,  # pylint: disable=line-too-long
+from ogx_client.models.open_ai_response_input_function_tool_call_output import (
+    OpenAIResponseInputFunctionToolCallOutput as FunctionCallOutput,
 )
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFileOpenAIResponseInputMessageContentImage as FunctionCallOutputImage,  # pylint: disable=line-too-long
+from ogx_client.models.open_ai_response_input_message_content_file import (
+    OpenAIResponseInputMessageContentFile as InputFileContent,
 )
-from ogx_client.types.conversations.item_list_response import (
-    OpenAIResponseInputFunctionToolCallOutputOutputListOpenAIResponseInputMessageContentTextOpenAIResponseInputMessageContentImageOpenAIResponseInputMessageContentFileOpenAIResponseInputMessageContentText as FunctionCallOutputText,  # pylint: disable=line-too-long
+from ogx_client.models.open_ai_response_input_message_content_image import (
+    OpenAIResponseInputMessageContentImage as InputImageContent,
+)
+from ogx_client.models.open_ai_response_input_message_content_text import (
+    OpenAIResponseInputMessageContentText as InputTextContent,
 )
 from pytest_mock import MockerFixture
 
@@ -336,13 +339,16 @@ class TestBuildToolCallSummaryFromItem:
 
     def test_function_call_output(self, mocker: MockerFixture) -> None:
         """Test parsing a function_call_output item."""
-        mock_item = mocker.Mock()
-        mock_item.type = "function_call_output"
-        mock_item.call_id = "call_123"
-        mock_item.status = "success"
-        mock_item.output = "Function result"
+        item = FunctionCallOutput.from_dict(
+            {
+                "call_id": "call_123",
+                "output": "Function result",
+                "type": "function_call_output",
+                "status": "success",
+            }
+        )
 
-        tool_call, tool_result = _build_tool_call_summary_from_item(mock_item)
+        tool_call, tool_result = _build_tool_call_summary_from_item(item)
 
         assert tool_call is None
         assert tool_result is not None
@@ -354,13 +360,15 @@ class TestBuildToolCallSummaryFromItem:
 
     def test_function_call_output_without_status(self, mocker: MockerFixture) -> None:
         """Test parsing a function_call_output item without status."""
-        mock_item = mocker.Mock()
-        mock_item.type = "function_call_output"
-        mock_item.call_id = "call_123"
-        mock_item.status = None
-        mock_item.output = "Function result"
+        item = FunctionCallOutput.from_dict(
+            {
+                "call_id": "call_123",
+                "output": "Function result",
+                "type": "function_call_output",
+            }
+        )
 
-        _, tool_result = _build_tool_call_summary_from_item(mock_item)
+        _, tool_result = _build_tool_call_summary_from_item(item)
 
         assert tool_result is not None
         assert tool_result.status == "success"  # Defaults to "success"
@@ -369,24 +377,27 @@ class TestBuildToolCallSummaryFromItem:
         self, mocker: MockerFixture
     ) -> None:
         """Test parsing function_call_output with mixed content parts."""
-        mock_item = mocker.Mock()
-        mock_item.type = "function_call_output"
-        mock_item.call_id = "call_456"
-        mock_item.status = "success"
-        mock_item.output = [
-            FunctionCallOutputText(type="input_text", text="result text"),
-            FunctionCallOutputImage(
-                type="input_image",
-                image_url="https://example.com/image.png",
-            ),
-            FunctionCallOutputFile(
-                type="input_file",
-                file_id="file_123",
-                filename="report.pdf",
-            ),
-        ]
+        item = FunctionCallOutput.from_dict(
+            {
+                "call_id": "call_456",
+                "output": [
+                    {"type": "input_text", "text": "result text"},
+                    {
+                        "type": "input_image",
+                        "image_url": "https://example.com/image.png",
+                    },
+                    {
+                        "type": "input_file",
+                        "file_id": "file_123",
+                        "filename": "report.pdf",
+                    },
+                ],
+                "type": "function_call_output",
+                "status": "success",
+            }
+        )
 
-        _, tool_result = _build_tool_call_summary_from_item(mock_item)
+        _, tool_result = _build_tool_call_summary_from_item(item)
 
         assert tool_result is not None
         content = tool_result.model_dump()["content"]
@@ -406,9 +417,9 @@ class TestFunctionCallOutputToStr:
     def test_extracts_text_and_serializes_other_parts(self) -> None:
         """Extract text parts and JSON-serialize image/file parts."""
         output = [
-            FunctionCallOutputText(type="input_text", text="hello"),
-            FunctionCallOutputImage(type="input_image", file_id="img_1"),
-            FunctionCallOutputFile(type="input_file", filename="data.csv"),
+            InputTextContent(type="input_text", text="hello"),
+            InputImageContent(type="input_image", file_id="img_1"),
+            InputFileContent(type="input_file", filename="data.csv"),
         ]
 
         content = _function_call_output_to_str(output)
@@ -542,15 +553,18 @@ class TestBuildConversationTurnsFromItems:
         create_mock_user_turn: Any,
     ) -> None:
         """Test building a turn with tool results."""
-        mock_function_output = mocker.Mock()
-        mock_function_output.type = "function_call_output"
-        mock_function_output.call_id = "call_1"
-        mock_function_output.status = "success"
-        mock_function_output.output = "Result"
+        function_output = FunctionCallOutput.from_dict(
+            {
+                "call_id": "call_1",
+                "output": "Result",
+                "type": "function_call_output",
+                "status": "success",
+            }
+        )
 
         items = [
             mocker.Mock(type="message", role="user", content="Use tool"),
-            mock_function_output,
+            function_output,
             mocker.Mock(type="message", role="assistant", content="Done"),
         ]
         turns_metadata = [create_mock_user_turn(turn_number=1)]
@@ -575,16 +589,19 @@ class TestBuildConversationTurnsFromItems:
         mock_function_call.name = "test_tool"
         mock_function_call.arguments = "{}"
 
-        mock_function_output = mocker.Mock()
-        mock_function_output.type = "function_call_output"
-        mock_function_output.call_id = "call_1"
-        mock_function_output.status = "success"
-        mock_function_output.output = "Result"
+        function_output = FunctionCallOutput.from_dict(
+            {
+                "call_id": "call_1",
+                "output": "Result",
+                "type": "function_call_output",
+                "status": "success",
+            }
+        )
 
         items = [
             mocker.Mock(type="message", role="user", content="Use tool"),
             mock_function_call,
-            mock_function_output,
+            function_output,
             mocker.Mock(type="message", role="assistant", content="Done"),
         ]
         turns_metadata = [create_mock_user_turn(turn_number=1)]

--- a/tests/unit/utils/test_llama_stack_version.py
+++ b/tests/unit/utils/test_llama_stack_version.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 from ogx_client import APIConnectionError
-from ogx_client.types import VersionInfo
+from ogx_client.models.version_info import VersionInfo
 from pytest_mock import MockerFixture
 from pytest_subtests import SubTests
 from semver import Version

--- a/tests/unit/utils/test_model_list.py
+++ b/tests/unit/utils/test_model_list.py
@@ -1,13 +1,14 @@
 """Unit tests for utils/model_list.py helpers."""
 
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
-from ogx_client.types.model_list_response import (
-    AnthropicListModelsResponse,
-    AnthropicListModelsResponseData,
-    GoogleListModelsResponse,
-    GoogleListModelsResponseModel,
+from ogx_client.models.anthropic_list_models_response import AnthropicListModelsResponse
+from ogx_client.models.anthropic_model_info import AnthropicModelInfo
+from ogx_client.models.google_list_models_response import GoogleListModelsResponse
+from ogx_client.models.google_model_info import GoogleModelInfo
+from ogx_client.models.list_models_v1_models_get200_response import (
+    ListModelsV1ModelsGet200Response,
 )
+from ogx_client.models.open_ai_list_models_response import OpenAIListModelsResponse
+from ogx_client.models.open_ai_model import OpenAIModel
 
 from models.common.models import CatalogModel
 from utils.model_list import (
@@ -20,7 +21,7 @@ from utils.model_list import (
 
 def test_parse_openai_style_model_with_custom_metadata() -> None:
     """OpenAI-style models map custom_metadata into CatalogModel."""
-    model = Model.model_construct(
+    model = OpenAIModel.model_construct(
         id="provider/model",
         created=1,
         owned_by="org",
@@ -47,7 +48,7 @@ def test_parse_openai_style_model_with_custom_metadata() -> None:
 
 def test_parse_anthropic_model() -> None:
     """Anthropic models are normalized as LLM CatalogModel entries."""
-    model = AnthropicListModelsResponseData.model_construct(
+    model = AnthropicModelInfo.model_construct(
         id="claude-sonnet",
         created_at="2024-01-01T00:00:00Z",
         display_name="Claude Sonnet",
@@ -68,7 +69,7 @@ def test_parse_anthropic_model() -> None:
 
 def test_parse_google_model() -> None:
     """Google models are normalized as LLM CatalogModel entries."""
-    model = GoogleListModelsResponseModel.model_construct(
+    model = GoogleModelInfo.model_construct(
         name="models/gemini-pro",
         display_name="Gemini Pro",
         description="A Gemini model",
@@ -84,16 +85,18 @@ def test_parse_google_model() -> None:
 
 
 def test_parse_model_list_response_openai() -> None:
-    """ListModelsResponse branch returns CatalogModel entries."""
-    response = ListModelsResponse.model_construct(
-        data=[
-            Model.model_construct(
-                id="p/m",
-                created=1,
-                owned_by="x",
-                custom_metadata={"model_type": "embedding", "provider_id": "p"},
-            )
-        ]
+    """OpenAIListModelsResponse branch returns CatalogModel entries."""
+    response = ListModelsV1ModelsGet200Response(
+        OpenAIListModelsResponse.model_construct(
+            data=[
+                OpenAIModel.model_construct(
+                    id="p/m",
+                    created=1,
+                    owned_by="x",
+                    custom_metadata={"model_type": "embedding", "provider_id": "p"},
+                )
+            ]
+        )
     )
 
     parsed = parse_model_list_response(response)
@@ -105,14 +108,16 @@ def test_parse_model_list_response_openai() -> None:
 
 def test_parse_model_list_response_anthropic() -> None:
     """AnthropicListModelsResponse branch returns CatalogModel entries."""
-    response = AnthropicListModelsResponse.model_construct(
-        data=[
-            AnthropicListModelsResponseData.model_construct(
-                id="claude",
-                created_at="2024-01-01T00:00:00Z",
-                display_name="Claude",
-            )
-        ]
+    response = ListModelsV1ModelsGet200Response(
+        AnthropicListModelsResponse.model_construct(
+            data=[
+                AnthropicModelInfo.model_construct(
+                    id="claude",
+                    created_at="2024-01-01T00:00:00Z",
+                    display_name="Claude",
+                )
+            ]
+        )
     )
 
     parsed = parse_model_list_response(response)
@@ -124,13 +129,15 @@ def test_parse_model_list_response_anthropic() -> None:
 
 def test_parse_model_list_response_google() -> None:
     """GoogleListModelsResponse branch returns CatalogModel entries."""
-    response = GoogleListModelsResponse.model_construct(
-        models=[
-            GoogleListModelsResponseModel.model_construct(
-                name="models/gemini",
-                display_name="Gemini",
-            )
-        ]
+    response = ListModelsV1ModelsGet200Response(
+        GoogleListModelsResponse.model_construct(
+            models=[
+                GoogleModelInfo.model_construct(
+                    name="models/gemini",
+                    display_name="Gemini",
+                )
+            ]
+        )
     )
 
     parsed = parse_model_list_response(response)
@@ -140,6 +147,7 @@ def test_parse_model_list_response_google() -> None:
     assert parsed[0].provider_id == "google"
 
 
-def test_parse_model_list_response_unsupported_type() -> None:
-    """Unsupported response types yield an empty catalog list."""
-    assert parse_model_list_response(object()) == []  # type: ignore[arg-type]
+def test_parse_model_list_response_empty_instance() -> None:
+    """Missing actual_instance yields an empty catalog list."""
+    response = ListModelsV1ModelsGet200Response.model_construct(actual_instance=None)
+    assert parse_model_list_response(response) == []

--- a/tests/unit/utils/test_query.py
+++ b/tests/unit/utils/test_query.py
@@ -9,8 +9,8 @@ from typing import Any
 import psycopg2
 import pytest
 from fastapi import HTTPException
-from ogx_client.types import ListModelsResponse, ModelListResponse
-from ogx_client.types.model import Model
+from ogx_client.models.list_models_response import ListModelsResponse
+from ogx_client.models.model import Model
 from pydantic_ai.messages import ImageUrl
 from pytest_mock import MockerFixture
 from sqlalchemy.exc import SQLAlchemyError
@@ -54,7 +54,7 @@ def mock_config_fixture() -> AppConfig:
 
 
 @pytest.fixture(name="mock_models")
-def mock_models_fixture() -> ModelListResponse:
+def mock_models_fixture() -> ListModelsResponse:
     """Create an OpenAI-style OGX models list response."""
     return ListModelsResponse.model_construct(
         data=[

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -51,8 +51,8 @@ from ogx_api.openai_responses import (
     OpenAIResponseOutputMessageWebSearchToolCall as WebSearchCall,
 )
 from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
-from ogx_client.types import ListModelsResponse
-from ogx_client.types.model import Model
+from ogx_client.models.list_models_response import ListModelsResponse
+from ogx_client.models.model import Model
 from pydantic import AnyUrl, BaseModel
 from pytest_mock import MockerFixture
 


### PR DESCRIPTION
## Description

Migrates OGX client imports from the removed ogx_client.types package to per-model ogx_client.models.* modules. Conversation item parsing now uses short client-model import aliases with type-based discrimination (relying on OneOf attribute proxying), and models.list handling unwraps the OpenAI/Anthropic/Google OneOf response. Unit and integration fixtures are updated to construct ListModelsV1ModelsGet200Response accordingly. Exception/APIConnectionError migration is left for a follow-up.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3309 https://redhat.atlassian.net/browse/LCORE-3308

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
