### PR TITLE
RHIDP-14083: extend customization profile for safety shield prompts

### DIFF
--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -1440,7 +1440,7 @@
                                             "config": {
                                                 "invalid_question_response": "I can only answer questions about the product.",
                                                 "model_id": "openai/gpt-4o-mini",
-                                                "model_prompt": "Is this question valid?"
+                                                "model_prompt": "Is this question valid? ${message}"
                                             },
                                             "name": "question-validity",
                                             "provider_id": "question_validity",
@@ -14054,7 +14054,34 @@
                         "type": "object",
                         "title": "System prompts",
                         "description": "Dictionary containing map of system prompts",
-                        "default": {}
+                        "default": {},
+                        "readOnly": true
+                    },
+                    "validation": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Question validity classifier prompt",
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt.",
+                        "readOnly": true
+                    },
+                    "invalid_resp": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Invalid question response",
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response.",
+                        "readOnly": true
                     }
                 },
                 "type": "object",
@@ -18988,16 +19015,28 @@
                         "description": "The model_id to use for the guard"
                     },
                     "model_prompt": {
-                        "type": "string",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Model prompt",
-                        "description": "The default prompt sent to the LLM used to validate the Users' question.",
-                        "default": "\nInstructions:\n- You are a question classifying tool\n- You are an expert in kubernetes and openshift\n- Your job is to determine where or a user's question is related to kubernetes and/or openshift technologies and to provide a one-word response.\n- If a question appears to be related to kubernetes or openshift technologies, answer with the word ${allowed}, otherwise answer with the word ${rejected}.\n- Do not explain your answer, just provide the one-word response. Do not give any other response.\n- If the given question is an empty string, answer with the word ${rejected}\n\n\nExample Question:\nWhy is the sky blue?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is the grass green?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is sand yellow?\nExample Response:\n${rejected}\n\nExample Question:\nCan you help configure my cluster to automatically scale?\nExample Response:\n${allowed}\n\nQuestion:\n${message}\nResponse:\n"
+                        "description": "Classifier prompt for the agent / wrap_run path. Null/omitted at load is filled from the profile module's system_prompts.validation, then the LCORE default; an explicit empty string is kept. Include $message or ${message} so the user question is substituted. Not used by responses-path run(), which sends raw user input."
                     },
                     "invalid_question_response": {
-                        "type": "string",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Invalid question response",
-                        "description": "The default response when the Users' question is determined to be invalid.",
-                        "default": "\nHi, I'm the OpenShift Lightspeed assistant, I can help you with questions about OpenShift, \nplease ask me a question related to OpenShift.\n"
+                        "description": "Refusal text used on both agent and responses / run() paths. Null/omitted at load is filled from the profile module's query_responses.invalid_resp, then the LCORE default; an explicit empty string is kept."
                     }
                 },
                 "additionalProperties": false,
@@ -21417,7 +21456,7 @@
                                 "config": {
                                     "invalid_question_response": "I can only answer questions about the product.",
                                     "model_id": "openai/gpt-4o-mini",
-                                    "model_prompt": "Is this question valid?"
+                                    "model_prompt": "Is this question valid? ${message}"
                                 },
                                 "name": "question-validity",
                                 "provider_id": "question_validity",

--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -1440,7 +1440,7 @@
                                             "config": {
                                                 "invalid_question_response": "I can only answer questions about the product.",
                                                 "model_id": "openai/gpt-4o-mini",
-                                                "model_prompt": "Is this question valid?"
+                                                "model_prompt": "Is this question valid? ${message}"
                                             },
                                             "name": "question-validity",
                                             "provider_id": "question_validity",
@@ -14045,7 +14045,34 @@
                         "type": "object",
                         "title": "System prompts",
                         "description": "Dictionary containing map of system prompts",
-                        "default": {}
+                        "default": {},
+                        "readOnly": true
+                    },
+                    "validation": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Question validity classifier prompt",
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt.",
+                        "readOnly": true
+                    },
+                    "invalid_resp": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Invalid question response",
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response.",
+                        "readOnly": true
                     }
                 },
                 "type": "object",
@@ -18996,16 +19023,28 @@
                         "description": "The model_id to use for the guard"
                     },
                     "model_prompt": {
-                        "type": "string",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Model prompt",
-                        "description": "The default prompt sent to the LLM used to validate the Users' question.",
-                        "default": "\nInstructions:\n- You are a question classifying tool\n- You are an expert in Kubernetes and OpenShift\n- Your job is to determine where or a user's question is related to Kubernetes and/or OpenShift technologies and to provide a one-word response.\n- If a question appears to be related to Kubernetes or OpenShift technologies, answer with the word ${allowed}, otherwise answer with the word ${rejected}.\n- Do not explain your answer, just provide the one-word response. Do not give any other response.\n- If the given question is an empty string, answer with the word ${rejected}\n\n\nExample Question:\nWhy is the sky blue?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is the grass green?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is sand yellow?\nExample Response:\n${rejected}\n\nExample Question:\nCan you help configure my cluster to automatically scale?\nExample Response:\n${allowed}\n\nQuestion:\n${message}\nResponse:\n"
+                        "description": "Classifier prompt for the agent / wrap_run path. Null/omitted at load is filled from the profile module's system_prompts.validation, then the LCORE default; an explicit empty string is kept. Include $message or ${message} so the user question is substituted. Not used by responses-path run(), which sends raw user input."
                     },
                     "invalid_question_response": {
-                        "type": "string",
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
                         "title": "Invalid question response",
-                        "description": "The default response when the Users' question is determined to be invalid.",
-                        "default": "\nHi, I'm the OpenShift Lightspeed assistant, I can help you with questions about OpenShift, \nplease ask me a question related to OpenShift.\n"
+                        "description": "Refusal text used on both agent and responses / run() paths. Null/omitted at load is filled from the profile module's query_responses.invalid_resp, then the LCORE default; an explicit empty string is kept."
                     }
                 },
                 "additionalProperties": false,
@@ -21633,7 +21672,7 @@
                                 "config": {
                                     "invalid_question_response": "I can only answer questions about the product.",
                                     "model_id": "openai/gpt-4o-mini",
-                                    "model_prompt": "Is this question valid?"
+                                    "model_prompt": "Is this question valid? ${message}"
                                 },
                                 "name": "question-validity",
                                 "provider_id": "question_validity",

--- a/docs/models/successful_responses.json
+++ b/docs/models/successful_responses.json
@@ -1559,8 +1559,25 @@
                         },
                         "default": {},
                         "description": "Dictionary containing map of system prompts",
+                        "readOnly": true,
                         "title": "System prompts",
                         "type": "object"
+                    },
+                    "validation": {
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt.",
+                        "readOnly": true,
+                        "title": "Question validity classifier prompt"
+                    },
+                    "invalid_resp": {
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response.",
+                        "readOnly": true,
+                        "title": "Invalid question response"
                     }
                 },
                 "required": [
@@ -4517,16 +4534,18 @@
                         "type": "string"
                     },
                     "model_prompt": {
-                        "default": "\nInstructions:\n- You are a question classifying tool\n- You are an expert in kubernetes and openshift\n- Your job is to determine where or a user's question is related to kubernetes and/or openshift technologies and to provide a one-word response.\n- If a question appears to be related to kubernetes or openshift technologies, answer with the word ${allowed}, otherwise answer with the word ${rejected}.\n- Do not explain your answer, just provide the one-word response. Do not give any other response.\n- If the given question is an empty string, answer with the word ${rejected}\n\n\nExample Question:\nWhy is the sky blue?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is the grass green?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is sand yellow?\nExample Response:\n${rejected}\n\nExample Question:\nCan you help configure my cluster to automatically scale?\nExample Response:\n${allowed}\n\nQuestion:\n${message}\nResponse:\n",
-                        "description": "The default prompt sent to the LLM used to validate the Users' question.",
-                        "title": "Model prompt",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Classifier prompt for the agent / wrap_run path. Null/omitted at load is filled from the profile module's system_prompts.validation, then the LCORE default; an explicit empty string is kept. Include $message or ${message} so the user question is substituted. Not used by responses-path run(), which sends raw user input.",
+                        "title": "Model prompt"
                     },
                     "invalid_question_response": {
-                        "default": "\nHi, I'm the OpenShift Lightspeed assistant, I can help you with questions about OpenShift, \nplease ask me a question related to OpenShift.\n",
-                        "description": "The default response when the Users' question is determined to be invalid.",
-                        "title": "Invalid question response",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Refusal text used on both agent and responses / run() paths. Null/omitted at load is filled from the profile module's query_responses.invalid_resp, then the LCORE default; an explicit empty string is kept.",
+                        "title": "Invalid question response"
                     }
                 },
                 "required": [
@@ -5926,7 +5945,7 @@
                                 "config": {
                                     "invalid_question_response": "I can only answer questions about the product.",
                                     "model_id": "openai/gpt-4o-mini",
-                                    "model_prompt": "Is this question valid?"
+                                    "model_prompt": "Is this question valid? ${message}"
                                 },
                                 "name": "question-validity",
                                 "provider_id": "question_validity",

--- a/docs/models/successful_responses.json
+++ b/docs/models/successful_responses.json
@@ -1501,8 +1501,25 @@
                         },
                         "default": {},
                         "description": "Dictionary containing map of system prompts",
