### PR TITLE
LCORE-1795: Add lightweight OTEL spans for probe endpoints

### DIFF
--- a/src/app/endpoints/health.py
+++ b/src/app/endpoints/health.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Response, status
 from ogx_client import APIConnectionError
+from opentelemetry import trace
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -34,6 +35,7 @@ from models.config import Action
 from utils.degraded_mode import DegradedModeTracker
 
 logger = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 router = APIRouter(tags=["health"])
 
 
@@ -148,81 +150,87 @@ async def readiness_probe_get_method(
     # Used only for authorization
     _ = auth
 
-    logger.info("Response to /readiness endpoint")
+    with tracer.start_as_current_span("readiness.handle_request") as span:
+        logger.info("Response to /readiness endpoint")
 
-    degraded_tracker = DegradedModeTracker()
-    is_degraded = degraded_tracker.is_degraded()
+        degraded_tracker = DegradedModeTracker()
+        is_degraded = degraded_tracker.is_degraded()
 
-    # Determine overall status
-    if is_degraded:
-        # Service is ready (can serve health checks, metrics, etc.) but degraded
-        impacts = [
-            "LLM inference unavailable",
-            "RAG functionality unavailable",
-            "Agent tools unavailable",
-        ]
-        return ReadinessResponse(
-            ready=True,
-            reason="Service running in degraded mode",
-            overall_status=HealthStatus.DEGRADED,
-            impacts=impacts,
-            providers=[],
-        )
-
-    # Not in degraded mode - check provider health
-    provider_statuses = await get_providers_health_statuses()
-    unhealthy_providers = [
-        p for p in provider_statuses if p.status == HealthStatus.ERROR.value
-    ]
-
-    if unhealthy_providers:
-        # Check if this is a connection error (provider_id="unknown")
-        is_connection_error = any(
-            p.provider_id == "unknown" for p in unhealthy_providers
-        )
-
-        if is_connection_error:
-            reason = "Cannot connect to backend service"
+        # Determine overall status
+        if is_degraded:
+            # Service is ready (can serve health checks, metrics, etc.) but degraded
             impacts = [
                 "LLM inference unavailable",
-                "Provider health checks unavailable",
+                "RAG functionality unavailable",
+                "Agent tools unavailable",
             ]
-        else:
-            unhealthy_provider_names = [p.provider_id for p in unhealthy_providers]
-            reason = f"Providers not healthy: {', '.join(unhealthy_provider_names)}"
-            impacts = [
-                f"Provider {p.provider_id}: {p.message}" for p in unhealthy_providers
-            ]
+            span.set_attribute("http.status_code", 200)
+            return ReadinessResponse(
+                ready=True,
+                reason="Service running in degraded mode",
+                overall_status=HealthStatus.DEGRADED,
+                impacts=impacts,
+                providers=[],
+            )
 
-        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-        return ReadinessResponse(
-            ready=False,
-            reason=reason,
-            overall_status=HealthStatus.UNHEALTHY,
-            impacts=impacts,
-            providers=unhealthy_providers if not is_connection_error else [],
-        )
+        # Not in degraded mode - check provider health
+        provider_statuses = await get_providers_health_statuses()
+        unhealthy_providers = [
+            p for p in provider_statuses if p.status == HealthStatus.ERROR.value
+        ]
 
-    # Check that the default model is registered in the model registry
-    model_available, model_reason = await check_default_model_available()
-    if not model_available:
-        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        if unhealthy_providers:
+            # Check if this is a connection error (provider_id="unknown")
+            is_connection_error = any(
+                p.provider_id == "unknown" for p in unhealthy_providers
+            )
+
+            if is_connection_error:
+                reason = "Cannot connect to backend service"
+                impacts = [
+                    "LLM inference unavailable",
+                    "Provider health checks unavailable",
+                ]
+            else:
+                unhealthy_provider_names = [p.provider_id for p in unhealthy_providers]
+                reason = f"Providers not healthy: {', '.join(unhealthy_provider_names)}"
+                impacts = [
+                    f"Provider {p.provider_id}: {p.message}"
+                    for p in unhealthy_providers
+                ]
+
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+            span.set_attribute("http.status_code", 503)
+            return ReadinessResponse(
+                ready=False,
+                reason=reason,
+                overall_status=HealthStatus.UNHEALTHY,
+                impacts=impacts,
+                providers=unhealthy_providers if not is_connection_error else [],
+            )
+
+        # Check that the default model is registered in the model registry
+        model_available, model_reason = await check_default_model_available()
+        if not model_available:
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+            span.set_attribute("http.status_code", 503)
+            return ReadinessResponse(
+                ready=False,
+                reason=model_reason,
+                overall_status=HealthStatus.UNHEALTHY,
+                impacts=["Default model not available in registry"],
+                providers=[],
+            )
+
+        # All healthy
+        span.set_attribute("http.status_code", 200)
         return ReadinessResponse(
-            ready=False,
-            reason=model_reason,
-            overall_status=HealthStatus.UNHEALTHY,
-            impacts=["Default model not available in registry"],
+            ready=True,
+            reason="All providers are healthy",
+            overall_status=HealthStatus.HEALTHY,
+            impacts=None,
             providers=[],
         )
-
-    # All healthy
-    return ReadinessResponse(
-        ready=True,
-        reason="All providers are healthy",
-        overall_status=HealthStatus.HEALTHY,
-        impacts=None,
-        providers=[],
-    )
 
 
 @router.get("/liveness", responses=get_liveness_responses)
@@ -250,6 +258,7 @@ async def liveness_probe_get_method(
     # Used only for authorization
     _ = auth
 
-    logger.info("Response to /v1/liveness endpoint")
-
-    return LivenessResponse(alive=True)
+    with tracer.start_as_current_span("liveness.handle_request") as span:
+        logger.info("Response to /v1/liveness endpoint")
+        span.set_attribute("http.status_code", 200)
+        return LivenessResponse(alive=True)

--- a/src/app/endpoints/metrics.py
+++ b/src/app/endpoints/metrics.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import PlainTextResponse
+from opentelemetry import trace
 from prometheus_client import (
     CONTENT_TYPE_LATEST,
     generate_latest,
@@ -21,6 +22,7 @@ from models.api.responses.error import (
 )
 from models.config import Action
 
+tracer = trace.get_tracer(__name__)
 router = APIRouter(tags=["metrics"])
 
 
@@ -62,4 +64,6 @@ async def metrics_endpoint_handler(
     # Nothing interesting in the request
     _ = request
 
-    return PlainTextResponse(generate_latest(), media_type=str(CONTENT_TYPE_LATEST))
+    with tracer.start_as_current_span("metrics.handle_request") as span:
+        span.set_attribute("http.status_code", 200)
+        return PlainTextResponse(generate_latest(), media_type=str(CONTENT_TYPE_LATEST))

--- a/src/app/endpoints/root.py
+++ b/src/app/endpoints/root.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
+from opentelemetry import trace
 
 from authentication import get_auth_dependency
 from authentication.interface import AuthTuple
@@ -18,6 +19,7 @@ from models.api.responses.error import (
 from models.config import Action
 
 logger = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 router = APIRouter(tags=["root"])
 
 
@@ -816,5 +818,7 @@ async def root_endpoint_handler(
     # Nothing interesting in the request
     _ = request
 
-    logger.info("Serving index page")
-    return HTMLResponse(INDEX_PAGE)
+    with tracer.start_as_current_span("root.handle_request") as span:
+        logger.info("Serving index page")
+        span.set_attribute("http.status_code", 200)
+        return HTMLResponse(INDEX_PAGE)

--- a/tests/unit/app/endpoints/test_health.py
+++ b/tests/unit/app/endpoints/test_health.py
@@ -4,6 +4,9 @@ from typing import Any
 
 import pytest
 from ogx_client import APIConnectionError
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pytest_mock import MockerFixture
 
 from app.endpoints.health import (
@@ -394,3 +397,107 @@ class TestReadinessDegradedMode:  # pylint: disable=too-few-public-methods
         assert "RAG functionality unavailable" in response.impacts
         assert "Agent tools unavailable" in response.impacts
         assert len(response.providers) == 0
+
+
+class TestHealthEndpointOtel:
+    """OTEL instrumentation tests for health probe endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_readiness_emits_span_on_healthy(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Test that a healthy readiness check emits a span with status 200."""
+        tracer, exporter = otel
+        mocker.patch("app.endpoints.health.tracer", tracer)
+        mock_authorization_resolvers(mocker)
+
+        mock_tracker = mocker.patch("app.endpoints.health.DegradedModeTracker")
+        mock_tracker.return_value.is_degraded.return_value = False
+
+        mocker.patch(
+            "app.endpoints.health.get_providers_health_statuses",
+            return_value=[
+                ProviderHealthStatus(
+                    provider_id="p1",
+                    status=HealthStatus.OK.value,
+                    message="ok",
+                )
+            ],
+        )
+        mocker.patch(
+            "app.endpoints.health.check_default_model_available",
+            return_value=(True, "Model available"),
+        )
+
+        mock_response = mocker.Mock()
+        auth: AuthTuple = ("uid", "uname", True, "tok")
+
+        await readiness_probe_get_method(auth=auth, response=mock_response)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "readiness.handle_request"
+        assert span.attributes is not None
+        assert span.attributes["http.status_code"] == 200
+
+    @pytest.mark.asyncio
+    async def test_readiness_emits_span_with_503_on_unhealthy(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Test that an unhealthy readiness check emits a span with status 503."""
+        tracer, exporter = otel
+        mocker.patch("app.endpoints.health.tracer", tracer)
+        mock_authorization_resolvers(mocker)
+
+        mock_tracker = mocker.patch("app.endpoints.health.DegradedModeTracker")
+        mock_tracker.return_value.is_degraded.return_value = False
+
+        mocker.patch(
+            "app.endpoints.health.get_providers_health_statuses",
+            return_value=[
+                ProviderHealthStatus(
+                    provider_id="bad-provider",
+                    status=HealthStatus.ERROR.value,
+                    message="down",
+                )
+            ],
+        )
+
+        mock_response = mocker.Mock()
+        auth: AuthTuple = ("uid", "uname", True, "tok")
+
+        await readiness_probe_get_method(auth=auth, response=mock_response)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "readiness.handle_request"
+        assert span.attributes is not None
+        assert span.attributes["http.status_code"] == 503
+
+    @pytest.mark.asyncio
+    async def test_liveness_emits_span(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Test that the liveness probe emits a span with status 200."""
+        tracer, exporter = otel
+        mocker.patch("app.endpoints.health.tracer", tracer)
+        mock_authorization_resolvers(mocker)
+
+        auth: AuthTuple = ("uid", "uname", True, "tok")
+
+        await liveness_probe_get_method(auth=auth)
+
+        spans = exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "liveness.handle_request"
+        assert span.attributes is not None
+        assert span.attributes["http.status_code"] == 200

--- a/tests/unit/app/endpoints/test_metrics.py
+++ b/tests/unit/app/endpoints/test_metrics.py
@@ -1,7 +1,12 @@
 """Unit tests for the /metrics REST API endpoint."""
 
+from typing import Any
+
 import pytest
 from fastapi import Request
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pytest_mock import MockerFixture
 
 import metrics  # noqa: F401 pylint: disable=unused-import
@@ -41,3 +46,26 @@ async def test_metrics_endpoint(mocker: MockerFixture) -> None:
     assert "# TYPE ls_llm_token_sent_total counter" in response_body
     assert "# TYPE ls_llm_token_received_total counter" in response_body
     assert "# TYPE ls_started_in_degraded_mode gauge" in response_body
+
+
+@pytest.mark.asyncio
+async def test_metrics_emits_otel_span(
+    mocker: MockerFixture,
+    otel: tuple[Any, InMemorySpanExporter],
+) -> None:
+    """Test that the metrics handler emits a lightweight span with HTTP status."""
+    tracer, exporter = otel
+    mocker.patch("app.endpoints.metrics.tracer", tracer)
+    mock_authorization_resolvers(mocker)
+
+    request = Request(scope={"type": "http"})
+    auth: AuthTuple = ("uid", "uname", True, "tok")
+
+    await metrics_endpoint_handler(auth=auth, request=request)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "metrics.handle_request"
+    assert span.attributes is not None
+    assert span.attributes["http.status_code"] == 200

--- a/tests/unit/app/endpoints/test_root.py
+++ b/tests/unit/app/endpoints/test_root.py
@@ -1,7 +1,12 @@
 """Unit tests for the / endpoint handler."""
 
+from typing import Any
+
 import pytest
 from fastapi import Request
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pytest_mock import MockerFixture
 
 from app.endpoints.root import root_endpoint_handler
@@ -22,3 +27,26 @@ async def test_root_endpoint(mocker: MockerFixture) -> None:
     )
     response = await root_endpoint_handler(auth=auth, request=request)
     assert response is not None
+
+
+@pytest.mark.asyncio
+async def test_root_emits_otel_span(
+    mocker: MockerFixture,
+    otel: tuple[Any, InMemorySpanExporter],
+) -> None:
+    """Test that the root handler emits a lightweight span with HTTP status."""
+    tracer, exporter = otel
+    mocker.patch("app.endpoints.root.tracer", tracer)
+    mock_authorization_resolvers(mocker)
+
+    auth = AuthTuple(("test_user_id", "test_user_name", False, "token"))
+    request = Request(scope={"type": "http"})
+
+    await root_endpoint_handler(auth=auth, request=request)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.name == "root.handle_request"
+    assert span.attributes is not None
+    assert span.attributes["http.status_code"] == 200


### PR DESCRIPTION
## Description

- Add single lightweight OTEL spans to probe endpoints (`root`, `readiness`, `liveness`, `metrics`) with only route name and HTTP status
- No child spans or detailed instrumentation — these are high-frequency, low-semantic-value endpoints
- Readiness probe span captures HTTP 503 vs 200 to surface health check failures in traces


## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distributed tracing to health, metrics, and root endpoint requests.
  * Captured request spans with relevant HTTP status codes, including unhealthy readiness responses.

* **Tests**
  * Added coverage verifying tracing for healthy and unhealthy readiness checks, liveness checks, metrics requests, and root page requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->