### PR TITLE
RSPEED-3444: fix REST API metrics middleware route discovery and root_path handling

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -10,7 +10,8 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from ogx_client import APIConnectionError, AsyncOgxClient
-from starlette.routing import Mount, Route, WebSocketRoute
+from fastapi.routing import iter_route_contexts
+
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 import version
@@ -212,7 +213,7 @@ class RestApiMetricsMiddleware:  # pylint: disable=too-few-public-methods
         # requests with the full prefixed path (/api/lightspeed/v1/infer) but
         # app_routes_paths contains only application-level paths (/v1/infer).
         # Strip the prefix so the path check and metric labels match the routes.
-        root_path = scope.get("root_path", "")
+        root_path: str = app.root_path
         path: str = scope["path"]
         if root_path and path.startswith(root_path + "/"):
             path = path[len(root_path) :]
@@ -292,9 +293,9 @@ logger.info("Including routers")
 routers.include_routers(app)
 
 app_routes_paths = [
-    route.path
-    for route in app.routes
-    if isinstance(route, (Mount, Route, WebSocketRoute))
+    rc.original_route.path
+    for rc in iter_route_contexts(app.routes)
+    if hasattr(rc.original_route, "path") and rc.original_route.path
 ]
 
 # Register pure ASGI middlewares.  Middleware execution order is the reverse of

--- a/tests/unit/app/test_main_middleware.py
+++ b/tests/unit/app/test_main_middleware.py
@@ -9,7 +9,14 @@ from fastapi import HTTPException, status
 from pytest_mock import MockerFixture
 from starlette.types import Message, Receive, Scope, Send
 
-from app.main import GlobalExceptionMiddleware, RestApiMetricsMiddleware
+from app.main import (
+    GlobalExceptionMiddleware,
+    RestApiMetricsMiddleware,
+    app_routes_paths,
+)
+from app.main import (
+    app as fastapi_app,
+)
 from models.api.responses.error import InternalServerErrorResponse
 
 
@@ -189,6 +196,7 @@ async def test_rest_api_metrics_strips_root_path(
 ) -> None:
     """Middleware must strip root_path so prefixed requests still match routes."""
     mocker.patch("app.main.app_routes_paths", ["/v1/infer"])
+    mocker.patch.object(fastapi_app, "root_path", "/api/lightspeed")
     mock_measure_duration = mocker.patch(
         "app.main.recording.measure_response_duration", return_value=nullcontext()
     )