+                        "readOnly": true,
                         "title": "System prompts",
                         "type": "object"
+                    },
+                    "validation": {
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt.",
+                        "readOnly": true,
+                        "title": "Question validity classifier prompt"
+                    },
+                    "invalid_resp": {
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response.",
+                        "readOnly": true,
+                        "title": "Invalid question response"
                     }
                 },
                 "required": [
@@ -4483,16 +4500,18 @@
                         "type": "string"
                     },
                     "model_prompt": {
-                        "default": "\nInstructions:\n- You are a question classifying tool\n- You are an expert in Kubernetes and OpenShift\n- Your job is to determine where or a user's question is related to Kubernetes and/or OpenShift technologies and to provide a one-word response.\n- If a question appears to be related to Kubernetes or OpenShift technologies, answer with the word ${allowed}, otherwise answer with the word ${rejected}.\n- Do not explain your answer, just provide the one-word response. Do not give any other response.\n- If the given question is an empty string, answer with the word ${rejected}\n\n\nExample Question:\nWhy is the sky blue?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is the grass green?\nExample Response:\n${rejected}\n\nExample Question:\nWhy is sand yellow?\nExample Response:\n${rejected}\n\nExample Question:\nCan you help configure my cluster to automatically scale?\nExample Response:\n${allowed}\n\nQuestion:\n${message}\nResponse:\n",
-                        "description": "The default prompt sent to the LLM used to validate the Users' question.",
-                        "title": "Model prompt",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Classifier prompt for the agent / wrap_run path. Null/omitted at load is filled from the profile module's system_prompts.validation, then the LCORE default; an explicit empty string is kept. Include $message or ${message} so the user question is substituted. Not used by responses-path run(), which sends raw user input.",
+                        "title": "Model prompt"
                     },
                     "invalid_question_response": {
-                        "default": "\nHi, I'm the OpenShift Lightspeed assistant, I can help you with questions about OpenShift, \nplease ask me a question related to OpenShift.\n",
-                        "description": "The default response when the Users' question is determined to be invalid.",
-                        "title": "Invalid question response",
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true,
+                        "default": null,
+                        "description": "Refusal text used on both agent and responses / run() paths. Null/omitted at load is filled from the profile module's query_responses.invalid_resp, then the LCORE default; an explicit empty string is kept.",
+                        "title": "Invalid question response"
                     }
                 },
                 "required": [
@@ -6075,7 +6094,7 @@
                                 "config": {
                                     "invalid_question_response": "I can only answer questions about the product.",
                                     "model_id": "openai/gpt-4o-mini",
-                                    "model_prompt": "Is this question valid?"
+                                    "model_prompt": "Is this question valid? ${message}"
                                 },
                                 "name": "question-validity",
                                 "provider_id": "question_validity",

--- a/docs/models/successful_responses.md
+++ b/docs/models/successful_responses.md
@@ -586,6 +586,8 @@ Custom profile customization for prompts and validation.
 |-------|------|-------------|
 | path | string | Path to Python modules containing custom profile. |
 | prompts | object | Dictionary containing map of system prompts |
+| validation | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt. |
+| invalid_resp | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response. |
 
 
 ## Customization
@@ -1970,8 +1972,8 @@ Configuration for the question validity guardrail.
 | Field | Type | Description |
 |-------|------|-------------|
 | model_id | string | The model_id to use for the guard |
-| model_prompt | string | The default prompt sent to the LLM used to validate the Users' question. |
-| invalid_question_response | string | The default response when the Users' question is determined to be invalid. |
+| model_prompt | string | Classifier prompt for the agent / wrap_run path. Null/omitted at load is filled from the profile module's system_prompts.validation, then the LCORE default; an explicit empty string is kept. Include $message or ${message} so the user question is substituted. Not used by responses-path run(), which sends raw user input. |
+| invalid_question_response | string | Refusal text used on both agent and responses / run() paths. Null/omitted at load is filled from the profile module's query_responses.invalid_resp, then the LCORE default; an explicit empty string is kept. |
 
 
 ## QuestionValidityShieldConfiguration

--- a/docs/models/successful_responses.md
+++ b/docs/models/successful_responses.md
@@ -592,8 +592,8 @@ Custom profile customization for prompts and validation.
 |-------|------|-------------|
 | path | string | Path to Python modules containing custom profile. |
 | prompts | object | Dictionary containing map of system prompts |
-| validation | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt. |
-| invalid_resp | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response. |
+| validation | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG["system_prompts"]["validation"]), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt. |
+| invalid_resp | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG["query_responses"]["invalid_resp"]), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response. |
 
 
 ## Customization

--- a/docs/models/successful_responses.md
+++ b/docs/models/successful_responses.md
@@ -586,8 +586,8 @@ Custom profile customization for prompts and validation.
 |-------|------|-------------|
 | path | string | Path to Python modules containing custom profile. |
 | prompts | object | Dictionary containing map of system prompts |
-| validation | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt. |
-| invalid_resp | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response. |
+| validation | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG["system_prompts"]["validation"]), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt. |
+| invalid_resp | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG["query_responses"]["invalid_resp"]), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response. |
 
 
 ## Customization

--- a/docs/models/successful_responses.md
+++ b/docs/models/successful_responses.md
@@ -592,6 +592,8 @@ Custom profile customization for prompts and validation.
 |-------|------|-------------|
 | path | string | Path to Python modules containing custom profile. |
 | prompts | object | Dictionary containing map of system prompts |
+| validation | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['system_prompts']['validation']), not from lightspeed-stack.yaml. Used when a question_validity shield omits model_prompt. |
+| invalid_resp | string | Read-only. Loaded from the custom profile Python module (PROFILE_CONFIG['query_responses']['invalid_resp']), not from lightspeed-stack.yaml. Used when a question_validity shield omits invalid_question_response. |
 
 
 ## Customization
@@ -1970,8 +1972,8 @@ Configuration for the question validity guardrail.
 | Field | Type | Description |
 |-------|------|-------------|
 | model_id | string | The model_id to use for the guard |
-| model_prompt | string | The default prompt sent to the LLM used to validate the Users' question. |
-| invalid_question_response | string | The default response when the Users' question is determined to be invalid. |
+| model_prompt | string | Classifier prompt for the agent / wrap_run path. Null/omitted at load is filled from the profile module's system_prompts.validation, then the LCORE default; an explicit empty string is kept. Include $message or ${message} so the user question is substituted. Not used by responses-path run(), which sends raw user input. |
+| invalid_question_response | string | Refusal text used on both agent and responses / run() paths. Null/omitted at load is filled from the profile module's query_responses.invalid_resp, then the LCORE default; an explicit empty string is kept. |
 
 
 ## QuestionValidityShieldConfiguration

--- a/docs/user_doc/config.md
+++ b/docs/user_doc/config.md
@@ -271,10 +271,12 @@ Conversation history configuration.
 Custom profile customization for prompts and validation.
 
 
-| Field   | Type   | Description                                       |
-|---------|--------|---------------------------------------------------|
-| path    | string | Path to Python modules containing custom profile. |
-| prompts | object | Dictionary containing map of system prompts       |
+| Field        | Type   | Description                                       |
+|--------------|--------|---------------------------------------------------|
+| path         | string | Path to Python modules containing custom profile. |
+| prompts      | object | Read-only map of system prompts loaded from the profile module |
+| validation   | string | Read-only. Loaded from profile module `PROFILE_CONFIG["system_prompts"]["validation"]` (not a YAML `customization` field). Used when a question_validity shield omits `model_prompt`. |
+| invalid_resp | string | Read-only. Loaded from profile module `PROFILE_CONFIG["query_responses"]["invalid_resp"]` (not a YAML `customization` field). Used when a question_validity shield omits `invalid_question_response`. |
 
 
 ## Customization
@@ -595,8 +597,8 @@ Configuration for the question validity guardrail.
 | Field                     | Type   | Description                                                                |
 |---------------------------|--------|----------------------------------------------------------------------------|
 | model_id                  | string | The model_id to use for the guard                                          |
-| model_prompt              | string | The default prompt sent to the LLM used to validate the Users' question.   |
-| invalid_question_response | string | The default response when the Users' question is determined to be invalid. |
+| model_prompt              | string | Optional classifier prompt (`null` when omitted in YAML). Filled at load from the profile module's `system_prompts.validation`, then the LCORE default. Explicit YAML (including `""`) is kept. Used on the agent / `wrap_run` path (with `$message` / `${message}` substitution). Not applied by responses-path `run()`. After load / on `GET /v1/shields`, the effective string is returned. |
+| invalid_question_response | string | Optional refusal text (`null` when omitted in YAML). Filled at load from the profile module's `query_responses.invalid_resp`, then the LCORE default. Explicit YAML (including `""`) is kept. Used on both agent and responses / `run()` paths. After load / on `GET /v1/shields`, the effective string is returned. |
 
 
 ## QuestionValidityShieldConfiguration

