### PR TITLE
LCORE-3475: Do not use type alias

### DIFF
--- a/src/models/common/agents/stream_payloads.py
+++ b/src/models/common/agents/stream_payloads.py
@@ -1,7 +1,7 @@
 """Typed JSON bodies for SSE streaming events."""
 
 import json
-from typing import Annotated, Literal, Optional, Self, TypeAlias
+from typing import Annotated, Literal, Optional, Self
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -257,7 +257,7 @@ class ToolResultStreamPayload(StreamPayloadBase):
         return "[Tool Result]\n"
 
 
-StreamEventPayload: TypeAlias = Annotated[
+type StreamEventPayload = Annotated[
     TokenStreamPayload
     | TurnCompleteStreamPayload
     | ToolCallStreamPayload


### PR DESCRIPTION
## Description

LCORE-3475: Do not use type alias

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3475


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal stream event type declarations without changing their supported event types or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->