### PR TITLE
LCORE-3607: set default values for default_run.yaml openai block

### DIFF
--- a/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
+++ b/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
@@ -231,7 +231,14 @@ defaults), so the unified signal is `inference.providers` being
 No persistent storage is added. The synthesized `run.yaml` is written
 once per boot to a deterministic path; not a database. `src/data/
 default_run.yaml` is a new package-shipped file, the built-in baseline
-Llama Stack configuration.
+Llama Stack configuration. Its `remote::openai` inference provider uses
+Llama Stack's `${env.OPENAI_API_KEY:+openai}` / `${env.OPENAI_API_KEY:=}`
+conditional-provider idiom, so the built-in baseline contributes openai
+only when `OPENAI_API_KEY` is set. Synthesis leaves those refs
+unevaluated (R6); Llama Stack resolves them at boot. With the key unset
+or empty the provider is disabled (`provider_id` becomes `None`) and
+the stack loads without `EnvVarError`. With the key set, the resolved
+config matches the previous unconditional openai provider.
 
 ### Configuration
 
@@ -431,7 +438,7 @@ September 2026.
 |---|---|
 | `src/models/config.py` | Add `UnifiedInferenceProvider`. Extend the existing `InferenceConfiguration` with `providers: list[UnifiedInferenceProvider]`. Add `UnifiedLlamaStackConfig` (`baseline`/`profile`/`native_override`) and a `config` field on `LlamaStackConfiguration`. Put the unified-vs-legacy `model_validator` on the **root** `Configuration` model (spans `inference.providers` + `llama_stack.*`). |
 | `src/llama_stack_configuration.py` | Add `synthesize_configuration`, `deep_merge_list_replace`, `apply_high_level_inference`, `load_default_baseline`, `synthesize_to_file`, `migrate_config_dumb`, `PROVIDER_TYPE_MAP`, `DEFAULT_BASELINE_RESOURCE`. Update `main()` to auto-detect unified vs legacy. |
-| `src/data/default_run.yaml` | New file — a thinner baseline than today's repo-root `run.yaml`. Notably do **not** reference `${env.EXTERNAL_PROVIDERS_DIR}` without a default (see "Findings discovered during PoC" in the spike doc). |
+| `src/data/default_run.yaml` | New file — a thinner baseline than today's repo-root `run.yaml`. Notably do **not** reference `${env.EXTERNAL_PROVIDERS_DIR}` without a default (see "Findings discovered during PoC" in the spike doc). OpenAI is conditional on `OPENAI_API_KEY` (`${env.OPENAI_API_KEY:+openai}` / `${env.OPENAI_API_KEY:=}`). |
 | `src/client.py` | In `_load_library_client`: branch on `config.config` presence. Add `_synthesize_library_config()` that calls the synthesizer and writes to the deterministic path (R10). Keep `_enrich_library_config` for legacy. |
 | `src/lightspeed_stack.py` | Add `--migrate-config`, `--run-yaml`, `--migrate-output`, `--synthesized-config-output` flags. Add an early-exit branch in `main()` that dispatches to `migrate_config_dumb` when `--migrate-config` is set. Clean up stale docstring. |
 | `scripts/llama-stack-entrypoint.sh` | No functional change — the Python CLI already auto-detects. Update the comment to document both modes. |
@@ -545,6 +552,7 @@ reference.
 | Date | Change | Reason |
 |---|---|---|
 | 2026-04-23 | Initial version | Spike completion |
+| 2026-08-20 | Default baseline openai provider is conditional on `OPENAI_API_KEY` | LCORE-3607: `baseline: default` must load when the key is unset |
 
 ## Appendix A — Worked example: legacy → unified migration
 

--- a/src/data/default_run.yaml
+++ b/src/data/default_run.yaml
@@ -35,10 +35,10 @@ external_providers_dir: ${env.EXTERNAL_PROVIDERS_DIR:=~/.llama/providers.d}
 
 providers:
   inference:
-  - provider_id: openai
+  - provider_id: ${env.OPENAI_API_KEY:+openai}
     provider_type: remote::openai
     config:
-      api_key: ${env.OPENAI_API_KEY}
+      api_key: ${env.OPENAI_API_KEY:=}
       allowed_models: ["${env.E2E_OPENAI_MODEL:=gpt-4o-mini}"]
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -1013,6 +1013,25 @@ def deep_merge_list_replace(
     return result
 
 
+def _matchable_provider_id(provider_id: Any) -> Any:
+    """Return the provider_id used for high-level replace matching.
+
+    The default baseline ships openai as ``${env.OPENAI_API_KEY:+openai}``
+    (R6: left unevaluated). Treat that literal as ``openai`` so a high-level
+    ``{type: openai}`` replaces the baseline row instead of appending.
+
+    Parameters:
+        provider_id: The raw ``provider_id`` from a baseline or emitted entry.
+
+    Returns:
+        ``openai`` when ``provider_id`` is the baseline conditional openai
+        ref, otherwise ``provider_id`` unchanged.
+    """
+    if provider_id == "${env.OPENAI_API_KEY:+openai}":
+        return "openai"
+    return provider_id
+
+
 def apply_high_level_inference(
     ls_config: dict[str, Any], inference: dict[str, Any]
 ) -> None:
@@ -1026,7 +1045,9 @@ def apply_high_level_inference(
     baseline's ecosystem convention (e.g. the default embedding model reference).
     An entry whose ``provider_id`` already exists in the baseline (or was emitted
     by an earlier high-level entry) is replaced with an info log; new ones are
-    appended. Secrets are emitted as ``${env.<VAR>}`` references, never resolved
+    appended. The baseline openai id ``${env.OPENAI_API_KEY:+openai}`` is matched
+    as ``openai``, so high-level ``{type: openai}`` still replaces that row.
+    Secrets are emitted as ``${env.<VAR>}`` references, never resolved
     values (R6).
 
     Parameters:
@@ -1066,8 +1087,12 @@ def apply_high_level_inference(
             entry["config"] = provider_config
 
         # Replace a baseline provider with the same id, else append.
+        # Baseline ${env.OPENAI_API_KEY:+openai} matches as "openai" (LCORE-3607).
         for index, existing in enumerate(inference_list):
-            if isinstance(existing, dict) and existing.get("provider_id") == emitted_id:
+            if not isinstance(existing, dict):
+                continue
+            existing_id = _matchable_provider_id(existing.get("provider_id"))
+            if existing_id == emitted_id:
                 logger.info(
                     "Replacing existing inference provider with "
                     "provider_id=%r; a later high-level entry overwrote it",

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -13,6 +13,7 @@ from typing import Any, Optional, get_args
 
 import pytest
 import yaml
+from ogx.core.stack import replace_env_vars
 
 from llama_stack_configuration import (
     PROVIDER_TYPE_MAP,
@@ -26,6 +27,9 @@ from llama_stack_configuration import (
 )
 from models.config import UnifiedInferenceProvider
 
+OPENAI_CONDITIONAL_PROVIDER_ID = "${env.OPENAI_API_KEY:+openai}"
+OPENAI_CONDITIONAL_API_KEY = "${env.OPENAI_API_KEY:=}"
+
 # ---------------------------------------------------------------------------
 # ensure_mcp_tool_runtime
 # ---------------------------------------------------------------------------
@@ -38,6 +42,24 @@ def _tool_runtime_ids(ls_config: dict[str, Any]) -> list[Optional[str]]:
         entry.get("provider_id")
         for entry in providers.get("tool_runtime") or []
         if isinstance(entry, dict)
+    ]
+
+
+def _inference_entries(ls_config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return inference provider dicts from a synthesized or baseline config."""
+    providers = ls_config.get("providers") or {}
+    return [
+        entry for entry in providers.get("inference") or [] if isinstance(entry, dict)
+    ]
+
+
+def _openai_inference_entries(ls_config: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return remote::openai inference rows, including the conditional-id form."""
+    return [
+        entry
+        for entry in _inference_entries(ls_config)
+        if entry.get("provider_type") == "remote::openai"
+        or entry.get("provider_id") in ("openai", OPENAI_CONDITIONAL_PROVIDER_ID)
     ]
 
 
@@ -132,6 +154,54 @@ def test_load_default_baseline_includes_file_processors() -> None:
         p.get("provider_id") == "pypdf" and p.get("provider_type") == "inline::pypdf"
         for p in processors
     )
+
+
+def test_load_default_baseline_openai_is_conditional_on_api_key() -> None:
+    """OpenAI is present only when OPENAI_API_KEY is set (LCORE-3607)."""
+    baseline = load_default_baseline()
+    openai_entries = _openai_inference_entries(baseline)
+    assert openai_entries == [
+        {
+            "provider_id": OPENAI_CONDITIONAL_PROVIDER_ID,
+            "provider_type": "remote::openai",
+            "config": {
+                "api_key": OPENAI_CONDITIONAL_API_KEY,
+                "allowed_models": ["${env.E2E_OPENAI_MODEL:=gpt-4o-mini}"],
+            },
+        }
+    ]
+    ids = [entry["provider_id"] for entry in _inference_entries(baseline)]
+    assert "sentence-transformers" in ids
+
+
+@pytest.mark.parametrize("openai_api_key", [None, ""])
+def test_default_baseline_resolves_when_openai_api_key_missing(
+    monkeypatch: pytest.MonkeyPatch, openai_api_key: Optional[str]
+) -> None:
+    """Unset or empty OPENAI_API_KEY disables openai without EnvVarError."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    if openai_api_key is not None:
+        monkeypatch.setenv("OPENAI_API_KEY", openai_api_key)
+
+    resolved = replace_env_vars(load_default_baseline())
+    openai_entries = _openai_inference_entries(resolved)
+    assert len(openai_entries) == 1
+    assert openai_entries[0]["provider_id"] is None
+    ids = [entry["provider_id"] for entry in _inference_entries(resolved)]
+    assert "sentence-transformers" in ids
+
+
+def test_default_baseline_resolves_when_openai_api_key_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A set OPENAI_API_KEY resolves to the same openai provider as before."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+    resolved = replace_env_vars(load_default_baseline())
+    openai_entries = _openai_inference_entries(resolved)
+    assert len(openai_entries) == 1
+    openai = openai_entries[0]
+    assert openai["provider_id"] == "openai"
+    assert openai["config"]["api_key"] == "sk-test-key"
 
 
 # ---------------------------------------------------------------------------
@@ -245,6 +315,33 @@ def test_apply_high_level_inference_replaces_existing_provider_id(
     openai = ls_config["providers"]["inference"][0]
     assert openai["config"]["api_key"] == "${env.NEW_KEY}"
     assert "provider_id='openai'" in caplog.text
+
+
+def test_apply_high_level_inference_replaces_conditional_provider_id() -> None:
+    """The baseline ${env.OPENAI_API_KEY:+openai} row matches id openai."""
+    ls_config: dict[str, Any] = {
+        "providers": {
+            "inference": [
+                {
+                    "provider_id": OPENAI_CONDITIONAL_PROVIDER_ID,
+                    "provider_type": "remote::openai",
+                    "config": {"api_key": OPENAI_CONDITIONAL_API_KEY},
+                },
+                {
+                    "provider_id": "sentence-transformers",
+                    "provider_type": "inline::sentence-transformers",
+                },
+            ]
+        }
+    }
+    inference = {"providers": [{"type": "openai", "api_key_env": "OPENAI_API_KEY"}]}
+    apply_high_level_inference(ls_config, inference)
+    openai_entries = _openai_inference_entries(ls_config)
+    assert len(openai_entries) == 1
+    assert openai_entries[0]["provider_id"] == "openai"
+    assert openai_entries[0]["config"]["api_key"] == "${env.OPENAI_API_KEY}"
+    ids = [entry["provider_id"] for entry in _inference_entries(ls_config)]
+    assert ids == ["openai", "sentence-transformers"]
 
 
 def test_apply_high_level_inference_uses_explicit_id() -> None:
@@ -597,13 +694,47 @@ def test_synthesize_from_default_baseline_applies_inference_and_override() -> No
         },
     }
     result = synthesize_configuration(lcs)
-    # high-level inference landed (env ref, never a literal secret)
-    openai = next(
-        p for p in result["providers"]["inference"] if p["provider_id"] == "openai"
-    )
+    openai_entries = _openai_inference_entries(result)
+    assert len(openai_entries) == 1
+    openai = openai_entries[0]
+    assert openai["provider_id"] == "openai"
     assert openai["config"]["api_key"] == "${env.OPENAI_API_KEY}"
     # native_override deep-merged last
     assert result["safety"]["default_shield_id"] == "custom"
+
+
+def test_synthesize_vllm_appends_and_keeps_conditional_openai(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """High-level vLLM appends; baseline openai stays conditional and disables."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("VLLM_API_KEY", "vllm-test-key")
+    lcs = {
+        "llama_stack": {"config": {"baseline": "default"}},
+        "inference": {
+            "providers": [
+                {
+                    "type": "vllm",
+                    "api_key_env": "VLLM_API_KEY",
+                    "extra": {"url": "http://vllm:8000"},
+                }
+            ]
+        },
+    }
+    result = synthesize_configuration(lcs)
+    openai_entries = _openai_inference_entries(result)
+    assert len(openai_entries) == 1
+    assert openai_entries[0]["provider_id"] == OPENAI_CONDITIONAL_PROVIDER_ID
+    vllm = next(
+        entry for entry in _inference_entries(result) if entry["provider_id"] == "vllm"
+    )
+    assert vllm["provider_type"] == "remote::vllm"
+
+    resolved = replace_env_vars(result)
+    resolved_openai = _openai_inference_entries(resolved)
+    assert len(resolved_openai) == 1
+    assert resolved_openai[0]["provider_id"] is None
+    assert any(entry["provider_id"] == "vllm" for entry in _inference_entries(resolved))
 
 
 def test_synthesize_loads_profile_relative_to_config_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- If `OPENAI_API_KEY` is unset/empty and user is using `default` baseline, the `provider_id` is registered as `None` and OGX excludes it without error
- If `OPENAI_API_KEY` is set, `openai` provider is registered by OGX
- If `OPENAI_API_KEY` is unset/empty and user defines a new `openai` provider in the high-level `inference.providers`, the high-level one takes over (if both called `openai` as provider_id)
- In all scenarios, `/v1/models` is served properly, if `openai` is disabled, it does not return any `openai` models, if it is properly set, it does
   - Tested myself by starting up a container built with these changes and running through the scenarios where `OPENAI_API_KEY` is both set and unset

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/LCORE-3607
- Closes https://redhat.atlassian.net/browse/LCORE-3607

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI is now enabled automatically when `OPENAI_API_KEY` is configured.
  * OpenAI remains disabled without errors when the key is missing or empty.
  * High-level OpenAI inference settings now correctly activate the conditional OpenAI provider.
  * vLLM configuration preserves the conditional OpenAI entry while adding vLLM support.
* **Documentation**
  * Updated configuration guidance to describe conditional OpenAI provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->