### PR TITLE
RHIDP-14130: OKP experience improvements - citation URLs, search mode, ogx provider migration

### DIFF
--- a/deploy/lightspeed-stack/Containerfile
+++ b/deploy/lightspeed-stack/Containerfile
@@ -36,7 +36,7 @@ COPY ${LSC_SOURCE_DIR}/pyproject.toml ${LSC_SOURCE_DIR}/LICENSE ${LSC_SOURCE_DIR
 
 # lightspeed-providers:
 # Fully hermetic — uses prefetched artifact or pinned commit from GitHub
-ARG LIGHTSPEED_PROVIDERS_COMMIT=8cd1b3d3bdd841ea99d31b334ae00a275581661c
+ARG LIGHTSPEED_PROVIDERS_COMMIT=faf6a89a3ad7856e2e7a934324f31d146108acdb
 RUN set -eux; \
     ZIP_PATH="/tmp/lightspeed-providers.zip"; \
     EXTRACT_DIR="/tmp/providers"; \

--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -15950,6 +15950,23 @@
                         ],
                         "title": "OKP chunk filter query",
                         "description": "Additional OKP filter query applied to every OKP search request. Use Solr boolean syntax, e.g. 'product:ansible AND product:*openshift*'."
+                    },
+                    "search_mode": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "enum": [
+                                    "semantic",
+                                    "hybrid",
+                                    "keyword"
+                                ]
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "OKP search mode",
+                        "description": "Default Solr search mode for OKP queries. 'keyword' uses BM25 text search (no embedding model needed). 'hybrid' combines vector + keyword search. 'semantic' uses pure vector search. When unset, falls back to the global default ('hybrid')."
                     }
                 },
                 "additionalProperties": false,
@@ -21277,7 +21294,8 @@
                                 "enum": [
                                     "semantic",
                                     "hybrid",
-                                    "lexical"
+                                    "lexical",
+                                    "keyword"
                                 ]
                             },
                             {
@@ -21285,10 +21303,11 @@
                             }
                         ],
                         "title": "Mode",
-                        "description": "Solr vector_io search mode. When omitted, the server default ('hybrid') is used.",
+                        "description": "Solr vector_io search mode. When omitted, the server default ('hybrid') is used. 'keyword' and 'lexical' both use BM25 text search.",
                         "examples": [
                             "hybrid",
                             "semantic",
+                            "keyword",
                             "lexical"
                         ]
                     },

--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -21363,7 +21363,7 @@
                 "additionalProperties": false,
                 "type": "object",
                 "title": "SolrVectorSearchRequest",
-                "description": "LCORE Solr inline RAG options for vector_io.query (mode and provider filters).\n\nAttributes:\n    mode: Solr vector_io search mode. When omitted, the server default (hybrid) is used.\n    filters: Solr provider filter payload passed through as params['solr'].\n\nLegacy clients may send a plain JSON object with filter keys only;\nthat object is accepted as filters with mode unset (server default applies)."
+                "description": "LCORE Solr inline RAG options for vector_io.query (mode and provider filters).\n\nAttributes:\n    mode: Solr vector_io search mode. When omitted, the configured OKP default is used.\n    filters: Solr provider filter payload passed through as params['solr'].\n\nLegacy clients may send a plain JSON object with filter keys only;\nthat object is accepted as filters with mode unset (server default applies)."
             },
             "SplunkConfiguration": {
                 "properties": {

--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -21303,7 +21303,7 @@
                             }
                         ],
                         "title": "Mode",
