### PR TITLE
LCORE-3414: Fix Vertex AI and Bedrock e2e model identifiers

### DIFF
--- a/.github/workflows/e2e_tests_providers.yaml
+++ b/.github/workflows/e2e_tests_providers.yaml
@@ -15,18 +15,18 @@ jobs:
         mode: ["server", "library"]
         environment: ["azure", "vertexai", "watsonx", "bedrock"]
         # Expected default LLM for Behave (matches tests/e2e/configs/run-<env>.yaml).
-        # | environment | model_id                            | provider_id   |
-        # |-------------|-------------------------------------|---------------|
-        # | azure       | gpt-4o-mini                         | azure         |
-        # | vertexai    | google/gemini-2.5-flash             | google-vertex |
-        # | watsonx     | meta-llama/llama-3-3-70b-instruct   | watsonx       |
-        # | bedrock     | deepseek.v3-v1:0                    | aws-bedrock   |
+        # | environment | model_id                                   | provider_id   |
+        # |-------------|--------------------------------------------| --------------|
+        # | azure       | gpt-4o-mini                                | azure         |
+        # | vertexai    | publishers/google/models/gemini-2.5-flash  | google-vertex |
+        # | watsonx     | meta-llama/llama-3-3-70b-instruct          | watsonx       |
+        # | bedrock     | deepseek.v3-v1:0                           | aws-bedrock   |
         include:
           - environment: azure
             e2e_default_model: gpt-4o-mini
             e2e_default_provider: azure
           - environment: vertexai
-            e2e_default_model: google/gemini-2.5-flash
+            e2e_default_model: publishers/google/models/gemini-2.5-flash
             e2e_default_provider: google-vertex
           - environment: watsonx
             e2e_default_model: meta-llama/llama-3-3-70b-instruct

--- a/examples/vertexai-run.yaml
+++ b/examples/vertexai-run.yaml
@@ -19,7 +19,7 @@ providers:
     config:
       project: ${env.VERTEX_AI_PROJECT}
       location: ${env.VERTEX_AI_LOCATION}
-      allowed_models: ["google/gemini-2.5-flash"]
+      allowed_models: ["publishers/google/models/gemini-2.5-flash"]
   - provider_id: openai
     provider_type: remote::openai
     config:
@@ -97,10 +97,10 @@ storage:
       backend: sql_default
 registered_resources:
   models:
-  - model_id: google/gemini-2.5-flash
+  - model_id: publishers/google/models/gemini-2.5-flash
     provider_id: google-vertex
     model_type: llm
-    provider_model_id: google/gemini-2.5-flash
+    provider_model_id: publishers/google/models/gemini-2.5-flash
   - model_id: all-mpnet-base-v2
     model_type: embedding
     provider_id: sentence-transformers

--- a/tests/e2e/configs/run-bedrock.yaml
+++ b/tests/e2e/configs/run-bedrock.yaml
@@ -97,7 +97,7 @@ storage:
       backend: sql_default
 registered_resources:
   models:
-  - model_id: custom-bedrock-model
+  - model_id: deepseek.v3-v1:0
     model_type: llm
     provider_id: aws-bedrock
     provider_model_id: deepseek.v3-v1:0

--- a/tests/e2e/configs/run-vertexai.yaml
+++ b/tests/e2e/configs/run-vertexai.yaml
@@ -19,7 +19,7 @@ providers:
     config:
       project: ${env.VERTEX_AI_PROJECT}
       location: ${env.VERTEX_AI_LOCATION}
-      allowed_models: ["google/gemini-2.5-flash"]
+      allowed_models: ["publishers/google/models/gemini-2.5-flash"]
   - provider_id: openai
     provider_type: remote::openai
     config:
@@ -98,10 +98,10 @@ storage:
       backend: sql_default
 registered_resources:
   models:
-  - model_id: google/gemini-2.5-flash
+  - model_id: publishers/google/models/gemini-2.5-flash
     provider_id: google-vertex
     model_type: llm
-    provider_model_id: google/gemini-2.5-flash
+    provider_model_id: publishers/google/models/gemini-2.5-flash
   - model_id: all-mpnet-base-v2
     model_type: embedding
     provider_id: sentence-transformers


### PR DESCRIPTION
## Description

Fix Vertex AI e2e/example configs to use the full publishers/google/models/gemini-2.5-flash resource ID that OGX returns from list_models(), so allowlist filtering and model registration no longer fail at startup. Also align the Bedrock registered model_id with deepseek.v3-v1:0 so it matches the e2e expected identifier.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3414

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Bedrock model identifier used in end-to-end testing to the current DeepSeek V3 model.
  * Updated Vertex AI model references to use the current full resource-name format.
* **Chores**
  * End-to-end provider checks now run on pushes instead of only on a daily schedule.
  * Updated provider examples and test configurations to reflect current model identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->