--- a/docs/user_doc/config.md
+++ b/docs/user_doc/config.md
@@ -281,10 +281,12 @@ Conversation history configuration.
 Custom profile customization for prompts and validation.
 
 
-| Field   | Type   | Description                                       |
-|---------|--------|---------------------------------------------------|
-| path    | string | Path to Python modules containing custom profile. |
-| prompts | object | Dictionary containing map of system prompts       |
+| Field        | Type   | Description                                       |
+|--------------|--------|---------------------------------------------------|
+| path         | string | Path to Python modules containing custom profile. |
+| prompts      | object | Read-only map of system prompts loaded from the profile module |
+| validation   | string | Read-only. Loaded from profile module `PROFILE_CONFIG["system_prompts"]["validation"]` (not a YAML `customization` field). Used when a question_validity shield omits `model_prompt`. |
+| invalid_resp | string | Read-only. Loaded from profile module `PROFILE_CONFIG["query_responses"]["invalid_resp"]` (not a YAML `customization` field). Used when a question_validity shield omits `invalid_question_response`. |
 
 
 ## Customization
@@ -767,8 +769,8 @@ Configuration for the question validity guardrail.
 | Field                     | Type   | Description                                                   |
 |---------------------------|--------|---------------------------------------------------------------|
 | model_id                  | string | The model_id to use for the guard                             |
-| model_prompt              | string | Prompt sent to the LLM used to validate the user's question   |
-| invalid_question_response | string | Response when the user's question is determined to be invalid |
+| model_prompt              | string | Optional classifier prompt (`null` when omitted in YAML). Filled at load from the profile module's `system_prompts.validation`, then the LCORE default. Explicit YAML (including `""`) is kept. Used on the agent / `wrap_run` path (with `$message` / `${message}` substitution). Not applied by responses-path `run()`. After load / on `GET /v1/shields`, the effective string is returned. |
+| invalid_question_response | string | Optional refusal text (`null` when omitted in YAML). Filled at load from the profile module's `query_responses.invalid_resp`, then the LCORE default. Explicit YAML (including `""`) is kept. Used on both agent and responses / `run()` paths. After load / on `GET /v1/shields`, the effective string is returned. |
 
 
 ## QuestionValidityShieldConfiguration

--- a/docs/user_doc/shields_guide.md
+++ b/docs/user_doc/shields_guide.md
@@ -81,8 +81,60 @@ for a complete example.
 | Config field | Required | Description |
 |--------------|----------|-------------|
 | `model_id` | Yes | Model used for the validity check (for example `openai/gpt-4o-mini`) |
-| `model_prompt` | No | Classifier prompt (has a built-in default) |
-| `invalid_question_response` | No | Reply returned when the question is rejected |
+| `model_prompt` | No | Classifier prompt. When omitted: customization profile `system_prompts.validation`, then the LCORE default |
+| `invalid_question_response` | No | Reply when rejected. When omitted: profile `query_responses.invalid_resp`, then the LCORE default |
+
+### Profile fallback (resolved at startup)
+
+When LCORE loads configuration, omitted `model_prompt` /
+`invalid_question_response` on each `question_validity` shield are filled
+once from the customization profile module (when `customization.profile_path`
+points at a Python profile) or from LCORE defaults:
+
+| Shield field | Profile module key | Runtime use |
+|--------------|--------------------|-------------|
+| `model_prompt` | `PROFILE_CONFIG["system_prompts"]["validation"]` | **Classifier template** — agent / `wrap_run` only |
+| `invalid_question_response` | `PROFILE_CONFIG["query_responses"]["invalid_resp"]` | **Refusal text** — agent and responses / `run()` paths |
+
+Those profile keys are read from the profile **Python module**
+(`PROFILE_CONFIG`), not from fields under `customization:` in
+`lightspeed-stack.yaml`.
+
+Explicit values in `lightspeed-stack.yaml` always win. Missing profile keys
+fall through silently to LCORE defaults. After load, `GET /v1/shields` returns
+the **effective** prompt and refusal text.
+
+**Omit vs empty string:** Only a missing / `null` field is filled. An explicit
+empty string (`""`) in YAML **or** in the profile (`validation` /
+`invalid_resp`) is kept as-is and is not replaced by LCORE defaults.
+
+**Upgrade note:** If a deployment already uses a customization profile that
+defines `validation` / `invalid_resp`, and a QV shield omits those YAML fields,
+the effective values change after upgrade (no YAML edit required): classifier
+text on the agent path, and refusal text on both agent and responses paths.
+Set the fields explicitly in YAML to keep the previous LCORE defaults.
+
+**Schema / OpenAPI note:** In the config model these fields are optional
+(`null` when omitted in YAML). After configuration load they are always filled
+with the effective string. Clients that read `GET /v1/shields` see the resolved
+values, not `null`.
+
+### `model_prompt` placeholders (agent / `wrap_run` only)
+
+On the agent capability path, the classifier prompt is rendered with Python
+`string.Template` before the validity model runs. Include `$message` or
+`${message}` so the user question is substituted into the prompt. Without it,
+the classifier still runs but does not see the user's question (same behavior
+as before). The responses moderation path (`run()`) does not use this template;
+it sends raw user input (see below).
+
+Optional placeholders:
+
+| Placeholder | Substituted value |
+|-------------|-------------------|
+| `${message}` / `$message` | User question text |
+| `${allowed}` / `$allowed` | `ALLOWED` |
+| `${rejected}` / `$rejected` | `REJECTED` |
 
 ## redaction
 
@@ -95,8 +147,9 @@ Invalid regex patterns are rejected at configuration load time.
 
 # How shields apply at runtime
 
-The same shield logic (`question_validity` and `redaction`) is used on both
-agent-based and responses-based endpoints; only the integration point differs.
+Both agent-based and responses-based endpoints use the configured
+`question_validity` and `redaction` shields; the integration point differs
+(see below for how `question_validity` prompts are applied on each path).
 
 ## Agent-based endpoints
 
@@ -108,10 +161,16 @@ questions or redacting PII from model messages — using the configured shields.
 ## Responses-based endpoints
 
 On pure responses-based endpoints (for example `/v1/responses` and `/v1/infer`),
-there is no agent capability layer. Instead, LCORE runs the **same core shield
-functionality directly** through a custom API (`run_shield_moderation`) before
-each request. When moderation blocks the input, the endpoint returns a refusal
-(and may persist the blocked turn) without calling the model.
+there is no agent capability layer. Instead, LCORE runs shield moderation
+directly through `run_shield_moderation_v2` before each request. When
+moderation blocks the input, the endpoint returns a refusal (and may persist
+the blocked turn) without calling the model.
+
+For `question_validity`, that moderation path sends the **raw user input** to
+the validity model. It does **not** render `model_prompt` with
+`$message` / `${message}` the way the agent capability path (`wrap_run`) does.
+Configured / profile-resolved `invalid_question_response` is still used for the
+refusal text on this path. This matches pre-existing moderation behavior.
 
 ## Per-endpoint behavior
 

--- a/examples/lightspeed-stack-shields.yaml
+++ b/examples/lightspeed-stack-shields.yaml
@@ -19,14 +19,14 @@ authentication:
 # LCORE-owned safety shields (not Llama Stack / OGX Safety API resources).
 # Listed via GET /v1/shields; selected per request with optional shield_ids.
 shields:
-  - identifier: topic-guard
+  - name: topic-guard
     provider_id: question_validity
     config:
       model_id: openai/gpt-4o-mini
-      # Optional; omit to use built-in defaults:
-      model_prompt: "Classify whether the question is about OpenShift. Reply ALLOWED or REJECTED."
+      # Optional; omit to use profile/LCORE defaults:
+      model_prompt: "Classify whether the question is about OpenShift. Reply ALLOWED or REJECTED. Question: ${message}"
       invalid_question_response: "I can only answer questions about OpenShift."
-  - identifier: pii-redaction
+  - name: pii-redaction
     provider_id: redaction
     config:
       rules:

--- a/examples/lightspeed-stack-shields.yaml
+++ b/examples/lightspeed-stack-shields.yaml
@@ -23,9 +23,9 @@ shields:
     provider_id: question_validity
     config:
       model_id: openai/gpt-4o-mini
-      # Optional; omit to use built-in defaults. Must reference ${message}
-      # (string.Template substitution) or the classifier never sees the
-      # question it's meant to classify.
+      # Optional; omit to use profile/LCORE defaults. If set, must
+      # reference ${message} (string.Template substitution) or the
+      # classifier never sees the question it's meant to classify.
       model_prompt: "Classify whether the following question is about OpenShift or Kubernetes. Reply with exactly one word: ${allowed} if it is about OpenShift or Kubernetes, or ${rejected} if it is not. Do not explain your answer or add any other text.\n\nQuestion: ${message}\nAnswer:"
       invalid_question_response: "I can only answer questions about OpenShift."
   - name: pii-redaction

