### PR TITLE
LCORE-3654: add byo-llm baseline

### DIFF
--- a/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
+++ b/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
@@ -33,9 +33,11 @@ Key shape:
   high-level sections don't express.
 - `llama_stack.config.profile` — path to a user-authored YAML that serves
   as the synthesis baseline.
-- `llama_stack.config.baseline: default | empty` — pick between LCORE's
-  built-in baseline and an empty dict (used by the migration tool for
-  exact round-trip).
+- `llama_stack.config.baseline: default | byo-llm | empty` — pick
+  LCORE's built-in baseline (includes a conditional OpenAI provider),
+  the same baseline without that OpenAI row, or an empty dict (used by
+  the migration tool for exact round-trip). `default` emits a deprecation
+  WARN naming `byo-llm`.
 - Legacy two-file mode (`llama_stack.library_client_config_path` +
   external `run.yaml`) is preserved during a deprecation window;
   mutually exclusive with the unified *synthesis inputs* (a non-empty
@@ -265,7 +267,7 @@ llama_stack:
   # with `library_client_config_path` is a validation error.
   config:
     # Baseline selection (backend-specific knobs stay here)
-    baseline: default              # default | empty; ignored if `profile` is set
+    baseline: default              # default | byo-llm | empty; ignored if `profile` is set
     profile: ./my-profile.yaml     # optional; resolves relative to lightspeed-stack.yaml
 
     # Escape hatch — raw Llama Stack schema, deep-merged with list replacement
@@ -299,7 +301,7 @@ class InferenceConfiguration(ConfigurationBase):
 class UnifiedLlamaStackConfig(ConfigurationBase):
     # Backend-specific knobs only. Per Decision S5, the backend-agnostic
     # high-level sections (inference, ...) live at the root, NOT here.
-    baseline: Literal["default", "empty"] = "default"
+    baseline: Literal["default", "empty", "byo-llm"] = "default"
     profile: Optional[str] = None
     native_override: dict[str, Any] = Field(default_factory=dict)
 
@@ -455,7 +457,10 @@ September 2026.
    defaults to `default`, no profile, no `native_override`).
 2. Baseline: if `unified` and `unified.profile` set → load that file.
    Else if `unified` and `unified.baseline == "empty"` → `{}`. Else →