-                        "description": "Solr vector_io search mode. When omitted, the server default ('hybrid') is used. 'keyword' and 'lexical' both use BM25 text search.",
+                        "description": "Solr vector_io search mode. When omitted, the configured OKP default is used; otherwise 'hybrid' applies. 'keyword' and 'lexical' both use BM25 text search.",
                         "examples": [
                             "hybrid",
                             "semantic",

--- a/src/constants.py
+++ b/src/constants.py
@@ -254,6 +254,7 @@ SOLR_DEFAULT_EMBEDDING_MODEL: Final[str] = (
     "sentence-transformers/ibm-granite/granite-embedding-30m-english"
 )
 SOLR_DEFAULT_EMBEDDING_DIMENSION: Final[int] = 384
+SOLR_EMBEDDING_MODEL_ID: Final[str] = "sentence-transformers/solr_embedding"
 
 # Default score multiplier for BYOK RAG vector stores
 DEFAULT_SCORE_MULTIPLIER: Final[float] = 1.0

--- a/src/constants.py
+++ b/src/constants.py
@@ -235,6 +235,8 @@ BYOK_RAG_RERANK_BOOST: Final[float] = 1.2
 SOLR_VECTOR_SEARCH_DEFAULT_K: Final[int] = 5
 SOLR_VECTOR_SEARCH_DEFAULT_SCORE_THRESHOLD: Final[float] = 0.3
 SOLR_VECTOR_SEARCH_DEFAULT_MODE: Final[str] = "hybrid"
+# LCORE exposes "lexical" but Llama Stack dispatch recognizes "keyword"
+SOLR_SEARCH_MODE_MAP: Final[dict[str, str]] = {"lexical": "keyword"}
 
 # Internal Solr filter always applied to restrict results to chunk documents
 SOLR_CHUNK_FILTER_QUERY: Final[str] = "is_chunk:true"

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -767,7 +767,7 @@ def enrich_vector_store(
 # =============================================================================
 
 
-def enrich_solr(  # pylint: disable=too-many-locals
+def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
     ls_config: dict[str, Any],
     rag_config: dict[str, Any],
     okp_config: dict[str, Any],
@@ -918,6 +918,27 @@ def enrich_solr(  # pylint: disable=too-many-locals
             }
         )
         logger.info("Added OKP embedding model to registered_resources.models")
+
+    # Propagate search_mode to OGX's top-level vector_stores config so that
+    # rag.tool (file_search) uses keyword/hybrid instead of defaulting to
+    # vector similarity — critical for air-gap environments without an
+    # embedding model.
+    okp_search_mode = okp_config.get("search_mode")
+    if okp_search_mode:
+        ogx_mode = constants.SOLR_SEARCH_MODE_MAP.get(okp_search_mode, okp_search_mode)
+        # LCORE uses "semantic"; OGX uses "vector"
+        if ogx_mode == "semantic":
+            ogx_mode = "vector"
+        if "vector_stores" not in ls_config:
+            ls_config["vector_stores"] = {}
+        chunk_params = ls_config["vector_stores"].setdefault(
+            "chunk_retrieval_params", {}
+        )
+        chunk_params["default_search_mode"] = ogx_mode
+        logger.info(
+            "Set vector_stores.chunk_retrieval_params.default_search_mode=%s",
+            ogx_mode,
+        )
 
 
 # =============================================================================

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -774,7 +774,7 @@ def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
 ) -> None:
     """Enrich Llama Stack config with Solr settings.
 
-    Args:
+    Parameters:
         ls_config: Llama Stack configuration dict (modified in place)
         rag_config: RAG configuration dict. Used keys:
             - inline (list[str]): inline RAG IDs

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -878,16 +878,11 @@ def enrich_solr(  # pylint: disable=too-many-locals
         for vs in ls_config["registered_resources"]["vector_stores"]
     ]
     if constants.SOLR_DEFAULT_VECTOR_STORE_ID not in existing_stores:
-        # Build environment variable expression
-        embedding_model_env = (
-            f"${{env.SOLR_EMBEDDING_MODEL:={constants.SOLR_DEFAULT_EMBEDDING_MODEL}}}"
-        )
-
         ls_config["registered_resources"]["vector_stores"].append(
             {
                 "vector_store_id": constants.SOLR_DEFAULT_VECTOR_STORE_ID,
                 "provider_id": constants.SOLR_PROVIDER_ID,
-                "embedding_model": embedding_model_env,
+                "embedding_model": constants.SOLR_EMBEDDING_MODEL_ID,
                 "embedding_dimension": constants.SOLR_DEFAULT_EMBEDDING_DIMENSION,
             }
         )
@@ -913,7 +908,7 @@ def enrich_solr(  # pylint: disable=too-many-locals
 
         ls_config["registered_resources"]["models"].append(
             {
-                "model_id": "solr_embedding",
+                "model_id": constants.SOLR_EMBEDDING_MODEL_ID,
                 "model_type": "embedding",
                 "provider_id": "sentence-transformers",
                 "provider_model_id": provider_model_env,

--- a/src/models/common/query.py
+++ b/src/models/common/query.py
@@ -144,13 +144,14 @@ class SolrVectorSearchRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    mode: Optional[Literal["semantic", "hybrid", "lexical"]] = Field(
+    mode: Optional[Literal["semantic", "hybrid", "lexical", "keyword"]] = Field(
         None,
         description=(
             "Solr vector_io search mode. When omitted, the server default "
-            f"({SOLR_VECTOR_SEARCH_DEFAULT_MODE!r}) is used."
+            f"({SOLR_VECTOR_SEARCH_DEFAULT_MODE!r}) is used. "
+            "'keyword' and 'lexical' both use BM25 text search."
         ),
-        examples=["hybrid", "semantic", "lexical"],
+        examples=["hybrid", "semantic", "keyword", "lexical"],
     )
     filters: Optional[dict[str, Any]] = Field(
         None,

--- a/src/models/common/query.py
+++ b/src/models/common/query.py
@@ -147,8 +147,8 @@ class SolrVectorSearchRequest(BaseModel):
     mode: Optional[Literal["semantic", "hybrid", "lexical", "keyword"]] = Field(
         None,
         description=(
-            "Solr vector_io search mode. When omitted, the server default "
-            f"({SOLR_VECTOR_SEARCH_DEFAULT_MODE!r}) is used. "
+            "Solr vector_io search mode. When omitted, the configured OKP default "
+            f"is used; otherwise {SOLR_VECTOR_SEARCH_DEFAULT_MODE!r} applies. "
             "'keyword' and 'lexical' both use BM25 text search."
         ),
         examples=["hybrid", "semantic", "keyword", "lexical"],
@@ -207,6 +207,6 @@ class SolrVectorSearchRequest(BaseModel):
         logger.warning(
             "Solr inline RAG: sending filter fields at the top level of `solr` without "
             "`mode` or `filters` is deprecated and will be removed; use "
-            '`{"mode": "<semantic|hybrid|lexical>", "filters": {...}}` instead.'
+            '`{"mode": "<semantic|hybrid|lexical|keyword>", "filters": {...}}` instead.'
         )
         return {"mode": None, "filters": data}

--- a/src/models/common/query.py
+++ b/src/models/common/query.py
@@ -135,7 +135,7 @@ class SolrVectorSearchRequest(BaseModel):
     """LCORE Solr inline RAG options for vector_io.query (mode and provider filters).
 
     Attributes:
-        mode: Solr vector_io search mode. When omitted, the server default (hybrid) is used.
+        mode: Solr vector_io search mode. When omitted, the configured OKP default is used.
         filters: Solr provider filter payload passed through as params['solr'].
 
     Legacy clients may send a plain JSON object with filter keys only;

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -2555,6 +2555,16 @@ class OkpConfiguration(ConfigurationBase):
         "Use Solr boolean syntax, e.g. 'product:ansible AND product:*openshift*'.",
     )
 
