### PR TITLE
LCORE-1627: fix e2e proxy teardown asyncio task warnings

### DIFF
--- a/tests/e2e/features/steps/proxy.py
+++ b/tests/e2e/features/steps/proxy.py
@@ -286,7 +286,11 @@ def _stop_proxy(context: Context, attr: str, loop_attr: str) -> None:
         except Exception:
             pass
         loop.call_soon_threadsafe(loop.stop)
-        time.sleep(0.5)
+        thread = getattr(proxy, "_thread", None)
+        if thread is not None:
+            thread.join(timeout=30)
+        else:
+            time.sleep(0.5)
     if hasattr(context, attr):
         delattr(context, attr)
     if hasattr(context, loop_attr):
@@ -368,10 +372,21 @@ def start_tunnel_proxy(context: Context, port: int) -> None:
 
     def run_proxy() -> None:
         asyncio.set_event_loop(loop)
-        loop.run_until_complete(proxy.start())
-        loop.run_forever()
+        try:
+            loop.run_until_complete(proxy.start())
+            loop.run_forever()
+        finally:
+            # Cancel leftover handler tasks so the loop can close cleanly.
+            if pending := asyncio.all_tasks(loop):
+                for task in pending:
+                    task.cancel()
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.close()
 
     thread = threading.Thread(target=run_proxy, daemon=True)
+    proxy._thread = thread
     thread.start()
     time.sleep(1)
 
@@ -463,10 +478,21 @@ def start_interception_proxy(context: Context, port: int) -> None:
 
     def run_proxy() -> None:
         asyncio.set_event_loop(loop)
-        loop.run_until_complete(proxy.start())
-        loop.run_forever()
+        try:
+            loop.run_until_complete(proxy.start())
+            loop.run_forever()
+        finally:
+            # Cancel leftover handler tasks so the loop can close cleanly.
+            if pending := asyncio.all_tasks(loop):
+                for task in pending:
+                    task.cancel()
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            loop.close()
 
     thread = threading.Thread(target=run_proxy, daemon=True)
+    proxy._thread = thread
     thread.start()
     time.sleep(1)
 

--- a/tests/e2e/proxy/interception_proxy.py
+++ b/tests/e2e/proxy/interception_proxy.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import logging
 import ssl
+import threading
 from pathlib import Path
 from typing import Any, Optional
 
@@ -39,7 +40,7 @@ ALTERNATE_INTERCEPTION_PROXY_PORT = 8890
 IN_CLUSTER_CA_CERT_PATH = Path("/tmp/interception-proxy-ca.pem")
 
 
-class InterceptionProxy:
+class InterceptionProxy:  # pylint: disable=too-many-instance-attributes
     """Async TLS-intercepting proxy for testing.
 
     Attributes:
@@ -64,6 +65,7 @@ class InterceptionProxy:
         self.connect_count = 0
         self._server: Optional[asyncio.Server] = None
         self._handler_tasks: set[asyncio.Task[Any]] = set()
+        self._thread: Optional[threading.Thread] = None
 
     def _make_server_ssl_context(self, hostname: str) -> ssl.SSLContext:
         """Create an SSL context with a certificate for the given hostname.

--- a/tests/e2e/proxy/tunnel_proxy.py
+++ b/tests/e2e/proxy/tunnel_proxy.py
@@ -21,6 +21,7 @@ In-cluster (Konflux/Prow) usage::
 import asyncio
 import json
 import logging
+import threading
 from typing import Any, Optional
 
 # In-cluster defaults (``python tunnel_proxy.py``).
@@ -48,6 +49,7 @@ class TunnelProxy:
         self.last_connect_target: Optional[str] = None
         self._server: Optional[asyncio.Server] = None
         self._handler_tasks: set[asyncio.Task[Any]] = set()
+        self._thread: Optional[threading.Thread] = None
 
     async def _handle_client(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter


### PR DESCRIPTION
## Description
- E2e tunnel/interception proxies run on a background thread with an asyncio loop.
- On stop we used to call `loop.stop()` and then `sleep(0.5)`, without waiting for the thread or closing the loop.
- Leftover connection-handler tasks were still pending when the loop was garbage-collected, which logged:
  `Task was destroyed but it is pending!`

## Fix
- Keep the proxy thread on `proxy._thread` and `join` it on stop (wait until it really finished, instead of guessing with sleep).
- When the thread exits, cancel any remaining tasks and close the loop in a `finally` block.

## Why this is safer
- `join` waits for real cleanup; `sleep(0.5)` might be too short.
- Closing the loop only after tasks are cancelled avoids abandoning work for the garbage collector.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-1627

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy shutdown reliability by ensuring background activity is stopped cleanly.
  * Reduced the likelihood of lingering connections, tasks, or processes after proxy shutdown.
  * Added a controlled wait during shutdown so proxy-based testing completes more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->