-   `default_baseline` arg or `load_default_baseline()`.
+   `default_baseline` arg or `load_default_baseline()`. If the selector
+   is `byo-llm`, strip the built-in conditional OpenAI inference row.
+   If the selector is `default` or omitted, emit a deprecation WARN
+   naming `byo-llm`. `empty` and `profile:` are unchanged.
 3. Run `dedupe_providers_vector_io` on the baseline.
 4. Apply existing enrichment: `enrich_byok_rag`, `enrich_solr` (Azure
    Entra ID intentionally stays separate because it's a `.env`
@@ -553,6 +558,7 @@ reference.
 |---|---|---|
 | 2026-04-23 | Initial version | Spike completion |
 | 2026-08-20 | Default baseline openai provider is conditional on `OPENAI_API_KEY` | LCORE-3607: `baseline: default` must load when the key is unset |
+| 2026-08-21 | Add `baseline: byo-llm` (default_run.yaml minus the OpenAI row); WARN on `default`/omitted | LCORE-3654: opt-in openai-free baseline |
 
 ## Appendix A — Worked example: legacy → unified migration
 

--- a/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
+++ b/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
@@ -36,8 +36,7 @@ Key shape:
 - `llama_stack.config.baseline: default | byo-llm | empty` — pick
   LCORE's built-in baseline (includes a conditional OpenAI provider),
   the same baseline without that OpenAI row, or an empty dict (used by
-  the migration tool for exact round-trip). `default` emits a deprecation
-  WARN naming `byo-llm`.
+  the migration tool for exact round-trip).
 - Legacy two-file mode (`llama_stack.library_client_config_path` +
   external `run.yaml`) is preserved during a deprecation window;
   mutually exclusive with the unified *synthesis inputs* (a non-empty
@@ -459,8 +458,7 @@ September 2026.
    Else if `unified` and `unified.baseline == "empty"` → `{}`. Else →
    `default_baseline` arg or `load_default_baseline()`. If the selector
    is `byo-llm`, strip the built-in conditional OpenAI inference row.
-   If the selector is `default` or omitted, emit a deprecation WARN
-   naming `byo-llm`. `empty` and `profile:` are unchanged.
+   `empty` and `profile:` are unchanged.
 3. Run `dedupe_providers_vector_io` on the baseline.
 4. Apply existing enrichment: `enrich_byok_rag`, `enrich_solr` (Azure
    Entra ID intentionally stays separate because it's a `.env`
@@ -558,7 +556,7 @@ reference.
 |---|---|---|
 | 2026-04-23 | Initial version | Spike completion |
 | 2026-08-20 | Default baseline openai provider is conditional on `OPENAI_API_KEY` | LCORE-3607: `baseline: default` must load when the key is unset |
-| 2026-08-21 | Add `baseline: byo-llm` (default_run.yaml minus the OpenAI row); WARN on `default`/omitted | LCORE-3654: opt-in openai-free baseline |
+| 2026-08-21 | Add `baseline: byo-llm` (default_run.yaml minus the OpenAI row) | LCORE-3654: opt-in openai-free baseline |
 
 ## Appendix A — Worked example: legacy → unified migration
 

--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -22256,10 +22256,11 @@
                         "type": "string",
                         "enum": [
                             "default",
-                            "empty"
+                            "empty",
+                            "byo-llm"
                         ],
                         "title": "Baseline selector",
-                        "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline, 'empty' starts from {}. Ignored when 'profile' is set.",
+                        "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline including the conditional OpenAI provider, 'byo-llm' uses the same baseline without that OpenAI row, 'empty' starts from {}. Ignored when 'profile' is set.",
                         "default": "default"
                     },
                     "profile": {
@@ -22284,7 +22285,7 @@
                 "additionalProperties": false,
                 "type": "object",
                 "title": "UnifiedLlamaStackConfig",
-                "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml); \"empty\" begins from\n        an empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express."
+                "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml) including the\n        conditional OpenAI inference provider. \"byo-llm\" begins from the\n        same file with that OpenAI row removed. \"empty\" begins from an\n        empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express."
             },
             "UnprocessableEntityResponse": {
                 "properties": {

--- a/docs/models/successful_responses.json
+++ b/docs/models/successful_responses.json
@@ -6533,14 +6533,15 @@
             },
             "UnifiedLlamaStackConfig": {
                 "additionalProperties": false,
-                "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml); \"empty\" begins from\n        an empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
+                "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml) including the\n        conditional OpenAI inference provider. \"byo-llm\" begins from the\n        same file with that OpenAI row removed. \"empty\" begins from an\n        empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
                 "properties": {
                     "baseline": {
                         "default": "default",
-                        "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline, 'empty' starts from {}. Ignored when 'profile' is set.",
+                        "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline including the conditional OpenAI provider, 'byo-llm' uses the same baseline without that OpenAI row, 'empty' starts from {}. Ignored when 'profile' is set.",
                         "enum": [
                             "default",
-                            "empty"
+                            "empty",
+                            "byo-llm"
                         ],
                         "title": "Baseline selector",
                         "type": "string"

--- a/docs/models/successful_responses.md
+++ b/docs/models/successful_responses.md
@@ -2864,8 +2864,10 @@ from, an optional profile file, and a raw native_override escape hatch.
 
 Attributes:
     baseline: Synthesis starting point. "default" begins from LCORE's
-        built-in baseline (src/data/default_run.yaml); "empty" begins from
-        an empty dict (used by the migration tool for an exact round-trip).
+        built-in baseline (src/data/default_run.yaml) including the
+        conditional OpenAI inference provider. "byo-llm" begins from the
+        same file with that OpenAI row removed. "empty" begins from an
+        empty dict (used by the migration tool for an exact round-trip).
         Ignored when `profile` is set.
     profile: Optional path to a user-authored run.yaml-shaped file used as
         the synthesis baseline. Relative paths resolve against the directory
@@ -2877,7 +2879,7 @@ Attributes:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| baseline | string | Synthesis starting point: 'default' uses LCORE's built-in baseline, 'empty' starts from {}. Ignored when 'profile' is set. |
+| baseline | string | Synthesis starting point: 'default' uses LCORE's built-in baseline including the conditional OpenAI provider, 'byo-llm' uses the same baseline without that OpenAI row, 'empty' starts from {}. Ignored when 'profile' is set. |
 | profile | string | Path to a run.yaml-shaped baseline file. Relative paths resolve against the directory of the loaded lightspeed-stack.yaml. |
 | native_override | object | Raw Llama Stack schema deep-merged last (maps merge recursively; lists and scalars replace). |
 

--- a/docs/user_doc/config.json
+++ b/docs/user_doc/config.json
@@ -1773,14 +1773,15 @@
       },
       "UnifiedLlamaStackConfig": {
         "additionalProperties": false,
-        "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml); \"empty\" begins from\n        an empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
+        "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml) including the\n        conditional OpenAI inference provider. \"byo-llm\" begins from the\n        same file with that OpenAI row removed. \"empty\" begins from an\n        empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
         "properties": {
           "baseline": {
             "default": "default",
-            "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline, 'empty' starts from {}. Ignored when 'profile' is set.",
+            "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline including the conditional OpenAI provider, 'byo-llm' uses the same baseline without that OpenAI row, 'empty' starts from {}. Ignored when 'profile' is set.",
             "enum": [
               "default",
-              "empty"
+              "empty",
+              "byo-llm"
             ],
             "title": "Baseline selector",
             "type": "string"

--- a/docs/user_doc/config.md
+++ b/docs/user_doc/config.md
@@ -954,8 +954,10 @@ in that case.
 
 Attributes:
     baseline: Synthesis starting point. "default" begins from LCORE's
-        built-in baseline (src/data/default_run.yaml); "empty" begins from
-        an empty dict (used by the migration tool for an exact round-trip).
+        built-in baseline (src/data/default_run.yaml) including the
+        conditional OpenAI inference provider. "byo-llm" begins from the
+        same file with that OpenAI row removed. "empty" begins from an
+        empty dict (used by the migration tool for an exact round-trip).
         Ignored when `profile` is set.
     profile: Optional path to a user-authored run.yaml-shaped file used as
         the synthesis baseline. Relative paths resolve against the directory
@@ -967,7 +969,7 @@ Attributes:
 
 | Field           | Type   | Description                                                                                                                |
 |-----------------|--------|----------------------------------------------------------------------------------------------------------------------------|
-| baseline        | string | Synthesis starting point: 'default' uses LCORE's built-in baseline, 'empty' starts from {}. Ignored when 'profile' is set. |
+| baseline        | string | Synthesis starting point: 'default' uses LCORE's built-in baseline including the conditional OpenAI provider, 'byo-llm' uses the same baseline without that OpenAI row, 'empty' starts from {}. Ignored when 'profile' is set. |
 | profile         | string | Path to a run.yaml-shaped baseline file. Relative paths resolve against the directory of the loaded lightspeed-stack.yaml. |
 | native_override | object | Raw Llama Stack schema deep-merged last (maps merge recursively; lists and scalars replace).                               |
 

--- a/src/data/default_run.yaml
+++ b/src/data/default_run.yaml
@@ -1,10 +1,12 @@
 # Built-in default Llama Stack baseline for unified-mode synthesis.
 #
 # This file is the starting point when a unified `lightspeed-stack.yaml`
-# selects `llama_stack.config.baseline: default` (the default) and does not
-# point at a `profile:`. The synthesizer (src/llama_stack_configuration.py)
-# layers enrichment, high-level `inference.providers`, and `native_override`
-# on top of this baseline to produce the final run.yaml handed to Llama Stack.
+# selects `llama_stack.config.baseline: default` (the default) or
+# `baseline: byo-llm` and does not point at a `profile:`. The synthesizer
+# (src/llama_stack_configuration.py) layers enrichment, high-level
+# `inference.providers`, and `native_override` on top of this baseline to
+# produce the final run.yaml handed to Llama Stack. `byo-llm` loads this
+# file then drops the conditional OpenAI inference row.
 #
 # It is intentionally thinner than the repo-root run.yaml: it carries only the
 # APIs and providers needed to boot a minimal, queryable stack (inference,

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -10,7 +10,7 @@ Two related responsibilities live here:
   layers dynamic values (BYOK RAG, Solr/OKP, Azure Entra ID) on top of it.
 - **Synthesis** (unified mode, LCORE-2336): builds a complete ``run.yaml`` from
   high-level operator inputs in ``lightspeed-stack.yaml`` — a baseline (built-in
-  default, a profile file, or empty), the same enrichment, the high-level
+  default, byo-llm, a profile file, or empty), the same enrichment, the high-level
   ``inference.providers`` section, and a raw ``native_override`` deep-merged
   last. ``run.yaml`` becomes an implementation detail LCORE owns rather than an
   operator-facing artifact.
@@ -22,7 +22,7 @@ import copy
 import os
 from argparse import ArgumentParser
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Final, Optional
 from urllib.parse import urljoin
 
 import yaml
@@ -57,8 +57,14 @@ API_KEY_FIELD_MAP: dict[str, str] = {
 }
 
 # Package-relative path to the built-in default baseline run.yaml shipped with
-# LCORE, used when unified mode selects baseline "default" without a profile.
+# LCORE, used when unified mode selects baseline "default" or "byo-llm" without
+# a profile. "byo-llm" loads this file then strips the conditional OpenAI row.
 DEFAULT_BASELINE_RESOURCE: Path = Path(__file__).parent / "data" / "default_run.yaml"
+
+# Unevaluated provider_id of the built-in OpenAI row in default_run.yaml
+# (LCORE-3607). Matched as "openai" during high-level replace, and stripped
+# when baseline is byo-llm (LCORE-3654).
+CONDITIONAL_OPENAI_PROVIDER_ID: Final[str] = "${env.OPENAI_API_KEY:+openai}"
 
 VECTOR_IO_TEMPLATES: dict[str, dict[str, Any]] = {
     "inline::faiss": {
@@ -976,8 +982,8 @@ def load_default_baseline() -> dict[str, Any]:
 
     Returns:
         dict[str, Any]: The parsed contents of ``src/data/default_run.yaml``,
-        the baseline used when unified mode selects ``baseline: default``
-        without a profile.
+        the baseline used when unified mode selects ``baseline: default`` or
+        ``baseline: byo-llm`` without a profile.
 
     Raises:
         OSError: If the shipped baseline file cannot be read.
@@ -1027,9 +1033,35 @@ def _matchable_provider_id(provider_id: Any) -> Any:
         ``openai`` when ``provider_id`` is the baseline conditional openai
         ref, otherwise ``provider_id`` unchanged.
     """
-    if provider_id == "${env.OPENAI_API_KEY:+openai}":
+    if provider_id == CONDITIONAL_OPENAI_PROVIDER_ID:
         return "openai"
     return provider_id
+
+
+def _strip_default_openai_inference(ls_config: dict[str, Any]) -> None:
+    """Remove the OpenAI inference provider from the default baseline.
+
+    Parameters:
+        ls_config: The Llama Stack configuration being synthesized (modified
+            in place).
+
+    Returns:
+        None: ``ls_config`` is modified in place.
+    """
+    providers = ls_config.get("providers")
+    if not isinstance(providers, dict):
+        return
+    inference = providers.get("inference")
+    if not isinstance(inference, list):
+        return
+    providers["inference"] = [
+        entry
+        for entry in inference
+        if not (
+            isinstance(entry, dict)
+            and entry.get("provider_id") == CONDITIONAL_OPENAI_PROVIDER_ID
+        )
+    ]
 
 
 def apply_high_level_inference(
@@ -1178,7 +1210,7 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     """Synthesize a full Llama Stack ``run.yaml`` dict from a unified config.
 
     Implements the unified-mode synthesis pipeline: select a baseline (profile
-    file, empty, or the built-in default), apply the existing enrichment
+    file, empty, byo-llm, or the built-in default), apply the existing enrichment
     (Azure Entra ID, BYOK RAG, Solr/OKP) for parity with legacy mode (R7),
     expand the high-level ``inference.providers`` section, ensure the default
     MCP tool_runtime provider when the baseline was not empty, and deep-merge
@@ -1198,6 +1230,7 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
 
     # 1-2. Select the baseline.
     baseline_was_empty = False
+    loaded_shipped_baseline = False
     if unified and unified.get("profile"):
         profile_path = _resolve_profile_path(unified["profile"], config_file_dir)
         logger.info("Loading synthesis baseline from profile %s", profile_path)
@@ -1208,6 +1241,8 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
         baseline_was_empty = True
         baseline = {}
     else:
+        # default, omitted, or byo-llm: start from default_run.yaml.
+        loaded_shipped_baseline = True
         baseline = (
             default_baseline
             if default_baseline is not None
@@ -1215,6 +1250,21 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
         )
 
     ls_config: dict[str, Any] = copy.deepcopy(baseline)
+
+    # Profile and empty are unchanged. The shipped file either keeps OpenAI
+    # (default/omitted, with a deprecation WARN) or drops it (byo-llm).
+    if loaded_shipped_baseline:
+        if unified and unified.get("baseline") == "byo-llm":
+            _strip_default_openai_inference(ls_config)
+        else:
+            logger.warning(
+                "DEPRECATED: llama_stack.config.baseline 'default' includes a "
+                "built-in conditional OpenAI inference provider (%s). Set "
+                "baseline to 'byo-llm' to start without that provider and "
+                "declare LLMs under inference.providers. 'byo-llm' will "
+                "become the default in a future release.",
+                CONDITIONAL_OPENAI_PROVIDER_ID,
+            )
 
     # 3. Normalize duplicated vector_io providers in the baseline.
     dedupe_providers_vector_io(ls_config)

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -1252,19 +1252,9 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     ls_config: dict[str, Any] = copy.deepcopy(baseline)
 
     # Profile and empty are unchanged. The shipped file either keeps OpenAI
-    # (default/omitted, with a deprecation WARN) or drops it (byo-llm).
-    if loaded_shipped_baseline:
-        if unified and unified.get("baseline") == "byo-llm":
-            _strip_default_openai_inference(ls_config)
-        else:
-            logger.warning(
-                "DEPRECATED: llama_stack.config.baseline 'default' includes a "
-                "built-in conditional OpenAI inference provider (%s). Set "
-                "baseline to 'byo-llm' to start without that provider and "
-                "declare LLMs under inference.providers. 'byo-llm' will "
-                "become the default in a future release.",
-                CONDITIONAL_OPENAI_PROVIDER_ID,
-            )
+    # (default/omitted) or drops it (byo-llm).
+    if loaded_shipped_baseline and unified and unified.get("baseline") == "byo-llm":
+        _strip_default_openai_inference(ls_config)
 
     # 3. Normalize duplicated vector_io providers in the baseline.
     dedupe_providers_vector_io(ls_config)

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -771,8 +771,10 @@ class UnifiedLlamaStackConfig(ConfigurationBase):
 
     Attributes:
         baseline: Synthesis starting point. "default" begins from LCORE's
-            built-in baseline (src/data/default_run.yaml); "empty" begins from
-            an empty dict (used by the migration tool for an exact round-trip).
+            built-in baseline (src/data/default_run.yaml) including the
+            conditional OpenAI inference provider. "byo-llm" begins from the
+            same file with that OpenAI row removed. "empty" begins from an
+            empty dict (used by the migration tool for an exact round-trip).
             Ignored when `profile` is set.
         profile: Optional path to a user-authored run.yaml-shaped file used as
             the synthesis baseline. Relative paths resolve against the directory
@@ -782,11 +784,13 @@ class UnifiedLlamaStackConfig(ConfigurationBase):
             anything the high-level sections do not express.
     """
 
-    baseline: Literal["default", "empty"] = Field(
+    baseline: Literal["default", "empty", "byo-llm"] = Field(
         "default",
         title="Baseline selector",
         description="Synthesis starting point: 'default' uses LCORE's built-in "
-        "baseline, 'empty' starts from {}. Ignored when 'profile' is set.",
+        "baseline including the conditional OpenAI provider, 'byo-llm' uses "
+        "the same baseline without that OpenAI row, 'empty' starts from {}. "
+        "Ignored when 'profile' is set.",
     )
 
     profile: Optional[str] = Field(

--- a/tests/integration/test_unified_synthesis.py
+++ b/tests/integration/test_unified_synthesis.py
@@ -25,6 +25,7 @@ from pydantic import ValidationError
 
 from configuration import configuration
 from llama_stack_configuration import (
+    CONDITIONAL_OPENAI_PROVIDER_ID,
     generate_configuration,
     load_default_baseline,
     migrate_config_dumb,
@@ -266,6 +267,35 @@ def test_default_baseline_through_real_load(tmp_path: Path) -> None:
     baseline = load_default_baseline()
     assert synthesized["version"] == baseline["version"]
     assert set(baseline["apis"]).issubset(set(synthesized["apis"]))
+    mcp_ids = {p["provider_id"] for p in synthesized["providers"]["tool_runtime"]}
+    assert "model-context-protocol" in mcp_ids
+
+
+def test_byo_llm_baseline_through_real_load(tmp_path: Path) -> None:
+    """baseline: byo-llm synthesizes from default_run.yaml without the OpenAI row."""
+    lcs_dict = _base_config_dict()
+    lcs_dict["llama_stack"] = {
+        "use_as_library_client": True,
+        "config": {"baseline": "byo-llm"},
+    }
+    synthesized, _ = _load_and_synthesize(tmp_path, lcs_dict)
+
+    baseline = load_default_baseline()
+    assert synthesized["version"] == baseline["version"]
+    for entry in synthesized["providers"]["inference"]:
+        if not isinstance(entry, dict):
+            continue
+        assert entry.get("provider_type") != "remote::openai"
+        assert entry.get("provider_id") not in (
+            "openai",
+            CONDITIONAL_OPENAI_PROVIDER_ID,
+        )
+    inference_ids = [
+        entry["provider_id"]
+        for entry in synthesized["providers"]["inference"]
+        if isinstance(entry, dict)
+    ]
+    assert "sentence-transformers" in inference_ids
     mcp_ids = {p["provider_id"] for p in synthesized["providers"]["tool_runtime"]}
     assert "model-context-protocol" in mcp_ids
 

--- a/tests/unit/models/config/test_llama_stack_configuration.py
+++ b/tests/unit/models/config/test_llama_stack_configuration.py
@@ -233,6 +233,12 @@ def test_unified_config_rejects_unknown_fields() -> None:
         UnifiedLlamaStackConfig(bogus=True)  # pyright: ignore[reportCallIssue]
 
 
+def test_unified_config_accepts_byo_llm_baseline() -> None:
+    """byo-llm is a valid baseline selector (LCORE-3654)."""
+    cfg = UnifiedLlamaStackConfig(baseline="byo-llm")
+    assert cfg.baseline == "byo-llm"
+
+
 def test_root_rejects_config_and_legacy_path_together() -> None:
     """A llama_stack.config block and a legacy path in one file fail at load (R3)."""
     config_dict = _base_config_dict()

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -6,6 +6,9 @@ high-level inference expansion, the full synthesis pipeline, and the
 write-to-file step (persistent path, mode 0600).
 """
 
+# pylint: disable=too-many-lines
+
+import logging
 import os
 import stat
 from pathlib import Path
@@ -16,6 +19,7 @@ import yaml
 from ogx.core.stack import replace_env_vars
 
 from llama_stack_configuration import (
+    CONDITIONAL_OPENAI_PROVIDER_ID,
     PROVIDER_TYPE_MAP,
     apply_high_level_inference,
     deep_merge_list_replace,
@@ -27,7 +31,7 @@ from llama_stack_configuration import (
 )
 from models.config import UnifiedInferenceProvider
 
-OPENAI_CONDITIONAL_PROVIDER_ID = "${env.OPENAI_API_KEY:+openai}"
+OPENAI_CONDITIONAL_PROVIDER_ID = CONDITIONAL_OPENAI_PROVIDER_ID
 OPENAI_CONDITIONAL_API_KEY = "${env.OPENAI_API_KEY:=}"
 
 # ---------------------------------------------------------------------------
@@ -735,6 +739,167 @@ def test_synthesize_vllm_appends_and_keeps_conditional_openai(
     assert len(resolved_openai) == 1
     assert resolved_openai[0]["provider_id"] is None
     assert any(entry["provider_id"] == "vllm" for entry in _inference_entries(resolved))
+
+
+def _byo_llm_deprecation_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return WARN records that name the byo-llm baseline replacement."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "byo-llm" in record.getMessage()
+    ]
+
+
+@pytest.mark.parametrize(
+    "lcs",
+    [
+        {"llama_stack": {"config": {"baseline": "default"}}},
+        {"llama_stack": {"config": {}}},
+        {},
+    ],
+)
+def test_synthesize_default_path_warns_and_keeps_conditional_openai(
+    caplog: pytest.LogCaptureFixture, lcs: dict[str, Any]
+) -> None:
+    """default or omitted baseline keeps the OpenAI row and warns naming byo-llm."""
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    openai_entries = _openai_inference_entries(result)
+    assert len(openai_entries) == 1
+    assert openai_entries[0]["provider_id"] == OPENAI_CONDITIONAL_PROVIDER_ID
+    ids = [entry["provider_id"] for entry in _inference_entries(result)]
+    assert "sentence-transformers" in ids
+    warnings = _byo_llm_deprecation_warnings(caplog)
+    assert len(warnings) == 1
+    assert "byo-llm" in warnings[0]
+
+
+def test_synthesize_byo_llm_strips_openai_without_warn(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """byo-llm drops the built-in OpenAI row, keeps the embedder, and does not warn."""
+    lcs = {"llama_stack": {"config": {"baseline": "byo-llm"}}}
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    assert _openai_inference_entries(result) == []
+    ids = [entry["provider_id"] for entry in _inference_entries(result)]
+    assert ids == ["sentence-transformers"]
+    assert "model-context-protocol" in _tool_runtime_ids(result)
+    assert _byo_llm_deprecation_warnings(caplog) == []
+
+
+def test_synthesize_byo_llm_with_vllm_appends_without_openai(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """byo-llm + high-level vLLM appends vLLM and does not restore OpenAI."""
+    lcs = {
+        "llama_stack": {"config": {"baseline": "byo-llm"}},
+        "inference": {
+            "providers": [
+                {
+                    "type": "vllm",
+                    "api_key_env": "VLLM_API_KEY",
+                    "extra": {"url": "http://vllm:8000"},
+                }
+            ]
+        },
+    }
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    assert _openai_inference_entries(result) == []
+    vllm = next(
+        entry for entry in _inference_entries(result) if entry["provider_id"] == "vllm"
+    )
+    assert vllm["provider_type"] == "remote::vllm"
+    assert "sentence-transformers" in [
+        entry["provider_id"] for entry in _inference_entries(result)
+    ]
+    assert _byo_llm_deprecation_warnings(caplog) == []
+
+
+def test_synthesize_byo_llm_with_openai_appends_one_row(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """byo-llm + high-level openai appends a single openai row and does not warn."""
+    lcs = {
+        "llama_stack": {"config": {"baseline": "byo-llm"}},
+        "inference": {
+            "providers": [{"type": "openai", "api_key_env": "OPENAI_API_KEY"}]
+        },
+    }
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    openai_entries = _openai_inference_entries(result)
+    assert len(openai_entries) == 1
+    assert openai_entries[0]["provider_id"] == "openai"
+    assert openai_entries[0]["config"]["api_key"] == "${env.OPENAI_API_KEY}"
+    assert _byo_llm_deprecation_warnings(caplog) == []
+
+
+def test_synthesize_empty_baseline_does_not_warn_byo_llm(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """baseline: empty is unchanged: no strip, no byo-llm WARN."""
+    lcs = {
+        "llama_stack": {
+            "config": {
+                "baseline": "empty",
+                "native_override": {"version": 2, "apis": ["inference"]},
+            }
+        }
+    }
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    assert result == {"version": 2, "apis": ["inference"]}
+    assert _byo_llm_deprecation_warnings(caplog) == []
+
+
+def test_synthesize_profile_ignores_byo_llm_and_does_not_warn(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """profile: wins over baseline: byo-llm; no strip and no deprecation WARN."""
+    profile = {
+        "version": 2,
+        "apis": ["inference"],
+        "providers": {
+            "inference": [
+                {
+                    "provider_id": "openai",
+                    "provider_type": "remote::openai",
+                    "config": {"api_key": "${env.OPENAI_API_KEY}"},
+                }
+            ]
+        },
+        "marker": "from-profile",
+    }
+    (tmp_path / "my-profile.yaml").write_text(yaml.dump(profile), encoding="utf-8")
+    lcs = {
+        "llama_stack": {
+            "config": {
+                "profile": "my-profile.yaml",
+                "baseline": "byo-llm",
+            }
+        }
+    }
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs, config_file_dir=str(tmp_path))
+    assert result["marker"] == "from-profile"
+    openai_entries = _openai_inference_entries(result)
+    assert len(openai_entries) == 1
+    assert openai_entries[0]["provider_id"] == "openai"
+    assert _byo_llm_deprecation_warnings(caplog) == []
 
 
 def test_synthesize_loads_profile_relative_to_config_dir(tmp_path: Path) -> None:

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -8,7 +8,6 @@ write-to-file step (persistent path, mode 0600).
 
 # pylint: disable=too-many-lines
 
-import logging
 import os
 import stat
 from pathlib import Path
@@ -741,15 +740,6 @@ def test_synthesize_vllm_appends_and_keeps_conditional_openai(
     assert any(entry["provider_id"] == "vllm" for entry in _inference_entries(resolved))
 
 
-def _byo_llm_deprecation_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
-    """Return WARN records that name the byo-llm baseline replacement."""
-    return [
-        record.getMessage()
-        for record in caplog.records
-        if record.levelno == logging.WARNING and "byo-llm" in record.getMessage()
-    ]
-
-
 @pytest.mark.parametrize(
     "lcs",
     [
@@ -758,43 +748,29 @@ def _byo_llm_deprecation_warnings(caplog: pytest.LogCaptureFixture) -> list[str]
         {},
     ],
 )
-def test_synthesize_default_path_warns_and_keeps_conditional_openai(
-    caplog: pytest.LogCaptureFixture, lcs: dict[str, Any]
+def test_synthesize_default_path_keeps_conditional_openai(
+    lcs: dict[str, Any],
 ) -> None:
-    """default or omitted baseline keeps the OpenAI row and warns naming byo-llm."""
-    with caplog.at_level(
-        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
-    ):
-        result = synthesize_configuration(lcs)
+    """default or omitted baseline keeps the OpenAI row."""
+    result = synthesize_configuration(lcs)
     openai_entries = _openai_inference_entries(result)
     assert len(openai_entries) == 1
     assert openai_entries[0]["provider_id"] == OPENAI_CONDITIONAL_PROVIDER_ID
     ids = [entry["provider_id"] for entry in _inference_entries(result)]
     assert "sentence-transformers" in ids
-    warnings = _byo_llm_deprecation_warnings(caplog)
-    assert len(warnings) == 1
-    assert "byo-llm" in warnings[0]
 
 
-def test_synthesize_byo_llm_strips_openai_without_warn(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """byo-llm drops the built-in OpenAI row, keeps the embedder, and does not warn."""
+def test_synthesize_byo_llm_strips_openai() -> None:
+    """byo-llm drops the built-in OpenAI row and keeps the embedder."""
     lcs = {"llama_stack": {"config": {"baseline": "byo-llm"}}}
-    with caplog.at_level(
-        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
-    ):
-        result = synthesize_configuration(lcs)
+    result = synthesize_configuration(lcs)
     assert _openai_inference_entries(result) == []
     ids = [entry["provider_id"] for entry in _inference_entries(result)]
     assert ids == ["sentence-transformers"]
     assert "model-context-protocol" in _tool_runtime_ids(result)
-    assert _byo_llm_deprecation_warnings(caplog) == []
 
 
-def test_synthesize_byo_llm_with_vllm_appends_without_openai(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_synthesize_byo_llm_with_vllm_appends_without_openai() -> None:
     """byo-llm + high-level vLLM appends vLLM and does not restore OpenAI."""
     lcs = {
         "llama_stack": {"config": {"baseline": "byo-llm"}},
@@ -808,10 +784,7 @@ def test_synthesize_byo_llm_with_vllm_appends_without_openai(
             ]
         },
     }
-    with caplog.at_level(
-        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
-    ):
-        result = synthesize_configuration(lcs)
+    result = synthesize_configuration(lcs)
     assert _openai_inference_entries(result) == []
     vllm = next(
         entry for entry in _inference_entries(result) if entry["provider_id"] == "vllm"
@@ -820,34 +793,25 @@ def test_synthesize_byo_llm_with_vllm_appends_without_openai(
     assert "sentence-transformers" in [
         entry["provider_id"] for entry in _inference_entries(result)
     ]
-    assert _byo_llm_deprecation_warnings(caplog) == []
 
 
-def test_synthesize_byo_llm_with_openai_appends_one_row(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """byo-llm + high-level openai appends a single openai row and does not warn."""
+def test_synthesize_byo_llm_with_openai_appends_one_row() -> None:
+    """byo-llm + high-level openai appends a single openai row."""
     lcs = {
         "llama_stack": {"config": {"baseline": "byo-llm"}},
         "inference": {
             "providers": [{"type": "openai", "api_key_env": "OPENAI_API_KEY"}]
         },
     }
-    with caplog.at_level(
-        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
-    ):
-        result = synthesize_configuration(lcs)
+    result = synthesize_configuration(lcs)
     openai_entries = _openai_inference_entries(result)
     assert len(openai_entries) == 1
     assert openai_entries[0]["provider_id"] == "openai"
     assert openai_entries[0]["config"]["api_key"] == "${env.OPENAI_API_KEY}"
-    assert _byo_llm_deprecation_warnings(caplog) == []
 
 
-def test_synthesize_empty_baseline_does_not_warn_byo_llm(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """baseline: empty is unchanged: no strip, no byo-llm WARN."""
+def test_synthesize_empty_baseline_does_not_strip_openai() -> None:
+    """baseline: empty is unchanged: no OpenAI strip."""
     lcs = {
         "llama_stack": {
             "config": {
@@ -856,18 +820,12 @@ def test_synthesize_empty_baseline_does_not_warn_byo_llm(
             }
         }
     }
-    with caplog.at_level(
-        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
-    ):
-        result = synthesize_configuration(lcs)
+    result = synthesize_configuration(lcs)
     assert result == {"version": 2, "apis": ["inference"]}
-    assert _byo_llm_deprecation_warnings(caplog) == []
 
 
-def test_synthesize_profile_ignores_byo_llm_and_does_not_warn(
-    tmp_path: Path, caplog: pytest.LogCaptureFixture
-) -> None:
-    """profile: wins over baseline: byo-llm; no strip and no deprecation WARN."""
+def test_synthesize_profile_ignores_byo_llm(tmp_path: Path) -> None:
+    """profile: wins over baseline: byo-llm; no OpenAI strip."""
     profile = {
         "version": 2,
         "apis": ["inference"],
@@ -891,15 +849,11 @@ def test_synthesize_profile_ignores_byo_llm_and_does_not_warn(
             }
         }
     }
-    with caplog.at_level(
-        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
-    ):
-        result = synthesize_configuration(lcs, config_file_dir=str(tmp_path))
+    result = synthesize_configuration(lcs, config_file_dir=str(tmp_path))
     assert result["marker"] == "from-profile"
     openai_entries = _openai_inference_entries(result)
     assert len(openai_entries) == 1
     assert openai_entries[0]["provider_id"] == "openai"
-    assert _byo_llm_deprecation_warnings(caplog) == []
 
 
 def test_synthesize_loads_profile_relative_to_config_dir(tmp_path: Path) -> None:

--- a/tests/unit/utils/test_models_dumper.py
+++ b/tests/unit/utils/test_models_dumper.py
@@ -9284,14 +9284,15 @@ def test_dump_models(tmpdir: Path) -> None:
                 },
                 "UnifiedLlamaStackConfig": {
                     "additionalProperties": false,
-                    "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml); \"empty\" begins from\n        an empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
+                    "description": "Backend-specific knobs for unified-mode Llama Stack synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml) including the\n        conditional OpenAI inference provider. \"byo-llm\" begins from the\n        same file with that OpenAI row removed. \"empty\" begins from an\n        empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw Llama Stack schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
                     "properties": {
                         "baseline": {
                             "default": "default",
-                            "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline, 'empty' starts from {}. Ignored when 'profile' is set.",
+                            "description": "Synthesis starting point: 'default' uses LCORE's built-in baseline including the conditional OpenAI provider, 'byo-llm' uses the same baseline without that OpenAI row, 'empty' starts from {}. Ignored when 'profile' is set.",
                             "enum": [
                                 "default",
-                                "empty"
+                                "empty",
+                                "byo-llm"
                             ],
                             "title": "Baseline selector",
                             "type": "string"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Adds `byo-llm` baseline, which is derived from the current `default` baseline, minus `openai` 
- Adds deprecation warning for the current `default` baseline that contains `openai` by default

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue https://redhat.atlassian.net/browse/LCORE-3654
- Closes https://redhat.atlassian.net/browse/LCORE-3654

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `byo-llm` configuration baseline.
  - This option uses the built-in baseline without the conditional OpenAI provider.
  - Existing `default` and `empty` baseline behaviors remain supported.
  - Provider configurations can be combined with `byo-llm`, with explicit profiles taking precedence.

- **Documentation**
  - Updated configuration guides, schemas, examples, and API documentation.
  - Clarified the behavior and provider composition rules for all baseline options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->