--- a/src/models/api/responses/successful/catalog.py
+++ b/src/models/api/responses/successful/catalog.py
@@ -127,7 +127,7 @@ class ShieldsResponse(AbstractSuccessfulResponse):
                             "type": "shield",
                             "config": {
                                 "model_id": "openai/gpt-4o-mini",
-                                "model_prompt": "Is this question valid?",
+                                "model_prompt": "Is this question valid? ${message}",
                                 "invalid_question_response": (
                                     "I can only answer questions about the product."
                                 ),

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -3299,20 +3299,21 @@ class Configuration(ConfigurationBase):
             profile_invalid_resp = profile.get_invalid_resp()
 
         for shield in self.shields:
-            match shield.config:
-                case QuestionValidityConfig() as qv_config:
-                    if qv_config.model_prompt is None:
-                        qv_config.model_prompt = (
-                            profile_validation
-                            if profile_validation is not None
-                            else constants.DEFAULT_MODEL_PROMPT
-                        )
-                    if qv_config.invalid_question_response is None:
-                        qv_config.invalid_question_response = (
-                            profile_invalid_resp
-                            if profile_invalid_resp is not None
-                            else constants.DEFAULT_INVALID_QUESTION_RESPONSE
-                        )
+            if not isinstance(shield.config, QuestionValidityConfig):
+                continue
+            qv_config = shield.config
+            if qv_config.model_prompt is None:
+                qv_config.model_prompt = (
+                    profile_validation
+                    if profile_validation is not None
+                    else constants.DEFAULT_MODEL_PROMPT
+                )
+            if qv_config.invalid_question_response is None:
+                qv_config.invalid_question_response = (
+                    profile_invalid_resp
+                    if profile_invalid_resp is not None
+                    else constants.DEFAULT_INVALID_QUESTION_RESPONSE
+                )
         return self
 
     @model_validator(mode="after")

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -3495,20 +3495,21 @@ class Configuration(ConfigurationBase):
             profile_invalid_resp = profile.get_invalid_resp()
 
         for shield in self.shields:
-            match shield.config:
-                case QuestionValidityConfig() as qv_config:
-                    if qv_config.model_prompt is None:
-                        qv_config.model_prompt = (
-                            profile_validation
-                            if profile_validation is not None
-                            else constants.DEFAULT_MODEL_PROMPT
-                        )
-                    if qv_config.invalid_question_response is None:
-                        qv_config.invalid_question_response = (
-                            profile_invalid_resp
-                            if profile_invalid_resp is not None
-                            else constants.DEFAULT_INVALID_QUESTION_RESPONSE
-                        )
+            if not isinstance(shield.config, QuestionValidityConfig):
+                continue
+            qv_config = shield.config
+            if qv_config.model_prompt is None:
+                qv_config.model_prompt = (
+                    profile_validation
+                    if profile_validation is not None
+                    else constants.DEFAULT_MODEL_PROMPT
+                )
+            if qv_config.invalid_question_response is None:
+                qv_config.invalid_question_response = (
+                    profile_invalid_resp
+                    if profile_invalid_resp is not None
+                    else constants.DEFAULT_INVALID_QUESTION_RESPONSE
+                )
         return self
 
     @model_validator(mode="after")

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1637,6 +1637,33 @@ class CustomProfile:
         init=False,
         title="System prompts",
         description="Dictionary containing map of system prompts",
+        json_schema_extra={"readOnly": True},
+    )
+
+    validation: Optional[str] = Field(
+        default=None,
+        init=False,
+        title="Question validity classifier prompt",
+        description=(
+            "Read-only. Loaded from the custom profile Python module "
+            "(PROFILE_CONFIG['system_prompts']['validation']), not from "
+            "lightspeed-stack.yaml. Used when a question_validity shield omits "
+            "model_prompt."
+        ),
+        json_schema_extra={"readOnly": True},
+    )
+
+    invalid_resp: Optional[str] = Field(
+        default=None,
+        init=False,
+        title="Invalid question response",
+        description=(
+            "Read-only. Loaded from the custom profile Python module "
+            "(PROFILE_CONFIG['query_responses']['invalid_resp']), not from "
+            "lightspeed-stack.yaml. Used when a question_validity shield omits "
+            "invalid_question_response."
+        ),
+        json_schema_extra={"readOnly": True},
     )
 
     def __post_init__(self) -> None:
@@ -1648,7 +1675,16 @@ class CustomProfile:
         checks.file_check(Path(self.path), "custom profile")
         profile_module = checks.import_python_module("profile", self.path)
         if profile_module is not None and checks.is_valid_profile(profile_module):
-            self.prompts = profile_module.PROFILE_CONFIG.get("system_prompts", {})
+            profile_config = profile_module.PROFILE_CONFIG
+            self.prompts = profile_config.get("system_prompts", {})
+            validation = self.prompts.get("validation")
+            if isinstance(validation, str):
+                self.validation = validation
+            query_responses = profile_config.get("query_responses")
+            if isinstance(query_responses, dict):
+                invalid_resp = query_responses.get("invalid_resp")
+                if isinstance(invalid_resp, str):
+                    self.invalid_resp = invalid_resp
 
     def get_prompts(self) -> dict[str, str]:
         """
@@ -1658,6 +1694,24 @@ class CustomProfile:
             dict[str, str]: Mapping from prompt names to prompt text.
         """
         return self.prompts
+
+    def get_validation(self) -> Optional[str]:
+        """Return the profile question-validity classifier prompt, if loaded.
+
+        Returns:
+            The ``system_prompts.validation`` string from the profile module,
+            or None when that key is absent or not a string.
+        """
+        return self.validation
+
+    def get_invalid_resp(self) -> Optional[str]:
+        """Return the profile invalid-question refusal text, if loaded.
+
+        Returns:
+            The ``query_responses.invalid_resp`` string from the profile module,
+            or None when that key is absent or not a string.
+        """
+        return self.invalid_resp
 
 
 class Customization(ConfigurationBase):
@@ -2678,15 +2732,26 @@ class QuestionValidityConfig(ConfigurationBase):
     model_id: str = Field(
         ..., title="Model id", description="The model_id to use for the guard"
     )