@@ -201,9 +209,9 @@ async def test_rest_api_metrics_strips_root_path(
     middleware = RestApiMetricsMiddleware(ok_app)
     collector = _ResponseCollector()
 
-    # Simulate 3scale forwarding /api/lightspeed/v1/infer with root_path set.
+    # Simulate 3scale forwarding /api/lightspeed/v1/infer — scope carries no root_path.
     await middleware(
-        _make_scope("/api/lightspeed/v1/infer", root_path="/api/lightspeed"),
+        _make_scope("/api/lightspeed/v1/infer"),
         _noop_receive,
         collector,
     )
@@ -241,3 +249,57 @@ async def test_rest_api_metrics_no_root_path_unchanged(
     assert collector.status_code == 200
     mock_measure_duration.assert_called_once_with("/v1/infer")
     mock_record_call.assert_called_once_with("/v1/infer", 200)
+
+
+@pytest.mark.asyncio
+async def test_rest_api_metrics_uses_app_root_path_not_scope(
+    mocker: MockerFixture,
+) -> None:
+    """Middleware must read root_path from app.root_path, not scope["root_path"].
+
+    The scope carries an empty root_path while app.root_path holds the real prefix.
+    If the middleware reads from the scope it will not strip the prefix, the path
+    will not match any route, and no metric will be recorded — causing both
+    mock_measure_duration and mock_record_call assertions to fail.
+    """
+    mocker.patch("app.main.app_routes_paths", ["/v1/infer"])
+    mocker.patch.object(fastapi_app, "root_path", "/api/lightspeed")
+    mock_measure_duration = mocker.patch(
+        "app.main.recording.measure_response_duration", return_value=nullcontext()
+    )
+    mock_record_call = mocker.patch("app.main.recording.record_rest_api_call")
+
+    async def ok_app(_scope: Scope, _receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = RestApiMetricsMiddleware(ok_app)
+    collector = _ResponseCollector()
+
+    # scope["root_path"] is explicitly empty while app.root_path is "/api/lightspeed".
+    # The middleware must use app.root_path to strip the prefix correctly.
+    scope = _make_scope("/api/lightspeed/v1/infer")
+    scope["root_path"] = ""
+    await middleware(scope, _noop_receive, collector)
+
+    assert collector.status_code == 200
+    mock_measure_duration.assert_called_once_with("/v1/infer")
+    mock_record_call.assert_called_once_with("/v1/infer", 200)
+
+
+# ---------------------------------------------------------------------------
+# app_routes_paths population
+# ---------------------------------------------------------------------------
+
+
+def test_app_routes_paths_contains_application_routes() -> None:
+    """app_routes_paths must include routes registered via include_router.
+
+    FastAPI >= 0.137 stores included routers as _IncludedRouter objects that
+    the old isinstance(route, (Mount, Route, WebSocketRoute)) filter silently
+    drops.  iter_route_contexts() resolves them correctly.  If this test fails
+    with only 4 entries (the FastAPI built-ins), the fix has been reverted.
+    """
+    assert "/liveness" in app_routes_paths
+    assert "/readiness" in app_routes_paths
+    assert len(app_routes_paths) > 4


### PR DESCRIPTION
## Description

Fix REST API middleware-level metrics never recording. `FastAPI 0.137.0` ([fastapi#15745](https://github.com/fastapi/fastapi/pull/15745)) refactored `include_router()` to include routers with lazy `_IncludedRouter` wrapper objects in `app.routes` instead of copying individual `Route` instances. The [old list comprehension](https://github.com/thepetk/lightspeed-stack/blob/main/src/app/main.py#L295-L298) filtered with `isinstance(route, (Mount, Route, WebSocketRoute))`, which silently drops `_IncludedRouter` objects — leaving `app_routes_paths` containing only the 4 built-in FastAPI routes (`/openapi.json`, `/docs`, `/docs/oauth2-redirect`, `/redoc`). No application route ever matched, so metrics were never 
recorded regardless of the `root_path` setting.

FastAPI was pinned to 0.141.1 in the LCORE-2922 dependency update, merged via PR [#2358](https://github.com/thepetk/lightspeed-stack/pull/2358) / commit [`18c0876d`](https://github.com/thepetk/lightspeed-stack/commit/18c0876d).

Additionally, `RestApiMetricsMiddleware` read `root_path` from [`scope.get("root_path", "")`](https://github.com/thepetk/lightspeed-stack/blob/main/src/app/main.py#L215). In older versions of FastAPI/Starlette the scope field was never populated by the framework for this use case, so it always returned `""`, the prefix-stripping logic never activated, and every prefixed path failed to be recorded.

About the fix:

Replaced the route discovery list comprehension with FastAPI's official `iter_route_contexts()` API (PR [fastapi#15785](https://github.com/fastapi/fastapi/pull/15785), discussion [#15791](https://github.com/fastapi/fastapi/discussions/15791)), which correctly resolves all registered routes including the lazy `_IncludedRouter` wrappers introduced in 0.137. We also read `root_path` from `app.root_path` instead of the ASGI scope, which is the actual source of the configured value. Together these two changes ensure `app_routes_paths` is fully populated and that proxy-prefixed paths are correctly stripped, so middleware-level metrics record for every API endpoint regardless of deployment configuration.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude Sonnet 4.6
- Generated by: N/A

## Related Tickets & Documents

- Related to RSPEED-3444: Partially related
- Fixes https://github.com/lightspeed-core/lightspeed-stack/issues/2379

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

**To reproduce:**

On `main`:

- Start the service locally with `service.root_path: /api/lightspeed` configured (that simulates 3scale), then send requests using the full prefixed path the proxy will forward:

```
GET /api/lightspeed/liveness
GET /api/lightspeed/readiness
```

- Check `/metrics` afterwards: `ls_rest_api_calls_total` should have zero samples despite successful responses. Metrics lke `ls_llm_token_sent_total` should be recorded cause they are being handled inside the scope of the endpoint.

**To verify the fix end-to-end:**

After the fix, repeat the same requests. `/metrics` should show:

```
ls_rest_api_calls_total{path="/liveness",status_code="200"} 2.0
ls_rest_api_calls_total{path="/readiness",status_code="200"} 1.0
```

**Unit test coverage:**

- `test_rest_api_metrics_strips_root_path` — updated to patch `app.root_path` directly (scope carries no `root_path`, matching actual runtime behaviour).
- `test_rest_api_metrics_no_root_path_unchanged` — unchanged; confirms empty `root_path` deployments are unaffected.
- `test_rest_api_metrics_uses_app_root_path_not_scope` — regression test; fails if the middleware is switched back to reading from the scope.
- `test_app_routes_paths_contains_application_routes` — new; asserts `app_routes_paths` contains application routes beyond the 4 FastAPI built-ins. Fails if the `iter_route_contexts()` call is reverted to the old `isinstance` filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API metrics path handling when an application is configured with a root path.
  - Metrics now correctly match routes and record request paths, including versioned endpoints such as `/v1/infer`.
  - Resolved inconsistencies when incoming requests do not include root-path information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->