### PR TITLE
LCORE-3316: Switch to flat OGX client APIs

### DIFF
--- a/src/app/endpoints/vector_stores.py
+++ b/src/app/endpoints/vector_stores.py
@@ -596,7 +596,7 @@ async def add_file_to_vector_store(  # pylint: disable=too-many-locals,too-many-
 
         for attempt in range(max_retries):
             try:
-                vs_file = await client.vector_stores.files.create(
+                vs_file = await client.vector_stores_files.create(
                     vector_store_id=vector_store_id,
                     **body.model_dump(exclude_none=True),
                 )
@@ -704,7 +704,7 @@ async def list_vector_store_files(
 
     try:
         client = AsyncOgxClientHolder().get_client()
-        files = await client.vector_stores.files.list(vector_store_id=vector_store_id)
+        files = await client.vector_stores_files.list(vector_store_id=vector_store_id)
 
         data = [
             VectorStoreFileResponse(
@@ -775,7 +775,7 @@ async def get_vector_store_file(
 
     try:
         client = AsyncOgxClientHolder().get_client()
-        vs_file = await client.vector_stores.files.retrieve(
+        vs_file = await client.vector_stores_files.retrieve(
             vector_store_id=vector_store_id,
             file_id=file_id,
         )
@@ -842,7 +842,7 @@ async def delete_vector_store_file(
 
     try:
         client = AsyncOgxClientHolder().get_client()
-        await client.vector_stores.files.delete(
+        await client.vector_stores_files.delete(
             vector_store_id=vector_store_id,
             file_id=file_id,
         )

--- a/src/utils/conversation_compaction.py
+++ b/src/utils/conversation_compaction.py
@@ -276,7 +276,7 @@ async def _write_summary_marker(
     summary_text: str,
 ) -> None:
     """Write the summary into the conversation as a recognizable marker message."""
-    await client.conversations.items.create(
+    await client.items.create(
         conversation_id,
         add_items_request=build_add_items_request(
             [

--- a/src/utils/conversations.py
+++ b/src/utils/conversations.py
@@ -547,7 +547,7 @@ async def append_turn_items_to_conversation(
 
     items.extend(item.model_dump(exclude_none=True) for item in llm_output)
     try:
-        await client.conversations.items.create(
+        await client.items.create(
             conversation_id,
             add_items_request=build_add_items_request(items),
         )
@@ -580,7 +580,7 @@ async def get_all_conversation_items(
     has_more = True
     try:
         while has_more:
-            page = await client.conversations.items.list(
+            page = await client.items.list(
                 conversation_id=conversation_id_llama_stack,
                 order="asc",
                 after=after,
@@ -620,7 +620,7 @@ async def append_turn_to_conversation(
         assistant_message: The shield violation response message.
     """
     try:
-        await client.conversations.items.create(
+        await client.items.create(
             conversation_id,
             add_items_request=build_add_items_request(
                 [

--- a/tests/integration/endpoints/test_conversations_v1_integration.py
+++ b/tests/integration/endpoints/test_conversations_v1_integration.py
@@ -268,7 +268,7 @@ ERROR_HANDLING_TEST_CASES = [
             "endpoint": "get",
             "error_type": "connection",
             "expected_status": 503,
-            "mock_path": "conversations.items.list",
+            "mock_path": "items.list",
         },
         id="get_handles_connection_error",
     ),
@@ -277,7 +277,7 @@ ERROR_HANDLING_TEST_CASES = [
             "endpoint": "get",
             "error_type": "api_status",
             "expected_status": 500,
-            "mock_path": "conversations.items.list",
+            "mock_path": "items.list",
         },
         id="get_handles_api_status_error",
     ),
@@ -454,7 +454,7 @@ async def test_get_conversation_returns_chat_history(
     mock_items = mocker.Mock()
     mock_items.data = [mock_user_message, mock_assistant_message]
     mock_items.has_more = False
-    mock_ogx_client.conversations.items.list = mocker.AsyncMock(return_value=mock_items)
+    mock_ogx_client.items.list = mocker.AsyncMock(return_value=mock_items)
 
     response = await get_conversation_endpoint_handler(
         request=non_admin_test_request,
@@ -544,7 +544,7 @@ async def test_get_conversation_with_turns_metadata(
     mock_items = mocker.Mock()
     mock_items.data = [mock_user_message, mock_assistant_message]
     mock_items.has_more = False
-    mock_ogx_client.conversations.items.list = mocker.AsyncMock(return_value=mock_items)
+    mock_ogx_client.items.list = mocker.AsyncMock(return_value=mock_items)
 
     response = await get_conversation_endpoint_handler(
         request=non_admin_test_request,

--- a/tests/integration/endpoints/test_streaming_query_byok_integration.py
+++ b/tests/integration/endpoints/test_streaming_query_byok_integration.py
@@ -55,12 +55,12 @@ def _build_base_streaming_mock_client(mocker: MockerFixture) -> Any:
     """Build a base mock Llama Stack client configured for streaming responses.
 
     Extends the base query mock client with streaming-specific stubs:
-    conversations.items.create and a non-streaming responses.create stub for
+    items.create and a non-streaming responses.create stub for
     topic summary generation. Agent inference is mocked separately via
     ``mock_streaming_query_agent``.
     """
     mock_client = _build_base_mock_client(mocker)
-    mock_client.conversations.items.create = mocker.AsyncMock()
+    mock_client.items.create = mocker.AsyncMock()
 
     async def _responses_create(**_kwargs: Any) -> Any:
         mock_resp = mocker.MagicMock()

--- a/tests/integration/endpoints/test_streaming_query_integration.py
+++ b/tests/integration/endpoints/test_streaming_query_integration.py
@@ -49,7 +49,7 @@ def mock_llama_stack_streaming_fixture(
 
     mock_client.shields.list.return_value = []
 
-    mock_client.conversations.items.create = mocker.AsyncMock()
+    mock_client.items.create = mocker.AsyncMock()
 
     mock_vector_io_response = mocker.MagicMock()
     mock_vector_io_response.chunks = []

--- a/tests/unit/app/endpoints/test_conversations.py
+++ b/tests/unit/app/endpoints/test_conversations.py
@@ -529,7 +529,7 @@ class TestGetConversationEndpoint:
         mock_database_session(mocker, query_result=[mock_conversation], db_turns=[])
 
         mock_client = mocker.AsyncMock()
-        mock_client.conversations.items.list.side_effect = APIConnectionError(
+        mock_client.items.list.side_effect = APIConnectionError(
             request=None  # type: ignore[arg-type]
         )
         mock_client_holder = mocker.patch(
@@ -578,7 +578,7 @@ class TestGetConversationEndpoint:
         mock_database_session(mocker, db_turns=[])
 
         mock_client = mocker.AsyncMock()
-        mock_client.conversations.items.list.side_effect = NotFoundError(
+        mock_client.items.list.side_effect = NotFoundError(
             message="Conversation not found",
             response=mocker.Mock(request=None),
             body=None,
@@ -686,7 +686,7 @@ class TestGetConversationEndpoint:
         mock_item2.content = "Hi there!"
         mock_items_response.data = [mock_item1, mock_item2]
         mock_items_response.has_more = False
-        mock_client.conversations.items.list = mocker.AsyncMock(
+        mock_client.items.list = mocker.AsyncMock(
             return_value=mock_items_response
         )
 
@@ -742,7 +742,7 @@ class TestGetConversationEndpoint:
             ),
         ]
         mock_items.has_more = False
-        mock_client.conversations.items.list = mocker.AsyncMock(return_value=mock_items)
+        mock_client.items.list = mocker.AsyncMock(return_value=mock_items)
 
         mock_client_holder = mocker.patch(
             "app.endpoints.conversations_v1.AsyncOgxClientHolder"
@@ -818,7 +818,7 @@ class TestGetConversationEndpoint:
         mock_items_response = mocker.Mock()
         mock_items_response.data = []
         mock_items_response.has_more = False
-        mock_client.conversations.items.list = mocker.AsyncMock(
+        mock_client.items.list = mocker.AsyncMock(
             return_value=mock_items_response
         )
         mock_client_holder = mocker.patch(
@@ -864,7 +864,7 @@ class TestGetConversationEndpoint:
         mock_database_session(mocker, db_turns=[])
 
         mock_client = mocker.AsyncMock()
-        mock_client.conversations.items.list.side_effect = APIStatusError(
+        mock_client.items.list.side_effect = APIStatusError(
             message="Conversation not found",
             response=mocker.Mock(status_code=404, request=None),
             body=None,
@@ -969,7 +969,7 @@ class TestGetConversationEndpoint:
             mocker.Mock(type="message", role="assistant", content="Hi!"),
         ]
         mock_items_response.has_more = False
-        mock_client.conversations.items.list.return_value = mock_items_response
+        mock_client.items.list.return_value = mock_items_response
         mock_client_holder = mocker.patch(
             "app.endpoints.conversations_v1.AsyncOgxClientHolder"
         )

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -757,7 +757,7 @@ class TestHandleNonStreamingResponse:
         mock_moderation.refusal_response = mock_refusal
 
         _patch_handle_non_streaming_common(mocker, minimal_config)
-        mock_client.conversations.items.create = mocker.AsyncMock()
+        mock_client.items.create = mocker.AsyncMock()
         mock_api_response = mocker.Mock()
         mock_api_response.output = [mock_refusal]
         mock_api_response.model_dump.return_value = {
@@ -1170,7 +1170,7 @@ class TestHandleStreamingResponse:
         )
         mocker.patch(f"{MODULE}.store_query_results")
 
-        mock_client.conversations.items.create = mocker.AsyncMock()
+        mock_client.items.create = mocker.AsyncMock()
         api_params, context = build_api_params_and_context(
             updated_request=request,
             client=mock_client,

--- a/tests/unit/app/endpoints/test_responses_splunk.py
+++ b/tests/unit/app/endpoints/test_responses_splunk.py
@@ -242,7 +242,7 @@ class TestSplunkTelemetryHooks:
         mock_moderation.refusal_response = mock_refusal
 
         _patch_handle_non_streaming_common(mocker, minimal_config)
-        mock_client.conversations.items.create = mocker.AsyncMock()
+        mock_client.items.create = mocker.AsyncMock()
         mock_api_response = mocker.Mock()
         mock_api_response.output = [mock_refusal]
         mock_api_response.model_dump.return_value = {
@@ -489,7 +489,7 @@ class TestSplunkTelemetryHooks:
             new=mocker.AsyncMock(return_value=None),
         )
         mocker.patch(f"{MODULE}.store_query_results")
-        mock_client.conversations.items.create = mocker.AsyncMock()
+        mock_client.items.create = mocker.AsyncMock()
 
         mock_queue = mocker.patch(f"{TELEMETRY_MODULE}.queue_responses_splunk_event")
 
@@ -713,7 +713,7 @@ class TestSplunkTelemetryHooks:
         mock_moderation.refusal_response = mock_refusal
 
         _patch_handle_non_streaming_common(mocker, minimal_config)
-        mock_client.conversations.items.create = mocker.AsyncMock()
+        mock_client.items.create = mocker.AsyncMock()
         mock_api_response = mocker.Mock()
         mock_api_response.output = [mock_refusal]
         mock_api_response.model_dump.return_value = {

--- a/tests/unit/app/endpoints/test_vector_stores.py
+++ b/tests/unit/app/endpoints/test_vector_stores.py
@@ -440,7 +440,7 @@ async def test_add_file_to_vector_store_success(mocker: MockerFixture) -> None:
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.create.return_value = VectorStoreFile(
+    mock_client.vector_stores_files.create.return_value = VectorStoreFile(
         "file_123", "vs_123"
     )
     mock_lsc = mocker.patch(
@@ -475,7 +475,7 @@ async def test_add_file_to_vector_store_retry_on_database_lock(
 
     mock_client = mocker.AsyncMock()
     # First call raises database lock error, second call succeeds
-    mock_client.vector_stores.files.create.side_effect = [
+    mock_client.vector_stores_files.create.side_effect = [
         Exception("database is locked"),
         VectorStoreFile("file_123", "vs_123"),
     ]
@@ -501,7 +501,7 @@ async def test_add_file_to_vector_store_retry_on_database_lock(
     assert response.status == "completed"
 
     # Verify retry logic was triggered
-    assert mock_client.vector_stores.files.create.call_count == 2
+    assert mock_client.vector_stores_files.create.call_count == 2
     # Verify sleep was called once with 0.5 seconds (first retry delay)
     mock_sleep.assert_called_once_with(0.5)
 
@@ -519,7 +519,7 @@ async def test_add_file_to_vector_store_max_retries_exceeded(
 
     mock_client = mocker.AsyncMock()
     # All attempts fail with database lock error
-    mock_client.vector_stores.files.create.side_effect = Exception("database is locked")
+    mock_client.vector_stores_files.create.side_effect = Exception("database is locked")
     mock_lsc = mocker.patch(
         "app.endpoints.vector_stores.AsyncOgxClientHolder.get_client"
     )
@@ -540,7 +540,7 @@ async def test_add_file_to_vector_store_max_retries_exceeded(
     assert e.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
     # Verify all 3 retry attempts were made
-    assert mock_client.vector_stores.files.create.call_count == 3
+    assert mock_client.vector_stores_files.create.call_count == 3
     # Verify exponential backoff: 0.5s, then 1s (0.5 * 2)
     assert mock_sleep.call_count == 2
     assert mock_sleep.call_args_list[0][0][0] == 0.5
@@ -563,7 +563,7 @@ async def test_add_file_to_vector_store_non_lock_error_no_retry(
 
     mock_client = mocker.AsyncMock()
     # Raise a non-lock error
-    mock_client.vector_stores.files.create.side_effect = Exception("Some other error")
+    mock_client.vector_stores_files.create.side_effect = Exception("Some other error")
     mock_lsc = mocker.patch(
         "app.endpoints.vector_stores.AsyncOgxClientHolder.get_client"
     )
@@ -584,7 +584,7 @@ async def test_add_file_to_vector_store_non_lock_error_no_retry(
         )
 
     # Verify only one attempt was made (no retries for non-lock errors)
-    assert mock_client.vector_stores.files.create.call_count == 1
+    assert mock_client.vector_stores_files.create.call_count == 1
     # Verify sleep was not called (no retry)
     mock_sleep.assert_not_called()
 
@@ -599,7 +599,7 @@ async def test_list_vector_store_files_success(mocker: MockerFixture) -> None:
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.list.return_value = VectorStoreFilesList(
+    mock_client.vector_stores_files.list.return_value = VectorStoreFilesList(
         [
             VectorStoreFile("file_1", "vs_123"),
             VectorStoreFile("file_2", "vs_123"),
@@ -633,7 +633,7 @@ async def test_get_vector_store_file_success(mocker: MockerFixture) -> None:
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.retrieve.return_value = VectorStoreFile(
+    mock_client.vector_stores_files.retrieve.return_value = VectorStoreFile(
         "file_123", "vs_123"
     )
     mock_lsc = mocker.patch(
@@ -663,7 +663,7 @@ async def test_delete_vector_store_file_success(mocker: MockerFixture) -> None:
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.delete.return_value = None
+    mock_client.vector_stores_files.delete.return_value = None
     mock_lsc = mocker.patch(
         "app.endpoints.vector_stores.AsyncOgxClientHolder.get_client"
     )
@@ -963,7 +963,7 @@ async def test_add_file_to_vector_store_connection_error(
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.create.side_effect = APIConnectionError(
+    mock_client.vector_stores_files.create.side_effect = APIConnectionError(
         request=None  # type: ignore
     )
     mock_lsc = mocker.patch(
@@ -995,7 +995,7 @@ async def test_add_file_to_vector_store_not_found(mocker: MockerFixture) -> None
     mock_client = mocker.AsyncMock()
     mock_response = mocker.Mock()
     mock_response.request = mocker.Mock()
-    mock_client.vector_stores.files.create.side_effect = BadRequestError(
+    mock_client.vector_stores_files.create.side_effect = BadRequestError(
         message="File not found", response=mock_response, body=None
     )
     mock_lsc = mocker.patch(
@@ -1027,7 +1027,7 @@ async def test_list_vector_store_files_connection_error(
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.list.side_effect = APIConnectionError(
+    mock_client.vector_stores_files.list.side_effect = APIConnectionError(
         request=None  # type: ignore
     )
     mock_lsc = mocker.patch(
@@ -1058,7 +1058,7 @@ async def test_list_vector_store_files_not_found(mocker: MockerFixture) -> None:
     mock_client = mocker.AsyncMock()
     mock_response = mocker.Mock()
     mock_response.request = mocker.Mock()
-    mock_client.vector_stores.files.list.side_effect = BadRequestError(
+    mock_client.vector_stores_files.list.side_effect = BadRequestError(
         message="Vector store not found", response=mock_response, body=None
     )
     mock_lsc = mocker.patch(
@@ -1088,7 +1088,7 @@ async def test_get_vector_store_file_connection_error(mocker: MockerFixture) -> 
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.retrieve.side_effect = APIConnectionError(
+    mock_client.vector_stores_files.retrieve.side_effect = APIConnectionError(
         request=None  # type: ignore
     )
     mock_lsc = mocker.patch(
@@ -1119,7 +1119,7 @@ async def test_get_vector_store_file_not_found(mocker: MockerFixture) -> None:
     mock_client = mocker.AsyncMock()
     mock_response = mocker.Mock()
     mock_response.request = mocker.Mock()
-    mock_client.vector_stores.files.retrieve.side_effect = BadRequestError(
+    mock_client.vector_stores_files.retrieve.side_effect = BadRequestError(
         message="File not found", response=mock_response, body=None
     )
     mock_lsc = mocker.patch(
@@ -1150,7 +1150,7 @@ async def test_delete_vector_store_file_connection_error(
     cfg.init_from_dict(config_dict)
 
     mock_client = mocker.AsyncMock()
-    mock_client.vector_stores.files.delete.side_effect = APIConnectionError(
+    mock_client.vector_stores_files.delete.side_effect = APIConnectionError(
         request=None  # type: ignore
     )
     mock_lsc = mocker.patch(
@@ -1181,7 +1181,7 @@ async def test_delete_vector_store_file_not_found(mocker: MockerFixture) -> None
     mock_client = mocker.AsyncMock()
     mock_response = mocker.Mock()
     mock_response.request = mocker.Mock()
-    mock_client.vector_stores.files.delete.side_effect = BadRequestError(
+    mock_client.vector_stores_files.delete.side_effect = BadRequestError(
         message="File not found", response=mock_response, body=None
     )
     mock_lsc = mocker.patch(

--- a/tests/unit/utils/test_conversations.py
+++ b/tests/unit/utils/test_conversations.py
@@ -887,7 +887,7 @@ class TestAppendTurnItemsToConversation:  # pylint: disable=too-few-public-metho
     ) -> None:
         """Test that append_turn_items_to_conversation creates conversation items correctly."""
         mock_client = mocker.Mock()
-        mock_client.conversations.items.create = mocker.AsyncMock(return_value=None)
+        mock_client.items.create = mocker.AsyncMock(return_value=None)
         assistant_msg = OpenAIResponseMessage(
             type="message",
             role="assistant",
@@ -901,8 +901,8 @@ class TestAppendTurnItemsToConversation:  # pylint: disable=too-few-public-metho
             llm_output=[assistant_msg],
         )
 
-        mock_client.conversations.items.create.assert_called_once()
-        call_args = mock_client.conversations.items.create.call_args
+        mock_client.items.create.assert_called_once()
+        call_args = mock_client.items.create.call_args
         assert call_args[0][0] == "conv-123"
         request = call_args[1]["add_items_request"]
         assert isinstance(request, AddItemsRequest)
@@ -923,7 +923,7 @@ class TestAppendTurnToConversation:  # pylint: disable=too-few-public-methods
     ) -> None:
         """Test that append_turn_to_conversation creates conversation items correctly."""
         mock_client = mocker.Mock()
-        mock_client.conversations.items.create = mocker.AsyncMock(return_value=None)
+        mock_client.items.create = mocker.AsyncMock(return_value=None)
 
         await append_turn_to_conversation(
             mock_client,
@@ -932,8 +932,8 @@ class TestAppendTurnToConversation:  # pylint: disable=too-few-public-methods
             assistant_message="I cannot help with that",
         )
 
-        mock_client.conversations.items.create.assert_called_once()
-        call_args = mock_client.conversations.items.create.call_args
+        mock_client.items.create.assert_called_once()
+        call_args = mock_client.items.create.call_args
         assert call_args[0][0] == "conv-123"
         request = call_args[1]["add_items_request"]
         assert isinstance(request, AddItemsRequest)
@@ -958,14 +958,14 @@ class TestGetAllConversationItems:
         mock_page.data = [item_a, item_b]
         mock_page.has_more = False
 
-        mock_client.conversations.items.list = mocker.AsyncMock(return_value=mock_page)
+        mock_client.items.list = mocker.AsyncMock(return_value=mock_page)
 
         result = await get_all_conversation_items(
             mock_client, "conv_0d21ba731f21f798dc9680125d5d6f49"
         )
 
         assert result == [item_a, item_b]
-        mock_client.conversations.items.list.assert_called_once_with(
+        mock_client.items.list.assert_called_once_with(
             conversation_id="conv_0d21ba731f21f798dc9680125d5d6f49",
             order="asc",
             after=None,
@@ -988,7 +988,7 @@ class TestGetAllConversationItems:
         second_page.data = [item_2, item_3]
         second_page.has_more = False
 
-        mock_client.conversations.items.list = mocker.AsyncMock(
+        mock_client.items.list = mocker.AsyncMock(
             side_effect=[first_page, second_page]
         )
 
@@ -1004,7 +1004,7 @@ class TestGetAllConversationItems:
         mock_page.data = []
         mock_page.has_more = False
 
-        mock_client.conversations.items.list = mocker.AsyncMock(return_value=mock_page)
+        mock_client.items.list = mocker.AsyncMock(return_value=mock_page)
 
         result = await get_all_conversation_items(mock_client, "conv_empty")
 
@@ -1014,7 +1014,7 @@ class TestGetAllConversationItems:
     async def test_handles_connection_error(self, mocker: MockerFixture) -> None:
         """Test that APIConnectionError is converted to HTTPException 503."""
         mock_client = mocker.Mock()
-        mock_client.conversations.items.list = mocker.AsyncMock(
+        mock_client.items.list = mocker.AsyncMock(
             side_effect=APIConnectionError(
                 message="connection refused", request=mocker.Mock()
             )
@@ -1030,7 +1030,7 @@ class TestGetAllConversationItems:
     async def test_handles_api_status_error(self, mocker: MockerFixture) -> None:
         """Test that APIStatusError is converted to HTTPException 500."""
         mock_client = mocker.Mock()
-        mock_client.conversations.items.list = mocker.AsyncMock(
+        mock_client.items.list = mocker.AsyncMock(
             side_effect=APIStatusError(
                 message="internal error",
                 response=mocker.Mock(request=None),


### PR DESCRIPTION
## Description

Updates LCORE to the flat OGX OpenAPI client surface by replacing nested resource paths with their flat equivalents (`client.conversations.items` → `client.items`, `client.vector_stores.files` → `client.vector_stores_files`), and aligns unit/integration mocks and assertions accordingly.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-3316

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
