### PR TITLE
LCORE-3496: add file processor to default config

### DIFF
--- a/src/data/default_run.yaml
+++ b/src/data/default_run.yaml
@@ -8,11 +8,13 @@
 #
 # It is intentionally thinner than the repo-root run.yaml: it carries only the
 # APIs and providers needed to boot a minimal, queryable stack (inference,
-# vector_io, responses, tool_runtime, files) plus the storage backends
-# those providers reference. tool_runtime includes file-search (file_search /
-# RAG) and model-context-protocol (MCP) so those capabilities work when
-# operators enable them. Operators extend it via high-level sections or
-# `native_override`.
+# vector_io, responses, tool_runtime, files, file_processors) plus the storage
+# backends those providers reference. tool_runtime includes file-search
+# (file_search / RAG) and model-context-protocol (MCP) so those capabilities
+# work when operators enable them. file_processors (inline::pypdf) is required
+# for vector-store file attach / Notebook indexing after OGX removed the
+# legacy PyPDF fallback. Operators extend it via high-level sections or
+# `native_override` (e.g. swap pypdf for inline::docling).
 #
 # NOTE: `external_providers_dir` carries a default (`:=~/.llama/providers.d`)
 # so the baseline resolves even when EXTERNAL_PROVIDERS_DIR is unset — see the
@@ -23,6 +25,7 @@ apis:
 - responses
 - conversations
 - files
+- file_processors
 - inference
 - tool_runtime
 - vector_io
@@ -47,6 +50,13 @@ providers:
       storage_dir: ${env.SQLITE_STORE_DIR:=~/.llama/storage/files}
     provider_id: meta-reference-files
     provider_type: inline::localfs
+  # required for /v1/vector-stores to work with files properly
+  file_processors:
+  - provider_id: pypdf
+    provider_type: inline::pypdf
+    config:
+      default_chunk_size_tokens: 800
+      default_chunk_overlap_tokens: 400
   tool_runtime:
   - config: {}
     provider_id: model-context-protocol

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -123,6 +123,17 @@ def test_load_default_baseline_includes_mcp_tool_runtime() -> None:
     assert "model-context-protocol" in ids
 
 
+def test_load_default_baseline_includes_file_processors() -> None:
+    """Default stack ships file_processors so vector-store file attach works."""
+    baseline = load_default_baseline()
+    assert "file_processors" in baseline["apis"]
+    processors = baseline["providers"]["file_processors"]
+    assert any(
+        p.get("provider_id") == "pypdf" and p.get("provider_type") == "inline::pypdf"
+        for p in processors
+    )
+
+
 # ---------------------------------------------------------------------------
 # deep_merge_list_replace
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Adds the `file_processors` OGX API and the built-in `pypdf` processor to the `default_run.yaml` base for unified config 

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-3496
- Closes # https://redhat.atlassian.net/browse/LCORE-3496

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added default file-processing support for vector-store attachments and Notebook indexing.
  - Enabled PDF processing with configurable 800-token chunks and 400-token overlap.

- **Tests**
  - Added coverage verifying the default file-processing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->