### PR TITLE
LCORE-1573: surface compaction outcome as context_status in query responses

### DIFF
--- a/docs/design/conversation-compaction/conversation-compaction.md
+++ b/docs/design/conversation-compaction/conversation-compaction.md
@@ -115,7 +115,7 @@ lightspeed-stack
   9. Append the completed turn to the conversation items (continuous history,
      same conversation_id) — Llama Stack did not auto-store it (no conversation param)
   10. Release per-conversation lock
-  11. Return response (context_status="summarized" when 1573 lands; "full" otherwise)
+  11. Return response (context_status="summarized" when compacted; "full" otherwise — LCORE-1573)
 ```
 
 Note: when no prior summary exists and the request is below the threshold,
@@ -237,17 +237,30 @@ This preserves a single continuous conversation identity. The `conversation_id` 
 
 ## API response changes
 
-Add `context_status` field to `QueryResponse` and `StreamingQueryResponse`:
+The `context_status` field is added in two places (LCORE-1573):
+
+- `QueryResponse` (`src/models/api/responses/successful/query.py`) — the
+  non-streaming `/v1/query` response body.
+- `EndEventData` (`src/models/common/agents/stream_payloads.py`) — the SSE
+  `end` event payload that streaming `/v1/streaming_query` clients actually
+  receive on the wire, alongside the analogous `truncated` signal.
 
 ``` python