-    model_prompt: str = Field(
-        default=constants.DEFAULT_MODEL_PROMPT,
+    model_prompt: Optional[str] = Field(
+        default=None,
         title="Model prompt",
-        description="The default prompt sent to the LLM used to validate the Users' question.",
+        description=(
+            "Classifier prompt for the agent / wrap_run path. Null/omitted at "
+            "load is filled from the profile module's system_prompts.validation, "
+            "then the LCORE default; an explicit empty string is kept. Include "
+            "$message or ${message} so the user question is substituted. Not "
+            "used by responses-path run(), which sends raw user input."
+        ),
     )
-    invalid_question_response: str = Field(
-        default=constants.DEFAULT_INVALID_QUESTION_RESPONSE,
+    invalid_question_response: Optional[str] = Field(
+        default=None,
         title="Invalid question response",
-        description="The default response when the Users' question is determined to be invalid.",
+        description=(
+            "Refusal text used on both agent and responses / run() paths. "
+            "Null/omitted at load is filled from the profile module's "
+            "query_responses.invalid_resp, then the LCORE default; an explicit "
+            "empty string is kept."
+        ),
     )
 
 
@@ -3210,6 +3275,44 @@ class Configuration(ConfigurationBase):
             raise ValueError(
                 f"Shield names must be unique, found duplicates: {sorted(duplicates)}"
             )
+        return self
+
+    @model_validator(mode="after")
+    def resolve_question_validity_shield_prompts(self) -> Self:
+        """Fill omitted QV prompt/refusal fields from profile or LCORE defaults.
+
+        Runs at configuration load so ``GET /v1/shields`` returns the effective
+        ``model_prompt`` and ``invalid_question_response``. Explicit YAML values
+        are left unchanged.
+
+        Returns:
+            Self: The model instance after resolving shield text fields.
+        """
+        profile = None
+        if self.customization is not None:
+            # pylint: disable=no-member  # Pydantic nested model field
+            profile = self.customization.custom_profile
+        profile_validation = None
+        profile_invalid_resp = None
+        if profile is not None:
+            profile_validation = profile.get_validation()
+            profile_invalid_resp = profile.get_invalid_resp()
+
+        for shield in self.shields:
+            match shield.config:
+                case QuestionValidityConfig() as qv_config:
+                    if qv_config.model_prompt is None:
+                        qv_config.model_prompt = (
+                            profile_validation
+                            if profile_validation is not None
+                            else constants.DEFAULT_MODEL_PROMPT
+                        )
+                    if qv_config.invalid_question_response is None:
+                        qv_config.invalid_question_response = (
+                            profile_invalid_resp
+                            if profile_invalid_resp is not None
+                            else constants.DEFAULT_INVALID_QUESTION_RESPONSE
+                        )
         return self
 
     @model_validator(mode="after")

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1681,6 +1681,33 @@ class CustomProfile:
         init=False,
         title="System prompts",
         description="Dictionary containing map of system prompts",
+        json_schema_extra={"readOnly": True},
+    )
+
+    validation: Optional[str] = Field(
+        default=None,
+        init=False,
+        title="Question validity classifier prompt",
+        description=(
+            "Read-only. Loaded from the custom profile Python module "
+            "(PROFILE_CONFIG['system_prompts']['validation']), not from "
+            "lightspeed-stack.yaml. Used when a question_validity shield omits "
+            "model_prompt."
+        ),
+        json_schema_extra={"readOnly": True},
+    )
+
+    invalid_resp: Optional[str] = Field(
+        default=None,
+        init=False,
+        title="Invalid question response",
+        description=(
+            "Read-only. Loaded from the custom profile Python module "
+            "(PROFILE_CONFIG['query_responses']['invalid_resp']), not from "
+            "lightspeed-stack.yaml. Used when a question_validity shield omits "
+            "invalid_question_response."
+        ),
+        json_schema_extra={"readOnly": True},
     )
 
     def __post_init__(self) -> None:
@@ -1692,7 +1719,16 @@ class CustomProfile:
         checks.file_check(Path(self.path), "custom profile")
         profile_module = checks.import_python_module("profile", self.path)
         if profile_module is not None and checks.is_valid_profile(profile_module):
-            self.prompts = profile_module.PROFILE_CONFIG.get("system_prompts", {})
+            profile_config = profile_module.PROFILE_CONFIG
+            self.prompts = profile_config.get("system_prompts", {})
+            validation = self.prompts.get("validation")
+            if isinstance(validation, str):
+                self.validation = validation
+            query_responses = profile_config.get("query_responses")
+            if isinstance(query_responses, dict):
+                invalid_resp = query_responses.get("invalid_resp")
+                if isinstance(invalid_resp, str):
+                    self.invalid_resp = invalid_resp
 
     def get_prompts(self) -> dict[str, str]:
         """
@@ -1702,6 +1738,24 @@ class CustomProfile:
             dict[str, str]: Mapping from prompt names to prompt text.
         """
         return self.prompts
+
+    def get_validation(self) -> Optional[str]:
+        """Return the profile question-validity classifier prompt, if loaded.
+
+        Returns:
+            The ``system_prompts.validation`` string from the profile module,
+            or None when that key is absent or not a string.
+        """
+        return self.validation
+
+    def get_invalid_resp(self) -> Optional[str]:
+        """Return the profile invalid-question refusal text, if loaded.
+
+        Returns:
+            The ``query_responses.invalid_resp`` string from the profile module,
+            or None when that key is absent or not a string.
+        """
+        return self.invalid_resp
 
 
 class Customization(ConfigurationBase):
@@ -2866,15 +2920,26 @@ class QuestionValidityConfig(ConfigurationBase):
     model_id: str = Field(
         ..., title="Model id", description="The model_id to use for the guard"
     )
-    model_prompt: str = Field(
-        default=constants.DEFAULT_MODEL_PROMPT,
+    model_prompt: Optional[str] = Field(
+        default=None,
         title="Model prompt",
-        description="The default prompt sent to the LLM used to validate the Users' question.",
+        description=(
+            "Classifier prompt for the agent / wrap_run path. Null/omitted at "
+            "load is filled from the profile module's system_prompts.validation, "
+            "then the LCORE default; an explicit empty string is kept. Include "
+            "$message or ${message} so the user question is substituted. Not "
+            "used by responses-path run(), which sends raw user input."
+        ),
     )
-    invalid_question_response: str = Field(
-        default=constants.DEFAULT_INVALID_QUESTION_RESPONSE,
+    invalid_question_response: Optional[str] = Field(
+        default=None,
         title="Invalid question response",
-        description="The default response when the Users' question is determined to be invalid.",
+        description=(
+            "Refusal text used on both agent and responses / run() paths. "
+            "Null/omitted at load is filled from the profile module's "
+            "query_responses.invalid_resp, then the LCORE default; an explicit "
+            "empty string is kept."
+        ),
     )
 
 
@@ -3406,6 +3471,44 @@ class Configuration(ConfigurationBase):
             raise ValueError(
                 f"Shield names must be unique, found duplicates: {sorted(duplicates)}"
             )
+        return self
+
+    @model_validator(mode="after")
+    def resolve_question_validity_shield_prompts(self) -> Self:
+        """Fill omitted QV prompt/refusal fields from profile or LCORE defaults.
+
+        Runs at configuration load so ``GET /v1/shields`` returns the effective
+        ``model_prompt`` and ``invalid_question_response``. Explicit YAML values
+        are left unchanged.
+
+        Returns:
+            Self: The model instance after resolving shield text fields.
+        """
+        profile = None
+        if self.customization is not None:
+            # pylint: disable=no-member  # Pydantic nested model field
+            profile = self.customization.custom_profile
+        profile_validation = None
+        profile_invalid_resp = None
+        if profile is not None:
+            profile_validation = profile.get_validation()
+            profile_invalid_resp = profile.get_invalid_resp()
+
+        for shield in self.shields:
+            match shield.config:
+                case QuestionValidityConfig() as qv_config:
+                    if qv_config.model_prompt is None:
+                        qv_config.model_prompt = (
+                            profile_validation
+                            if profile_validation is not None
+                            else constants.DEFAULT_MODEL_PROMPT
+                        )
+                    if qv_config.invalid_question_response is None:
+                        qv_config.invalid_question_response = (
+                            profile_invalid_resp
+                            if profile_invalid_resp is not None
+                            else constants.DEFAULT_INVALID_QUESTION_RESPONSE
+                        )
         return self
 
     @model_validator(mode="after")

--- a/src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py
+++ b/src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py
@@ -116,21 +116,43 @@ class QuestionValidity(AbstractSafetyCapability):
 
     The guard function receives the user prompt and returns True if safe.
 
+    ``config.model_prompt`` and ``config.invalid_question_response`` must be
+    set before construction. In service startup,
+    ``Configuration.resolve_question_validity_shield_prompts`` fills omitted
+    fields from the customization profile or LCORE defaults.
+
     Example:
         ```python
         from pydantic_ai import Agent
-        from pydantic_ai.models.openai import OpenAIResponsesModel
+        from models.config import QuestionValidityConfig
 
-        model = OpenAIResponsesModel("gpt-4o-mini")
-        agent = Agent("openai:gpt-4.1", capabilities=[QuestionValidity(model)])
+        config = QuestionValidityConfig(
+            model_id="gpt-4o-mini",
+            model_prompt="Is this on-topic? ${message}",
+            invalid_question_response="Off-topic.",
+        )
+        agent = Agent("openai:gpt-4.1", capabilities=[QuestionValidity(config=config)])
         ```
     """
 
     config: QuestionValidityConfig
     _model: Model = field(init=False)
+    _model_prompt: str = field(init=False)
+    _invalid_question_response: str = field(init=False)
 
     def __post_init__(self) -> None:
-        """Initialize the model instance from the configured model ID."""
+        """Validate required prompt fields and initialize the model."""
+        model_prompt = self.config.model_prompt
+        invalid_question_response = self.config.invalid_question_response
+        if model_prompt is None or invalid_question_response is None:
+            raise ValueError(
+                "question_validity model_prompt and invalid_question_response "
+                "must be set; Configuration resolves omitted fields at load time"
+            )
+
+        self._model_prompt = model_prompt
+        self._invalid_question_response = invalid_question_response
+
         ogx_client = AsyncOgxClientHolder().get_client()
 
         self._model = OgxResponsesModel.from_ogx_client(
@@ -148,7 +170,7 @@ class QuestionValidity(AbstractSafetyCapability):
         Returns:
             The rendered prompt string ready to send to the validity model.
         """
-        return Template(self.config.model_prompt).substitute(
+        return Template(self._model_prompt).substitute(
             message=_message_to_str(message),
             allowed=SUBJECT_ALLOWED,
             rejected=SUBJECT_REJECTED,
@@ -191,7 +213,7 @@ class QuestionValidity(AbstractSafetyCapability):
             message_history=[
                 ModelRequest.user_text_prompt(user_message),
                 ModelResponse(
-                    [TextPart(self.config.invalid_question_response)],
+                    [TextPart(self._invalid_question_response)],
                     finish_reason="stop",
                 ),
             ],
@@ -203,7 +225,7 @@ class QuestionValidity(AbstractSafetyCapability):
                 AsyncOgxClientHolder().get_client(),
                 conversation_id,
                 user_message,
-                self.config.invalid_question_response,
+                self._invalid_question_response,
             )
         else:
             logger.warning(
@@ -211,12 +233,16 @@ class QuestionValidity(AbstractSafetyCapability):
                 "skipping v1/conversation persistence for rejected question."
             )
 
-        return AgentRunResult(
-            output=self.config.invalid_question_response, _state=state
-        )
+        return AgentRunResult(output=self._invalid_question_response, _state=state)
 
     async def run(self, input_text: str) -> ShieldModerationResult:
-        """Run question-validity check and return a moderation result."""
+        """Run question-validity check and return a moderation result.
+
+        Sends ``input_text`` to the validity model as-is (no ``_build_prompt`` /
+        ``model_prompt`` template rendering). Used by responses-path shield
+        moderation. The agent path uses ``wrap_run``, which renders
+        ``model_prompt``.
+        """
         result = await model_request(
             model=self._model, messages=[ModelRequest.user_text_prompt(input_text)]
         )
@@ -225,6 +251,6 @@ class QuestionValidity(AbstractSafetyCapability):
             return ShieldModerationPassed()
 
         return ShieldModerationBlocked(
-            message=self.config.invalid_question_response,
+            message=self._invalid_question_response,
             moderation_id=f"modr-{uuid4()}",
         )

--- a/tests/profiles/empty_qv_strings/profile.py
+++ b/tests/profiles/empty_qv_strings/profile.py
@@ -1,0 +1,9 @@
+"""Profile that sets QV validation / invalid_resp to empty strings."""
+
+PROFILE_CONFIG = {
+    "system_prompts": {
+        "default": "Default system prompt only.",
+        "validation": "",
+    },
+    "query_responses": {"invalid_resp": ""},
+}

--- a/tests/profiles/no_qv_keys/profile.py
+++ b/tests/profiles/no_qv_keys/profile.py
@@ -1,0 +1,7 @@
+"""Profile with system prompts but no QV validation / invalid_resp keys."""
+
+PROFILE_CONFIG = {
+    "system_prompts": {
+        "default": "Default system prompt only.",
+    },
+}

--- a/tests/profiles/test/profile.py
+++ b/tests/profiles/test/profile.py
@@ -32,6 +32,10 @@ Example Question:
 How can I integrate GitOps into my pipeline?
 Example Response:
 {SUBJECT_ALLOWED}
+
+Question:
+${{message}}
+Response:
 """
 
 TOPIC_SUMMARY_PROMPT_TEMPLATE = """

--- a/tests/unit/app/endpoints/test_shields.py
+++ b/tests/unit/app/endpoints/test_shields.py
@@ -107,7 +107,7 @@ async def test_shields_endpoint_handler_configured_shields(
             "provider_id": "question_validity",
             "config": {
                 "model_id": "openai/gpt-4o-mini",
-                "model_prompt": "Is this question valid?",
+                "model_prompt": "Is this question valid? ${message}",
                 "invalid_question_response": "I can only answer product questions.",
             },
         },

--- a/tests/unit/app/endpoints/test_shields.py
+++ b/tests/unit/app/endpoints/test_shields.py
@@ -139,6 +139,9 @@ async def test_shields_endpoint_handler_configured_shields(
     assert response.shields[0].provider_id == "question_validity"
     assert response.shields[0].type == "shield"
     assert response.shields[0].config["model_id"] == "openai/gpt-4o-mini"
+    assert response.shields[0].config["model_prompt"] == (
+        "Is this question valid? ${message}"
+    )
     assert response.shields[1].name == "pii-redaction"
     assert response.shields[1].provider_id == "redaction"
     assert response.shields[1].type == "shield"

--- a/tests/unit/app/endpoints/test_shields.py
+++ b/tests/unit/app/endpoints/test_shields.py
@@ -135,6 +135,9 @@ async def test_shields_endpoint_handler_configured_shields(
     assert response.shields[0].provider_id == "question_validity"
     assert response.shields[0].type == "shield"
     assert response.shields[0].config["model_id"] == "openai/gpt-4o-mini"
+    assert response.shields[0].config["model_prompt"] == (
+        "Is this question valid? ${message}"
+    )
     assert response.shields[1].name == "pii-redaction"
     assert response.shields[1].provider_id == "redaction"
     assert response.shields[1].type == "shield"

--- a/tests/unit/app/endpoints/test_shields.py
+++ b/tests/unit/app/endpoints/test_shields.py
@@ -103,7 +103,7 @@ async def test_shields_endpoint_handler_configured_shields(
             "provider_id": "question_validity",
             "config": {
                 "model_id": "openai/gpt-4o-mini",
-                "model_prompt": "Is this question valid?",
+                "model_prompt": "Is this question valid? ${message}",
                 "invalid_question_response": "I can only answer product questions.",
             },
         },

--- a/tests/unit/models/responses/test_successful_responses.py
+++ b/tests/unit/models/responses/test_successful_responses.py
@@ -193,7 +193,7 @@ class TestShieldsResponse:
                 "type": "shield",
                 "config": {
                     "model_id": "openai/gpt-4o-mini",
-                    "model_prompt": "Is this question valid?",
+                    "model_prompt": "Is this question valid? ${message}",
                     "invalid_question_response": (
                         "I can only answer questions about the product."
                     ),

--- a/tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
+++ b/tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
@@ -10,10 +10,7 @@ from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 from pydantic_ai.usage import RequestUsage, RunUsage
 from pytest_mock import MockerFixture, MockType
 
-from constants import (
-    DEFAULT_INVALID_QUESTION_RESPONSE,
-    DEFAULT_MODEL_PROMPT,
-)
+from constants import DEFAULT_INVALID_QUESTION_RESPONSE
 from models.common.moderation import ShieldModerationBlocked, ShieldModerationPassed
 from models.config import (
     QuestionValidityConfig,
@@ -25,6 +22,7 @@ from pydantic_ai_lightspeed.capabilities.question_validity._capability import (
     _extract_conversation_id,
     _extract_message_str_from_user_content,
 )
+from tests.unit.qv_config import make_qv_config
 
 _MODULE = "pydantic_ai_lightspeed.capabilities.question_validity._capability"
 
@@ -110,17 +108,17 @@ class TestExtractConversationId:
 class TestQuestionValidityConfigInit:
     """Tests for QuestionValidityConfig initialization."""
 
-    def test_default_model_prompt(self) -> None:
-        """Test that default model_prompt is used."""
+    def test_omitted_model_prompt_is_none(self) -> None:
+        """Omitted model_prompt defaults to None before Configuration load fills it."""
         qv_config = QuestionValidityConfig(model_id="test")
 
-        assert qv_config.model_prompt == DEFAULT_MODEL_PROMPT
+        assert qv_config.model_prompt is None
 
-    def test_default_invalid_question_response(self) -> None:
-        """Test that default invalid_question_response is used."""
+    def test_omitted_invalid_question_response_is_none(self) -> None:
+        """Omitted invalid_question_response defaults to None before Configuration load fills it."""
         qv_config = QuestionValidityConfig(model_id="test")
 
-        assert qv_config.invalid_question_response == DEFAULT_INVALID_QUESTION_RESPONSE
+        assert qv_config.invalid_question_response is None
 
     def test_custom_model_prompt(self) -> None:
         """Test that custom model_prompt can be provided."""
@@ -162,8 +160,7 @@ class TestQuestionValidityInit:
             f"{_MODULE}.OgxResponsesModel.from_ogx_client",
         )
 
-        config = QuestionValidityConfig(model_id="test-model")
-        QuestionValidity(config=config)
+        QuestionValidity(config=make_qv_config(model_id="test-model"))
 
         mock_holder.return_value.get_client.assert_called_once()
         mock_from_client.assert_called_once_with(
@@ -180,11 +177,18 @@ class TestQuestionValidityInit:
             f"{_MODULE}.OgxResponsesModel.from_ogx_client",
             return_value=mock_model,
         )
-        config = QuestionValidityConfig(model_id="test")
 
-        qv = QuestionValidity(config=config)
+        qv = QuestionValidity(config=make_qv_config())
 
         assert qv._model is mock_model
+
+    def test_unset_prompt_fields_raise(self, mocker: MockerFixture) -> None:
+        """Capability requires prompt fields already set by Configuration load."""
+        mocker.patch(f"{_MODULE}.AsyncOgxClientHolder")
+        mocker.patch(f"{_MODULE}.OgxResponsesModel.from_ogx_client")
+
+        with pytest.raises(ValueError, match="must be set"):
+            QuestionValidity(config=QuestionValidityConfig(model_id="test"))
 
 
 class TestBuildPrompt:
@@ -199,7 +203,7 @@ class TestBuildPrompt:
     @pytest.fixture(name="question_validity")
     def question_validity_fixture(self) -> QuestionValidity:
         """Create a QuestionValidity instance with a mock model."""
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         return QuestionValidity(config=config)
 
     def test_string_input(self, question_validity: QuestionValidity) -> None:
@@ -238,8 +242,7 @@ class TestBuildPrompt:
 
     def test_custom_prompt_template(self) -> None:
         """Test with a custom prompt template."""
-        config = QuestionValidityConfig(
-            model_id="test",
+        config = make_qv_config(
             model_prompt="Is '${message}' valid? ${allowed}/${rejected}",
         )
         qv = QuestionValidity(config=config)
@@ -299,7 +302,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -323,7 +326,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -353,7 +356,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -383,7 +386,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -408,7 +411,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -431,7 +434,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -461,7 +464,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -486,7 +489,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -511,7 +514,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -536,7 +539,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -559,9 +562,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(
-            model_id="test", invalid_question_response="Custom rejection."
-        )
+        config = make_qv_config(invalid_question_response="Custom rejection.")
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -583,7 +584,7 @@ class TestWrapRun:
             ),
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         await qv.wrap_run(mock_ctx, handler=mock_handler)
 
@@ -615,7 +616,7 @@ class TestWrapRun:
             return_value=mock_response,
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.wrap_run(ctx, handler=mock_handler)
 
@@ -634,7 +635,7 @@ class TestWrapRun:
             side_effect=RuntimeError("connection failed"),
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
 
         with pytest.raises(RuntimeError, match="connection failed"):
@@ -661,7 +662,7 @@ class TestWrapRun:
             ),
         )
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         await qv.wrap_run(ctx, handler=mock_handler)
 
@@ -689,7 +690,7 @@ class TestQuestionValidityRun:
         )
         mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.run("How do I create a pod?")
 
@@ -705,7 +706,7 @@ class TestQuestionValidityRun:
         )
         mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.run("What is the meaning of life?")
 
@@ -726,7 +727,7 @@ class TestQuestionValidityRun:
         )
         mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.run("some input")
 
@@ -749,7 +750,7 @@ class TestQuestionValidityRun:
         )
         mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
 
-        config = QuestionValidityConfig(model_id="test")
+        config = make_qv_config()
         qv = QuestionValidity(config=config)
         result = await qv.run("How do I scale pods?")
 
@@ -764,9 +765,7 @@ class TestQuestionValidityRun:
         )
         mocker.patch(f"{_MODULE}.model_request", return_value=mock_response)
 
