### PR TITLE
LCORE-1796: Add OTEL spans for authorized, info, and config endpoints

### DIFF
--- a/src/app/endpoints/authorized.py
+++ b/src/app/endpoints/authorized.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
+from opentelemetry import trace
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -14,8 +15,10 @@ from models.api.responses.error import (
     UnauthorizedResponse,
 )
 from models.api.responses.successful import AuthorizedResponse
+from utils.otel_tracing import SpanAttributes, anonymize_value, set_span_attributes
 
 logger = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 router = APIRouter(tags=["authorized"])
 
 authorized_responses: dict[int | str, dict[str, Any]] = {
@@ -44,8 +47,10 @@ async def authorized_endpoint_handler(
     ### Returns:
     - AuthorizedResponse: Contains the user ID and username of the authenticated user.
     """
-    # Ignore the user token, we should not return it in the response
-    user_id, user_name, skip_userid_check, _ = auth
-    return AuthorizedResponse(
-        user_id=user_id, username=user_name, skip_userid_check=skip_userid_check
-    )
+    with tracer.start_as_current_span("authorized.handle_request") as span:
+        # Ignore the user token, we should not return it in the response
+        user_id, user_name, skip_userid_check, _ = auth
+        set_span_attributes(span, {SpanAttributes.USER_ID: anonymize_value(user_id)})
+        return AuthorizedResponse(
+            user_id=user_id, username=user_name, skip_userid_check=skip_userid_check
+        )

--- a/src/app/endpoints/config.py
+++ b/src/app/endpoints/config.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request
+from opentelemetry import trace
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -21,6 +22,7 @@ from models.config import Action
 from utils.endpoints import check_configuration_loaded
 
 logger = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 router = APIRouter(tags=["config"])
 
 
@@ -68,7 +70,8 @@ async def config_endpoint_handler(
     # Nothing interesting in the request
     _ = request
 
-    # ensure that configuration is loaded
-    check_configuration_loaded(configuration)
+    with tracer.start_as_current_span("config.handle_request"):
+        # ensure that configuration is loaded
+        check_configuration_loaded(configuration)
 
-    return ConfigurationResponse(configuration=configuration.configuration)
+        return ConfigurationResponse(configuration=configuration.configuration)

--- a/src/app/endpoints/info.py
+++ b/src/app/endpoints/info.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from ogx_client import APIConnectionError
+from opentelemetry import trace
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -19,9 +20,11 @@ from models.api.responses.error import (
 )
 from models.api.responses.successful import InfoResponse
 from models.config import Action
+from utils.otel_tracing import set_span_attributes
 from version import __version__
 
 logger = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 router = APIRouter(tags=["info"])
 
 
@@ -66,24 +69,32 @@ async def info_endpoint_handler(
     # Nothing interesting in the request
     _ = request
 
-    logger.info("Response to /v1/info endpoint")
+    with tracer.start_as_current_span("info.handle_request") as span:
+        logger.info("Response to /v1/info endpoint")
 
-    try:
-        # try to get Llama Stack client
-        client = AsyncOgxClientHolder().get_client()
-        # retrieve version
-        llama_stack_version_object = await client.inspect.version()
-        llama_stack_version = llama_stack_version_object.version
-        logger.debug("Service name: %s", configuration.configuration.name)
-        logger.debug("Service version: %s", __version__)
-        logger.debug("Llama Stack version: %s", llama_stack_version)
-        return InfoResponse(
-            name=configuration.configuration.name,
-            service_version=__version__,
-            llama_stack_version=llama_stack_version,
-        )
-    # connection to Llama Stack server
-    except APIConnectionError as e:
-        logger.error("Unable to connect to Llama Stack: %s", e)
-        response = ServiceUnavailableResponse(backend_name="OGX", cause=str(e))
-        raise HTTPException(**response.model_dump()) from e
+        try:
+            # try to get Llama Stack client
+            client = AsyncOgxClientHolder().get_client()
+            # retrieve version
+            llama_stack_version_object = await client.inspect.version()
+            llama_stack_version = llama_stack_version_object.version
+            logger.debug("Service name: %s", configuration.configuration.name)
+            logger.debug("Service version: %s", __version__)
+            logger.debug("Llama Stack version: %s", llama_stack_version)
+            set_span_attributes(
+                span,
+                {
+                    "service.name": configuration.configuration.name,
+                    "service.version": __version__,
+                },
+            )
+            return InfoResponse(
+                name=configuration.configuration.name,
+                service_version=__version__,
+                llama_stack_version=llama_stack_version,
+            )
+        # connection to Llama Stack server
+        except APIConnectionError as e:
+            logger.error("Unable to connect to Llama Stack: %s", e)
+            response = ServiceUnavailableResponse(backend_name="OGX", cause=str(e))
+            raise HTTPException(**response.model_dump()) from e

--- a/tests/unit/app/endpoints/test_authorized.py
+++ b/tests/unit/app/endpoints/test_authorized.py
@@ -1,11 +1,18 @@
 """Unit tests for the /authorized REST API endpoint."""
 
+from typing import Any
+
 import pytest
 from fastapi import HTTPException
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from pytest_mock import MockerFixture
 from starlette.datastructures import Headers
 
 from app.endpoints.authorized import authorized_endpoint_handler
 from authentication.utils import extract_user_token
+from utils.otel_tracing import SpanAttributes
 
 MOCK_AUTH = ("test-id", "test-user", True, "token")
 
@@ -84,3 +91,26 @@ async def test_authorized_dependency_unauthorized() -> None:
     assert exc_info.value.detail["cause"] == (  # type: ignore[index]
         "No token found in Authorization header"
     )
+
+
+@pytest.mark.asyncio
+async def test_authorized_emits_otel_span_with_user_id(
+    mocker: MockerFixture,
+    otel: tuple[Any, InMemorySpanExporter],
+) -> None:
+    """Test that the handler emits a span with anonymized user ID."""
+    tracer, exporter = otel
+    mocker.patch("app.endpoints.authorized.tracer", tracer)
+    mocker.patch(
+        "app.endpoints.authorized.anonymize_value",
+        side_effect=lambda v: f"[anon:{v}]",
+    )
+
+    await authorized_endpoint_handler(auth=MOCK_AUTH)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "authorized.handle_request"
+    assert span.attributes is not None
+    assert span.attributes[SpanAttributes.USER_ID] == "[anon:test-id]"

--- a/tests/unit/app/endpoints/test_config.py
+++ b/tests/unit/app/endpoints/test_config.py
@@ -1,7 +1,13 @@
 """Unit tests for the /config REST API endpoint."""
 
+from typing import Any
+
 import pytest
 from fastapi import HTTPException, Request, status
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
 from pytest_mock import MockerFixture
 
 from app.endpoints.config import config_endpoint_handler
@@ -72,3 +78,60 @@ async def test_config_endpoint_handler_configuration_loaded(
     )
     assert response is not None
     assert response.configuration == minimal_config.configuration
+
+
+class TestConfigEndpointOtel:
+    """OTEL instrumentation tests for the /config endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_emits_span_on_success(
+        self,
+        mocker: MockerFixture,
+        minimal_config: AppConfig,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Test that a successful /config request emits a span."""
+        tracer, exporter = otel
+        mocker.patch("app.endpoints.config.tracer", tracer)
+        mock_authorization_resolvers(mocker)
+        mocker.patch("app.endpoints.config.configuration", minimal_config)
+
+        request = Request(scope={"type": "http"})
+        auth: AuthTuple = ("uid", "uname", True, "tok")
+
+        await config_endpoint_handler(
+            auth=auth, request=request  # pyright:ignore[reportArgumentType]
+        )
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        assert spans[0].name == "config.handle_request"
+
+    @pytest.mark.asyncio
+    async def test_span_records_error_when_config_not_loaded(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Test that the span records an error when configuration is not loaded."""
+        tracer, exporter = otel
+        mocker.patch("app.endpoints.config.tracer", tracer)
+        mock_authorization_resolvers(mocker)
+
+        mock_config = AppConfig()
+        mock_config._configuration = None  # pylint: disable=protected-access
+        mocker.patch("app.endpoints.config.configuration", mock_config)
+
+        request = Request(scope={"type": "http"})
+        auth: AuthTuple = ("uid", "uname", True, "tok")
+
+        with pytest.raises(HTTPException):
+            await config_endpoint_handler(
+                auth=auth, request=request  # pyright:ignore[reportArgumentType]
+            )
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "config.handle_request"
+        assert span.status.status_code == StatusCode.ERROR

--- a/tests/unit/app/endpoints/test_info.py
+++ b/tests/unit/app/endpoints/test_info.py
@@ -6,6 +6,10 @@ import pytest
 from fastapi import HTTPException, Request, status
 from ogx_client import APIConnectionError
 from ogx_client.types import VersionInfo
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
 from pytest_mock import MockerFixture
 
 from app.endpoints.info import info_endpoint_handler
@@ -145,3 +149,98 @@ async def test_info_endpoint_connection_error(mocker: MockerFixture) -> None:
         assert e.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
         assert e.value.detail["response"] == "Service unavailable"  # type: ignore
         assert "Unable to connect to OGX" in e.value.detail["cause"]  # type: ignore
+
+
+class TestInfoEndpointOtel:
+    """OTEL instrumentation tests for the /info endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_emits_span_on_success(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Test that a successful /info request emits a span with service metadata."""
+        tracer, exporter = otel
+        mocker.patch("app.endpoints.info.tracer", tracer)
+        mock_authorization_resolvers(mocker)
+
+        cfg = AppConfig()
+        cfg.init_from_dict(
+            {
+                "name": "test-service",
+                "service": {"host": "localhost", "port": 8080},
+                "llama_stack": {
+                    "api_key": "k",
+                    "url": "http://x:1234",
+                    "use_as_library_client": False,
+                },
+                "user_data_collection": {},
+                "authorization": {"access_rules": []},
+                "authentication": {"module": "noop"},
+            }
+        )
+        mocker.patch("configuration.configuration", cfg)
+
+        mock_client = mocker.AsyncMock()
+        mock_client.inspect.version.return_value = VersionInfo(version="0.1.2")
+        mocker.patch("client.AsyncOgxClientHolder.get_client", return_value=mock_client)
+
+        request = Request(scope={"type": "http"})
+        auth: AuthTuple = ("uid", "uname", True, "tok")
+
+        await info_endpoint_handler(auth=auth, request=request)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "info.handle_request"
+        assert span.attributes is not None
+        assert span.attributes["service.name"] == "test-service"
+        assert span.attributes["service.version"] is not None
+
+    @pytest.mark.asyncio
+    async def test_span_records_error_on_connection_failure(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Test that the span records an error when Llama Stack is unreachable."""
+        tracer, exporter = otel
+        mocker.patch("app.endpoints.info.tracer", tracer)
+        mock_authorization_resolvers(mocker)
+
+        cfg = AppConfig()
+        cfg.init_from_dict(
+            {
+                "name": "test-service",
+                "service": {"host": "localhost", "port": 8080},
+                "llama_stack": {
+                    "api_key": "k",
+                    "url": "http://x:1234",
+                    "use_as_library_client": False,
+                },
+                "user_data_collection": {},
+                "authorization": {"access_rules": []},
+                "authentication": {"module": "noop"},
+            }
+        )
+        mocker.patch("configuration.configuration", cfg)
+
+        mock_client = mocker.AsyncMock()
+        mock_client.inspect.version.side_effect = APIConnectionError(
+            request=None  # type: ignore
+        )
+        mocker.patch("client.AsyncOgxClientHolder.get_client", return_value=mock_client)
+
+        request = Request(scope={"type": "http"})
+        auth: AuthTuple = ("uid", "uname", True, "tok")
+
+        with pytest.raises(HTTPException):
+            await info_endpoint_handler(auth=auth, request=request)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "info.handle_request"
+        assert span.status.status_code == StatusCode.ERROR


### PR DESCRIPTION
## Description

Add handler-level OpenTelemetry spans for the three operational endpoints to provide request-level observability for success and error outcomes.

No secrets or configuration content included in span attributes. Unit tests verify span emission, attributes, and error status for each endpoint.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