+    search_mode: Optional[Literal["semantic", "hybrid", "keyword"]] = Field(
+        default=None,
+        title="OKP search mode",
+        description="Default Solr search mode for OKP queries. "
+        "'keyword' uses BM25 text search (no embedding model needed). "
+        "'hybrid' combines vector + keyword search. "
+        "'semantic' uses pure vector search. "
+        "When unset, falls back to the global default ('hybrid').",
+    )
+
 
 class RerankerConfiguration(ConfigurationBase):
     """Reranker configuration for RAG chunk reranking."""

--- a/src/utils/agents/tool_processor.py
+++ b/src/utils/agents/tool_processor.py
@@ -17,6 +17,7 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.native_tools import FileSearchTool, MCPServerTool, WebSearchTool
 
+import constants
 from constants import DEFAULT_RAG_TOOL
 from log import get_logger
 from models.common.agents import AgentTurnAccumulator
@@ -28,7 +29,7 @@ from models.common.turn_summary import (
     ToolInfoSummary,
     ToolResultSummary,
 )
-from utils.responses import resolve_source_for_result
+from utils.responses import _build_okp_doc_url, resolve_source_for_result
 
 logger = get_logger(__name__)
 
@@ -286,9 +287,17 @@ def build_referenced_document(
         Referenced document when metadata is present, otherwise None.
     """
     attributes = result.attributes or {}
+    resolved_source = resolve_source_for_result(
+        attributes, vector_store_ids, rag_id_mapping
+    )
 
     doc_url = _file_search_attribute_url(attributes)
     doc_title = _file_search_attribute_str(attributes, "title")
+
+    # OKP/Solr chunks need URL construction with the OKP base URL
+    if resolved_source == constants.OKP_RAG_ID:
+        doc_url = _build_okp_doc_url(attributes)
+
     if not (doc_title or doc_url):
         return None
 
@@ -298,7 +307,7 @@ def build_referenced_document(
     return ReferencedDocument(
         doc_url=AnyUrl(doc_url) if doc_url else None,
         doc_title=doc_title,
-        source=resolve_source_for_result(attributes, vector_store_ids, rag_id_mapping),
+        source=resolved_source,
         document_id=doc_id,
     )
 

--- a/src/utils/agents/tool_processor.py
+++ b/src/utils/agents/tool_processor.py
@@ -296,7 +296,7 @@ def build_referenced_document(
 
     # OKP/Solr chunks need URL construction with the OKP base URL
     if resolved_source == constants.OKP_RAG_ID:
-        doc_url = _build_okp_doc_url(attributes)
+        doc_url = _build_okp_doc_url(attributes) or doc_url
 
     if not (doc_title or doc_url):
         return None

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -858,7 +858,7 @@ def _build_okp_doc_url(attributes: dict[str, Any]) -> Optional[str]:
     ``source_path`` (disconnected clusters) and ``reference_url`` (online).
     The chosen relative path is joined with the OKP base URL.
 
-    Args:
+    Parameters:
         attributes: Metadata dict from a file_search result chunk.
 
     Returns:

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -5,6 +5,7 @@
 import json
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional, cast
+from urllib.parse import urljoin
 
 from fastapi import HTTPException
 from ogx_api import OpenAIResponseObject
@@ -850,6 +851,33 @@ def apply_mcp_headers_to_explicit_tools(
     return out
 
 
+def _build_okp_doc_url(attributes: dict[str, Any]) -> Optional[str]:
+    """Build a full OKP document URL from file_search result attributes.
+
+    Uses the ``offline`` flag from OKP configuration to choose between
+    ``source_path`` (disconnected clusters) and ``reference_url`` (online).
+    The chosen relative path is joined with the OKP base URL.
+
+    Args:
+        attributes: Metadata dict from a file_search result chunk.
+
+    Returns:
+        Fully-qualified document URL, or None if no usable path is found.
+    """
+    offline = configuration.okp.offline
+    if offline:
+        reference = attributes.get("source_path") or attributes.get("doc_id")
+    else:
+        reference = attributes.get("reference_url") or attributes.get("doc_id")
+
+    if not reference:
+        return None
+
+    rhokp = configuration.okp.rhokp_url
+    base_url = str(rhokp) if rhokp is not None else constants.RH_SERVER_OKP_DEFAULT_URL
+    return urljoin(base_url, str(reference))
+
+
 def parse_referenced_documents(  # pylint: disable=too-many-locals
     response: Optional[ResponseObject],
     vector_store_ids: Optional[list[str]] = None,
@@ -899,9 +927,12 @@ def parse_referenced_documents(  # pylint: disable=too-many-locals
                 doc_title = attributes.get("title")
                 doc_id = attributes.get("document_id") or attributes.get("doc_id")
 
+                # OKP/Solr chunks use reference_url/source_path instead
+                if not doc_url and resolved_source == constants.OKP_RAG_ID:
+                    doc_url = _build_okp_doc_url(attributes)
+
                 if doc_title or doc_url:
-                    # Treat empty string as None for URL to satisfy Optional[AnyUrl]
-                    final_url = doc_url or None
+                    final_url: Any = doc_url or None
                     if (final_url, doc_title) not in seen_docs:
                         documents.append(
                             ReferencedDocument(

--- a/src/utils/vector_search.py
+++ b/src/utils/vector_search.py
@@ -121,8 +121,11 @@ def _build_query_params(
     resolved_mode = (
         solr.mode
         if solr is not None and solr.mode is not None
-        else constants.SOLR_VECTOR_SEARCH_DEFAULT_MODE
+        else (
+            configuration.okp.search_mode or constants.SOLR_VECTOR_SEARCH_DEFAULT_MODE
+        )
     )
+    resolved_mode = constants.SOLR_SEARCH_MODE_MAP.get(resolved_mode, resolved_mode)
     params: dict[str, Any] = {
         "k": k if k is not None else constants.SOLR_VECTOR_SEARCH_DEFAULT_K,
         "score_threshold": constants.SOLR_VECTOR_SEARCH_DEFAULT_SCORE_THRESHOLD,

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -248,6 +248,7 @@ def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -477,6 +478,7 @@ def test_dump_configuration_valid_values(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -857,6 +859,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -1121,6 +1124,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -1418,6 +1422,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -1642,6 +1647,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -2026,6 +2032,7 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -2256,6 +2263,7 @@ def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -2486,6 +2494,7 @@ def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,
@@ -2723,6 +2732,7 @@ def test_dump_configuration_specific_compaction_values(tmp_path: Path) -> None:
                 "rhokp_url": None,
                 "offline": True,
                 "chunk_filter_query": None,
+                "search_mode": None,
             },
             "rlsapi_v1": {
                 "allow_verbose_infer": False,

--- a/tests/unit/test_llama_stack_configuration.py
+++ b/tests/unit/test_llama_stack_configuration.py
@@ -808,7 +808,7 @@ def test_enrich_solr_adds_embedding_model() -> None:
     enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
 
     model_ids = [m["model_id"] for m in ls_config["registered_resources"]["models"]]
-    assert "solr_embedding" in model_ids
+    assert "sentence-transformers/solr_embedding" in model_ids
 
 
 def test_enrich_solr_skips_duplicate_provider() -> None:

--- a/tests/unit/test_llama_stack_configuration.py
+++ b/tests/unit/test_llama_stack_configuration.py
@@ -884,6 +884,70 @@ def test_enrich_solr_user_chunk_filter_query_is_conjoined() -> None:
     )
 
 
+def test_enrich_solr_sets_default_search_mode_keyword() -> None:
+    """Test enrich_solr propagates search_mode keyword to vector_stores config."""
+    ls_config: dict[str, Any] = {}
+    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "keyword"})
+
+    assert (
+        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        == "keyword"
+    )
+
+
+def test_enrich_solr_sets_default_search_mode_hybrid() -> None:
+    """Test enrich_solr propagates search_mode hybrid to vector_stores config."""
+    ls_config: dict[str, Any] = {}
+    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "hybrid"})
+
+    assert (
+        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        == "hybrid"
+    )
+
+
+def test_enrich_solr_maps_semantic_to_vector() -> None:
+    """Test enrich_solr maps LCORE semantic to OGX vector search mode."""
+    ls_config: dict[str, Any] = {}
+    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "semantic"})
+
+    assert (
+        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        == "vector"
+    )
+
+
+def test_enrich_solr_maps_lexical_to_keyword() -> None:
+    """Test enrich_solr maps LCORE lexical to OGX keyword via SOLR_SEARCH_MODE_MAP."""
+    ls_config: dict[str, Any] = {}
+    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "lexical"})
+
+    assert (
+        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        == "keyword"
+    )
+
+
+def test_enrich_solr_no_search_mode_skips_vector_stores() -> None:
+    """Test enrich_solr does not set vector_stores when search_mode is absent."""
+    ls_config: dict[str, Any] = {}
+    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+
+    assert "vector_stores" not in ls_config
+
+
+def test_enrich_solr_preserves_existing_vector_stores() -> None:
+    """Test enrich_solr preserves existing vector_stores config when adding search_mode."""
+    ls_config: dict[str, Any] = {"vector_stores": {"default_provider_id": "faiss"}}
+    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "keyword"})
+
+    assert ls_config["vector_stores"]["default_provider_id"] == "faiss"
+    assert (
+        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        == "keyword"
+    )
+
+
 # =============================================================================
 # Test enrich_vector_store
 # =============================================================================

--- a/tests/unit/utils/agents/test_tool_processor.py
+++ b/tests/unit/utils/agents/test_tool_processor.py
@@ -343,6 +343,65 @@ class TestBuildReferencedDocument:
         assert doc.doc_url is None
         assert doc.doc_title == "Title Only"
 
+    def test_okp_online_builds_full_url(self, mocker: MockerFixture) -> None:
+        """Test OKP online mode joins reference_url with OKP base URL."""
+        mock_config = mocker.patch("utils.responses.configuration")
+        mock_config.okp.offline = False
+        mock_config.okp.rhokp_url = AnyUrl("https://docs.example.com/")
+
+        result = _file_search_result(
+            attributes={
+                "reference_url": "/en/docs/guide/index",
+                "source_path": "/en/docs/guide/index",
+                "title": "OKP Guide",
+                "source": "okp",
+            }
+        )
+
+        doc = build_referenced_document(result, ["portal-rag"], {"portal-rag": "okp"})
+
+        assert doc is not None
+        assert str(doc.doc_url) == "https://docs.example.com/en/docs/guide/index"
+        assert doc.source == "okp"
+
+    def test_okp_offline_builds_url_from_source_path(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test OKP offline mode uses source_path with OKP base URL."""
+        mock_config = mocker.patch("utils.responses.configuration")
+        mock_config.okp.offline = True
+        mock_config.okp.rhokp_url = AnyUrl("http://localhost:8081/")
+
+        result = _file_search_result(
+            attributes={
+                "reference_url": "https://docs.redhat.com/en/docs/guide/index",
+                "source_path": "/en/docs/guide/index",
+                "title": "OKP Guide",
+                "source": "okp",
+            }
+        )
+
+        doc = build_referenced_document(result, ["portal-rag"], {"portal-rag": "okp"})
+
+        assert doc is not None
+        assert str(doc.doc_url) == "http://localhost:8081/en/docs/guide/index"
+        assert doc.source == "okp"
+
+    def test_non_okp_source_uses_reference_url_directly(self) -> None:
+        """Test non-OKP sources still use reference_url from attribute keys."""
+        result = _file_search_result(
+            attributes={
+                "reference_url": "https://example.com/doc",
+                "title": "Non-OKP Doc",
+            }
+        )
+
+        doc = build_referenced_document(result, ["vs-001"], {"vs-001": "other"})
+
+        assert doc is not None
+        assert str(doc.doc_url) == "https://example.com/doc"
+        assert doc.source == "other"
+
 
 class TestReferencedDocumentsFromFileSearchResults:
     """Tests for referenced_documents_from_file_search_results."""

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -69,6 +69,7 @@ from models.config import (
 from utils.query import normalize_vertex_ai_model_id
 from utils.responses import (
     _build_chunk_attributes,
+    _build_okp_doc_url,
     _merge_tools,
     build_mcp_tool_call_from_arguments_done,
     build_tool_call_summary,
@@ -3144,6 +3145,237 @@ class TestParseReferencedDocumentsWithSource:
 
         assert len(docs) == 1
         assert docs[0].source is None
+
+
+class TestBuildOkpDocUrl:
+    """Tests for _build_okp_doc_url OKP URL construction."""
+
+    def test_online_mode_uses_reference_url(self, mocker: MockerFixture) -> None:
+        """Test that online mode (offline=False) uses reference_url."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = False
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        url = _build_okp_doc_url(
+            {
+                "reference_url": "/docs/pipelines/config.html",
+                "source_path": "pipelines/config.html",
+            }
+        )
+        assert url == "https://docs.openshift.com/docs/pipelines/config.html"
+
+    def test_offline_mode_uses_source_path(self, mocker: MockerFixture) -> None:
+        """Test that offline mode (offline=True) uses source_path."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = True
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        url = _build_okp_doc_url(
+            {
+                "reference_url": "/docs/pipelines/config.html",
+                "source_path": "pipelines/config.html",
+            }
+        )
+        assert url == "https://docs.openshift.com/pipelines/config.html"
+
+    def test_online_falls_back_to_doc_id(self, mocker: MockerFixture) -> None:
+        """Test online mode falls back to doc_id when reference_url is absent."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = False
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        url = _build_okp_doc_url({"doc_id": "some-doc-id"})
+        assert url == "https://docs.openshift.com/some-doc-id"
+
+    def test_offline_falls_back_to_doc_id(self, mocker: MockerFixture) -> None:
+        """Test offline mode falls back to doc_id when source_path is absent."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = True
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        url = _build_okp_doc_url({"doc_id": "some-doc-id"})
+        assert url == "https://docs.openshift.com/some-doc-id"
+
+    def test_returns_none_when_no_reference(self, mocker: MockerFixture) -> None:
+        """Test returns None when no reference_url, source_path, or doc_id."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = False
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        url = _build_okp_doc_url({"title": "Some Doc"})
+        assert url is None
+
+    def test_uses_default_url_when_rhokp_url_is_none(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test uses RH_SERVER_OKP_DEFAULT_URL when rhokp_url is not configured."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = False
+        mock_okp.rhokp_url = None
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        url = _build_okp_doc_url({"reference_url": "/docs/page.html"})
+        assert url == "http://localhost:8081/docs/page.html"
+
+
+class TestParseReferencedDocumentsOkp:
+    """Tests for parse_referenced_documents with OKP/Solr file_search results."""
+
+    def test_okp_online_builds_full_url(self, mocker: MockerFixture) -> None:
+        """Test OKP result builds full URL from reference_url in online mode."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = False
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        mock_result = mocker.Mock()
+        mock_result.attributes = {
+            "reference_url": "/docs/pipelines/config.html",
+            "source_path": "pipelines/config.html",
+            "title": "Pipeline Config",
+            "doc_id": "doc-001",
+            "source": "okp",
+        }
+
+        mock_output = mocker.Mock()
+        mock_output.type = "file_search_call"
+        mock_output.results = [mock_result]
+
+        mock_response = mocker.Mock()
+        mock_response.output = [mock_output]
+
+        docs = parse_referenced_documents(
+            mock_response,
+            vector_store_ids=["portal-rag"],
+            rag_id_mapping={"portal-rag": "okp"},
+        )
+
+        assert len(docs) == 1
+        assert (
+            str(docs[0].doc_url)
+            == "https://docs.openshift.com/docs/pipelines/config.html"
+        )
+        assert docs[0].doc_title == "Pipeline Config"
+        assert docs[0].source == "okp"
+
+    def test_okp_offline_builds_url_from_source_path(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test OKP result builds URL from source_path in offline mode."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = True
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        mock_result = mocker.Mock()
+        mock_result.attributes = {
+            "reference_url": "/docs/pipelines/config.html",
+            "source_path": "pipelines/config.html",
+            "title": "Pipeline Config",
+            "doc_id": "doc-001",
+            "source": "okp",
+        }
+
+        mock_output = mocker.Mock()
+        mock_output.type = "file_search_call"
+        mock_output.results = [mock_result]
+
+        mock_response = mocker.Mock()
+        mock_response.output = [mock_output]
+
+        docs = parse_referenced_documents(
+            mock_response,
+            vector_store_ids=["portal-rag"],
+            rag_id_mapping={"portal-rag": "okp"},
+        )
+
+        assert len(docs) == 1
+        assert (
+            str(docs[0].doc_url) == "https://docs.openshift.com/pipelines/config.html"
+        )
+        assert docs[0].source == "okp"
+
+    def test_okp_multistore_detected_via_source_attribute(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test OKP detected in multi-store scenario via source attribute."""
+        mock_okp = mocker.Mock()
+        mock_okp.offline = False
+        mock_okp.rhokp_url = "https://docs.openshift.com"
+        mock_config = mocker.Mock()
+        mock_config.okp = mock_okp
+        mocker.patch("utils.responses.configuration", mock_config)
+
+        mock_result = mocker.Mock()
+        mock_result.attributes = {
+            "reference_url": "/docs/builds.html",
+            "title": "Builds",
+            "source": "okp",
+        }
+
+        mock_output = mocker.Mock()
+        mock_output.type = "file_search_call"
+        mock_output.results = [mock_result]
+
+        mock_response = mocker.Mock()
+        mock_response.output = [mock_output]
+
+        docs = parse_referenced_documents(
+            mock_response,
+            vector_store_ids=["portal-rag", "byok-store"],
+            rag_id_mapping={"portal-rag": "okp", "byok-store": "my-docs"},
+        )
+
+        assert len(docs) == 1
+        assert str(docs[0].doc_url) == "https://docs.openshift.com/docs/builds.html"
+        assert docs[0].source == "okp"
+
+    def test_non_okp_result_unaffected(self, mocker: MockerFixture) -> None:
+        """Test non-OKP results still use existing doc_url/url attribute lookup."""
+        mock_result = mocker.Mock()
+        mock_result.attributes = {
+            "url": "https://example.com/byok-doc",
+            "title": "BYOK Doc",
+            "document_id": "byok-001",
+        }
+
+        mock_output = mocker.Mock()
+        mock_output.type = "file_search_call"
+        mock_output.results = [mock_result]
+
+        mock_response = mocker.Mock()
+        mock_response.output = [mock_output]
+
+        docs = parse_referenced_documents(
+            mock_response,
+            vector_store_ids=["byok-store"],
+            rag_id_mapping={"byok-store": "my-docs"},
+        )
+
+        assert len(docs) == 1
+        assert str(docs[0].doc_url) == "https://example.com/byok-doc"
+        assert docs[0].source == "my-docs"
 
 
 class TestGetRAGToolsWithConfig:

--- a/tests/unit/utils/test_vector_search.py
+++ b/tests/unit/utils/test_vector_search.py
@@ -162,7 +162,16 @@ class TestBuildQueryParams:
         solr = SolrVectorSearchRequest(mode="lexical")
         params = _build_query_params(solr=solr)
 
-        assert params["mode"] == "lexical"
+        # "lexical" is translated to "keyword" for Llama Stack dispatch
+        assert params["mode"] == "keyword"
+        assert "solr" not in params
+
+    def test_keyword_mode_direct(self) -> None:
+        """Request mode 'keyword' is passed through unchanged."""
+        solr = SolrVectorSearchRequest(mode="keyword")
+        params = _build_query_params(solr=solr)
+
+        assert params["mode"] == "keyword"
         assert "solr" not in params
 
     def test_mode_with_solr_filters(self) -> None:
@@ -185,6 +194,60 @@ class TestBuildQueryParams:
 
         assert params["mode"] == constants.SOLR_VECTOR_SEARCH_DEFAULT_MODE
         assert params["solr"] == {"fq": ["product:*openshift*"]}
+
+    def test_config_search_mode_keyword(self, mocker: MockerFixture) -> None:
+        """OKP config search_mode is used when no per-request mode is set."""
+        config_mock = mocker.Mock(spec=AppConfig)
+        config_mock.okp.search_mode = "keyword"
+        mocker.patch("utils.vector_search.configuration", config_mock)
+
+        params = _build_query_params()
+
+        assert params["mode"] == "keyword"
+
+    def test_config_search_mode_semantic(self, mocker: MockerFixture) -> None:
+        """OKP config search_mode 'semantic' is used as default."""
+        config_mock = mocker.Mock(spec=AppConfig)
+        config_mock.okp.search_mode = "semantic"
+        mocker.patch("utils.vector_search.configuration", config_mock)
+
+        params = _build_query_params()
+
+        assert params["mode"] == "semantic"
+
+    def test_per_request_mode_overrides_config(self, mocker: MockerFixture) -> None:
+        """Per-request solr mode takes precedence over OKP config default."""
+        config_mock = mocker.Mock(spec=AppConfig)
+        config_mock.okp.search_mode = "keyword"
+        mocker.patch("utils.vector_search.configuration", config_mock)
+
+        solr = SolrVectorSearchRequest(mode="semantic")
+        params = _build_query_params(solr=solr)
+
+        assert params["mode"] == "semantic"
+
+    def test_no_config_no_request_mode_uses_global_default(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Without config or per-request mode, global default is used."""
+        config_mock = mocker.Mock(spec=AppConfig)
+        config_mock.okp.search_mode = None
+        mocker.patch("utils.vector_search.configuration", config_mock)
+
+        params = _build_query_params()
+
+        assert params["mode"] == constants.SOLR_VECTOR_SEARCH_DEFAULT_MODE
+
+    def test_lexical_config_translated_to_keyword(self, mocker: MockerFixture) -> None:
+        """Per-request 'lexical' is translated to 'keyword' even with config set."""
+        config_mock = mocker.Mock(spec=AppConfig)
+        config_mock.okp.search_mode = "hybrid"
+        mocker.patch("utils.vector_search.configuration", config_mock)
+
+        solr = SolrVectorSearchRequest(mode="lexical")
+        params = _build_query_params(solr=solr)
+
+        assert params["mode"] == "keyword"
 
 
 class TestExtractByokRagChunks:


### PR DESCRIPTION
## Description

Fixes and enhances OKP (Offline Knowledge Portal) integration across both `rag.tool` and `rag.inline` paths, and adds air-gap support via BM25 keyword search.

## What changed

### 1. Fix OKP citation URLs for `rag.tool` path
Previously, OKP citation URLs only worked in the `rag.inline` path. The `rag.tool` path (Responses API / `file_search`) was broken because:
- The tool path looked for `doc_url` in result attributes, but Solr provider returns `reference_url` and `source_path` instead
- No OKP-specific URL construction existed in the tool path — `reference_url` is origin-relative, not a full URL

**Fix:** Added OKP URL building to both `rag.tool` (`src/utils/responses.py`, `src/utils/agents/tool_processor.py`) and `rag.inline` paths, supporting both offline (localhost) and online (docs.redhat.com) modes.

### 2. Fix `lexical` → `keyword` search mode translation
The Solr provider internally used the term `lexical` for BM25 search, but LCORE config exposed it as `keyword` (more user-friendly). This mismatch meant BM25 mode was silently broken — requests with `search_mode: keyword` would not translate correctly to the Solr provider.

**Fix:** Added mode translation in `src/utils/vector_search.py` so `keyword` maps correctly to the Solr provider's `lexical` mode.

### 3. Add configurable `search_mode` for air-gap deployments
In air-gapped environments, users cannot download embedding models from HuggingFace. Previously there was no way to configure the search mode — it always defaulted to vector/hybrid search which requires an embedding model.

**Fix:** Added `search_mode` field to `OkpConfiguration` with three options:
- `vector` (default) — semantic search, requires embedding model
- `keyword` — BM25 text search, **no embedding model needed** (air-gap friendly)
- `hybrid` — combines both

Also added per-request `search_mode` override in query request models.

### 4. Fix Solr embedding model registration prefix
The Solr embedding model was registered as `solr_embedding`, but the `sentence-transformers` inference provider expects the `sentence-transformers/` prefix.

**Fix:** Added `SOLR_EMBEDDING_MODEL_ID` constant (`sentence-transformers/solr_embedding`) in `src/constants.py` and used it consistently in `src/llama_stack_configuration.py` for model and vector store registration.

### 5. Update providers submodule + Containerfile pin
Updated to include merged [lightspeed-providers PR #160](https://github.com/lightspeed-core/lightspeed-providers/pull/160) which migrates the Solr vector_io provider from `llama_stack` to `ogx` imports (`faf6a89`).

### 6. Regenerated OpenAPI schema + updated tests
- Regenerated `docs/devel_doc/openapi.json` to include new `search_mode` field
- Updated 10 config dump test assertions and Solr enrichment test for new model ID prefix

### 7. Propagate `search_mode` to OGX for `rag.tool` keyword search
Previously, `search_mode: keyword` only affected the `rag.inline` path. The `rag.tool` path (file_search via Responses API) always defaulted to vector similarity search because OGX's `default_search_mode` config was never set by LCORE.

**Fix:** `enrich_solr()` now reads `search_mode` from the OKP config and sets `vector_stores.chunk_retrieval_params.default_search_mode` in the OGX top-level config. OGX auto-injects this into both the file_search tool runtime and responses provider, so both rag paths now respect `search_mode: keyword`. This is critical for air-gap environments where no embedding model is available.

## Air-gap scenario

With `search_mode: keyword`, OKP uses Solr BM25 text search — no embedding model is downloaded or needed. This works for **both** `rag.tool` and `rag.inline` paths:

```yaml
# rag.tool — air-gap with keyword search (Responses API / file_search)
rag:
  tool:
    - okp
okp:
  rhokp_url: http://my-okp-instance:8080
  offline: true
  search_mode: keyword
```

```yaml
# rag.inline — air-gap with keyword search (streaming_query)
rag:
  inline:
    - okp
okp:
  rhokp_url: http://my-okp-instance:8080
  offline: true
  search_mode: keyword
```

**Tradeoff:** Keyword search returns less precise document references than hybrid/semantic (matches on term frequency, not meaning), but the LLM answer quality is still good. For air-gapped deployments, this is the acceptable tradeoff to avoid the HuggingFace dependency.


## Type of change

- [ ] Refactor
- [x] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Code (Claude Opus 4.6)
- Generated by: N/A

## Related Tickets & Documents

- Related Issue: https://redhat.atlassian.net/browse/RHIDP-14130
- Related PR: https://github.com/lightspeed-core/lightspeed-providers/pull/160

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## How to test

### 1. Automated tests
```bash
uv sync --group dev --group llslibdev
uv run make test-unit       # 3157 tests, all passing
uv run make verify           # linters + type checks
```

### 2. Verify OpenAPI schema is up to date
```bash
uv run scripts/generate_openapi_schema.py
diff <(cat docs/devel_doc/openapi.json) <(cat /tmp/openapi.json)  # should be empty
```

### 3. Test `search_mode` config parsing (manual)
Add `search_mode` to any config that has an `okp:` section:
```yaml
okp:
  rhokp_url: http://my-okp-instance:8080
  offline: true
  search_mode: keyword   # new field: vector (default), keyword, or hybrid
```
Start the service — it should boot without errors. Invalid values (e.g. `search_mode: foo`) should be rejected by Pydantic validation.

### 4. Test with a local OKP instance (optional, requires OKP/Solr)
If you have a running OKP instance, you can test all RAG + search_mode combinations:

**rag.tool (default vector search via Responses API):**
```yaml
rag:
  tool:
    - okp
okp:
  rhokp_url: http://localhost:8080
  offline: true
```
Ask a question via the Responses API — the `file_search` tool should return OKP chunks with `reference_url` links. The embedding model will be downloaded.

**rag.tool + keyword (air-gap simulation via Responses API):**
```yaml
rag:
  tool:
    - okp
okp:
  rhokp_url: http://localhost:8080
  offline: true
  search_mode: keyword
```
Ask a question via the Responses API — `file_search` should return OKP chunks using BM25 keyword search. No embedding model should be downloaded (check `~/.cache/huggingface/hub/` is empty).

**rag.inline + keyword (air-gap simulation via streaming_query):**
```yaml
rag:
  inline:
    - okp
okp:
  rhokp_url: http://localhost:8080
  offline: true
  search_mode: keyword
```
Ask a question via `streaming_query` — OKP results should come back using BM25 keyword search. No embedding model should be downloaded.

### 5. What was tested locally and on OpenShift

**Local testing (all 4 scenarios):**

| Test | Config | Result |
|------|--------|--------|
| rag.tool (default vector) | `rag.tool: [okp]` | 10 OKP sources, embedding model downloaded |
| rag.tool + keyword | `rag.tool: [okp]` + `search_mode: keyword` | 10 OKP sources, **no embedding model** |
| rag.inline + keyword | `rag.inline: [okp]` + `search_mode: keyword` | 3 OKP sources, **no embedding model** |
| rag.inline (default) | `rag.inline: [okp]` | OKP sources with hybrid search |

**OpenShift testing (RHDH + OKP on OpenShift cluster with Solr, unified synthesis mode):**

Air-gap verification: with `search_mode: keyword`, the container's HuggingFace cache (`/tmp/hf_cache/`) does not exist — confirming no embedding model was downloaded. Without keyword mode, the cache contains the expected embedding model.

| Test | Config | Result | Air-gap safe |
|------|--------|--------|:------------:|
| rag.tool (default vector) | `rag.tool: [okp]` | 10 OKP sources with valid docs.redhat.com URLs, embedding model downloaded | No |
| rag.tool + keyword | `rag.tool: [okp]` + `search_mode: keyword` | 10 OKP sources with valid docs.redhat.com URLs, **no embedding model downloaded** | **Yes** |
| rag.inline + keyword | `rag.inline: [okp]` + `search_mode: keyword` | OKP sources returned via BM25 search, **no embedding model downloaded** | **Yes** |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable OKP search modes: semantic, hybrid, and keyword.
  - Added keyword search support for Solr vector queries, including BM25 behavior.
  - Added automatic search-mode defaults and terminology mapping.
  - Improved referenced-document links for OKP and Solr results, including offline configurations.
  - Updated API documentation with the new search options and defaults.

- **Tests**
  - Expanded coverage for search modes, configuration behavior, and document URL generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->