-        config = QuestionValidityConfig(
-            model_id="test", invalid_question_response="Custom rejection."
-        )
+        config = make_qv_config(invalid_question_response="Custom rejection.")
         qv = QuestionValidity(config=config)
         result = await qv.run("off-topic question")
 

--- a/tests/unit/qv_config.py
+++ b/tests/unit/qv_config.py
@@ -1,0 +1,23 @@
+"""Shared helpers for constructing resolved QuestionValidityConfig in tests."""
+
+from constants import (
+    DEFAULT_INVALID_QUESTION_RESPONSE,
+    DEFAULT_MODEL_PROMPT,
+)
+from models.config import QuestionValidityConfig
+
+
+def make_qv_config(**kwargs: object) -> QuestionValidityConfig:
+    """Build a QuestionValidityConfig with startup-resolved text fields filled.
+
+    Production code fills omitted prompt/refusal fields in Configuration load.
+    Unit tests that construct configs directly should use this helper so
+    ``QuestionValidity`` construction succeeds.
+    """
+    defaults: dict[str, object] = {
+        "model_id": "test",
+        "model_prompt": DEFAULT_MODEL_PROMPT,
+        "invalid_question_response": DEFAULT_INVALID_QUESTION_RESPONSE,
+    }
+    defaults.update(kwargs)
+    return QuestionValidityConfig(**defaults)  # type: ignore[arg-type]

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -250,9 +250,13 @@ def test_init_from_dict() -> None:
     assert cfg.shields == []
 
 
