### PR TITLE
LCORE-2982: Add OTEL spans for responses pipeline utils

### DIFF
--- a/src/utils/otel_tracing.py
+++ b/src/utils/otel_tracing.py
@@ -7,6 +7,7 @@ the application with OpenTelemetry spans, attributes, and events.
 import hashlib
 import hmac
 import os
+from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any, Optional
 
@@ -25,6 +26,8 @@ class SpanAttributes(StrEnum):
     USER_ID = "user.id"  # anonymized
     INPUT = "request.input"  # anonymized
     OUTPUT = "response.output"  # anonymized
+    RESPONSE_ERROR = "response.error"
+    RESPONSE_CAUSE = "response.cause"
     REQUEST_ATTACHMENTS_COUNT = "request.attachments.count"
     LLM_MODEL_ID = "llm.model.id"
     LLM_PROVIDER_ID = "llm.provider.id"
@@ -39,6 +42,7 @@ class SpanAttributes(StrEnum):
     TOOL_CALLS_NAMES = "tool.calls.names"
     SKILL_ACTIVATIONS = "skill.activations"
     RLS_TEMPLATE_OK = "rls.template.ok"
+    TOPIC_SUMMARY_SUCCESS = "topic.summary.success"
 
 
 class SpanEvents(StrEnum):
@@ -55,6 +59,8 @@ class SpanEvents(StrEnum):
     SKILL_ACTIVATED = "skill.activated"
     LLM_RESPONSE_COMPLETED = "llm.response.completed"
     TURN_PERSISTED = "turn.persisted"
+    TOPIC_SUMMARY_TASK_STARTED = "topic.summary.task.started"
+    TOPIC_SUMMARY_TASK_FINISHED = "topic.summary.task.finished"
 
 
 def anonymize_value(value: str, max_length: int = 50) -> str:
@@ -125,7 +131,9 @@ def add_span_event(
 
 
 def record_exception(
-    span: trace.Span, exception: Exception, attributes: Optional[dict[str, Any]] = None
+    span: trace.Span,
+    exception: Exception,
+    attributes: Optional[Mapping[SpanAttributes, Any]] = None,
 ) -> None:
     """Record an exception on a span.
 
@@ -134,4 +142,7 @@ def record_exception(
         exception: The exception to record.
         attributes: Optional additional attributes for the exception event.
     """
-    span.record_exception(exception, attributes=attributes)
+    span_attributes = (
+        {str(key): value for key, value in attributes.items()} if attributes else None
+    )
+    span.record_exception(exception, attributes=span_attributes)

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -80,6 +80,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseUsageOutputTokensDetails as UsageOutputTokensDetails,
 )
 from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
+from opentelemetry import trace
 
 import constants
 from configuration import configuration
@@ -115,6 +116,12 @@ from utils.mcp_headers import (
     find_unresolved_auth_headers,
 )
 from utils.model_list import parse_model_list_response
