### PR TITLE
LCORE-3478: Do not use type alias

### DIFF
--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -8,7 +8,7 @@ import asyncio
 import datetime
 from collections.abc import AsyncIterator
 from functools import singledispatch
-from typing import Any, Final, Optional, TypeAlias, cast
+from typing import Any, Final, Optional, cast
 
 from fastapi import HTTPException
 from ogx_client import APIConnectionError, APIStatusError
@@ -79,7 +79,7 @@ from utils.stream_interrupts import (
 )
 from utils.streaming_sse import shield_violation_generator
 
-AgentDispatchEvent: TypeAlias = AgentStreamEvent | AgentRunResultEvent
+type AgentDispatchEvent = AgentStreamEvent | AgentRunResultEvent
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Description

LCORE-3478: Do not use type alias

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal type declaration to use modern syntax.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->