-context_status: str = Field(
+context_status: ContextStatus = Field(
     "full",
-    description="Context status: 'full' (no compaction), "
-    "'summarized' (older turns summarized).",
+    description='Context status: "full" (no compaction) or '
+    '"summarized" (older turns replaced by a summary)',
 )
 ```
 
-The existing `truncated` field remains deprecated.
+`StreamingQueryResponse` is a documentation-only class with an empty body
+(its `openapi_response()` inlines an SSE example string); adding a field
+there would change nothing on the wire, so it is intentionally skipped —
+only its SSE example is updated to show `context_status` in the `end` event.
+
+The value maps directly from `CompactionResult.compacted`
+(`utils/conversation_compaction.py`): `"summarized"` when True, `"full"`
+otherwise. The existing `truncated` field remains deprecated.
 
 ## Configuration
 
@@ -307,7 +320,8 @@ Add `compaction` field to the root `Configuration` class.
 | `src/app/endpoints/streaming_query.py` | Compaction-aware SSE path that emits the `compaction` event before summarizing (R12) |
 | `src/app/endpoints/a2a.py`             | Inline compaction (no SSE event); store the turn on `response.completed` |
 | `src/app/endpoints/responses.py`       | Silent compaction (OpenAI-compatible); store the turn via `_append_previous_response_turn` |
-| `src/models/responses.py` (now relocated) | `context_status` field — deferred to LCORE-1573 |
+| `src/models/api/responses/successful/query.py` | `context_status` on `QueryResponse` (non-streaming `/v1/query`) — LCORE-1573 |
+| `src/models/common/agents/stream_payloads.py` | `context_status` on `EndEventData`, the streaming SSE `end` event payload (`StreamingQueryResponse` is docs-only and intentionally skipped) — LCORE-1573 |
 | `src/cache/` (all backends)            | `ConversationSummary` storage — LCORE-1571 |
 
 ## How compaction is invoked

--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -5860,6 +5860,7 @@
                                         "ClusterQuotaLimiter": 998911,
                                         "UserQuotaLimiter": 998911
                                     },
+                                    "context_status": "full",
                                     "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
                                     "input_tokens": 123,
                                     "output_tokens": 456,
@@ -6265,7 +6266,7 @@
                                 "schema": {
                                     "type": "string"
                                 },
-                                "example": "data: {\"event\": \"start\", \"data\": {\"conversation_id\": \"123e4567-e89b-12d3-a456-426614174000\", \"request_id\": \"123e4567-e89b-12d3-a456-426614174001\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 0, \"token\": \"No Violation\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 1, \"token\": \"\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 2, \"token\": \"Hello\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 3, \"token\": \"!\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 4, \"token\": \" How\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 5, \"token\": \" can\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 6, \"token\": \" I\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 7, \"token\": \" assist\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 8, \"token\": \" you\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 9, \"token\": \" today\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 10, \"token\": \"?\"}}\n\ndata: {\"event\": \"turn_complete\", \"data\": {\"token\": \"Hello! How can I assist you today?\"}}\n\ndata: {\"event\": \"end\", \"data\": {\"referenced_documents\": [], \"truncated\": null, \"input_tokens\": 11, \"output_tokens\": 19}, \"available_quotas\": {}}\n\n"
+                                "example": "data: {\"event\": \"start\", \"data\": {\"conversation_id\": \"123e4567-e89b-12d3-a456-426614174000\", \"request_id\": \"123e4567-e89b-12d3-a456-426614174001\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 0, \"token\": \"No Violation\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 1, \"token\": \"\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 2, \"token\": \"Hello\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 3, \"token\": \"!\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 4, \"token\": \" How\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 5, \"token\": \" can\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 6, \"token\": \" I\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 7, \"token\": \" assist\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 8, \"token\": \" you\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 9, \"token\": \" today\"}}\n\ndata: {\"event\": \"token\", \"data\": {\"id\": 10, \"token\": \"?\"}}\n\ndata: {\"event\": \"turn_complete\", \"data\": {\"token\": \"Hello! How can I assist you today?\"}}\n\ndata: {\"event\": \"end\", \"data\": {\"referenced_documents\": [], \"truncated\": null, \"context_status\": \"full\", \"input_tokens\": 11, \"output_tokens\": 19}, \"available_quotas\": {}}\n\n"
                             }
                         }
                     },
@@ -13425,6 +13426,13 @@
                     }
                 ]
             },
+            "ContextStatus": {
+                "type": "string",
+                "enum": [
+                    "full",
+                    "summarized"
+                ]
+            },
             "ConversationData": {
                 "properties": {
                     "conversation_id": {
@@ -18813,6 +18821,15 @@
                             true
                         ]
                     },
+                    "context_status": {
+                        "$ref": "#/components/schemas/ContextStatus",
+                        "description": "Context status: \"full\" (no compaction) or \"summarized\" (older turns replaced by a summary)",
+                        "default": "full",
+                        "examples": [
+                            "full",
+                            "summarized"
+                        ]
+                    },
                     "input_tokens": {
                         "type": "integer",
                         "title": "Input Tokens",
@@ -18871,13 +18888,14 @@
                     "response"
                 ],
                 "title": "QueryResponse",
-                "description": "Model representing LLM response to a query.\n\nAttributes:\n    conversation_id: The optional conversation ID (UUID).\n    response: The response.\n    rag_chunks: Deprecated. List of RAG chunks used to generate the response.\n        This information is now available in tool_results under file_search_call type.\n    referenced_documents: The URLs and titles for the documents used to generate the response.\n    tool_calls: List of tool calls made during response generation.\n    tool_results: List of tool results.\n    truncated: Whether conversation history was truncated.\n    input_tokens: Number of tokens sent to LLM.\n    output_tokens: Number of tokens received from LLM.\n    available_quotas: Quota available as measured by all configured quota limiters.",
+                "description": "Model representing LLM response to a query.\n\nAttributes:\n    conversation_id: The optional conversation ID (UUID).\n    response: The response.\n    rag_chunks: Deprecated. List of RAG chunks used to generate the response.\n        This information is now available in tool_results under file_search_call type.\n    referenced_documents: The URLs and titles for the documents used to generate the response.\n    tool_calls: List of tool calls made during response generation.\n    tool_results: List of tool results.\n    truncated: Whether conversation history was truncated.\n    context_status: Whether the conversation context was sent in full\n        (\"full\") or older turns were replaced by a summary (\"summarized\").\n    input_tokens: Number of tokens sent to LLM.\n    output_tokens: Number of tokens received from LLM.\n    available_quotas: Quota available as measured by all configured quota limiters.",
                 "examples": [
                     {
                         "available_quotas": {
                             "ClusterQuotaLimiter": 998911,
                             "UserQuotaLimiter": 998911
                         },
+                        "context_status": "full",
                         "conversation_id": "123e4567-e89b-12d3-a456-426614174000",
                         "input_tokens": 123,
                         "output_tokens": 456,

--- a/src/app/endpoints/query.py
+++ b/src/app/endpoints/query.py
@@ -356,6 +356,7 @@ async def _handle_query_with_tracing(
         rag_chunks=turn_summary.rag_chunks,
         referenced_documents=turn_summary.referenced_documents,
         truncated=False,
+        context_status=compaction.context_status,
         input_tokens=turn_summary.token_usage.input_tokens,
         output_tokens=turn_summary.token_usage.output_tokens,
         available_quotas=available_quotas,

--- a/src/app/endpoints/streaming_query.py
+++ b/src/app/endpoints/streaming_query.py
@@ -48,6 +48,7 @@ from models.common.query import Attachment
 from models.common.responses.contexts import ResponseGeneratorContext
 from models.common.responses.responses_api_params import ResponsesApiParams
 from models.common.responses.types import ResponseInput
+from models.common.turn_summary import ContextStatus
 from models.config import Action
 from utils.agents.streaming import (
     generate_agent_response,
@@ -431,6 +432,7 @@ async def generate_response_with_compaction(
         )
 
         compacted_original_input: Optional[ResponseInput] = None
+        context_status: ContextStatus = "full"
         try:
             async for item in apply_compaction(
                 context.client,
@@ -447,6 +449,7 @@ async def generate_response_with_compaction(
                 elif isinstance(item, CompactionResult):
                     responses_params = item.params
                     compacted_original_input = item.original_input
+                    context_status = item.context_status
 
             generator, turn_summary = await retrieve_agent_response_generator(
                 responses_params=responses_params,
@@ -495,6 +498,7 @@ async def generate_response_with_compaction(
             emit_start=False,
             original_input=compacted_original_input,
             root_span=root_span,
+            context_status=context_status,
         ):
             yield event
     finally:

--- a/src/models/api/responses/successful/query.py
+++ b/src/models/api/responses/successful/query.py
@@ -9,6 +9,7 @@ from constants import MEDIA_TYPE_EVENT_STREAM
 from models.api.responses.constants import SUCCESSFUL_RESPONSE_DESCRIPTION
 from models.api.responses.successful.bases import AbstractSuccessfulResponse
 from models.common.turn_summary import (
+    ContextStatus,
     RAGChunk,
     ReferencedDocument,
     ToolCallSummary,
@@ -28,6 +29,8 @@ class QueryResponse(AbstractSuccessfulResponse):
         tool_calls: List of tool calls made during response generation.
         tool_results: List of tool results.
         truncated: Whether conversation history was truncated.
+        context_status: Whether the conversation context was sent in full
+            ("full") or older turns were replaced by a summary ("summarized").
         input_tokens: Number of tokens sent to LLM.
         output_tokens: Number of tokens received from LLM.
         available_quotas: Quota available as measured by all configured quota limiters.
@@ -69,6 +72,13 @@ class QueryResponse(AbstractSuccessfulResponse):
         False,
         description="Deprecated: whether conversation history was truncated",
         examples=[False, True],
+    )
+
+    context_status: ContextStatus = Field(
+        "full",
+        description='Context status: "full" (no compaction) or '
+        '"summarized" (older turns replaced by a summary)',
+        examples=["full", "summarized"],
     )
 
     input_tokens: int = Field(
@@ -113,6 +123,7 @@ class QueryResponse(AbstractSuccessfulResponse):
                         },
                     ],
                     "truncated": False,
+                    "context_status": "full",
                     "input_tokens": 123,
                     "output_tokens": 456,
                     "available_quotas": {
@@ -198,7 +209,8 @@ class StreamingQueryResponse(AbstractSuccessfulResponse):
                     '"token": "Hello! How can I assist you today?"}}\n\n'
                     'data: {"event": "end", "data": {'
                     '"referenced_documents": [], '
-                    '"truncated": null, "input_tokens": 11, "output_tokens": 19}, '
+                    '"truncated": null, "context_status": "full", '
+                    '"input_tokens": 11, "output_tokens": 19}, '
                     '"available_quotas": {}}\n\n'
                 ),
             ]

--- a/src/models/common/__init__.py
+++ b/src/models/common/__init__.py
@@ -28,6 +28,7 @@ from models.common.tools import (
 )
 from models.common.transcripts import Transcript, TranscriptMetadata
 from models.common.turn_summary import (
+    ContextStatus,
     MCPListToolsSummary,
     RAGChunk,
     RAGContext,
@@ -44,6 +45,7 @@ __all__ = [
     "CatalogShield",
     "CatalogTool",
     "CatalogToolParameter",
+    "ContextStatus",
     "ConversationData",
     "ConversationDetails",
     "ConversationTurn",

--- a/src/models/common/agents/stream_payloads.py
+++ b/src/models/common/agents/stream_payloads.py
@@ -6,7 +6,12 @@ from typing import Annotated, Literal, Optional, Self
 from pydantic import BaseModel, ConfigDict, Field
 
 from models.api.responses.error import AbstractErrorResponse
-from models.common import ReferencedDocument, ToolCallSummary, ToolResultSummary
+from models.common import (
+    ContextStatus,
+    ReferencedDocument,
+    ToolCallSummary,
+    ToolResultSummary,
+)
 
 
 class StreamPayloadBase(BaseModel):
@@ -49,6 +54,7 @@ class EndEventData(BaseModel):
 
     referenced_documents: list[ReferencedDocument]
     truncated: Optional[bool]
+    context_status: ContextStatus = "full"
     input_tokens: int
     output_tokens: int
 
@@ -149,6 +155,7 @@ class EndStreamPayload(StreamPayloadBase):
         cls,
         *,
         referenced_documents: list[ReferencedDocument],
+        context_status: ContextStatus,
         input_tokens: int,
         output_tokens: int,
         available_quotas: dict[str, int],
@@ -157,6 +164,9 @@ class EndStreamPayload(StreamPayloadBase):
 
         Args:
             referenced_documents: Documents referenced during the turn.
+            context_status: Whether the conversation context was sent in full
+                ("full") or older turns were replaced by a summary
+                ("summarized").
             input_tokens: Input token count for the turn.
             output_tokens: Output token count for the turn.
             available_quotas: Remaining quota limits by quota name.
@@ -168,6 +178,7 @@ class EndStreamPayload(StreamPayloadBase):
             data=EndEventData(
                 referenced_documents=referenced_documents,
                 truncated=None,
+                context_status=context_status,
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,
             ),

--- a/src/models/common/turn_summary.py
+++ b/src/models/common/turn_summary.py
@@ -3,12 +3,19 @@
 Used on query and streaming paths.
 """
 
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 
 from ogx_api import OpenAIResponseOutput
 from pydantic import AnyUrl, BaseModel, Field
 
 from utils.token_counter import TokenCounter
+
+type ContextStatus = Literal["full", "summarized"]
+"""How the conversation context was assembled for a turn.
+
+``"full"`` means the full history was used; ``"summarized"`` means older
+turns were replaced by a compaction summary (LCORE-1573).
+"""
 
 
 class RAGChunk(BaseModel):

--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -46,7 +46,7 @@ from models.common.query import Attachment
 from models.common.responses import ResponseInput
 from models.common.responses.contexts import ResponseGeneratorContext
 from models.common.responses.responses_api_params import ResponsesApiParams
-from models.common.turn_summary import TurnSummary
+from models.common.turn_summary import ContextStatus, TurnSummary
 from utils.agents.error_handler import map_agent_inference_error
 from utils.agents.query import (
     AgentFinishReason,
@@ -170,6 +170,7 @@ async def generate_agent_response(  # pylint: disable=too-many-statements
     emit_start: bool = True,
     original_input: Optional[ResponseInput] = None,
     root_span: Optional[trace.Span] = None,
+    context_status: ContextStatus = "full",
 ) -> AsyncIterator[str]:
     """Wrap an agent SSE generator with cleanup logic.
 
@@ -189,6 +190,9 @@ async def generate_agent_response(  # pylint: disable=too-many-statements
             explicit-input rewrite. Used to persist the completed turn with its
             structured input (preserving attachments); ``None`` otherwise.
         root_span: OpenTelemetry root span for this request.
+        context_status: Whether the conversation context was sent in full
+            ("full") or older turns were replaced by a summary ("summarized").
+            Reported to the client in the SSE end event.
 
     Yields:
         SSE-formatted strings from the wrapped generator.
@@ -298,6 +302,7 @@ async def generate_agent_response(  # pylint: disable=too-many-statements
     )
     end_payload = EndStreamPayload.create(
         referenced_documents=turn_summary.referenced_documents,
+        context_status=context_status,
         input_tokens=turn_summary.token_usage.input_tokens,
         output_tokens=turn_summary.token_usage.output_tokens,
         available_quotas=available_quotas,

--- a/src/utils/conversation_compaction.py
+++ b/src/utils/conversation_compaction.py
@@ -57,6 +57,7 @@ from configuration import configuration
 from log import get_logger
 from models.common.responses.responses_api_params import ResponsesApiParams
 from models.common.responses.types import ResponseInput
+from models.common.turn_summary import ContextStatus
 from models.compaction import ConversationSummary
 from models.config import CompactionConfiguration, InferenceConfiguration
 from utils.compaction import (
@@ -180,6 +181,11 @@ class CompactionResult:
     params: ResponsesApiParams
     compacted: bool
     original_input: Optional[ResponseInput] = None
+
+    @property
+    def context_status(self) -> ContextStatus:
+        """The API ``context_status`` value for this result (LCORE-1573)."""
+        return "summarized" if self.compacted else "full"
 
 
 def is_marker_item(item: Any) -> bool:

--- a/tests/unit/app/endpoints/test_query.py
+++ b/tests/unit/app/endpoints/test_query.py
@@ -1,7 +1,7 @@
 # pylint: disable=too-many-locals
 """Unit tests for the /query (v2) REST API endpoint using Responses API."""
 
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from fastapi import Request
@@ -22,6 +22,7 @@ from models.common.turn_summary import (
     TurnSummary,
 )
 from models.database.conversations import UserConversation
+from utils.conversation_compaction import CompactionResult
 
 # User ID must be proper UUID
 MOCK_AUTH = (
@@ -175,6 +176,88 @@ class TestQueryEndpointHandler:
         assert isinstance(response, QueryResponse)
         assert response.conversation_id == "123"
         assert response.response == "Kubernetes is a container orchestration platform"
+        assert response.context_status == "full"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("compacted", "expected_status"),
+        [(False, "full"), (True, "summarized")],
+    )
+    async def test_query_reports_context_status(
+        self,
+        dummy_request: Request,
+        setup_configuration: AppConfig,
+        mocker: MockerFixture,
+        compacted: bool,
+        expected_status: str,
+    ) -> None:
+        """Test that the compaction outcome is surfaced as context_status."""
+        query_request = QueryRequest(
+            query="What is Kubernetes?"
+        )  # pyright: ignore[reportCallIssue]
+
+        mocker.patch("app.endpoints.query.configuration", setup_configuration)
+        mocker.patch("app.endpoints.query.check_configuration_loaded")
+        mocker.patch("app.endpoints.query.check_tokens_available")
+        mocker.patch("app.endpoints.query.validate_model_provider_override")
+
+        mock_client = mocker.AsyncMock(spec=AsyncOgxClient)
+        mock_client_holder = mocker.Mock()
+        mock_client_holder.get_client.return_value = mock_client
+        mocker.patch(
+            "app.endpoints.query.AsyncOgxClientHolder",
+            return_value=mock_client_holder,
+        )
+        mocker.patch(
+            "app.endpoints.query.maybe_get_topic_summary",
+            new=mocker.AsyncMock(return_value=None),
+        )
+        mocker.patch(
+            "app.endpoints.query.run_shield_moderation",
+            new=mocker.AsyncMock(return_value=ShieldModerationPassed()),
+        )
+
+        mock_responses_params = mocker.Mock(spec=ResponsesApiParams)
+        mock_responses_params.model = "provider1/model1"
+        mock_responses_params.conversation = "conv_123"
+        mock_responses_params.tools = None
+        mocker.patch(
+            "app.endpoints.query.prepare_responses_params",
+            new=mocker.AsyncMock(return_value=mock_responses_params),
+        )
+
+        compaction_result = CompactionResult(
+            cast(ResponsesApiParams, mock_responses_params),
+            compacted=compacted,
+        )
+        mocker.patch(
+            "app.endpoints.query.apply_compaction_blocking",
+            new=mocker.AsyncMock(return_value=compaction_result),
+        )
+
+        mock_turn_summary = TurnSummary()
+        mock_turn_summary.llm_response = "An answer"
+        mocker.patch(
+            "app.endpoints.query.retrieve_agent_response",
+            new=mocker.AsyncMock(return_value=mock_turn_summary),
+        )
+
+        mocker.patch(
+            "app.endpoints.query.normalize_conversation_id", return_value="123"
+        )
+        mocker.patch("app.endpoints.query.store_query_results")
+        mocker.patch("app.endpoints.query.consume_query_tokens")
+        mocker.patch("app.endpoints.query.get_available_quotas", return_value={})
+
+        response = await query_endpoint_handler(
+            request=dummy_request,
+            query_request=query_request,
+            auth=MOCK_AUTH,
+            mcp_headers={},
+        )
+
+        assert isinstance(response, QueryResponse)
+        assert response.context_status == expected_status
 
     @pytest.mark.asyncio
     async def test_query_merges_inline_and_tool_rag_chunks_and_documents(

--- a/tests/unit/app/endpoints/test_streaming_query.py
+++ b/tests/unit/app/endpoints/test_streaming_query.py
@@ -14,6 +14,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 from pytest_mock import MockerFixture
 
 from app.endpoints.streaming_query import (
+    generate_response_with_compaction,
     streaming_query_endpoint_handler,
 )
 from configuration import AppConfig
@@ -30,6 +31,7 @@ from models.common.turn_summary import (
     TurnSummary,
 )
 from models.config import Action
+from utils.conversation_compaction import CompactionResult
 from utils.otel_tracing import SpanAttributes, SpanEvents
 
 INTERRUPTED_INDICATOR = f"\n\n*{INTERRUPTED_RESPONSE_MESSAGE}*"
@@ -907,3 +909,92 @@ class TestStreamingQueryOtelInstrumentation:
             assert child.parent is not None  # pyright narrowing
             assert root_spans[0].context is not None  # pyright narrowing
             assert child.parent.span_id == root_spans[0].context.span_id
+
+
+class TestGenerateResponseWithCompaction:  # pylint: disable=too-few-public-methods
+    """Tests for the compaction-aware SSE generator."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("compacted", "expected_status"),
+        [(False, "full"), (True, "summarized")],
+    )
+    async def test_threads_context_status_to_agent_response(
+        self,
+        mocker: MockerFixture,
+        compacted: bool,
+        expected_status: str,
+    ) -> None:
+        """Test the CompactionResult outcome reaches generate_agent_response."""
+        responses_params = ResponsesApiParams.model_validate(
+            {
+                "model": "provider1/model1",
+                "input": "What is OpenShift?",
+                "conversation": "conv_123",
+                "stream": True,
+                "store": True,
+            }
+        )
+
+        context = mocker.Mock()
+        context.conversation_id = "conv_123"
+        context.request_id = "req_123"
+        context.user_id = "user_123"
+        context.skip_userid_check = False
+        context.client = mocker.AsyncMock()
+        context.moderation_result = ShieldModerationPassed()
+        context.inline_rag_context = RAGContext()
+        context.query_request = QueryRequest(
+            query="What is OpenShift?"
+        )  # pyright: ignore[reportCallIssue]
+
+        compaction_result = CompactionResult(responses_params, compacted=compacted)
+
+        async def fake_apply_compaction(
+            *_args: Any, **_kwargs: Any
+        ) -> AsyncIterator[CompactionResult]:
+            yield compaction_result
+
+        mocker.patch(
+            "app.endpoints.streaming_query.apply_compaction",
+            new=fake_apply_compaction,
+        )
+        mocker.patch(
+            "app.endpoints.streaming_query.configured_conversation_cache",
+            return_value=None,
+        )
+        mock_config = mocker.Mock()
+        mocker.patch("app.endpoints.streaming_query.configuration", mock_config)
+
+        async def inner_generator() -> AsyncIterator[str]:
+            yield "data: test\n\n"
+
+        mocker.patch(
+            "app.endpoints.streaming_query.retrieve_agent_response_generator",
+            new=mocker.AsyncMock(return_value=(inner_generator(), TurnSummary())),
+        )
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def fake_generate_agent_response(
+            *_args: Any, **kwargs: Any
+        ) -> AsyncIterator[str]:
+            captured_kwargs.update(kwargs)
+            yield "data: end\n\n"
+
+        mocker.patch(
+            "app.endpoints.streaming_query.generate_agent_response",
+            new=fake_generate_agent_response,
+        )
+
+        events = [
+            event
+            async for event in generate_response_with_compaction(
+                context=context,
+                responses_params=responses_params,
+                endpoint_path="/v1/streaming_query",
+            )
+        ]
+
+        assert events  # the start event plus the delegated events
+        assert captured_kwargs["context_status"] == expected_status

--- a/tests/unit/models/responses/test_query_response.py
+++ b/tests/unit/models/responses/test_query_response.py
@@ -1,6 +1,7 @@
 """Unit tests for QueryResponse model."""
 
-from pydantic import AnyUrl
+import pytest
+from pydantic import AnyUrl, ValidationError
 
 from models.api.responses.successful import QueryResponse
 from models.common.turn_summary import (
@@ -32,6 +33,27 @@ class TestQueryResponse:
         qr = QueryResponse(response="LLM answer")  # type: ignore[call-arg]
         assert qr.conversation_id is None
         assert qr.response == "LLM answer"
+
+    def test_context_status_defaults_to_full(self) -> None:
+        """Test that context_status defaults to "full" when not provided."""
+        qr = QueryResponse(response="LLM answer")  # type: ignore[call-arg]
+        assert qr.context_status == "full"
+
+    def test_context_status_summarized(self) -> None:
+        """Test that context_status accepts the "summarized" value."""
+        qr = QueryResponse(  # type: ignore[call-arg]
+            response="LLM answer",
+            context_status="summarized",
+        )
+        assert qr.context_status == "summarized"
+
+    def test_context_status_rejects_unknown_value(self) -> None:
+        """Test that context_status rejects values outside full/summarized."""
+        with pytest.raises(ValidationError):
+            QueryResponse(  # type: ignore[call-arg]
+                response="LLM answer",
+                context_status="partial",  # type: ignore[arg-type]
+            )
 
     def test_complete_query_response_with_all_fields(self) -> None:
         """Test QueryResponse with all fields including tool calls, and tool results."""

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -679,6 +679,70 @@ class TestGenerateAgentResponse:
         store_mock.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("generate_kwargs", "expected_status"),
+        [
+            ({}, "full"),
+            ({"context_status": "summarized"}, "summarized"),
+        ],
+    )
+    async def test_end_event_reports_context_status(
+        self,
+        mocker: MockerFixture,
+        make_generator_context: Callable[..., ResponseGeneratorContext],
+        responses_params: ResponsesApiParams,
+        generate_kwargs: dict[str, Any],
+        expected_status: str,
+    ) -> None:
+        """Test the end event carries context_status ("full" by default)."""
+        context = make_generator_context()
+        turn_summary = TurnSummary()
+        turn_summary.token_usage = TokenCounter(input_tokens=3, output_tokens=7)
+        background_tasks: list[asyncio.Task[None]] = []
+
+        async def inner() -> AsyncIterator[str]:
+            yield serialize_event(
+                TokenStreamPayload.create(chunk_id=0, token="Hi"),
+                MEDIA_TYPE_JSON,
+            )
+
+        mocker.patch("utils.agents.streaming.consume_query_tokens")
+        mocker.patch(
+            "utils.agents.streaming.get_available_quotas",
+            return_value={"daily": 100},
+        )
+        mocker.patch(
+            "utils.agents.streaming.maybe_get_topic_summary",
+            new=mocker.AsyncMock(return_value=None),
+        )
+        mocker.patch("utils.agents.streaming.store_query_results")
+        mock_config = mocker.Mock()
+        mock_config.quota_limiters = []
+        mocker.patch("utils.agents.streaming.configuration", mock_config)
+
+        result = [
+            event
+            async for event in generate_agent_response(
+                inner(),
+                context,
+                responses_params,
+                turn_summary,
+                background_tasks,
+                **generate_kwargs,
+            )
+        ]
+
+        end_events = [
+            parsed
+            for event in result
+            if event.startswith("data: ")
+            and (parsed := json.loads(event.removeprefix("data: ").strip()))["event"]
+            == "end"
+        ]
+        assert len(end_events) == 1
+        assert end_events[0]["data"]["context_status"] == expected_status
+
+    @pytest.mark.asyncio
     async def test_cancelled_persists_interrupted_turn(
         self,
         mocker: MockerFixture,

--- a/tests/unit/utils/test_conversation_compaction.py
+++ b/tests/unit/utils/test_conversation_compaction.py
@@ -121,6 +121,13 @@ def test_should_compact() -> None:
     )
 
 
+def test_compaction_result_context_status() -> None:
+    """The compacted flag maps to the API context_status value (LCORE-1573)."""
+    params = _params()
+    assert cc.CompactionResult(params, compacted=False).context_status == "full"
+    assert cc.CompactionResult(params, compacted=True).context_status == "summarized"
+
+
 # --- apply_compaction ---
 
 


### PR DESCRIPTION
## Description

Add a `context_status` field (`"full"` / `"summarized"`) to query responses so clients know whether conversation compaction occurred (LCORE-1573, part of the conversation-compaction feature, LCORE-1631 epic).

The field is added in the two places clients actually receive on the wire:

- `QueryResponse` (`src/models/api/responses/successful/query.py`) — the non-streaming `/v1/query` response body.
- `EndEventData` (`src/models/common/agents/stream_payloads.py`) — the SSE `end` event payload for `/v1/streaming_query`, alongside the analogous `truncated` signal. `StreamingQueryResponse` is a documentation-only class with an empty body, so the field is intentionally NOT added there; only its SSE example string is updated.

The value maps directly from `CompactionResult.compacted` (set by the LCORE-1572 integration) via a new `context_status` property on `CompactionResult`. The non-streaming endpoint reads it when building `QueryResponse`; the streaming compaction-aware path captures it from the yielded `CompactionResult` and threads it through `generate_agent_response` (new parameter, default `"full"`) into `EndStreamPayload.create`. The shared `ContextStatus` Literal type alias lives in `models/common/turn_summary.py`.

`/v1/responses` intentionally does not get the field (stays OpenAI-shaped, compacts silently per R12); the A2A executor is out of scope.

The compaction design doc (`docs/design/conversation-compaction/conversation-compaction.md`) is updated to record the two-place split, and `docs/devel_doc/openapi.json` is regenerated (`ContextStatus` appears as a named enum schema referenced by `QueryResponse.context_status`; the streaming endpoint's SSE example shows `context_status` in the `end` event).

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-1573
- Closes # LCORE-1573

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. Start the full local stack (Llama Stack + Lightspeed Stack, compaction disabled or defaults) and send a non-streaming query:
   ```
   curl -s -X POST http://localhost:8080/v1/query -H "Content-Type: application/json" \
     -d '{"query": "What is Kubernetes? Answer in one sentence."}'
   ```
   Expected: response JSON includes `"context_status": "full"`.
   Actual (verified locally against llama-stack 0.6.0):
   ```
   context_status: full
   conversation_id: 778541b3698e8d3c1043ec3366ab8f94ae627e9d3aa193d9
   ```

2. Connect to the streaming endpoint and inspect the SSE `end` event:
   ```
   curl -s -N -X POST http://localhost:8080/v1/streaming_query -H "Content-Type: application/json" \
     -d '{"query": "What is a container image? One sentence."}'
   ```
   Expected: the `end` event's `data` includes `context_status`.
   Actual (verified locally):
   ```
   data: {"event": "end", "data": {"referenced_documents": [], "truncated": null,
          "context_status": "full", "input_tokens": 25, "output_tokens": 44}, ...}
   ```

3. The `"summarized"` value could not be verified live: compacted-mode requests (explicit-input rewrite) currently fail with HTTP 500 on both `/v1/query` and `/v1/streaming_query` before the response is built — a pre-existing issue in the agent pipeline (`retrieve_agent_response` passes `responses_params.input` through `cast(str, ...)` into `agent.run()`, but in compacted mode `input` is an item list). Filed as LCORE-3582. The `compacted → "summarized"` mapping is covered by unit tests at every layer (model, `CompactionResult` property, end-event payload, and both endpoint pipelines).

4. Run the unit tests specific to this change:
   ```
   uv run pytest tests/unit -k context_status -q
   ```
   Result: 10 passed.

5. Run the full suites:
   ```
   uv run make test-unit          # 3222 passed, 1 skipped, coverage 90.44%
   uv run python -m pytest tests/integration --ignore=tests/integration/container_lifecycle -q
                                  # 260 passed, 1 xfailed (container_lifecycle skipped: no container runtime)
   ```

6. Regenerate and inspect the OpenAPI schema:
   ```
   uv run make schema
   python3 -c "import json; s=json.load(open('docs/devel_doc/openapi.json'))['components']['schemas']; \
     print(s['QueryResponse']['properties']['context_status'], s['ContextStatus'])"
   ```
   Expected/Actual: `context_status` present on `QueryResponse` with `$ref` to the `ContextStatus` enum (`["full", "summarized"]`); the `/v1/streaming_query` SSE example shows `"context_status": "full"` in the `end` event.
