### PR TITLE
LCORE-3370: apply enrichment after the native_override merge

### DIFF
--- a/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
+++ b/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
@@ -83,7 +83,10 @@ detail that LCORE owns, not an operator-facing artifact.
 - **R5:** When `llama_stack.config.native_override` overlaps a key set
   by the high-level section or by the baseline, deep-merge semantics
   apply with list replacement (maps merge recursively; lists are
-  replaced wholesale; scalars are replaced).
+  replaced wholesale; scalars are replaced). The override wins over the
+  baseline and the high-level expansion; enrichment (R7) applies after
+  the merge, exactly as in legacy mode, where enrichment always
+  post-processes the operator's final run.yaml (LCORE-3370).
 - **R6:** Secrets that LCORE itself emits are never resolved on disk:
   `apply_high_level_inference` writes `${env.<VAR>}` references
   verbatim, and LCORE does not eagerly resolve env refs in the
@@ -557,6 +560,7 @@ reference.
 | Date | Change | Reason |
 |---|---|---|
 | 2026-04-23 | Initial version | Spike completion |
+| 2026-08-04 | R5: enrichment applies after the `native_override` merge | LCORE-3370 — migrated configs (run.yaml lifted into the override) replaced list-shaped enrichment artifacts wholesale, silently dropping BYOK/Solr providers, registered embedding models, and Azure `model_validation`; ordering now matches legacy, where the operator's run.yaml never beats enrichment |
 | 2026-08-20 | Default baseline openai provider is conditional on `OPENAI_API_KEY` | LCORE-3607: `baseline: default` must load when the key is unset |
 | 2026-08-21 | Add `baseline: byo-llm` (default_run.yaml minus the OpenAI row) | LCORE-3654: opt-in openai-free baseline |
 | 2026-08-25 | `baseline: default`'s built-in OpenAI provider deprecated in 0.7, removed in 0.8 | LCORE-3696: `default` shipped in 0.6.0 GA, so the ESA one-minor deprecation phase applies (confirmed by @sbunciak) |

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -1210,11 +1210,13 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     """Synthesize a full OGX ``run.yaml`` dict from a unified config.
 
     Implements the unified-mode synthesis pipeline: select a baseline (profile
-    file, empty, byo-llm, or the built-in default), apply the existing enrichment
-    (Azure Entra ID, BYOK RAG, Solr/OKP) for parity with legacy mode (R7),
-    expand the high-level ``inference.providers`` section, ensure the default
-    MCP tool_runtime provider when the baseline was not empty, and deep-merge
-    the raw ``native_override`` last (R5).
+    file, empty, byo-llm, or the built-in default), expand the high-level
+    ``inference.providers`` section, ensure the default MCP tool_runtime
+    provider when the baseline was not empty, deep-merge the raw
+    ``native_override`` (R5: it wins over the baseline and the high-level
+    expansion), and apply the existing enrichment (Azure Entra ID, BYOK RAG,
+    vector_store, Solr/OKP) last — matching legacy mode, where enrichment
+    always post-processes the operator's final run.yaml (R7, LCORE-3370).
 
     Parameters:
         lcs_config: The full ``lightspeed-stack.yaml`` parsed into a dict.
@@ -1275,8 +1277,30 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     # 3. Normalize duplicated vector_io providers in the baseline.
     dedupe_providers_vector_io(ls_config)
 
-    # 4. Existing enrichment — same calls as legacy generate_configuration so
+    # 4. High-level inference providers (Decision S5 — a root-level section).
+    inference = lcs_config.get("inference") or {}
+    if inference.get("providers"):
+        apply_high_level_inference(ls_config, inference)
+
+    # 5. Ensure MCP tool_runtime for default/profile baselines (skipped for
+    #    baseline: empty so migrate round-trips stay lossless).
+    if not baseline_was_empty:
+        ensure_mcp_tool_runtime(ls_config)
+
+    # 6. Raw escape hatch, deep-merged with list replacement. It wins over the
+    #    baseline and the high-level expansion (R5) but deliberately NOT over
+    #    enrichment (step 7).
+    if unified and unified.get("native_override"):
+        ls_config = deep_merge_list_replace(ls_config, unified["native_override"])
+
+    # 7. Existing enrichment — same calls as legacy generate_configuration so
     #    unified output matches legacy output for equivalent inputs (R7).
+    #    Applied AFTER the native_override merge (LCORE-3370): in legacy mode
+    #    enrichment always post-processes the operator's final run.yaml, so a
+    #    migrated config (whose native_override IS the lifted run.yaml) must
+    #    get the same treatment or list-shaped enrichment artifacts
+    #    (vector_io providers, registered models, azure model_validation) are
+    #    replaced wholesale by the lifted lists and silently lost.
     enrich_azure_entra_id_inference(ls_config, lcs_config.get("azure_entra_id"))
     rag_section = lcs_config.get("rag", {})
     byok_stores = rag_section.get("byok", {}).get("stores", [])
@@ -1289,20 +1313,6 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     okp_config = rag_section.get("okp", {})
     enrich_solr(ls_config, rag_config_for_solr, okp_config)
     enrich_vector_store(ls_config, lcs_config.get("vector_store"))
-
-    # 5. High-level inference providers (Decision S5 — a root-level section).
-    inference = lcs_config.get("inference") or {}
-    if inference.get("providers"):
-        apply_high_level_inference(ls_config, inference)
-
-    # 6. Ensure MCP tool_runtime for default/profile baselines (skipped for
-    #    baseline: empty so migrate round-trips stay lossless).
-    if not baseline_was_empty:
-        ensure_mcp_tool_runtime(ls_config)
-
-    # 7. Raw escape hatch, deep-merged last with list replacement (R5).
-    if unified and unified.get("native_override"):
-        ls_config = deep_merge_list_replace(ls_config, unified["native_override"])
 
     # 8. Dedupe again in case native_override or enrichment reintroduced dupes.
     dedupe_providers_vector_io(ls_config)

--- a/tests/integration/test_unified_synthesis.py
+++ b/tests/integration/test_unified_synthesis.py
@@ -139,7 +139,7 @@ _AZURE_INPUTS: dict[str, Any] = {
     "azure_entra_id": {
         "tenant_id": "test-tenant",
         "client_id": "test-client",
-        "client_secret_path": "/run/secrets/azure",
+        "client_secret": "test-secret",
     }
 }
 
@@ -447,15 +447,6 @@ def test_migrate_then_synthesize_round_trip_without_enrichment(
     assert legacy == synthesized
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Known defect (LCORE-3370): dumb migration lifts run.yaml "
-    "into native_override, which deep-merges after enrichment and replaces "
-    "lists wholesale (R5) — so BYOK/Solr vector_io providers, registered "
-    "embedding models, and the Azure model_validation enrichment are lost "
-    "whenever the original run.yaml already carried those list sections. "
-    "Contradicts migrate_config_dumb's enrichment-keeps-working promise.",
-)
 def test_migrate_then_synthesize_preserves_enrichment_parity(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Description

Fixes LCORE-3370: after `--migrate-config`, synthesis silently lost enrichment whenever the original legacy run.yaml carried list-shaped sections. Dumb migration lifts the whole run.yaml into `llama_stack.config.native_override`, and the synthesis pipeline applied enrichment to the baseline *before* deep-merging the override with list-replacement semantics — so the merge replaced the enriched lists wholesale: BYOK and Solr/OKP `vector_io` providers, registered embedding models, and the Azure `model_validation=false` tweak were all dropped, contradicting `migrate_config_dumb`'s documented "enrichment keeps working" promise and R7-after-migration.

**The fix** reorders `synthesize_configuration` so enrichment is the last content step: baseline → high-level `inference.providers` expansion → MCP ensure (non-empty baselines) → `native_override` merge → enrichment → dedupe. This is exactly legacy mode's semantics — enrichment always post-processes the operator's final run.yaml, which never beats it — so R5 keeps meaning "the override wins over the baseline and the high-level expansion" while R7 parity now also holds for migrated configs. The dumb-migration round-trip (T7, no enrichment inputs) is order-insensitive and unaffected.

Bonus: the reorder fixes a latent same-family bug — azure enrichment used to run *before* `apply_high_level_inference`, so a high-level `azure` provider entry replaced the enriched provider and silently dropped `model_validation=false` even without migration involved.

Also included: the strict xfail that documented the defect (added in LCORE-2747, PR #2318 — now merged) flips to a plain assertion; the test's `azure_entra_id` fixture moves to the current model schema (`client_secret` — `client_secret_path` no longer exists post-OGX-rename, and the xfail had been failing partly for that stale reason); spec R5 wording + changelog record the ordering change.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-2747, LCORE-2337, LCORE-2336
- Closes # LCORE-3370

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

Rebased onto current main (PR #2318 merged, so this is a one-commit diff); all results below are from the rebased head:

1. The regression test that found the bug (formerly a strict xfail, now a plain assertion):
   `uv run pytest tests/integration/test_unified_synthesis.py::test_migrate_then_synthesize_preserves_enrichment_parity -v`
   Expected: migrate-then-synthesize over a legacy pair with BYOK + Solr/OKP + Azure enrichment equals the legacy enrichment output exactly (dict equality).
   Actual: passes.
2. The full synthesis surface (integration + synthesizer unit tests):
   `uv run pytest tests/integration/test_unified_synthesis.py tests/unit/test_llama_stack_synthesize.py`
   Actual: 64 passed — including the T7 round-trip, R7 profile-parity for all enrichment kinds, native_override replacement semantics, and every ordering-sensitive unit case, unchanged.
3. Full unit suite: `uv run pytest tests/unit`
   Actual: 3212 passed, 1 skipped.
4. `uv run make format` — clean. Full `make verify` deferred to CI (local machine constraint).
