### PR TITLE
LCORE-3310: Adapt OGX list responses to use proxy iterators and paginators

### DIFF
--- a/src/app/endpoints/prompts.py
+++ b/src/app/endpoints/prompts.py
@@ -245,10 +245,7 @@ async def get_prompt_handler(
 
     try:
         client = AsyncOgxClientHolder().get_client()
-        if version is not None:
-            retrieved = await client.prompts.retrieve(prompt_id, version=version)
-        else:
-            retrieved = await client.prompts.retrieve(prompt_id)
+        retrieved = await client.prompts.retrieve(prompt_id, version=version)
         return PromptResourceResponse.model_validate(retrieved.model_dump())
     except APIConnectionError as e:
         logger.error("Unable to connect to Llama Stack: %s", e)

--- a/src/app/endpoints/rags.py
+++ b/src/app/endpoints/rags.py
@@ -94,13 +94,13 @@ async def rags_endpoint_handler(
         client = AsyncOgxClientHolder().get_client()
         # retrieve list of RAGs
         rags = await client.vector_stores.list()
-        logger.info("List of rags: %d", len(rags.data))
+        logger.info("List of rags: %d", len(rags))
 
         # Map llama-stack vector store IDs to user-facing rag_ids from config
         rag_id_mapping = configuration.rag_id_mapping
         rag_ids = [
             configuration.resolve_index_name(rag.id, rag_id_mapping)
-            for rag in rags.data
+            for rag in rags
         ]
 
         return RAGListResponse(rags=rag_ids)

--- a/src/app/endpoints/vector_stores.py
+++ b/src/app/endpoints/vector_stores.py
@@ -244,7 +244,7 @@ async def list_vector_stores(
                 usage_bytes=vs.usage_bytes or 0,
                 metadata=vs.metadata,
             )
-            for vs in vector_stores.data
+            for vs in vector_stores
         ]
 
         return VectorStoresListResponse(data=data)
@@ -646,7 +646,7 @@ async def add_file_to_vector_store(  # pylint: disable=too-many-locals,too-many-
             attributes=vs_file.attributes,
             last_error=(
                 vs_file.last_error.message
-                if vs_file.last_error and hasattr(vs_file.last_error, "message")
+                if vs_file.last_error is not None
                 else None
             ),
             object=vs_file.object or "vector_store.file",
@@ -714,12 +714,12 @@ async def list_vector_store_files(
                 attributes=f.attributes,
                 last_error=(
                     f.last_error.message
-                    if f.last_error and hasattr(f.last_error, "message")
+                    if f.last_error is not None
                     else None
                 ),
                 object=f.object or "vector_store.file",
             )
-            for f in files.data
+            for f in files
         ]
         return VectorStoreFilesListResponse(data=data)
     except APIConnectionError as e:
@@ -787,7 +787,7 @@ async def get_vector_store_file(
             attributes=vs_file.attributes,
             last_error=(
                 vs_file.last_error.message
-                if vs_file.last_error and hasattr(vs_file.last_error, "message")
+                if vs_file.last_error is not None
                 else None
             ),
             object=vs_file.object or "vector_store.file",

--- a/src/utils/conversations.py
+++ b/src/utils/conversations.py
@@ -543,17 +543,19 @@ async def get_all_conversation_items(
     Returns:
         List of all items in the conversation, oldest first.
     """
+    items: list[ConversationItem] = []
+    after: Optional[str] = None
+    has_more = True
     try:
-        paginator = client.conversations.items.list(
-            conversation_id=conversation_id_llama_stack,
-            order="asc",
-        )
-        first_page = await paginator
-        items: list[ConversationItem] = list(first_page.data or [])
-        page = first_page
-        while page.has_next_page():
-            page = await page.get_next_page()
-            items.extend(page.data or [])
+        while has_more:
+            page = await client.conversations.items.list(
+                conversation_id=conversation_id_llama_stack,
+                order="asc",
+                after=after,
+            )
+            items.extend(page.data)
+            has_more = page.has_more
+            after = page.last_id
         return items
     except APIConnectionError as e:
         error_response = ServiceUnavailableResponse(

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -153,7 +153,7 @@ async def get_vector_store_ids(
 
     try:
         vector_stores = await client.vector_stores.list()
-        return [vector_store.id for vector_store in vector_stores.data]
+        return [vector_store.id for vector_store in vector_stores]
     except APIConnectionError as e:
         error_response = ServiceUnavailableResponse(
             backend_name="OGX",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -824,9 +824,7 @@ def mock_ogx_client_fixture(
     mock_client.shields.list.return_value = []
 
     # Mock vector_stores.list (empty by default)
-    mock_vector_stores_response = mocker.MagicMock()
-    mock_vector_stores_response.data = []
-    mock_client.vector_stores.list.return_value = mock_vector_stores_response
+    mock_client.vector_stores.list.return_value = []
 
     # Mock conversations.create
     mock_conversation = mocker.MagicMock()

--- a/tests/integration/endpoints/test_conversations_v1_integration.py
+++ b/tests/integration/endpoints/test_conversations_v1_integration.py
@@ -453,7 +453,7 @@ async def test_get_conversation_returns_chat_history(
     # Mock Llama Stack response
     mock_items = mocker.Mock()
     mock_items.data = [mock_user_message, mock_assistant_message]
-    mock_items.has_next_page.return_value = False
+    mock_items.has_more = False
     mock_ogx_client.conversations.items.list = mocker.AsyncMock(return_value=mock_items)
 
     response = await get_conversation_endpoint_handler(
@@ -543,7 +543,7 @@ async def test_get_conversation_with_turns_metadata(
     # Mock paginator response
     mock_items = mocker.Mock()
     mock_items.data = [mock_user_message, mock_assistant_message]
-    mock_items.has_next_page.return_value = False
+    mock_items.has_more = False
     mock_ogx_client.conversations.items.list = mocker.AsyncMock(return_value=mock_items)
 
     response = await get_conversation_endpoint_handler(

--- a/tests/integration/endpoints/test_query_byok_integration.py
+++ b/tests/integration/endpoints/test_query_byok_integration.py
@@ -157,9 +157,7 @@ def mock_byok_client_fixture(
     )
 
     # No tool-based vector stores
-    mock_vector_stores_response = mocker.MagicMock()
-    mock_vector_stores_response.data = []
-    mock_client.vector_stores.list.return_value = mock_vector_stores_response
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
     yield mock_client
@@ -187,9 +185,7 @@ def mock_byok_tool_rag_client_fixture(
     # Tool-based vector stores available
     mock_vector_store = mocker.MagicMock()
     mock_vector_store.id = "vs-byok-knowledge"
-    mock_list_result = mocker.MagicMock()
-    mock_list_result.data = [mock_vector_store]
-    mock_client.vector_stores.list.return_value = mock_list_result
+    mock_client.vector_stores.list.return_value = [mock_vector_store]
 
     tool_run_result = create_file_search_agent_run_result(
         mocker,
@@ -434,9 +430,7 @@ async def test_query_byok_inline_rag_with_request_vector_store_ids(
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -507,9 +501,7 @@ async def test_query_byok_request_vector_store_ids_filters_configured_stores(
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -774,9 +766,7 @@ async def test_query_byok_combined_inline_and_tool_rag(  # pylint: disable=too-m
     # Tool RAG vector stores
     mock_vector_store = mocker.MagicMock()
     mock_vector_store.id = "vs-byok-knowledge"
-    mock_list_result = mocker.MagicMock()
-    mock_list_result.data = [mock_vector_store]
-    mock_client.vector_stores.list.return_value = mock_list_result
+    mock_client.vector_stores.list.return_value = [mock_vector_store]
 
     # Agent run includes file_search tool RAG result
     combined_run_result = create_file_search_agent_run_result(
@@ -879,9 +869,7 @@ async def test_query_byok_inline_rag_only_configured_rag_id_is_queried(
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -984,9 +972,7 @@ async def test_query_byok_score_multiplier_shifts_chunk_priority(  # pylint: dis
 
     mock_client.vector_io.query = mocker.AsyncMock(side_effect=_side_effect)
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -1074,9 +1060,7 @@ async def test_query_rag_content_limit_caps_retrieved_results(  # pylint: disabl
         return_value=_make_vector_io_response(mocker, chunks_data)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -1181,9 +1165,7 @@ async def test_query_rag_content_limit_caps_across_multiple_sources(  # pylint: 
 
     mock_client.vector_io.query = mocker.AsyncMock(side_effect=_side_effect)
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -1273,9 +1255,7 @@ async def test_query_rag_content_limit_caps_inline_rag(  # pylint: disable=too-m
         return_value=_make_vector_io_response(mocker, chunks_data)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 

--- a/tests/integration/endpoints/test_query_integration.py
+++ b/tests/integration/endpoints/test_query_integration.py
@@ -652,10 +652,7 @@ async def test_query_v2_endpoint_bypasses_tools_when_no_tools_true(
     mock_vector_store = mocker.MagicMock()
     mock_vector_store.id = "vs-test-123"
 
-    mock_list_result = mocker.MagicMock()
-    mock_list_result.data = [mock_vector_store]
-
-    mock_ogx_client.vector_stores.list.return_value = mock_list_result
+    mock_ogx_client.vector_stores.list.return_value = [mock_vector_store]
 
     query_request = QueryRequest(query="What is Ansible?", no_tools=True)
 

--- a/tests/integration/endpoints/test_responses_byok_integration.py
+++ b/tests/integration/endpoints/test_responses_byok_integration.py
@@ -125,9 +125,7 @@ async def test_responses_byok_inline_rag_injects_context(  # pylint: disable=too
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     responses_request = ResponsesRequest(input="What is OpenShift?", stream=False)
 
@@ -178,9 +176,7 @@ async def test_responses_byok_inline_rag_error_is_handled_gracefully(  # pylint:
         side_effect=Exception("Connection refused")
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     responses_request = ResponsesRequest(input="What is OpenShift?", stream=False)
 
@@ -235,9 +231,7 @@ async def test_responses_byok_tool_rag_returns_tool_calls(  # pylint: disable=to
 
     mock_vector_store = mocker.MagicMock()
     mock_vector_store.id = "vs-byok-knowledge"
-    mock_list_result = mocker.MagicMock()
-    mock_list_result.data = [mock_vector_store]
-    mock_client.vector_stores.list.return_value = mock_list_result
+    mock_client.vector_stores.list.return_value = [mock_vector_store]
 
     responses_request = ResponsesRequest(input="What is OpenShift?", stream=False)
 
@@ -312,9 +306,7 @@ async def test_responses_byok_combined_inline_and_tool_rag(  # pylint: disable=t
     # Tool RAG vector stores
     mock_vector_store = mocker.MagicMock()
     mock_vector_store.id = "vs-byok-knowledge"
-    mock_list_result = mocker.MagicMock()
-    mock_list_result.data = [mock_vector_store]
-    mock_client.vector_stores.list.return_value = mock_list_result
+    mock_client.vector_stores.list.return_value = [mock_vector_store]
 
     responses_request = ResponsesRequest(input="What is OpenShift?", stream=False)
 
@@ -390,9 +382,7 @@ async def test_responses_byok_inline_rag_only_configured_rag_id_is_queried(  # p
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     responses_request = ResponsesRequest(input="What is OpenShift?", stream=False)
 
@@ -471,9 +461,7 @@ async def test_responses_byok_score_multiplier_shifts_chunk_priority(  # pylint:
 
     mock_client.vector_io.query = mocker.AsyncMock(side_effect=_side_effect)
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     responses_request = ResponsesRequest(input="test query", stream=False)
 
@@ -542,9 +530,7 @@ async def test_responses_rag_content_limit_caps_retrieved_results(  # pylint: di
         return_value=_make_vector_io_response(mocker, chunks_data)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     responses_request = ResponsesRequest(input="test query", stream=False)
 
@@ -624,9 +610,7 @@ async def test_responses_rag_content_limit_caps_across_multiple_sources(  # pyli
 
     mock_client.vector_io.query = mocker.AsyncMock(side_effect=_side_effect)
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     responses_request = ResponsesRequest(input="test query", stream=False)
 
@@ -691,9 +675,7 @@ async def test_responses_rag_content_limit_caps_inline_rag(  # pylint: disable=t
         return_value=_make_vector_io_response(mocker, chunks_data)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     responses_request = ResponsesRequest(input="test query", stream=False)
 

--- a/tests/integration/endpoints/test_responses_integration.py
+++ b/tests/integration/endpoints/test_responses_integration.py
@@ -96,9 +96,7 @@ def _build_mock_client(mocker: MockerFixture) -> Any:
 
     mock_client.shields.list.return_value = []
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_conv = mocker.MagicMock()
     mock_conv.id = MOCK_CONV_ID

--- a/tests/integration/endpoints/test_streaming_query_byok_integration.py
+++ b/tests/integration/endpoints/test_streaming_query_byok_integration.py
@@ -109,9 +109,7 @@ def mock_streaming_byok_client_fixture(
     )
 
     # No tool-based vector stores
-    mock_vector_stores_response = mocker.MagicMock()
-    mock_vector_stores_response.data = []
-    mock_client.vector_stores.list.return_value = mock_vector_stores_response
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
     yield mock_client
@@ -165,9 +163,7 @@ def mock_streaming_byok_tool_client_fixture(  # pylint: disable=too-many-stateme
     # Tool-based vector stores available
     mock_vector_store = mocker.MagicMock()
     mock_vector_store.id = "vs-byok-knowledge"
-    mock_list_result = mocker.MagicMock()
-    mock_list_result.data = [mock_vector_store]
-    mock_client.vector_stores.list.return_value = mock_list_result
+    mock_client.vector_stores.list.return_value = [mock_vector_store]
 
     mock_holder_class.return_value.get_client.return_value = mock_client
     yield mock_client
@@ -306,9 +302,7 @@ async def test_streaming_query_byok_inline_rag_with_request_vector_store_ids(
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -371,9 +365,7 @@ async def test_streaming_query_byok_request_vector_store_ids_filters_configured_
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -653,9 +645,7 @@ async def test_streaming_query_byok_combined_inline_and_tool_rag(
     # Tool RAG vector stores
     mock_vector_store = mocker.MagicMock()
     mock_vector_store.id = "vs-byok-knowledge"
-    mock_list_result = mocker.MagicMock()
-    mock_list_result.data = [mock_vector_store]
-    mock_client.vector_stores.list.return_value = mock_list_result
+    mock_client.vector_stores.list.return_value = [mock_vector_store]
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -727,9 +717,7 @@ async def test_streaming_query_byok_only_configured_rag_id_is_queried(
         return_value=_make_byok_vector_io_response(mocker)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -821,9 +809,7 @@ async def test_streaming_query_byok_score_multiplier_shifts_priority(  # pylint:
 
     mock_client.vector_io.query = mocker.AsyncMock(side_effect=_side_effect)
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -892,9 +878,7 @@ async def test_streaming_query_rag_content_limit_caps_context(  # pylint: disabl
         return_value=_make_vector_io_response(mocker, chunks_data)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -981,9 +965,7 @@ async def test_streaming_query_rag_content_limit_caps_across_multiple_sources(  
 
     mock_client.vector_io.query = mocker.AsyncMock(side_effect=_side_effect)
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 
@@ -1054,9 +1036,7 @@ async def test_streaming_query_rag_content_limit_caps_inline_rag(  # pylint: dis
         return_value=_make_vector_io_response(mocker, chunks_data)
     )
 
-    mock_vs_resp = mocker.MagicMock()
-    mock_vs_resp.data = []
-    mock_client.vector_stores.list.return_value = mock_vs_resp
+    mock_client.vector_stores.list.return_value = []
 
     mock_holder_class.return_value.get_client.return_value = mock_client
 

--- a/tests/integration/endpoints/test_streaming_query_integration.py
+++ b/tests/integration/endpoints/test_streaming_query_integration.py
@@ -38,9 +38,7 @@ def mock_llama_stack_streaming_fixture(
         make_openai_model()
     )
 
-    mock_vector_stores_response = mocker.MagicMock()
-    mock_vector_stores_response.data = []
-    mock_client.vector_stores.list.return_value = mock_vector_stores_response
+    mock_client.vector_stores.list.return_value = []
 
     mock_conversation = mocker.MagicMock()
     mock_conversation.id = "conv_" + "a" * 48

--- a/tests/unit/app/endpoints/test_conversations.py
+++ b/tests/unit/app/endpoints/test_conversations.py
@@ -685,7 +685,7 @@ class TestGetConversationEndpoint:
         mock_item2.role = "assistant"
         mock_item2.content = "Hi there!"
         mock_items_response.data = [mock_item1, mock_item2]
-        mock_items_response.has_next_page.return_value = False
+        mock_items_response.has_more = False
         mock_client.conversations.items.list = mocker.AsyncMock(
             return_value=mock_items_response
         )
@@ -741,7 +741,7 @@ class TestGetConversationEndpoint:
                 type="message", role="assistant", content="I'm doing well, thanks!"
             ),
         ]
-        mock_items.has_next_page.return_value = False
+        mock_items.has_more = False
         mock_client.conversations.items.list = mocker.AsyncMock(return_value=mock_items)
 
         mock_client_holder = mocker.patch(
@@ -817,7 +817,7 @@ class TestGetConversationEndpoint:
         mock_client = mocker.AsyncMock()
         mock_items_response = mocker.Mock()
         mock_items_response.data = []
-        mock_items_response.has_next_page.return_value = False
+        mock_items_response.has_more = False
         mock_client.conversations.items.list = mocker.AsyncMock(
             return_value=mock_items_response
         )
@@ -968,6 +968,7 @@ class TestGetConversationEndpoint:
             mocker.Mock(type="message", role="user", content="Hello"),
             mocker.Mock(type="message", role="assistant", content="Hi!"),
         ]
+        mock_items_response.has_more = False
         mock_client.conversations.items.list.return_value = mock_items_response
         mock_client_holder = mocker.patch(
             "app.endpoints.conversations_v1.AsyncOgxClientHolder"

--- a/tests/unit/app/endpoints/test_prompts.py
+++ b/tests/unit/app/endpoints/test_prompts.py
@@ -145,24 +145,6 @@ async def test_get_prompt_with_version(
 
 
 @pytest.mark.asyncio
-async def test_get_prompt_without_version_omits_kwarg(
-    prompts_client_mocks: tuple[Any, Any],
-    prompts_http_request: Request,
-) -> None:
-    """get_prompt calls retrieve with prompt_id only when version is omitted."""
-    _, mock_prompts = prompts_client_mocks
-    mock_prompts.retrieve.return_value = _sample_prompt(VALID_PMPT_ID, 1)
-
-    await get_prompt_handler(
-        request=prompts_http_request,
-        prompt_id=VALID_PMPT_ID,
-        auth=MOCK_AUTH,
-    )
-
-    mock_prompts.retrieve.assert_awaited_once_with(VALID_PMPT_ID)
-
-
-@pytest.mark.asyncio
 async def test_update_prompt_success(
     prompts_client_mocks: tuple[Any, Any],
     prompts_http_request: Request,

--- a/tests/unit/app/endpoints/test_rags.py
+++ b/tests/unit/app/endpoints/test_rags.py
@@ -1,7 +1,7 @@
 """Unit tests for the /rags REST API endpoints."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 from fastapi import HTTPException, Request, status
@@ -99,6 +99,14 @@ async def test_rags_endpoint_success(
                 RagInfo("vs_7b52a8cf-0fa3-489c-beab-27e061d102f3"),
                 RagInfo("vs_7b52a8cf-0fa3-489c-cafe-27e061d102f3"),
             ]
+
+        def __iter__(self) -> "Iterator[RagInfo]":
+            """Iterate over RAG entries."""
+            return iter(self.data)
+
+        def __len__(self) -> int:
+            """Return number of RAG entries."""
+            return len(self.data)
 
     mock_client = mocker.AsyncMock()
     mock_client.vector_stores.list.return_value = RagList()
@@ -319,6 +327,14 @@ async def test_rags_endpoint_returns_rag_ids_from_config(
                 RagInfo("vs_def456"),  # mapped to company-kb
                 RagInfo("vs_unmapped"),  # not in config, passed through
             ]
+
+        def __iter__(self) -> "Iterator[RagInfo]":
+            """Iterate over RAG entries."""
+            return iter(self.data)
+
+        def __len__(self) -> int:
+            """Return number of RAG entries."""
+            return len(self.data)
 
     mock_client = mocker.AsyncMock()
     mock_client.vector_stores.list.return_value = RagList()

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -132,7 +132,7 @@ def _patch_client(mocker: MockerFixture) -> Any:
     """Patch AsyncOgxClientHolder; return (mock_client, mock_holder)."""
     mock_client = mocker.AsyncMock(spec=AsyncOgxClient)
     mock_vector_stores = mocker.Mock()
-    mock_vector_stores.list = mocker.AsyncMock(return_value=mocker.Mock(data=[]))
+    mock_vector_stores.list = mocker.AsyncMock(return_value=[])
     mock_client.vector_stores = mock_vector_stores
     mock_holder = mocker.Mock()
     mock_holder.get_client.return_value = mock_client

--- a/tests/unit/app/endpoints/test_vector_stores.py
+++ b/tests/unit/app/endpoints/test_vector_stores.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=too-many-lines
 
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 from fastapi import HTTPException, Request, status
@@ -62,6 +62,14 @@ class VectorStoresList:
         """Initialize vector stores list mock."""
         self.data = stores
 
+    def __iter__(self) -> Iterator[VectorStore]:
+        """Iterate over vector stores."""
+        return iter(self.data)
+
+    def __len__(self) -> int:
+        """Return number of vector stores."""
+        return len(self.data)
+
 
 # pylint: disable=R0903
 class File:
@@ -101,6 +109,14 @@ class VectorStoreFilesList:
     def __init__(self, files: list[VectorStoreFile]) -> None:
         """Initialize vector store files list mock."""
         self.data = files
+
+    def __iter__(self) -> Iterator[VectorStoreFile]:
+        """Iterate over vector store files."""
+        return iter(self.data)
+
+    def __len__(self) -> int:
+        """Return number of files."""
+        return len(self.data)
 
 
 def get_test_config() -> dict[str, Any]:

--- a/tests/unit/utils/test_conversations.py
+++ b/tests/unit/utils/test_conversations.py
@@ -885,7 +885,7 @@ class TestGetAllConversationItems:
         item_b = mocker.Mock(type="message", role="assistant", content="Hi")
         mock_page = mocker.Mock()
         mock_page.data = [item_a, item_b]
-        mock_page.has_next_page.return_value = False
+        mock_page.has_more = False
 
         mock_client.conversations.items.list = mocker.AsyncMock(return_value=mock_page)
 
@@ -897,6 +897,7 @@ class TestGetAllConversationItems:
         mock_client.conversations.items.list.assert_called_once_with(
             conversation_id="conv_0d21ba731f21f798dc9680125d5d6f49",
             order="asc",
+            after=None,
         )
 
     @pytest.mark.asyncio
@@ -909,14 +910,16 @@ class TestGetAllConversationItems:
 
         first_page = mocker.Mock()
         first_page.data = [item_1]
-        first_page.has_next_page.return_value = True
+        first_page.has_more = True
+        first_page.last_id = "item_1"
+
         second_page = mocker.Mock()
         second_page.data = [item_2, item_3]
-        second_page.has_next_page.return_value = False
+        second_page.has_more = False
 
-        first_page.get_next_page = mocker.AsyncMock(return_value=second_page)
-
-        mock_client.conversations.items.list = mocker.AsyncMock(return_value=first_page)
+        mock_client.conversations.items.list = mocker.AsyncMock(
+            side_effect=[first_page, second_page]
+        )
 
         result = await get_all_conversation_items(mock_client, "conv_abc")
 
@@ -924,11 +927,11 @@ class TestGetAllConversationItems:
 
     @pytest.mark.asyncio
     async def test_handles_empty_data(self, mocker: MockerFixture) -> None:
-        """Test that None or empty page data is handled."""
+        """Test that empty page data is handled."""
         mock_client = mocker.Mock()
         mock_page = mocker.Mock()
-        mock_page.data = None
-        mock_page.has_next_page.return_value = False
+        mock_page.data = []
+        mock_page.has_more = False
 
         mock_client.conversations.items.list = mocker.AsyncMock(return_value=mock_page)
 


### PR DESCRIPTION
## Description

Updates list handling for OGX responses so vector stores, RAGs, and related callers iterate the response object directly instead of .data, switches conversation item pagination to has_more/after, and adjusts unit and integration tests to match.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3310

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