+from utils.otel_tracing import (
+    SpanAttributes,
+    SpanEvents,
+    add_span_event,
+    set_span_attributes,
+)
 from utils.prompts import get_system_prompt, get_topic_summary_system_prompt
 from utils.query import (
     extract_provider_and_model_from_model_id,
@@ -126,6 +133,7 @@ from utils.suid import to_llama_stack_conversation_id
 from utils.token_counter import TokenCounter
 
 logger = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 async def get_vector_store_ids(
@@ -226,7 +234,19 @@ async def maybe_get_topic_summary(
     if not generate_topic_summary:
         return None
     logger.debug("Generating topic summary for new conversation")
-    return await get_topic_summary(input_text, client, model_id)
+    with tracer.start_as_current_span("topic.summary") as span:
+        add_span_event(span, SpanEvents.TOPIC_SUMMARY_TASK_STARTED)
+        success = False
+        try:
+            summary = await get_topic_summary(input_text, client, model_id)
+            success = True
+            return summary
+        finally:
+            set_span_attributes(
+                span,
+                {SpanAttributes.TOPIC_SUMMARY_SUCCESS: success},
+            )
+            add_span_event(span, SpanEvents.TOPIC_SUMMARY_TASK_FINISHED)
 
 
 async def prepare_tools(  # pylint: disable=too-many-arguments,too-many-positional-arguments

--- a/src/utils/shields.py
+++ b/src/utils/shields.py
@@ -31,7 +31,7 @@ from pydantic_ai_lightspeed.capabilities.redaction._capability import (
 )
 from utils.agents.error_handler import map_agent_inference_error
 from utils.input_sanitization import sanitize_input
-from utils.otel_tracing import SpanAttributes
+from utils.otel_tracing import SpanAttributes, SpanEvents, add_span_event
 
 logger = get_logger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -90,41 +90,58 @@ async def run_shield_moderation_v2(
     Returns:
         Result indicating if content was blocked or passed.
     """
-    # Sanitize input before running any shields (OFFSEC-307 / LCORE-2749).
-    # Normalizes Unicode and rejects obfuscated content (unusual Unicode
-    # blocks, binary/hex encoding, XML injection patterns).
-    normalized_text, rejection_reason = sanitize_input(input_text)
-    if rejection_reason:
-        logger.warning("Input blocked by sanitization: %s", rejection_reason)
-        return ShieldModerationBlocked(
-            decision="blocked",
-            message=OBFUSCATION_REJECTION_MESSAGE,
-            moderation_id=str(uuid.uuid4()),
+    with tracer.start_as_current_span("shield.moderate") as span:
+        # Sanitize input before running any shields (OFFSEC-307 / LCORE-2749).
+        # Normalizes Unicode and rejects obfuscated content (unusual Unicode
+        # blocks, binary/hex encoding, XML injection patterns).
+        normalized_text, rejection_reason = sanitize_input(input_text)
+        if rejection_reason:
+            logger.warning("Input blocked by sanitization: %s", rejection_reason)
+            span.set_attribute(SpanAttributes.SHIELD_RESULT, "blocked")
+            add_span_event(
+                span,
+                SpanEvents.SHIELD_REJECTED,
+                {"shield.reason": "input_sanitization"},
+            )
+            return ShieldModerationBlocked(
+                decision="blocked",
+                message=OBFUSCATION_REJECTION_MESSAGE,
+                moderation_id=str(uuid.uuid4()),
+            )
+        input_text = normalized_text
+
+        selected_shield_configs = get_shields_for_request(
+            shield_configs, selected_shield_ids
         )
-    input_text = normalized_text
 
-    selected_shield_configs = get_shields_for_request(
-        shield_configs, selected_shield_ids
-    )
+        for shield_config in selected_shield_configs:
+            shield = build_shield(shield_config)
 
-    for shield_config in selected_shield_configs:
-        shield = build_shield(shield_config)
+            try:
+                shield_result = await shield.run(input_text)
+            # APIConnectionError and APIStatusError from ogx should not be raised
+            # from model_request, because they will be caught inside AsyncOpenAI
+            # and transferred into openai's APIConnectionError. The openai's
+            # exceptions will further transferred into ModelHTTPError or
+            # ModelAPIError by _map_api_errors in OpenAIResponseModel.
+            except (AgentRunError, RuntimeError) as exc:
+                model_id = getattr(
+                    shield_config.config, "model_id", "unknown-shield-model"
+                )
+                response = map_agent_inference_error(exc, model_id)
+                raise HTTPException(**response.model_dump()) from exc
 
-        try:
-            shield_result = await shield.run(input_text)
-        # APIConnectionError and APIStatusError from ogx should not be raised from model_request,
-        # because they will be caught inside AsyncOpenAI and transferred into openai's
-        # APIConnectionError. The openai's exceptions will further transferred into ModelHTTPError
-        # or ModelAPIError by _map_api_errors in OpenAIResponseModel.
-        except (AgentRunError, RuntimeError) as exc:
-            model_id = getattr(shield_config.config, "model_id", "unknown-shield-model")
-            response = map_agent_inference_error(exc, model_id)
-            raise HTTPException(**response.model_dump()) from exc
+            if shield_result.decision == "blocked":
+                span.set_attribute(SpanAttributes.SHIELD_RESULT, "blocked")
+                add_span_event(
+                    span,
+                    SpanEvents.SHIELD_REJECTED,
+                    {"shield.name": shield_config.name},
+                )
+                return shield_result
 
-        if shield_result.decision == "blocked":
-            return shield_result
-
-    return ShieldModerationPassed()
+        span.set_attribute(SpanAttributes.SHIELD_RESULT, "passed")
+        return ShieldModerationPassed()
 
 
 def build_shield(shield_config: ShieldConfiguration) -> AbstractSafetyCapability:

--- a/tests/unit/utils/test_otel_tracing.py
+++ b/tests/unit/utils/test_otel_tracing.py
@@ -307,7 +307,9 @@ class TestRecordException:
 
         with tracer.start_as_current_span("test_span") as span:
             record_exception(
-                span, test_exception, attributes={"error.context": "quota_check"}
+                span,
+                test_exception,
+                {SpanAttributes.RESPONSE_ERROR: "quota_check"},
             )
 
         spans = exporter.get_finished_spans()
@@ -316,7 +318,7 @@ class TestRecordException:
         assert len(events) == 1
         assert events[0].name == "exception"
         assert events[0].attributes["exception.type"] == "RuntimeError"
-        assert events[0].attributes["error.context"] == "quota_check"
+        assert events[0].attributes[SpanAttributes.RESPONSE_ERROR] == "quota_check"
 
     def test_record_multiple_exceptions(self, otel):
         """Test recording multiple exceptions on a span."""

--- a/tests/unit/utils/test_responses.py
+++ b/tests/unit/utils/test_responses.py
@@ -53,6 +53,9 @@ from ogx_api.openai_responses import (
 from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
 from ogx_client.types import ListModelsResponse
 from ogx_client.types.model import Model
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pydantic import AnyUrl, BaseModel
 from pytest_mock import MockerFixture
 
@@ -66,6 +69,7 @@ from models.config import (
     ModelContextProtocolServer,
     RagStore,
 )
+from utils.otel_tracing import SpanAttributes, SpanEvents
 from utils.query import normalize_vertex_ai_model_id
 from utils.responses import (
     _build_chunk_attributes,
@@ -84,6 +88,7 @@ from utils.responses import (
     get_rag_tools,
     get_topic_summary,
     is_server_deployed_output,
+    maybe_get_topic_summary,
     parse_arguments_string,
     parse_referenced_documents,
     prepare_responses_params,
@@ -1012,6 +1017,81 @@ class TestGetTopicSummary:
 
         with pytest.raises(HTTPException):
             await get_topic_summary("test question", mock_client, "model1")
+
+
+class TestMaybeGetTopicSummaryOtel:
+    """OpenTelemetry events/attributes for maybe_get_topic_summary."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("success", "expect_attr"),
+        [(True, True), (False, False)],
+    )
+    async def test_emits_started_success_and_finished(
+        self,
+        success: bool,
+        expect_attr: bool,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Topic summary span records success attr and started/finished events."""
+        tracer, exporter = otel
+        mocker.patch("utils.responses.tracer", tracer)
+        if success:
+            mocker.patch(
+                "utils.responses.get_topic_summary",
+                new=mocker.AsyncMock(return_value="Topic"),
+            )
+            result = await maybe_get_topic_summary(
+                True, "hello", mocker.AsyncMock(), "provider/model"
+            )
+            assert result == "Topic"
+        else:
+            mocker.patch(
+                "utils.responses.get_topic_summary",
+                new=mocker.AsyncMock(side_effect=RuntimeError("boom")),
+            )
+            with pytest.raises(RuntimeError, match="boom"):
+                await maybe_get_topic_summary(
+                    True, "hello", mocker.AsyncMock(), "provider/model"
+                )
+
+        span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "topic.summary"
+        )
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.TOPIC_SUMMARY_SUCCESS] is expect_attr
+        event_names = [event.name for event in span.events]
+        assert SpanEvents.TOPIC_SUMMARY_TASK_STARTED in event_names
+        assert SpanEvents.TOPIC_SUMMARY_TASK_FINISHED in event_names
+        if success:
+            assert event_names == [
+                SpanEvents.TOPIC_SUMMARY_TASK_STARTED,
+                SpanEvents.TOPIC_SUMMARY_TASK_FINISHED,
+            ]
+        else:
+            assert event_names.index(
+                SpanEvents.TOPIC_SUMMARY_TASK_STARTED
+            ) < event_names.index(SpanEvents.TOPIC_SUMMARY_TASK_FINISHED)
+
+    @pytest.mark.asyncio
+    async def test_disabled_emits_no_span(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Disabled topic summary does not create a span."""
+        tracer, exporter = otel
+        mocker.patch("utils.responses.tracer", tracer)
+        result = await maybe_get_topic_summary(
+            False, "hello", mocker.AsyncMock(), "provider/model"
+        )
+        assert result is None
+        assert not [
+            s for s in exporter.get_finished_spans() if s.name == "topic.summary"
+        ]
 
 
 class TestResolveToolChoice:

--- a/tests/unit/utils/test_shields.py
+++ b/tests/unit/utils/test_shields.py
@@ -1,7 +1,12 @@
 """Unit tests for utils/shields.py functions."""
 
+from typing import Any
+
 import pytest
 from fastapi import HTTPException, status
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
 from pytest_mock import MockerFixture
 
@@ -11,6 +16,7 @@ from models.config import (
     QuestionValidityShieldConfiguration,
     ShieldConfiguration,
 )
+from utils.otel_tracing import SpanAttributes, SpanEvents
 from utils.shields import (
     get_shields_for_request,
     run_shield_moderation_v2,
@@ -247,6 +253,92 @@ class TestRunShieldModerationV2:
         assert exc_info.value.status_code == status.HTTP_413_CONTENT_TOO_LARGE
         assert "test-model" in str(exc_info.value.detail)
         assert "Prompt is too long" in str(exc_info.value.detail)
+
+
+class TestRunShieldModerationV2Otel:
+    """OpenTelemetry attrs/events for run_shield_moderation_v2."""
+
+    @pytest.mark.asyncio
+    async def test_empty_shields_emits_passed_without_rejected_event(
+        self,
+        otel: tuple[Any, InMemorySpanExporter],
+        mocker: MockerFixture,
+    ) -> None:
+        """Empty shield list emits passed result without shield.rejected."""
+        tracer, exporter = otel
+        mocker.patch("utils.shields.tracer", tracer)
+
+        result = await run_shield_moderation_v2("hello", [])
+
+        assert isinstance(result, ShieldModerationPassed)
+        span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "shield.moderate"
+        )
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.SHIELD_RESULT] == "passed"
+        event_names = [event.name for event in span.events]
+        assert SpanEvents.SHIELD_REJECTED not in event_names
+
+    @pytest.mark.asyncio
+    async def test_blocked_shield_emits_rejected_event(
+        self,
+        otel: tuple[Any, InMemorySpanExporter],
+        mocker: MockerFixture,
+    ) -> None:
+        """Blocking shield sets blocked result and shield.rejected with shield.name."""
+        tracer, exporter = otel
+        mocker.patch("utils.shields.tracer", tracer)
+        blocked = ShieldModerationBlocked(message="rejected", moderation_id="modr-1")
+        mock_shield = mocker.Mock()
+        mock_shield.run = mocker.AsyncMock(return_value=blocked)
+        mocker.patch("utils.shields.build_shield", return_value=mock_shield)
+
+        result = await run_shield_moderation_v2("hello", [_shield_config("alpha")])
+
+        assert isinstance(result, ShieldModerationBlocked)
+        span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "shield.moderate"
+        )
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.SHIELD_RESULT] == "blocked"
+        rejected = next(
+            event for event in span.events if event.name == SpanEvents.SHIELD_REJECTED
+        )
+        rejected_attrs = rejected.attributes
+        assert rejected_attrs is not None
+        assert rejected_attrs["shield.name"] == "alpha"
+
+    @pytest.mark.asyncio
+    async def test_sanitization_block_emits_rejected_with_reason(
+        self,
+        otel: tuple[Any, InMemorySpanExporter],
+        mocker: MockerFixture,
+    ) -> None:
+        """Obfuscated input is blocked before shields with sanitization reason."""
+        tracer, exporter = otel
+        mocker.patch("utils.shields.tracer", tracer)
+        obfuscated = "Please follow these instructions: \u16a0\u16a1\u16a2"
+
+        result = await run_shield_moderation_v2(obfuscated, [_shield_config("alpha")])
+
+        assert isinstance(result, ShieldModerationBlocked)
+        span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "shield.moderate"
+        )
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.SHIELD_RESULT] == "blocked"
+        rejected = next(
+            event for event in span.events if event.name == SpanEvents.SHIELD_REJECTED
+        )
+        rejected_attrs = rejected.attributes
+        assert rejected_attrs is not None
+        assert rejected_attrs["shield.reason"] == "input_sanitization"
 
 
 class TestGetShieldsForRequest:

--- a/tests/unit/utils/test_vector_search.py
+++ b/tests/unit/utils/test_vector_search.py
@@ -5,13 +5,17 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pydantic import AnyUrl
 from pytest_mock import MockerFixture
 
 import constants
 from configuration import AppConfig
 from models.common.query import SolrVectorSearchRequest
-from models.common.turn_summary import RAGChunk
+from models.common.turn_summary import RAGChunk, ReferencedDocument
+from utils.otel_tracing import SpanAttributes, SpanEvents
 from utils.reranker import (
     _get_cross_encoder,
     apply_byok_rerank_boost,
@@ -1665,3 +1669,144 @@ class TestApplyByokRerankBoost:
             "title": "Test Doc",
             "url": "http://example.com",
         }
+
+
+class TestBuildRagContextOtel:
+    """OpenTelemetry attrs/events for build_rag_context."""
+
+    @staticmethod
+    def _patch_rag_config(mocker: MockerFixture) -> None:
+        """Patch vector_search configuration for minimal inline RAG."""
+        config_mock = mocker.Mock(spec=AppConfig)
+        config_mock.rag.retrieval.inline.sources = []
+        config_mock.rag.byok.stores = []
+        config_mock.rag.retrieval.inline.max_chunks = (
+            constants.DEFAULT_INLINE_RAG_MAX_CHUNKS
+        )
+        config_mock.rag.byok.max_chunks = constants.DEFAULT_BYOK_RAG_MAX_CHUNKS
+        config_mock.inline_solr_enabled = False
+        config_mock.reranker = None
+        mocker.patch("utils.vector_search.configuration", config_mock)
+
+    @pytest.mark.asyncio
+    async def test_blocked_moderation_sets_zero_sources_without_completed_event(
+        self,
+        otel: tuple[Any, InMemorySpanExporter],
+        mocker: MockerFixture,
+    ) -> None:
+        """Blocked moderation skips retrieval and does not emit completed event."""
+        tracer, exporter = otel
+        mocker.patch("utils.vector_search.tracer", tracer)
+        mocker.patch(
+            "utils.vector_search.anonymize_value",
+            side_effect=lambda value: f"[anon:{value}]",
+        )
+        self._patch_rag_config(mocker)
+        client = mocker.AsyncMock()
+
+        await build_rag_context(client, "blocked", "test query", None)
+
+        span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "rag.retrieve"
+        )
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.RAG_INPUT] == "[anon:test query]"
+        assert span.attributes[SpanAttributes.RAG_SOURCES_COUNT] == 0
+        event_names = [event.name for event in span.events]
+        assert SpanEvents.RAG_RETRIEVAL_COMPLETED not in event_names
+
+    @pytest.mark.asyncio
+    async def test_passed_with_no_chunks_emits_zero_count_event(
+        self,
+        otel: tuple[Any, InMemorySpanExporter],
+        mocker: MockerFixture,
+    ) -> None:
+        """Passed moderation with no chunks emits retrieval completed with count 0."""
+        tracer, exporter = otel
+        mocker.patch("utils.vector_search.tracer", tracer)
+        mocker.patch(
+            "utils.vector_search.anonymize_value",
+            side_effect=lambda value: f"[anon:{value}]",
+        )
+        self._patch_rag_config(mocker)
+        mocker.patch(
+            "utils.vector_search._fetch_byok_rag",
+            new=mocker.AsyncMock(return_value=([], [])),
+        )
+        mocker.patch(
+            "utils.vector_search._fetch_okp_rag",
+            new=mocker.AsyncMock(return_value=([], [])),
+        )
+        client = mocker.AsyncMock()
+
+        await build_rag_context(client, "passed", "test query", None)
+
+        span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "rag.retrieve"
+        )
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.RAG_SOURCES_COUNT] == 0
+        completed = next(
+            event
+            for event in span.events
+            if event.name == SpanEvents.RAG_RETRIEVAL_COMPLETED
+        )
+        completed_attrs = completed.attributes
+        assert completed_attrs is not None
+        assert completed_attrs["rag.chunks.count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_passed_with_chunks_sets_sources_and_chunk_count(
+        self,
+        otel: tuple[Any, InMemorySpanExporter],
+        mocker: MockerFixture,
+    ) -> None:
+        """Passed moderation with chunks sets source attrs and chunk count event."""
+        tracer, exporter = otel
+        mocker.patch("utils.vector_search.tracer", tracer)
+        mocker.patch(
+            "utils.vector_search.anonymize_value",
+            side_effect=lambda value: f"[anon:{value}]",
+        )
+        self._patch_rag_config(mocker)
+        chunk = RAGChunk(
+            content="chunk text",
+            source="source-a",
+            score=0.9,
+            attributes={"doc_url": "http://example.com/doc"},
+        )
+        document = ReferencedDocument(
+            doc_url=AnyUrl("http://example.com/doc"),
+            doc_title="Example Doc",
+        )
+        mocker.patch(
+            "utils.vector_search._fetch_byok_rag",
+            new=mocker.AsyncMock(return_value=([chunk], [document])),
+        )
+        mocker.patch(
+            "utils.vector_search._fetch_okp_rag",
+            new=mocker.AsyncMock(return_value=([], [])),
+        )
+        client = mocker.AsyncMock()
+
+        await build_rag_context(client, "passed", "test query", None)
+
+        span = next(
+            span
+            for span in exporter.get_finished_spans()
+            if span.name == "rag.retrieve"
+        )
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.RAG_SOURCES_COUNT] == 1
+        completed = next(
+            event
+            for event in span.events
+            if event.name == SpanEvents.RAG_RETRIEVAL_COMPLETED
+        )
+        completed_attrs = completed.attributes
+        assert completed_attrs is not None
+        assert completed_attrs["rag.chunks.count"] == 1


### PR DESCRIPTION
## Description

This PR adds OpenTelemetry instrumentation to the shared utilities used by the `/responses` pipeline, without changing the responses endpoint itself. Shield moderation now emits a `shield.moderate` span with pass/block attributes and rejection events, and topic summary generation is wrapped in a `topic.summary` span with start/finish events. It also extends `otel_tracing.py` with the span attribute and event names those paths need, and tightens record_exception so it accepts `SpanAttributes` keys. Unit tests cover the new span attributes and events in `shields`, `maybe_get_topic_summary`, and `build_rag_context` (RAG spans already exist on main).

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-2982

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- [x] `uv run pytest tests/unit/utils/test_shields.py tests/unit/utils/test_responses.py tests/unit/utils/test_vector_search.py tests/unit/utils/test_otel_tracing.py`