-def test_init_from_dict_with_shields() -> None:
-    """Test initialization with guardrail shields configuration."""
-    config_dict: dict[str, Any] = {
+def _base_config_dict(
+    *,
+    shields: list[dict[str, Any]],
+    customization: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal AppConfig dict for shield / QV resolution tests."""
+    return {
         "name": "foo",
         "service": {
             "host": "localhost",
@@ -271,44 +275,307 @@ def test_init_from_dict_with_shields() -> None:
             "feedback_enabled": False,
         },
         "mcp_servers": [],
-        "customization": None,
+        "customization": customization,
         "authentication": {
             "module": "noop",
         },
-        "shields": [
-            {
-                "name": "topic-guard-a",
-                "provider_id": "question_validity",
-                "config": {"model_id": "test-model"},
-            },
-            {
-                "name": "topic-guard-b",
-                "provider_id": "question_validity",
-                "config": {"model_id": "test-model-2"},
-            },
-            {
-                "name": "pii-guard",
-                "provider_id": "redaction",
-                "config": {
-                    "rules": [
-                        {"pattern": r"\d+", "replacement": "[NUM]"},
-                    ],
-                },
-            },
-        ],
+        "shields": shields,
     }
+
+
+def _init_config_from_dict(config_dict: dict[str, Any]) -> AppConfig:
+    """Initialize AppConfig from a dict and return it."""
     cfg = AppConfig()
     cfg.init_from_dict(config_dict)
+    return cfg
+
+
+def test_init_from_dict_with_shields() -> None:
+    """Test initialization with guardrail shields configuration."""
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            shields=[
+                {
+                    "name": "topic-guard-a",
+                    "provider_id": "question_validity",
+                    "config": {"model_id": "test-model"},
+                },
+                {
+                    "name": "topic-guard-b",
+                    "provider_id": "question_validity",
+                    "config": {"model_id": "test-model-2"},
+                },
+                {
+                    "name": "pii-guard",
+                    "provider_id": "redaction",
+                    "config": {
+                        "rules": [
+                            {"pattern": r"\d+", "replacement": "[NUM]"},
+                        ],
+                    },
+                },
+            ],
+        )
+    )
 
     assert len(cfg.shields) == 3
     assert cfg.shields[0].name == "topic-guard-a"
     assert cfg.shields[0].provider_id == "question_validity"
     assert cfg.shields[0].config.model_id == "test-model"  # type: ignore[union-attr]
+    # Omitted QV text fields are filled at load from LCORE defaults.
+    assert (
+        cfg.shields[0].config.model_prompt  # type: ignore[union-attr]
+        == constants.DEFAULT_MODEL_PROMPT
+    )
+    assert (
+        cfg.shields[0].config.invalid_question_response  # type: ignore[union-attr]
+        == constants.DEFAULT_INVALID_QUESTION_RESPONSE
+    )
     assert cfg.shields[1].name == "topic-guard-b"
     assert cfg.shields[1].config.model_id == "test-model-2"  # type: ignore[union-attr]
     assert cfg.shields[2].name == "pii-guard"
     assert cfg.shields[2].provider_id == "redaction"
     assert len(cfg.shields[2].config.compiled_patterns) == 1  # type: ignore[union-attr]
+
+
+def test_qv_shield_prompts_resolve_from_profile_at_startup() -> None:
+    """Omitted QV fields are filled from the customization profile at load."""
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            customization={
+                "profile_path": "tests/profiles/test/profile.py",
+            },
+            shields=[
+                {
+                    "name": "topic-guard",
+                    "provider_id": "question_validity",
+                    "config": {"model_id": "test-model"},
+                },
+            ],
+        )
+    )
+
+    profile = CustomProfile(path="tests/profiles/test/profile.py")
+    assert (
+        cfg.shields[0].config.model_prompt  # type: ignore[union-attr]
+        == profile.get_validation()
+    )
+    assert (
+        cfg.shields[0].config.invalid_question_response  # type: ignore[union-attr]
+        == profile.get_invalid_resp()
+    )
+
+
+def test_qv_shield_yaml_prompt_wins_over_profile_at_startup() -> None:
+    """Explicit YAML model_prompt is kept when a profile is also configured."""
+    yaml_prompt = "YAML wins ${message}"
+    yaml_refusal = "YAML refusal"
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            customization={
+                "profile_path": "tests/profiles/test/profile.py",
+            },
+            shields=[
+                {
+                    "name": "topic-guard",
+                    "provider_id": "question_validity",
+                    "config": {
+                        "model_id": "test-model",
+                        "model_prompt": yaml_prompt,
+                        "invalid_question_response": yaml_refusal,
+                    },
+                },
+            ],
+        )
+    )
+
+    assert cfg.shields[0].config.model_prompt == yaml_prompt  # type: ignore[union-attr]
+    assert (
+        cfg.shields[0].config.invalid_question_response  # type: ignore[union-attr]
+        == yaml_refusal
+    )
+
+
+def test_qv_shield_explicit_prompt_without_message_placeholder_still_loads() -> None:
+    """Explicit YAML prompts without $message remain valid (additive; no hard-fail)."""
+    explicit_prompt = "Classify whether the question is about OpenShift."
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            shields=[
+                {
+                    "name": "topic-guard",
+                    "provider_id": "question_validity",
+                    "config": {
+                        "model_id": "test-model",
+                        "model_prompt": explicit_prompt,
+                    },
+                },
+            ],
+        )
+    )
+
+    assert cfg.shields[0].config.model_prompt == explicit_prompt  # type: ignore[union-attr]
+
+
+def test_qv_shield_empty_string_is_not_replaced_by_defaults() -> None:
+    """Explicit empty-string YAML values are kept; only None is filled."""
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            customization={
+                "profile_path": "tests/profiles/test/profile.py",
+            },
+            shields=[
+                {
+                    "name": "topic-guard",
+                    "provider_id": "question_validity",
+                    "config": {
+                        "model_id": "test-model",
+                        "model_prompt": "",
+                        "invalid_question_response": "",
+                    },
+                },
+            ],
+        )
+    )
+
+    assert cfg.shields[0].config.model_prompt == ""  # type: ignore[union-attr]
+    assert cfg.shields[0].config.invalid_question_response == ""  # type: ignore[union-attr]
+
+
+def test_qv_shield_partial_yaml_override_fills_only_omitted_fields() -> None:
+    """Each omitted field is filled independently when the other is set in YAML."""
+    yaml_prompt = "YAML prompt only ${message}"
+    yaml_refusal = "YAML refusal only"
+    profile = CustomProfile(path="tests/profiles/test/profile.py")
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            customization={
+                "profile_path": "tests/profiles/test/profile.py",
+            },
+            shields=[
+                {
+                    "name": "prompt-only",
+                    "provider_id": "question_validity",
+                    "config": {
+                        "model_id": "test-model",
+                        "model_prompt": yaml_prompt,
+                    },
+                },
+                {
+                    "name": "refusal-only",
+                    "provider_id": "question_validity",
+                    "config": {
+                        "model_id": "test-model-2",
+                        "invalid_question_response": yaml_refusal,
+                    },
+                },
+            ],
+        )
+    )
+
+    assert cfg.shields[0].config.model_prompt == yaml_prompt  # type: ignore[union-attr]
+    assert (
+        cfg.shields[0].config.invalid_question_response  # type: ignore[union-attr]
+        == profile.get_invalid_resp()
+    )
+    assert (
+        cfg.shields[1].config.model_prompt  # type: ignore[union-attr]
+        == profile.get_validation()
+    )
+    assert (
+        cfg.shields[1].config.invalid_question_response  # type: ignore[union-attr]
+        == yaml_refusal
+    )
+
+
+def test_qv_shield_profile_empty_strings_are_kept() -> None:
+    """Profile empty-string validation / invalid_resp are kept (not treated as missing)."""
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            customization={
+                "profile_path": "tests/profiles/empty_qv_strings/profile.py",
+            },
+            shields=[
+                {
+                    "name": "topic-guard",
+                    "provider_id": "question_validity",
+                    "config": {"model_id": "test-model"},
+                },
+            ],
+        )
+    )
+
+    assert cfg.shields[0].config.model_prompt == ""  # type: ignore[union-attr]
+    assert cfg.shields[0].config.invalid_question_response == ""  # type: ignore[union-attr]
+
+
+def test_qv_shield_profile_without_qv_keys_falls_back_to_defaults() -> None:
+    """Missing profile validation / invalid_resp keys fall through to LCORE defaults."""
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            customization={
+                "profile_path": "tests/profiles/no_qv_keys/profile.py",
+            },
+            shields=[
+                {
+                    "name": "topic-guard",
+                    "provider_id": "question_validity",
+                    "config": {"model_id": "test-model"},
+                },
+            ],
+        )
+    )
+
+    assert (
+        cfg.shields[0].config.model_prompt  # type: ignore[union-attr]
+        == constants.DEFAULT_MODEL_PROMPT
+    )
+    assert (
+        cfg.shields[0].config.invalid_question_response  # type: ignore[union-attr]
+        == constants.DEFAULT_INVALID_QUESTION_RESPONSE
+    )
+
+
+def test_qv_shield_multiple_shields_resolve_independently() -> None:
+    """Each question_validity shield resolves its own omitted fields."""
+    yaml_prompt = "Shield-A YAML ${message}"
+    profile = CustomProfile(path="tests/profiles/test/profile.py")
+    cfg = _init_config_from_dict(
+        _base_config_dict(
+            customization={
+                "profile_path": "tests/profiles/test/profile.py",
+            },
+            shields=[
+                {
+                    "name": "shield-a",
+                    "provider_id": "question_validity",
+                    "config": {
+                        "model_id": "model-a",
+                        "model_prompt": yaml_prompt,
+                    },
+                },
+                {
+                    "name": "shield-b",
+                    "provider_id": "question_validity",
+                    "config": {"model_id": "model-b"},
+                },
+            ],
+        )
+    )
+
+    assert cfg.shields[0].config.model_prompt == yaml_prompt  # type: ignore[union-attr]
+    assert (
+        cfg.shields[0].config.invalid_question_response  # type: ignore[union-attr]
+        == profile.get_invalid_resp()
+    )
+    assert (
+        cfg.shields[1].config.model_prompt  # type: ignore[union-attr]
+        == profile.get_validation()
+    )
+    assert (
+        cfg.shields[1].config.invalid_question_response  # type: ignore[union-attr]
+        == profile.get_invalid_resp()
+    )
 
 
 def test_init_from_dict_with_mcp_servers() -> None:

--- a/tests/unit/utils/test_prompts.py
+++ b/tests/unit/utils/test_prompts.py
@@ -333,3 +333,22 @@ def test_get_topic_summary_system_prompt_no_customization(
 
     topic_summary_prompt = prompts.get_topic_summary_system_prompt()
     assert topic_summary_prompt == constants.DEFAULT_TOPIC_SUMMARY_SYSTEM_PROMPT
+
+
+def test_custom_profile_loads_invalid_resp() -> None:
+    """CustomProfile loads query_responses.invalid_resp from the profile module."""
+    custom_profile = CustomProfile(path="tests/profiles/test/profile.py")
+    invalid_resp = custom_profile.get_invalid_resp()
+
+    assert invalid_resp is not None
+    assert "Red Hat Developer Hub" in invalid_resp
+
+
+def test_custom_profile_loads_validation() -> None:
+    """CustomProfile loads system_prompts.validation from the profile module."""
+    custom_profile = CustomProfile(path="tests/profiles/test/profile.py")
+    validation = custom_profile.get_validation()
+
+    assert validation is not None
+    assert "${message}" in validation
+    assert validation == custom_profile.get_prompts().get("validation")

--- a/tests/unit/utils/test_pydantic_ai.py
+++ b/tests/unit/utils/test_pydantic_ai.py
@@ -15,7 +15,6 @@ from pytest_mock import MockerFixture
 from configuration import AppConfig
 from models.common.responses.responses_api_params import ResponsesApiParams
 from models.config import (
-    QuestionValidityConfig,
     QuestionValidityShieldConfiguration,
     RedactionConfig,
     RedactionShieldConfiguration,
@@ -23,6 +22,7 @@ from models.config import (
 )
 from pydantic_ai_lightspeed.capabilities import QuestionValidity
 from pydantic_ai_lightspeed.capabilities.redaction import PiiRedactionCapability
+from tests.unit.qv_config import make_qv_config
 from utils.pydantic_ai_helpers import (
     _agent_capabilities,
     _shield_capability,
@@ -75,7 +75,7 @@ class TestShieldCapability:
         shield = QuestionValidityShieldConfiguration(
             name="topic-guard",
             provider_id="question_validity",
-            config=QuestionValidityConfig(model_id="test-model"),
+            config=make_qv_config(model_id="test-model"),
         )
 
         capability = _shield_capability(shield)
@@ -132,7 +132,7 @@ class TestAgentCapabilities:
             QuestionValidityShieldConfiguration(
                 name="topic-guard",
                 provider_id="question_validity",
-                config=QuestionValidityConfig(model_id="test-model"),
+                config=make_qv_config(model_id="test-model"),
             ),
             RedactionShieldConfiguration(
                 name="pii-guard",
@@ -298,7 +298,7 @@ class TestBuildAgent:
             QuestionValidityShieldConfiguration(
                 name="topic-guard",
                 provider_id="question_validity",
-                config=QuestionValidityConfig(model_id="test-model"),
+                config=make_qv_config(model_id="test-model"),
             ),
             RedactionShieldConfiguration(
                 name="pii-guard",
@@ -367,7 +367,7 @@ class TestBuildAgent:
             QuestionValidityShieldConfiguration(
                 name="topic-guard",
                 provider_id="question_validity",
-                config=QuestionValidityConfig(model_id="test-model"),
+                config=make_qv_config(model_id="test-model"),
             ),
             RedactionShieldConfiguration(
                 name="pii-guard",


### PR DESCRIPTION
## Description

When a question_validity shield omits model_prompt or invalid_question_response, we now fill those at configuration load from the customization profile (then LCORE defaults). That way GET /v1/shields and the agent QV path see the effective text without copying the same prompts into YAML. This lets users include long model_prompts in the profile, rather than stuffing them inline in the yaml.

Resolution order:

1. Explicit value in lightspeed-stack.yaml always wins (including "")
2. If omitted / null: profile system_prompts.validation / query_responses.invalid_resp
3. If those profile keys are missing: LCORE defaults

Profile keys come from the profile Python module (PROFILE_CONFIG), not from YAML under customization:.

Example (omit the prompt fields and let the profile supply them):
```yaml
customization:
  profile_path: /path/to/profile.py
shields:
  - name: topic-guard
    provider_id: question_validity
    config:
      model_id: openai/gpt-4o-mini
      # model_prompt and invalid_question_response omitted on purpose
```
With a profile that looks like:
```python
PROFILE_CONFIG = {
    "system_prompts": {
        "validation": "Is this on-topic? ${message}",
        # ...
    },
    "query_responses": {
        "invalid_resp": "I can only answer questions about the product.",
    },
}
```
After load, both fields are set to the profile values. GET /v1/shields returns those resolved strings.


<!--- Describe your changes in detail -->

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Grok 4.5
- Generated by: Grok 4.5

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/RHIDP-14083
- Closes # https://redhat.atlassian.net/browse/RHIDP-14083

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Question-validity shield prompts and responses can inherit values from the active profile or built-in defaults.
  - Explicit configuration values, including empty strings, take precedence over fallback values.
  - Effective validation and invalid-response settings are exposed through shield and profile responses.
  - Prompts support `${message}` substitution during agent execution; responses moderation evaluates raw input.

- **Documentation**
  - Updated configuration, API, shield guidance, examples, and response documentation to explain fallback behavior, precedence, empty values, and placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->