### PR TITLE
fix: update embedding model handling to work with ogx

### DIFF
--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -250,7 +250,8 @@ def construct_vector_stores_section(
         list[dict[str, Any]]: The `vector_stores` list where each entry is a mapping with keys:
             - `vector_store_id`: identifier of the vector store (for Llama Stack config)
             - `provider_id`: provider identifier prefixed with `"byok_"`
-            - `embedding_model`: name of the embedding model
+            - `embedding_model`: registered OGX model id
+              (``sentence-transformers/byok_<rag_id>_embedding``), not the load path
             - `embedding_dimension`: embedding vector dimensionality
     """
     output = []
@@ -280,12 +281,13 @@ def construct_vector_stores_section(
             continue
         existing_store_ids.add(vector_db_id)
         added += 1
-        embedding_model = brag.get("embedding_model", constants.DEFAULT_EMBEDDING_MODEL)
+        # OGX registers BYOK embeddings as sentence-transformers/byok_<rag_id>_embedding
+        # (see construct_models_section). Lookups must use that id, not the load path.
         output.append(
             {
                 "vector_store_id": vector_db_id,
                 "provider_id": f"byok_{rag_id}",
-                "embedding_model": embedding_model,
+                "embedding_model": f"sentence-transformers/byok_{rag_id}_embedding",
                 "embedding_dimension": brag.get("embedding_dimension"),
             }
         )
@@ -544,10 +546,12 @@ def _upsert_vsprov_embedding_model(
     embedding_model: str,
     embedding_dimension: int,
 ) -> None:
-    """Register an embedding model if provider_model_id is not already present.
+    """Register a vsprov embedding model alias if that model_id is not present.
 
-    Dedupes against BYOK/baseline rows by ``provider_model_id`` (after stripping
-    a leading ``sentence-transformers/`` prefix).
+    Dedupes by ``model_id`` (``vsprov_<provider_id>_embedding``), not by load
+    path. BYOK and ``vector_store`` often share the same
+    ``provider_model_id``; both aliases must be registered so
+    ``default_embedding_model`` can resolve.
 
     Parameters:
         ls_config: Llama Stack configuration modified in place.
@@ -557,12 +561,13 @@ def _upsert_vsprov_embedding_model(
             validated ``vector_store.providers`` entries).
     """
     models = ls_config.setdefault("registered_resources", {}).setdefault("models", [])
-    provider_model_id = embedding_model.removeprefix("sentence-transformers/")
-    if any(model.get("provider_model_id") == provider_model_id for model in models):
+    model_id = f"vsprov_{provider_id}_embedding"
+    if any(model.get("model_id") == model_id for model in models):
         return
+    provider_model_id = embedding_model.removeprefix("sentence-transformers/")
     models.append(
         {
-            "model_id": f"vsprov_{provider_id}_embedding",
+            "model_id": model_id,
             "model_type": "embedding",
             "provider_id": "sentence-transformers",
             "provider_model_id": provider_model_id,
@@ -655,12 +660,14 @@ def _apply_vector_stores_defaults(
     if not isinstance(vector_stores, dict):
         vector_stores = {}
         ls_config["vector_stores"] = vector_stores
-    vector_stores["default_provider_id"] = str(designated["id"]).strip()
-    emb = designated.get("embedding_model")
-    if emb:
+    provider_id = str(designated["id"]).strip()
+    vector_stores["default_provider_id"] = provider_id
+    # Match _upsert_vsprov_embedding_model model_id; OGX validates
+    # provider_id/model_id against registered models, not the load path.
+    if designated.get("embedding_model"):
         vector_stores["default_embedding_model"] = {
             "provider_id": "sentence-transformers",
-            "model_id": emb,
+            "model_id": f"vsprov_{provider_id}_embedding",
         }
 
 

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -338,14 +338,16 @@ def construct_models_section(
         provider_model_id = embedding_model
         provider_model_id = provider_model_id.removeprefix("sentence-transformers/")
 
-        # Skip if embedding model already registered
-        existing_model_ids = [m.get("provider_model_id") for m in output]
-        if provider_model_id in existing_model_ids:
+        # Dedupe by generated model_id (not load path). Vector stores look up
+        # sentence-transformers/byok_<rag_id>_embedding; shared paths still need
+        # one alias per rag_id.
+        model_id = f"byok_{rag_id}_embedding"
+        if any(model.get("model_id") == model_id for model in output):
             continue
 
         output.append(
             {
-                "model_id": f"byok_{rag_id}_embedding",
+                "model_id": model_id,
                 "model_type": "embedding",
                 "provider_id": "sentence-transformers",
                 "provider_model_id": provider_model_id,
@@ -546,12 +548,12 @@ def _upsert_vsprov_embedding_model(
     embedding_model: str,
     embedding_dimension: int,
 ) -> None:
-    """Register a vsprov embedding model alias if that model_id is not present.
+    """Register or refresh a vsprov embedding model alias by model_id.
 
-    Dedupes by ``model_id`` (``vsprov_<provider_id>_embedding``), not by load
-    path. BYOK and ``vector_store`` often share the same
-    ``provider_model_id``; both aliases must be registered so
-    ``default_embedding_model`` can resolve.
+    Uses ``model_id`` ``vsprov_<provider_id>_embedding`` (not load path) so
+    BYOK and ``vector_store`` can share a ``provider_model_id`` and both
+    resolve. Re-enrichment updates path and metadata when the same
+    ``model_id`` already exists.
 
     Parameters:
         ls_config: Llama Stack configuration modified in place.
@@ -562,18 +564,19 @@ def _upsert_vsprov_embedding_model(
     """
     models = ls_config.setdefault("registered_resources", {}).setdefault("models", [])
     model_id = f"vsprov_{provider_id}_embedding"
-    if any(model.get("model_id") == model_id for model in models):
-        return
     provider_model_id = embedding_model.removeprefix("sentence-transformers/")
-    models.append(
-        {
-            "model_id": model_id,
-            "model_type": "embedding",
-            "provider_id": "sentence-transformers",
-            "provider_model_id": provider_model_id,
-            "metadata": {"embedding_dimension": embedding_dimension},
-        }
-    )
+    entry = {
+        "model_id": model_id,
+        "model_type": "embedding",
+        "provider_id": "sentence-transformers",
+        "provider_model_id": provider_model_id,
+        "metadata": {"embedding_dimension": embedding_dimension},
+    }
+    for index, model in enumerate(models):
+        if model.get("model_id") == model_id:
+            models[index] = entry
+            return
+    models.append(entry)
 
 
 def _vsprov_fields_and_backend(

--- a/tests/unit/test_llama_stack_configuration.py
+++ b/tests/unit/test_llama_stack_configuration.py
@@ -151,7 +151,7 @@ def test_construct_vector_stores_section_adds_new() -> None:
     assert len(output) == 1
     assert output[0]["vector_store_id"] == "store1"
     assert output[0]["provider_id"] == "byok_rag1"
-    assert output[0]["embedding_model"] == "test-model"
+    assert output[0]["embedding_model"] == "sentence-transformers/byok_rag1_embedding"
     assert output[0]["embedding_dimension"] == 512
 
 
@@ -234,7 +234,7 @@ def test_construct_vector_stores_section_skips_duplicate_within_byok() -> None:
     ]
     output = construct_vector_stores_section(ls_config, byok_rag)
     assert len(output) == 1
-    assert output[0]["embedding_model"] == "model-a"
+    assert output[0]["embedding_model"] == "sentence-transformers/byok_rag1_embedding"
 
 
 # =============================================================================
@@ -555,6 +555,26 @@ def test_construct_models_section_strips_prefix() -> None:
     output = construct_models_section(ls_config, byok_rag)
     assert len(output) == 1
     assert output[0]["provider_model_id"] == "/usr/path/model"
+
+
+def test_byok_vector_store_uses_registered_embedding_id_not_load_path() -> None:
+    """BYOK store lookup id matches registered model; path stays on provider_model_id."""
+    ls_config: dict[str, Any] = {}
+    byok_rag = [
+        {
+            "rag_id": "rhdh-docs",
+            "vector_db_id": "vs_abc",
+            "embedding_model": "sentence-transformers//rag-content/embeddings_model",
+            "embedding_dimension": 768,
+        },
+    ]
+    stores = construct_vector_stores_section(ls_config, byok_rag)
+    models = construct_models_section(ls_config, byok_rag)
+    assert stores[0]["embedding_model"] == (
+        "sentence-transformers/byok_rhdh-docs_embedding"
+    )
+    assert models[0]["model_id"] == "byok_rhdh-docs_embedding"
+    assert models[0]["provider_model_id"] == "/rag-content/embeddings_model"
 
 
 def test_construct_storage_backends_section_raises_on_missing_rag_id() -> None:
@@ -938,7 +958,7 @@ def test_enrich_vector_store_faiss_appends() -> None:
     )
     assert ls_config["vector_stores"]["default_provider_id"] == "notebooks"
     assert ls_config["vector_stores"]["default_embedding_model"]["model_id"] == (
-        "/rag-content/embeddings_model"
+        "vsprov_notebooks_embedding"
     )
     assert (
         ls_config["vector_stores"]["annotation_prompt_params"]["enable_annotations"]
@@ -1084,7 +1104,7 @@ def test_enrich_vector_store_multiple_entries() -> None:
     assert "vsprov_nb-pg_storage" not in ls_config["storage"]["backends"]
     assert ls_config["vector_stores"]["default_provider_id"] == "notebooks"
     assert ls_config["vector_stores"]["default_embedding_model"]["model_id"] == (
-        "/emb-faiss"
+        "vsprov_notebooks_embedding"
     )
     assert (
         ls_config["vector_stores"]["annotation_prompt_params"]["enable_annotations"]
@@ -1110,8 +1130,8 @@ def test_enrich_vector_store_noop_without_entries() -> None:
     assert ls_config["vector_stores"]["default_provider_id"] == "faiss"
 
 
-def test_enrich_vector_store_dedupes_embedding_model() -> None:
-    """Same provider_model_id as an existing model does not add a second row."""
+def test_enrich_vector_store_registers_alias_when_load_path_shared_with_byok() -> None:
+    """Shared provider_model_id with BYOK still registers vsprov_* for defaults."""
     ls_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
@@ -1144,7 +1164,43 @@ def test_enrich_vector_store_dedupes_embedding_model() -> None:
             ],
         },
     )
+    model_ids = {m["model_id"] for m in ls_config["registered_resources"]["models"]}
+    assert model_ids == {
+        "byok_rhdh-docs_embedding",
+        "vsprov_notebooks_embedding",
+    }
+    assert ls_config["vector_stores"]["default_embedding_model"]["model_id"] == (
+        "vsprov_notebooks_embedding"
+    )
+
+
+def test_enrich_vector_store_dedupes_same_vsprov_model_id() -> None:
+    """Re-enriching the same vector_store provider does not duplicate its model."""
+    ls_config: dict[str, Any] = {
+        "providers": {},
+        "storage": {"backends": {}},
+        "registered_resources": {"models": [], "vector_stores": []},
+        "vector_stores": {},
+    }
+    vector_store = {
+        "default_provider": "notebooks",
+        "providers": [
+            {
+                "id": "notebooks",
+                "type": "faiss",
+                "embedding_model": "/rag-content/embeddings_model",
+                "embedding_dimension": 768,
+                "config": {"path": "/tmp/n.db"},
+            }
+        ],
+    }
+    enrich_vector_store(ls_config, vector_store)
+    enrich_vector_store(ls_config, vector_store)
     assert len(ls_config["registered_resources"]["models"]) == 1
+    assert (
+        ls_config["registered_resources"]["models"][0]["model_id"]
+        == "vsprov_notebooks_embedding"
+    )
 
 
 def test_enrich_vector_store_skips_embedding_without_dimension() -> None:

--- a/tests/unit/test_llama_stack_configuration.py
+++ b/tests/unit/test_llama_stack_configuration.py
@@ -577,6 +577,38 @@ def test_byok_vector_store_uses_registered_embedding_id_not_load_path() -> None:
     assert models[0]["provider_model_id"] == "/rag-content/embeddings_model"
 
 
+def test_construct_models_section_registers_alias_per_rag_id_for_shared_path() -> None:
+    """Two BYOK entries sharing a load path each get a byok_<rag_id>_embedding alias."""
+    ls_config: dict[str, Any] = {}
+    byok_rag = [
+        {
+            "rag_id": "docs-a",
+            "vector_db_id": "vs_a",
+            "embedding_model": "/rag-content/embeddings_model",
+            "embedding_dimension": 768,
+        },
+        {
+            "rag_id": "docs-b",
+            "vector_db_id": "vs_b",
+            "embedding_model": "/rag-content/embeddings_model",
+            "embedding_dimension": 768,
+        },
+    ]
+    models = construct_models_section(ls_config, byok_rag)
+    stores = construct_vector_stores_section(ls_config, byok_rag)
+    assert {m["model_id"] for m in models} == {
+        "byok_docs-a_embedding",
+        "byok_docs-b_embedding",
+    }
+    assert all(
+        m["provider_model_id"] == "/rag-content/embeddings_model" for m in models
+    )
+    assert {s["embedding_model"] for s in stores} == {
+        "sentence-transformers/byok_docs-a_embedding",
+        "sentence-transformers/byok_docs-b_embedding",
+    }
+
+
 def test_construct_storage_backends_section_raises_on_missing_rag_id() -> None:
     """Test raises ValueError when rag_id is missing from a BYOK RAG entry."""
     ls_config: dict[str, Any] = {}
@@ -1201,6 +1233,51 @@ def test_enrich_vector_store_dedupes_same_vsprov_model_id() -> None:
         ls_config["registered_resources"]["models"][0]["model_id"]
         == "vsprov_notebooks_embedding"
     )
+
+
+def test_enrich_vector_store_updates_vsprov_alias_on_path_change() -> None:
+    """Re-enrichment with a new embedding path refreshes the vsprov_* model row."""
+    ls_config: dict[str, Any] = {
+        "providers": {},
+        "storage": {"backends": {}},
+        "registered_resources": {"models": [], "vector_stores": []},
+        "vector_stores": {},
+    }
+    enrich_vector_store(
+        ls_config,
+        {
+            "default_provider": "notebooks",
+            "providers": [
+                {
+                    "id": "notebooks",
+                    "type": "faiss",
+                    "embedding_model": "/old/embeddings_model",
+                    "embedding_dimension": 768,
+                    "config": {"path": "/tmp/n.db"},
+                }
+            ],
+        },
+    )
+    enrich_vector_store(
+        ls_config,
+        {
+            "default_provider": "notebooks",
+            "providers": [
+                {
+                    "id": "notebooks",
+                    "type": "faiss",
+                    "embedding_model": "/new/embeddings_model",
+                    "embedding_dimension": 384,
+                    "config": {"path": "/tmp/n.db"},
+                }
+            ],
+        },
+    )
+    models = ls_config["registered_resources"]["models"]
+    assert len(models) == 1
+    assert models[0]["model_id"] == "vsprov_notebooks_embedding"
+    assert models[0]["provider_model_id"] == "/new/embeddings_model"
+    assert models[0]["metadata"]["embedding_dimension"] == 384
 
 
 def test_enrich_vector_store_skips_embedding_without_dimension() -> None:

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -655,7 +655,7 @@ def test_synthesize_includes_vector_store() -> None:
     assert "notebooks" in ids
     assert result["vector_stores"]["default_provider_id"] == "notebooks"
     assert result["vector_stores"]["default_embedding_model"]["model_id"] == (
-        "/rag-content/embeddings_model"
+        "vsprov_notebooks_embedding"
     )
 
 


### PR DESCRIPTION
## Description
- Fixes some naming for embedding models to work with ogx
   - When mounting your own embedding model it was failing with the old implementation

<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Grok 4.5
- Generated by: Grok 4.5

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vector-store embedding configuration to consistently use registered model identifiers.
  * Prevented duplicate model registrations when providers share embedding paths.
  * Preserved separate BYOK and vector-store embedding registrations when configurations overlap.

* **Tests**
  * Expanded coverage for embedding registration, deduplication, and default configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->