### PR TITLE
LCORE-3441: Enable UP012 rule on CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,8 +247,8 @@ line-length = 88
 extend-exclude = ["tests/profiles/syntax_error.py"]
 
 [tool.ruff.lint]
-extend-select = ["TID251", "UP006", "UP007", "UP008", "UP010", "UP017", "UP035", "UP040", "RUF100", "B009", "B010", "DTZ005", "D202", "I001", "PLR1733", "RUF022", "TC004", "PIE790"]
-ignore = ["UP047", "UP045", "BLE", "S", "C", "RUF", "SIM", "B017", "TRY004", "TRY201", "TRY203", "TRY401", "UP012", "UP024", "UP041", "B008", "EXE001", "FURB129", "G201", "ISC004", "LOG014", "PERF402", "PLW1510", "PYI034", "PYI064", "RET501"]
+extend-select = ["TID251", "UP006", "UP007", "UP008", "UP010", "UP012", "UP017", "UP035", "UP040", "RUF100", "B009", "B010", "DTZ005", "D202", "I001", "PLR1733", "RUF022", "TC004", "PIE790"]
+ignore = ["UP047", "UP045", "BLE", "S", "C", "RUF", "SIM", "B017", "TRY004", "TRY201", "TRY203", "TRY401", "UP024", "UP041", "B008", "EXE001", "FURB129", "G201", "ISC004", "LOG014", "PERF402", "PLW1510", "PYI034", "PYI064", "RET501"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 unittest = { msg = "use pytest instead of unittest" }


### PR DESCRIPTION
## Description

LCORE-3441: Enable `UP012` rule on CI

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [x] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3441


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality checks to enforce additional linting rules.
  * Adjusted an existing linting exception to maintain compatibility with current code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->