### PR TITLE
LCORE-2982: Add OTEL span tree for POST /v1/responses

### DIFF
--- a/src/app/endpoints/responses.py
+++ b/src/app/endpoints/responses.py
@@ -30,6 +30,7 @@ from ogx_client import (
 from openai._exceptions import (
     APIStatusError as OpenAIAPIStatusError,
 )
+from opentelemetry import trace
 
 from app.endpoints.responses_telemetry import (
     queue_blocked_response_event,
@@ -58,11 +59,12 @@ from models.api.responses.error import (
     UnauthorizedResponse,
     UnprocessableEntityResponse,
 )
+from models.api.responses.error.bases import AbstractErrorResponse
 from models.api.responses.successful import ResponsesResponse
 from models.common.moderation import ShieldModerationBlocked
 from models.common.responses.contexts import ResponsesContext
 from models.common.responses.responses_api_params import ResponsesApiParams
-from models.common.responses.types import ResponseInput
+from models.common.responses.types import ResponseInput, ResponseMessage
 from models.common.turn_summary import TurnSummary
 from models.config import Action
 from utils.conversation_compaction import (
@@ -76,6 +78,14 @@ from utils.endpoints import (
 )
 from utils.mcp_headers import mcp_headers_dependency
 from utils.mcp_oauth_probe import check_mcp_auth
+from utils.otel_tracing import (
+    SpanAttributes,
+    SpanEvents,
+    add_span_event,
+    anonymize_value,
+    record_exception,
+    set_span_attributes,
+)
 from utils.prompts import get_system_prompt
 from utils.query import (
     consume_query_tokens,
@@ -116,9 +126,127 @@ from utils.vector_search import (
 )
 
 logger = get_logger(__name__)
+tracer = trace.get_tracer(__name__)
 router = APIRouter(tags=["responses"])
 
 _USER_AGENT_MAX_LENGTH: Final[int] = 128
+
+
+def _count_request_attachments(response_input: ResponseInput) -> int:
+    """Count file and image attachment parts in a Responses API input.
+
+    Args:
+        response_input: Raw Responses API input (string or item list).
+
+    Returns:
+        Number of input_file and input_image content parts.
+    """
+    if isinstance(response_input, str):
+        return 0
+    count = 0
+    for item in response_input:
+        if item.type != "message":
+            continue
+        message = cast(ResponseMessage, item)
+        content = message.content
+        if isinstance(content, str):
+            continue
+        for part in content:
+            if part.type in ("input_file", "input_image"):
+                count += 1
+    return count
+
+
+def _finalize_responses_root_span(
+    root_span: trace.Span,
+    turn_summary: TurnSummary,
+) -> None:
+    """Set final root-span attributes and completion events for /responses.
+
+    Args:
+        root_span: OpenTelemetry root span for the request.
+        turn_summary: Completed turn summary with tokens, tools, and output.
+    """
+    tool_names = [tc.name for tc in turn_summary.tool_calls]
+    set_span_attributes(
+        root_span,
+        {
+            SpanAttributes.TOOL_CALLS_COUNT: len(tool_names),
+            SpanAttributes.TOOL_CALLS_NAMES: tool_names,
+        },
+    )
+    if tool_names:
+        add_span_event(
+            root_span,
+            SpanEvents.TOOL_EXECUTION_COMPLETED,
+            {"tool.calls": ", ".join(tool_names)},
+        )
+
+    set_span_attributes(
+        root_span,
+        {
+            SpanAttributes.LLM_USAGE_INPUT_TOKENS: (
+                turn_summary.token_usage.input_tokens
+            ),
+            SpanAttributes.LLM_USAGE_OUTPUT_TOKENS: (
+                turn_summary.token_usage.output_tokens
+            ),
+            SpanAttributes.OUTPUT: anonymize_value(turn_summary.llm_response),
+        },
+    )
+    add_span_event(root_span, SpanEvents.LLM_RESPONSE_COMPLETED)
+
+
+def _start_llm_inference_span(
+    model_id: str,
+    parent: trace.Span,
+) -> trace.Span:
+    """Start an ``llm.inference`` child span with model/provider attributes.
+
+    Args:
+        model_id: Composite model identifier in ``provider/model`` format.
+        parent: Parent span to nest the inference span under.
+
+    Returns:
+        Started OpenTelemetry span for the inference call.
+    """
+    provider_id, bare_model_id = extract_provider_and_model_from_model_id(model_id)
+    span = tracer.start_span(
+        "llm.inference",
+        context=trace.set_span_in_context(parent),
+    )
+    set_span_attributes(
+        span,
+        {
+            SpanAttributes.LLM_MODEL_ID: bare_model_id,
+            SpanAttributes.LLM_PROVIDER_ID: provider_id,
+        },
+    )
+    add_span_event(span, SpanEvents.LLM_INFERENCE_STARTED)
+    return span
+
+
+def _complete_llm_inference_span(
+    span: trace.Span,
+    input_tokens: int,
+    output_tokens: int,
+) -> None:
+    """Record token usage and completion event, then end an inference span.
+
+    Args:
+        span: The ``llm.inference`` span to finalize.
+        input_tokens: Input token count for the inference call.
+        output_tokens: Output token count for the inference call.
+    """
+    set_span_attributes(
+        span,
+        {
+            SpanAttributes.LLM_USAGE_INPUT_TOKENS: input_tokens,
+            SpanAttributes.LLM_USAGE_OUTPUT_TOKENS: output_tokens,
+        },
+    )
+    add_span_event(span, SpanEvents.LLM_INFERENCE_COMPLETED)
+    span.end()
 
 
 def _get_user_agent(request: Request) -> Optional[str]:
@@ -166,39 +294,61 @@ responses_response: dict[int | str, dict[str, Any]] = {
 }
 
 
-def _http_exception_for_response_api_error(
+def _error_response_for_response_api_error(
     error: Exception,
     api_params: ResponsesApiParams,
-) -> Optional[HTTPException]:
-    """Map known Responses API backend errors to HTTP exceptions.
+) -> Optional[AbstractErrorResponse]:
+    """Map known Responses API backend errors to structured error responses.
 
     Args:
         error: The backend exception raised while creating a response.
         api_params: Responses API parameters for the request.
 
     Returns:
-        HTTPException for known API failures, or None for unknown RuntimeError.
+        Structured error response for known API failures, or None for unknown errors.
     """
     if isinstance(error, RuntimeError):
         if not is_context_length_error(str(error)):
             return None
-        error_response = PromptTooLongResponse(model=api_params.model)
-    elif isinstance(error, APIConnectionError):
-        error_response = ServiceUnavailableResponse(
+        return PromptTooLongResponse(model=api_params.model)
+    if isinstance(error, APIConnectionError):
+        return ServiceUnavailableResponse(
             backend_name="OGX",
             cause=str(error),
         )
-    elif isinstance(error, (LLSApiStatusError, OpenAIAPIStatusError)):
-        error_response = handle_known_apistatus_errors(error, api_params.model)
-    else:
-        return None
-    return HTTPException(**error_response.model_dump())
+    if isinstance(error, (LLSApiStatusError, OpenAIAPIStatusError)):
+        return handle_known_apistatus_errors(error, api_params.model)
+    return None
+
+
+def _record_inference_span_exception(
+    inference_span: trace.Span,
+    error: Exception,
+    error_response: Optional[AbstractErrorResponse] = None,
+) -> None:
+    """Record a failure on the inference span without ending it.
+
+    Args:
+        inference_span: The ``llm.inference`` span to annotate.
+        error: Exception to record on the span.
+        error_response: Mapped structured error response for attribute enrichment.
+    """
+    attributes = (
+        {
+            SpanAttributes.RESPONSE_ERROR: error_response.detail.response,
+            SpanAttributes.RESPONSE_CAUSE: error_response.detail.cause,
+        }
+        if error_response is not None
+        else None
+    )
+    record_exception(inference_span, error, attributes)
 
 
 def _raise_response_api_http_exception(
     error: Exception,
     api_params: ResponsesApiParams,
     context: ResponsesContext,
+    inference_span: trace.Span,
 ) -> NoReturn:
     """Queue error telemetry and raise the mapped Responses API HTTP error.
 
@@ -206,16 +356,19 @@ def _raise_response_api_http_exception(
         error: The backend exception raised while creating a response.
         api_params: Responses API parameters for the request.
         context: Request-scoped Responses API context.
+        inference_span: OpenTelemetry ``llm.inference`` span for this request.
 
     Raises:
         Exception: Re-raises unknown RuntimeError instances unchanged.
         HTTPException: Raised for known Responses API failures.
     """
-    http_exception = _http_exception_for_response_api_error(error, api_params)
-    if http_exception is None:
+    error_response = _error_response_for_response_api_error(error, api_params)
+    _record_inference_span_exception(inference_span, error, error_response)
+    inference_span.end()
+    if error_response is None:
         raise error
     queue_responses_error_event(error, api_params, context)
-    raise http_exception from error
+    raise HTTPException(**error_response.model_dump()) from error
 
 
 async def _persist_blocked_response_turn(
@@ -289,7 +442,7 @@ def _store_response_query_results(
     turn_summary: TurnSummary,
     completed_at: datetime,
     topic_summary: Optional[str],
-) -> None:
+) -> bool:
     """Persist Responses API query results when request storage is enabled.
 
     Args:
@@ -298,9 +451,12 @@ def _store_response_query_results(
         turn_summary: Summary of the completed model turn.
         completed_at: Time when response handling completed.
         topic_summary: Optional generated topic summary for the conversation.
+
+    Returns:
+        True when query results were stored, False when storage is disabled.
     """
     if not api_params.store:
-        return
+        return False
     user_id, _, skip_userid_check, _ = context.auth
     store_query_results(
         user_id=user_id,
@@ -314,6 +470,7 @@ def _store_response_query_results(
         skip_userid_check=skip_userid_check,
         topic_summary=topic_summary,
     )
+    return True
 
 
 @router.post(
@@ -354,6 +511,57 @@ async def responses_endpoint_handler(
             - 500: Internal Server Error - Configuration not loaded or other server errors
             - 503: Service Unavailable - Unable to connect to OGX backend
     """
+    span_name = "responses.handle_request"
+    if responses_request.stream:
+        root_span = tracer.start_span(span_name)
+        try:
+            with trace.use_span(  # pylint: disable=not-context-manager
+                root_span, end_on_exit=False
+            ):
+                return await handle_responses_with_tracing(
+                    request,
+                    responses_request,
+                    auth,
+                    mcp_headers,
+                    background_tasks,
+                    root_span,
+                )
+        except Exception:
+            root_span.end()
+            raise
+
+    with tracer.start_as_current_span(span_name) as root_span:
+        return await handle_responses_with_tracing(
+            request,
+            responses_request,
+            auth,
+            mcp_headers,
+            background_tasks,
+            root_span,
+        )
+
+
+async def handle_responses_with_tracing(  # pylint: disable=too-many-locals
+    request: Request,
+    responses_request: ResponsesRequest,
+    auth: AuthTuple,
+    mcp_headers: dict[str, dict[str, str]],
+    background_tasks: BackgroundTasks,
+    root_span: trace.Span,
+) -> ResponsesResponse | StreamingResponse:
+    """Handle responses request with OTEL tracing instrumentation.
+
+    Parameters:
+        request: The incoming HTTP request.
+        responses_request: Request payload for the Responses API.
+        auth: Authentication tuple (user_id, username, skip_check, token).
+        mcp_headers: Headers to be passed to MCP servers.
+        background_tasks: FastAPI background task registry.
+        root_span: OpenTelemetry root span for this request.
+
+    Returns:
+        ResponsesResponse or StreamingResponse depending on ``stream``.
+    """
     original_request = responses_request  # read-only request
     updated_request = responses_request.model_copy(deep=True)
     _ = responses_request
@@ -367,6 +575,22 @@ async def responses_endpoint_handler(
     started_at = datetime.now(UTC)
     rh_identity_context = get_rh_identity_context(request)
     user_id, _, skip_userid_check, token = auth
+
+    input_text = (
+        original_request.input
+        if isinstance(original_request.input, str)
+        else extract_text_from_response_items(original_request.input)
+    )
+    attachments_count = _count_request_attachments(original_request.input)
+
+    set_span_attributes(
+        root_span,
+        {
+            SpanAttributes.USER_ID: anonymize_value(user_id),
+            SpanAttributes.INPUT: anonymize_value(input_text),
+            SpanAttributes.REQUEST_ATTACHMENTS_COUNT: attachments_count,
+        },
+    )
 
     await check_mcp_auth(configuration, mcp_headers, token, request.headers)
 
@@ -394,6 +618,14 @@ async def responses_endpoint_handler(
         generate_topic_summary=original_request.generate_topic_summary,
     )
     updated_request.conversation = response_context.conversation
+    set_span_attributes(
+        root_span,
+        {
+            SpanAttributes.SESSION_ID: normalize_conversation_id(
+                response_context.conversation
+            ),
+        },
+    )
     updated_request.generate_topic_summary = response_context.generate_topic_summary
     client = AsyncOgxClientHolder().get_client()
 
@@ -416,12 +648,8 @@ async def responses_endpoint_handler(
     ):
         client = await AsyncOgxClientHolder().update_azure_token()
 
-    input_text = (
-        original_request.input
-        if isinstance(original_request.input, str)
-        else extract_text_from_response_items(original_request.input)
-    )
     attachments_text = extract_attachments_text(original_request.input)
+    add_span_event(root_span, SpanEvents.VALIDATION_COMPLETED)
 
     endpoint_path = ENDPOINT_PATH_RESPONSES
 
@@ -510,6 +738,7 @@ async def responses_endpoint_handler(
         endpoint_path=endpoint_path,
         generate_topic_summary=updated_request.generate_topic_summary,
         compacted_original_input=compacted_original_input,
+        root_span=root_span,
     )
     response_handler = (
         handle_streaming_response
@@ -559,13 +788,13 @@ async def handle_streaming_response(
     """Handle streaming response from Responses API.
 
     Args:
-        client: The AsyncOgxClient instance
         original_request: Original request (read-only)
         api_params: API parameters
-        responses_context: Responses context
+        context: Responses context
     Returns:
         StreamingResponse with SSE-formatted events
     """
+    root_span = context.root_span
     turn_summary = TurnSummary()
     # Handle blocked response
     if context.moderation_result.decision == "blocked":
@@ -580,6 +809,10 @@ async def handle_streaming_response(
         )
     else:
         inference_start_time = time.monotonic()
+        inference_span = _start_llm_inference_span(
+            api_params.model,
+            parent=root_span,
+        )
         try:
             response = await context.client.responses.create(
                 **api_params.model_dump(
@@ -593,6 +826,7 @@ async def handle_streaming_response(
                 context=context,
                 turn_summary=turn_summary,
                 inference_start_time=inference_start_time,
+                inference_span=inference_span,
             )
         except (
             RuntimeError,
@@ -607,7 +841,7 @@ async def handle_streaming_response(
                 time.monotonic() - inference_start_time,
                 record_failure=True,
             )
-            _raise_response_api_http_exception(e, api_params, context)
+            _raise_response_api_http_exception(e, api_params, context, inference_span)
 
     return StreamingResponse(
         generate_response(
@@ -861,6 +1095,7 @@ async def response_generator(
     context: ResponsesContext,
     turn_summary: TurnSummary,
     inference_start_time: float,
+    inference_span: trace.Span,
 ) -> AsyncIterator[str]:
     """Generate SSE-formatted streaming response with LCORE-enriched events.
 
@@ -871,6 +1106,7 @@ async def response_generator(
         context: Responses context
         turn_summary: TurnSummary to populate during streaming
         inference_start_time: Monotonic timestamp taken before the inference call.
+        inference_span: OpenTelemetry ``llm.inference`` span for this stream.
     Yields:
         SSE-formatted strings for streaming events, ending with [DONE]
     """
@@ -974,8 +1210,20 @@ async def response_generator(
                 )
                 chunk_dict["response"]["output_text"] = turn_summary.llm_response
 
+                if chunk.type == "response.failed":
+                    _record_inference_span_exception(
+                        inference_span,
+                        Exception(
+                            chunk.response.error.message
+                            if chunk.response.error
+                            else "response.failed"
+                        ),
+                    )
+
             yield f"event: {chunk.type or 'error'}\ndata: {json.dumps(chunk_dict)}\n\n"
-    except Exception:
+    except Exception as exc:
+        _record_inference_span_exception(inference_span, exc)
+        inference_span.end()
         if not inference_metric_recorded:
             _record_response_inference_result(
                 api_params.model,
@@ -985,6 +1233,12 @@ async def response_generator(
                 record_failure=True,
             )
         raise
+
+    _complete_llm_inference_span(
+        inference_span,
+        turn_summary.token_usage.input_tokens,
+        turn_summary.token_usage.output_tokens,
+    )
 
     # Extract response metadata from final response object
     if latest_response_object:
@@ -1018,37 +1272,45 @@ async def generate_response(
 
     Args:
         generator: The SSE event generator
-        turn_summary: TurnSummary populated during streaming
         api_params: ResponsesApiParams
         context: Responses context
         turn_summary: TurnSummary to populate during streaming
     Yields:
         SSE-formatted strings from the generator
     """
-    async for event in generator:
-        yield event
+    root_span = context.root_span
+    try:
+        async for event in generator:
+            yield event
 
-    topic_summary = await maybe_get_topic_summary(
-        generate_topic_summary=context.generate_topic_summary,
-        input_text=context.input_text,
-        client=context.client,
-        model_id=api_params.model,
-    )
-    completed_at = datetime.now(UTC)
-    _store_response_query_results(
-        api_params,
-        context,
-        turn_summary,
-        completed_at,
-        topic_summary,
-    )
-    queue_completed_response_event(
-        api_params,
-        context,
-        turn_summary,
-        completed_at,
-        turn_summary.llm_response,
-    )
+        with trace.use_span(  # pylint: disable=not-context-manager
+            root_span, end_on_exit=False
+        ):
+            topic_summary = await maybe_get_topic_summary(
+                generate_topic_summary=context.generate_topic_summary,
+                input_text=context.input_text,
+                client=context.client,
+                model_id=api_params.model,
+            )
+        completed_at = datetime.now(UTC)
+        if _store_response_query_results(
+            api_params,
+            context,
+            turn_summary,
+            completed_at,
+            topic_summary,
+        ):
+            add_span_event(root_span, SpanEvents.TURN_PERSISTED)
+        queue_completed_response_event(
+            api_params,
+            context,
+            turn_summary,
+            completed_at,
+            turn_summary.llm_response,
+        )
+        _finalize_responses_root_span(root_span, turn_summary)
+    finally:
+        root_span.end()
 
 
 async def handle_non_streaming_response(
@@ -1065,6 +1327,7 @@ async def handle_non_streaming_response(
     Returns:
         ResponsesResponse with the completed response
     """
+    root_span = context.root_span
     user_id = context.auth[0]
 
     # Fork: Get response object (blocked vs normal)
@@ -1083,6 +1346,10 @@ async def handle_non_streaming_response(
     else:
         inference_start_time = time.monotonic()
         inference_metric_recorded = False
+        inference_span = _start_llm_inference_span(
+            api_params.model,
+            parent=root_span,
+        )
         try:
             api_response = cast(
                 OpenAIResponseObject,
@@ -1101,6 +1368,11 @@ async def handle_non_streaming_response(
             inference_metric_recorded = True
             token_usage = extract_token_usage(
                 api_response.usage, api_params.model, context.endpoint_path
+            )
+            _complete_llm_inference_span(
+                inference_span,
+                token_usage.input_tokens,
+                token_usage.output_tokens,
             )
             logger.info("Consuming tokens")
             consume_query_tokens(
@@ -1130,7 +1402,7 @@ async def handle_non_streaming_response(
                     time.monotonic() - inference_start_time,
                     record_failure=True,
                 )
-            _raise_response_api_http_exception(e, api_params, context)
+            _raise_response_api_http_exception(e, api_params, context, inference_span)
 
     # Get available quotas
     logger.info("Getting available quotas")
@@ -1159,13 +1431,14 @@ async def handle_non_streaming_response(
     )
     turn_summary.rag_chunks.extend(context.inline_rag_context.rag_chunks)
     completed_at = datetime.now(UTC)
-    _store_response_query_results(
+    if _store_response_query_results(
         api_params,
         context,
         turn_summary,
         completed_at,
         topic_summary,
-    )
+    ):
+        add_span_event(root_span, SpanEvents.TURN_PERSISTED)
     queue_completed_response_event(
         api_params,
         context,
@@ -1173,6 +1446,7 @@ async def handle_non_streaming_response(
         completed_at,
         output_text,
     )
+    _finalize_responses_root_span(root_span, turn_summary)
     configured_mcp_labels = {s.name for s in configuration.mcp_servers}
     response_dict = api_response.model_dump(exclude_none=True)
     _sanitize_response_dict(

--- a/src/models/common/responses/contexts.py
+++ b/src/models/common/responses/contexts.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from fastapi import BackgroundTasks
 from ogx_client import AsyncOgxClient
+from opentelemetry import trace
 from pydantic import BaseModel, ConfigDict, Field
 
 from models.api.requests import QueryRequest
@@ -63,6 +64,9 @@ class ResponsesContext(BaseModel):
         "rewrite. When present, the completed turn is appended to the "
         "conversation using this input, since the conversation parameter was "
         "dropped and Llama Stack therefore does not store the turn.",
+    )
+    root_span: trace.Span = Field(
+        description="OpenTelemetry root span for this request",
     )
 
 

--- a/tests/unit/app/endpoints/responses_otel_helpers.py
+++ b/tests/unit/app/endpoints/responses_otel_helpers.py
@@ -1,0 +1,307 @@
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+"""Shared helpers for responses endpoint OpenTelemetry unit tests."""
+
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+from ogx_client import AsyncOgxClient
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import Tracer
+from pytest_mock import MockerFixture
+
+from app.endpoints.responses import responses_endpoint_handler
+from authentication.interface import AuthTuple
+from configuration import AppConfig
+from models.api.requests import ResponsesRequest
+from models.api.responses.successful import ResponsesResponse
+from models.common.responses.responses_conversation_context import (
+    ResponsesConversationContext,
+)
+from models.common.turn_summary import ToolCallSummary, TurnSummary
+from utils.otel_tracing import SpanAttributes, SpanEvents
+
+MODULE = "app.endpoints.responses"
+UTILS_RESPONSES_MODULE = "utils.responses"
+VECTOR_SEARCH_MODULE = "utils.vector_search"
+
+MOCK_AUTH: AuthTuple = (
+    "00000001-0001-0001-0001-000000000001",
+    "mock_username",
+    False,
+    "mock_token",
+)
+OTEL_CONV_ID = "conv_e6afd7aaa97b49ce8f4f96a801b07893d9cb784d72e53e3c"
+OTEL_SESSION_ID = "e6afd7aaa97b49ce8f4f96a801b07893d9cb784d72e53e3c"
+MODEL = "google-vertex/publishers/google/models/gemini-2.5-flash"
+ROOT_SPAN_NAME = "responses.handle_request"
+
+
+def find_span(spans: Sequence[ReadableSpan], name: str) -> ReadableSpan:
+    """Return the single finished span with the given name."""
+    matches = [span for span in spans if span.name == name]
+    assert len(matches) == 1, f"Expected one span named {name!r}, got {len(matches)}"
+    return matches[0]
+
+
+def make_turn_summary_without_tools(
+    *,
+    llm_response: str = "The answer is 42",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+) -> TurnSummary:
+    """Build a turn summary with no tool calls."""
+    turn_summary = TurnSummary()
+    turn_summary.llm_response = llm_response
+    turn_summary.token_usage.input_tokens = input_tokens
+    turn_summary.token_usage.output_tokens = output_tokens
+    return turn_summary
+
+
+def make_turn_summary_with_tools(
+    tool_names: list[str],
+    *,
+    llm_response: str = "The answer is 42",
+    input_tokens: int = 10,
+    output_tokens: int = 5,
+) -> TurnSummary:
+    """Build a turn summary containing the given tool call names."""
+    turn_summary = make_turn_summary_without_tools(
+        llm_response=llm_response,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+    turn_summary.tool_calls = [
+        ToolCallSummary(id=f"call-{index}", name=name, args={})
+        for index, name in enumerate(tool_names)
+    ]
+    return turn_summary
+
+
+def patch_responses_otel_tracers(
+    mocker: MockerFixture,
+    tracer: Tracer,
+    minimal_config: AppConfig,
+) -> None:
+    """Patch responses and downstream tracers to use the test tracer."""
+    mocker.patch(f"{MODULE}.configuration", minimal_config)
+    mocker.patch(f"{MODULE}.tracer", tracer)
+    mocker.patch(f"{UTILS_RESPONSES_MODULE}.tracer", tracer)
+    mocker.patch("utils.shields.tracer", tracer)
+    mocker.patch("utils.quota_utils.tracer", tracer)
+    mocker.patch("utils.vector_search.tracer", tracer)
+    mocker.patch(
+        f"{MODULE}.anonymize_value",
+        side_effect=lambda value: f"[anon:{value}]",
+    )
+    mocker.patch(
+        f"{VECTOR_SEARCH_MODULE}._fetch_byok_rag",
+        new=mocker.AsyncMock(return_value=([], [])),
+    )
+    mocker.patch(
+        f"{VECTOR_SEARCH_MODULE}._fetch_okp_rag",
+        new=mocker.AsyncMock(return_value=([], [])),
+    )
+
+
+def patch_responses_endpoint_setup(
+    mocker: MockerFixture,
+    _minimal_config: AppConfig,
+) -> Any:
+    """Patch endpoint setup dependencies and return the mock OGX client.
+
+    Returns:
+        Mock AsyncOgxClient wired through AsyncOgxClientHolder.
+    """
+    mocker.patch(f"{MODULE}.check_configuration_loaded")
+    mocker.patch(f"{MODULE}.validate_model_provider_override")
+    mocker.patch(
+        f"{UTILS_RESPONSES_MODULE}.prepare_tools",
+        new=mocker.AsyncMock(return_value=None),
+    )
+
+    mock_client = mocker.AsyncMock(spec=AsyncOgxClient)
+    mock_vector_stores = mocker.Mock()
+    mock_vector_stores.list = mocker.AsyncMock(return_value=mocker.Mock(data=[]))
+    mock_client.vector_stores = mock_vector_stores
+    mock_holder = mocker.Mock()
+    mock_holder.get_client.return_value = mock_client
+    mocker.patch(f"{MODULE}.AsyncOgxClientHolder", return_value=mock_holder)
+
+    mocker.patch(
+        f"{MODULE}.resolve_response_context",
+        new=mocker.AsyncMock(
+            return_value=ResponsesConversationContext(
+                conversation=OTEL_CONV_ID,
+                user_conversation=None,
+                generate_topic_summary=False,
+            )
+        ),
+    )
+    mocker.patch(
+        f"{MODULE}.select_model_for_responses",
+        new=mocker.AsyncMock(return_value="provider1/model1"),
+    )
+    mocker.patch(
+        f"{MODULE}.check_model_configured",
+        new=mocker.AsyncMock(return_value=True),
+    )
+    return mock_client
+
+
+def patch_handler_success_mocks(mocker: MockerFixture) -> None:
+    """Patch inference, quota, and persistence helpers for a success path."""
+    mocker.patch(f"{MODULE}.recording.record_llm_inference_duration")
+    mocker.patch(f"{MODULE}.consume_query_tokens")
+    mocker.patch(f"{MODULE}.get_available_quotas", return_value={})
+    mocker.patch(
+        f"{MODULE}.extract_provider_and_model_from_model_id",
+        return_value=("provider1", "model1"),
+    )
+    mocker.patch(
+        f"{MODULE}.extract_token_usage",
+        return_value=TurnSummary().token_usage,
+    )
+    mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
+    mocker.patch(
+        f"{MODULE}.build_turn_summary",
+        return_value=TurnSummary(referenced_documents=[]),
+    )
+    mocker.patch(f"{MODULE}.store_query_results")
+    mocker.patch(
+        f"{MODULE}.normalize_conversation_id",
+        return_value=OTEL_SESSION_ID,
+    )
+
+
+def configure_non_streaming_client(
+    mocker: MockerFixture,
+    mock_client: Any,
+    *,
+    output_text: str = "The answer is 42",
+) -> None:
+    """Configure mock_client.responses.create for a non-streaming success response."""
+    mock_response = mocker.Mock()
+    mock_response.id = "resp_1"
+    mock_response.output = []
+    mock_response.usage = mocker.Mock(input_tokens=10, output_tokens=5, total_tokens=15)
+    mock_response.status = "completed"
+    mock_response.model = "provider1/model1"
+    mock_response.model_dump.return_value = {
+        "id": "resp_1",
+        "object": "response",
+        "created_at": 0,
+        "status": "completed",
+        "model": "provider1/model1",
+        "output": [],
+        "conversation": OTEL_CONV_ID,
+        "completed_at": 0,
+        "output_text": output_text,
+        "available_quotas": {},
+    }
+    mock_client.responses.create = mocker.AsyncMock(return_value=mock_response)
+    mocker.patch(
+        f"{MODULE}.extract_text_from_response_items",
+        return_value=output_text,
+    )
+
+
+def make_completed_stream_chunk(mocker: MockerFixture) -> Any:
+    """Build a minimal response.completed streaming chunk mock."""
+    mock_chunk = mocker.Mock()
+    mock_chunk.type = "response.completed"
+    mock_chunk.response = mocker.Mock(
+        id="r1",
+        output=[],
+        usage=mocker.Mock(input_tokens=1, output_tokens=2, total_tokens=3),
+    )
+    mock_chunk.model_dump.return_value = {
+        "type": "response.completed",
+        "response": {"id": "r1", "usage": {"input_tokens": 1}},
+    }
+    return mock_chunk
+
+
+def configure_streaming_client(mocker: MockerFixture, mock_client: Any) -> None:
+    """Configure mock_client.responses.create for a one-chunk streaming success."""
+
+    async def mock_stream() -> AsyncIterator[Any]:
+        yield make_completed_stream_chunk(mocker)
+
+    mock_client.responses.create = mocker.AsyncMock(return_value=mock_stream())
+    mocker.patch(
+        f"{MODULE}.extract_text_from_response_items",
+        return_value="Hello",
+    )
+
+
+def assert_root_setup_attributes(
+    root: ReadableSpan,
+    *,
+    input_text: str,
+    attachments_count: int = 0,
+) -> None:
+    """Assert root span carries setup attributes and validation.completed."""
+    assert root.name == ROOT_SPAN_NAME
+    assert root.attributes is not None
+    assert root.attributes[SpanAttributes.USER_ID] == f"[anon:{MOCK_AUTH[0]}]"
+    assert root.attributes[SpanAttributes.INPUT] == f"[anon:{input_text}]"
+    assert (
+        root.attributes[SpanAttributes.REQUEST_ATTACHMENTS_COUNT] == attachments_count
+    )
+    assert root.attributes[SpanAttributes.SESSION_ID] == OTEL_SESSION_ID
+    event_names = [event.name for event in root.events]
+    assert SpanEvents.VALIDATION_COMPLETED in event_names
+
+
+async def consume_streaming_response(response: StreamingResponse) -> None:
+    """Drain a StreamingResponse body so spans are finalized."""
+    async for _ in response.body_iterator:
+        pass
+
+
+async def run_responses_setup_smoke(
+    mocker: MockerFixture,
+    dummy_request: Request,
+    tracer: Tracer,
+    minimal_config: AppConfig,
+    exporter: InMemorySpanExporter,
+    *,
+    stream: bool,
+    input_text: str = "What is Kubernetes?",
+) -> ReadableSpan:
+    """Run the handler through setup and return the root span."""
+    patch_responses_otel_tracers(mocker, tracer, minimal_config)
+    mock_client = patch_responses_endpoint_setup(mocker, minimal_config)
+    patch_handler_success_mocks(mocker)
+
+    if stream:
+        configure_streaming_client(mocker, mock_client)
+    else:
+        configure_non_streaming_client(mocker, mock_client)
+
+    result = await responses_endpoint_handler(
+        request=dummy_request,
+        responses_request=ResponsesRequest(
+            input=input_text,
+            model=MODEL,
+            stream=stream,
+            store=False,
+            conversation=OTEL_CONV_ID,
+            generate_topic_summary=False,
+        ),
+        auth=MOCK_AUTH,
+        mcp_headers={},
+    )
+
+    if stream:
+        assert isinstance(result, StreamingResponse)
+        await consume_streaming_response(result)
+    else:
+        assert isinstance(result, ResponsesResponse)
+
+    return find_span(exporter.get_finished_spans(), ROOT_SPAN_NAME)

--- a/tests/unit/app/endpoints/test_responses.py
+++ b/tests/unit/app/endpoints/test_responses.py
@@ -17,6 +17,7 @@ from ogx_api.openai_responses import (
     OpenAIResponseMessage,
 )
 from ogx_client import APIConnectionError, APIStatusError, AsyncOgxClient
+from opentelemetry import trace
 from pytest_mock import MockerFixture
 
 from app.endpoints.responses import (
@@ -42,7 +43,7 @@ from models.common.responses.responses_conversation_context import (
     ResponsesConversationContext,
 )
 from models.common.responses.types import InputToolMCP
-from models.common.turn_summary import RAGContext, TurnSummary
+from models.common.turn_summary import RAGContext, ToolCallSummary, TurnSummary
 from models.config import Action, ModelContextProtocolServer
 from models.database.conversations import UserConversation
 
@@ -59,6 +60,31 @@ ENDPOINTS_MODULE = "utils.endpoints"
 UTILS_RESPONSES_MODULE = "utils.responses"
 MODEL = "google-vertex/publishers/google/models/gemini-2.5-flash"
 SERVER_INSTRUCTIONS = "Server instructions"
+
+
+class _MockSpan:
+    """Minimal OTEL span stand-in for direct handler unit tests."""
+
+    def end(self) -> None:
+        """No-op span end."""
+
+    def set_attribute(self, *_args: Any, **_kwargs: Any) -> None:
+        """No-op attribute setter."""
+
+    def add_event(self, *_args: Any, **_kwargs: Any) -> None:
+        """No-op event recorder."""
+
+    def record_exception(self, *_args: Any, **_kwargs: Any) -> None:
+        """No-op exception recorder."""
+
+    def is_recording(self) -> bool:
+        """Report that the span accepts recordings."""
+        return True
+
+
+def _mock_span() -> trace.Span:
+    """Return a typed span stand-in for behavioral handler unit tests."""
+    return cast(trace.Span, _MockSpan())
 
 
 def build_api_params_and_context(  # pylint: disable=too-many-arguments
@@ -92,6 +118,7 @@ def build_api_params_and_context(  # pylint: disable=too-many-arguments
         generate_topic_summary=generate_topic_summary,
         endpoint_path=endpoint_path,
         user_agent=user_agent,
+        root_span=_mock_span(),
     )
     return api_params, context
 
@@ -842,7 +869,7 @@ class TestHandleNonStreamingResponse:
         mocker.patch(f"{MODULE}.consume_query_tokens")
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=mocker.Mock(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.extract_text_from_response_items",
@@ -923,7 +950,7 @@ class TestHandleNonStreamingResponse:
         mocker.patch(f"{MODULE}.consume_query_tokens")
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=mocker.Mock(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.extract_text_from_response_items",
@@ -1241,7 +1268,7 @@ class TestHandleStreamingResponse:
         mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=TurnSummary(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.maybe_get_topic_summary",
@@ -1328,7 +1355,7 @@ class TestHandleStreamingResponse:
         mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=TurnSummary(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.maybe_get_topic_summary",
@@ -1408,11 +1435,14 @@ class TestHandleStreamingResponse:
         mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=TurnSummary(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mock_build_tool_call = mocker.patch(
             f"{MODULE}.build_tool_call_summary",
-            return_value=(mocker.Mock(), mocker.Mock()),
+            return_value=(
+                ToolCallSummary(id="call_1", name="search", type="function_call"),
+                None,
+            ),
         )
         mocker.patch(
             f"{MODULE}.maybe_get_topic_summary",
@@ -1494,7 +1524,7 @@ class TestHandleStreamingResponse:
         mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=TurnSummary(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.maybe_get_topic_summary",
@@ -2319,11 +2349,7 @@ class TestSanitizesOutputAndModel:
         mocker.patch(f"{MODULE}.consume_query_tokens")
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=mocker.Mock(
-                referenced_documents=[],
-                rag_chunks=[],
-                token_usage=mocker.Mock(input_tokens=1, output_tokens=2),
-            ),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.extract_text_from_response_items",
@@ -2446,7 +2472,7 @@ class TestSanitizesOutputAndModel:
         mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=TurnSummary(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.maybe_get_topic_summary",
@@ -2572,7 +2598,7 @@ class TestMcpEventsFilteredUnconditionally:
         mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=TurnSummary(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.maybe_get_topic_summary",
@@ -2668,7 +2694,7 @@ class TestMcpEventsFilteredUnconditionally:
         mocker.patch(f"{MODULE}.extract_vector_store_ids_from_tools", return_value=[])
         mocker.patch(
             f"{MODULE}.build_turn_summary",
-            return_value=TurnSummary(referenced_documents=[]),
+            return_value=TurnSummary(),
         )
         mocker.patch(
             f"{MODULE}.maybe_get_topic_summary",
@@ -2761,6 +2787,7 @@ async def test_response_generator_records_failure_when_stream_iteration_raises(
         context=context,
         turn_summary=TurnSummary(),
         inference_start_time=0.0,
+        inference_span=_mock_span(),
     )
 
     with pytest.raises(RuntimeError, match="stream broken"):

--- a/tests/unit/app/endpoints/test_responses_otel.py
+++ b/tests/unit/app/endpoints/test_responses_otel.py
@@ -1,0 +1,258 @@
+# pylint: disable=redefined-outer-name
+"""OpenTelemetry unit tests for the /responses REST API endpoint."""
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+import pytest
+from fastapi import HTTPException, Request
+from ogx_client import APIConnectionError
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from pytest_mock import MockerFixture
+
+from app.endpoints.responses import (
+    _complete_llm_inference_span,
+    _finalize_responses_root_span,
+    _record_inference_span_exception,
+    _start_llm_inference_span,
+    responses_endpoint_handler,
+)
+from configuration import AppConfig
+from models.api.requests import ResponsesRequest
+from models.api.responses.error import ServiceUnavailableResponse
+from models.config import Action
+from tests.unit.app.endpoints.responses_otel_helpers import (
+    MOCK_AUTH,
+    MODULE,
+    assert_root_setup_attributes,
+    find_span,
+    make_turn_summary_with_tools,
+    make_turn_summary_without_tools,
+    patch_responses_endpoint_setup,
+    patch_responses_otel_tracers,
+    run_responses_setup_smoke,
+)
+from utils.otel_tracing import SpanAttributes, SpanEvents
+
+INPUT_TEXT = "What is Kubernetes?"
+
+
+@pytest.fixture(name="dummy_request")
+def dummy_request_fixture() -> Request:
+    """Minimal FastAPI Request with authorized_actions for responses endpoint."""
+    req = Request(scope={"type": "http", "headers": []})
+    req.state.authorized_actions = {Action.RESPONSES, Action.READ_OTHERS_CONVERSATIONS}
+    return req
+
+
+@pytest.fixture(name="minimal_config")
+def minimal_config_fixture() -> AppConfig:
+    """Minimal AppConfig for responses endpoint OTEL tests."""
+    cfg = AppConfig()
+    cfg.init_from_dict(
+        {
+            "name": "test",
+            "service": {"host": "localhost", "port": 8080},
+            "llama_stack": {
+                "api_key": "test-key",
+                "url": "http://test.com:1234",
+                "use_as_library_client": False,
+            },
+            "user_data_collection": {},
+            "authentication": {"module": "noop"},
+            "authorization": {"access_rules": []},
+        }
+    )
+    return cfg
+
+
+class TestFinalizeResponsesRootSpanOtel:  # pylint: disable=too-few-public-methods
+    """OTEL attrs/events for _finalize_responses_root_span."""
+
+    @pytest.mark.parametrize(
+        ("tool_names", "expect_tool_event"),
+        [
+            ([], False),
+            (["file_search", "mcp_tool"], True),
+        ],
+    )
+    def test_finalize_tool_attrs_and_events(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+        tool_names: list[str],
+        expect_tool_event: bool,
+    ) -> None:
+        """Tool count/names are always set; tool event only when tools ran."""
+        tracer, exporter = otel
+        root_span = tracer.start_span("responses.handle_request")
+        turn_summary = (
+            make_turn_summary_with_tools(tool_names)
+            if tool_names
+            else make_turn_summary_without_tools()
+        )
+        mocker.patch(
+            f"{MODULE}.anonymize_value",
+            side_effect=lambda value: f"[anon:{value}]",
+        )
+
+        _finalize_responses_root_span(root_span, turn_summary)
+        root_span.end()
+
+        span = find_span(exporter.get_finished_spans(), "responses.handle_request")
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.TOOL_CALLS_COUNT] == len(tool_names)
+        assert (
+            list(cast(Sequence[str], span.attributes[SpanAttributes.TOOL_CALLS_NAMES]))
+            == tool_names
+        )
+        assert span.attributes[SpanAttributes.LLM_USAGE_INPUT_TOKENS] == 10
+        assert span.attributes[SpanAttributes.LLM_USAGE_OUTPUT_TOKENS] == 5
+        assert span.attributes[SpanAttributes.OUTPUT] == "[anon:The answer is 42]"
+
+        event_names = [event.name for event in span.events]
+        assert SpanEvents.LLM_RESPONSE_COMPLETED in event_names
+        if expect_tool_event:
+            tool_events = [
+                event
+                for event in span.events
+                if event.name == SpanEvents.TOOL_EXECUTION_COMPLETED
+            ]
+            assert len(tool_events) == 1
+            tool_event_attrs = tool_events[0].attributes
+            assert tool_event_attrs is not None
+            assert tool_event_attrs["tool.calls"] == ", ".join(tool_names)
+        else:
+            assert SpanEvents.TOOL_EXECUTION_COMPLETED not in event_names
+
+
+class TestResponsesInferenceSpanOtel:
+    """OTEL attrs/events for llm.inference helper spans."""
+
+    def test_start_sets_model_provider_and_started_event(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """_start_llm_inference_span sets model attrs and started event."""
+        tracer, exporter = otel
+        mocker.patch(f"{MODULE}.tracer", tracer)
+        mocker.patch(
+            f"{MODULE}.extract_provider_and_model_from_model_id",
+            return_value=("provider1", "model1"),
+        )
+        parent = tracer.start_span("responses.handle_request")
+
+        inference_span = _start_llm_inference_span("provider1/model1", parent=parent)
+        inference_span.end()
+        parent.end()
+
+        span = find_span(exporter.get_finished_spans(), "llm.inference")
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.LLM_MODEL_ID] == "model1"
+        assert span.attributes[SpanAttributes.LLM_PROVIDER_ID] == "provider1"
+        event_names = [event.name for event in span.events]
+        assert event_names == [SpanEvents.LLM_INFERENCE_STARTED]
+
+    def test_complete_sets_tokens_and_completed_event(
+        self,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """_complete_llm_inference_span records usage and completed event."""
+        tracer, exporter = otel
+        inference_span = tracer.start_span("llm.inference")
+
+        _complete_llm_inference_span(inference_span, input_tokens=12, output_tokens=7)
+
+        span = find_span(exporter.get_finished_spans(), "llm.inference")
+        assert span.attributes is not None
+        assert span.attributes[SpanAttributes.LLM_USAGE_INPUT_TOKENS] == 12
+        assert span.attributes[SpanAttributes.LLM_USAGE_OUTPUT_TOKENS] == 7
+        event_names = [event.name for event in span.events]
+        assert SpanEvents.LLM_INFERENCE_COMPLETED in event_names
+
+    def test_record_exception_adds_response_attrs(
+        self,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """_record_inference_span_exception enriches mapped error attrs."""
+        tracer, exporter = otel
+        inference_span = tracer.start_span("llm.inference")
+        error_response = ServiceUnavailableResponse(backend_name="OGX", cause="down")
+
+        _record_inference_span_exception(
+            inference_span,
+            APIConnectionError(
+                message="connection failed",
+                request=mocker.Mock(),
+            ),
+            error_response,
+        )
+        inference_span.end()
+
+        span = find_span(exporter.get_finished_spans(), "llm.inference")
+        exception_events = [event for event in span.events if event.name == "exception"]
+        assert len(exception_events) == 1
+        assert exception_events[0].attributes is not None
+        assert (
+            exception_events[0].attributes[SpanAttributes.RESPONSE_ERROR]
+            == "Unable to connect to OGX"
+        )
+        assert exception_events[0].attributes[SpanAttributes.RESPONSE_CAUSE] == "down"
+
+
+class TestResponsesRootSpanSetupOtel:
+    """OTEL attrs/events on the responses root span during setup."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stream", [False, True])
+    async def test_root_setup_attributes_and_validation_event(
+        self,
+        stream: bool,
+        mocker: MockerFixture,
+        dummy_request: Request,
+        minimal_config: AppConfig,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Root span carries setup attributes and validation.completed for both modes."""
+        tracer, exporter = otel
+        root = await run_responses_setup_smoke(
+            mocker,
+            dummy_request,
+            tracer,
+            minimal_config,
+            exporter,
+            stream=stream,
+            input_text=INPUT_TEXT,
+        )
+        assert_root_setup_attributes(root, input_text=INPUT_TEXT)
+
+    @pytest.mark.asyncio
+    async def test_streaming_root_span_closed_on_setup_error(
+        self,
+        dummy_request: Request,
+        minimal_config: AppConfig,
+        mocker: MockerFixture,
+        otel: tuple[Any, InMemorySpanExporter],
+    ) -> None:
+        """Streaming root span is ended when setup raises before the stream starts."""
+        tracer, exporter = otel
+        patch_responses_otel_tracers(mocker, tracer, minimal_config)
+        patch_responses_endpoint_setup(mocker, minimal_config)
+        mocker.patch(
+            f"{MODULE}.check_configuration_loaded",
+            side_effect=HTTPException(status_code=500, detail="not loaded"),
+        )
+
+        with pytest.raises(HTTPException):
+            await responses_endpoint_handler(
+                request=dummy_request,
+                responses_request=ResponsesRequest(input="test", stream=True),
+                auth=MOCK_AUTH,
+                mcp_headers={},
+            )
+
+        find_span(exporter.get_finished_spans(), "responses.handle_request")

--- a/tests/unit/app/endpoints/test_responses_splunk.py
+++ b/tests/unit/app/endpoints/test_responses_splunk.py
@@ -421,6 +421,8 @@ class TestSplunkTelemetryHooks:
         mock_turn_summary = mocker.Mock()
         mock_turn_summary.referenced_documents = []
         mock_turn_summary.rag_chunks = []
+        mock_turn_summary.tool_calls = []
+        mock_turn_summary.llm_response = "Model reply"
         mock_token_usage = mocker.Mock()
         mock_token_usage.input_tokens = 100
         mock_token_usage.output_tokens = 50


### PR DESCRIPTION
## Description

This PR adds OpenTelemetry instrumentation to the /v1/responses endpoint. Each request gets a root responses.handle_request span, with child spans for validation, quota, shield, RAG, and llm.inference, and root-span attributes/events for token usage, tool calls, and completed output. Streaming and non-streaming paths share the same span lifecycle, including inference error recording on failures. Unit tests assert span attributes, events, and helper behavior; integration parentage tests land in a follow-up PR.

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-2982

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- [x] `uv run pytest tests/unit/app/endpoints/test_responses.py tests/unit/app/endpoints/test_responses_otel.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed OpenTelemetry tracing for responses, including request metadata, model inference, token usage, streaming events, persistence, and errors.
  * Improved visibility into tool calls, attachments, sessions, and response processing outcomes.
* **Bug Fixes**
  * Improved backend error mapping and ensured tracing is finalized consistently for successful and failed requests.
* **Tests**
  * Added comprehensive coverage for tracing, streaming, inference lifecycle, exceptions, and response setup validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->