### PR TITLE
LCORE-2982: Responses otel integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for integration tests."""
 
+import importlib
 import os
 from collections.abc import AsyncIterator, Generator
 from pathlib import Path
@@ -11,6 +12,12 @@ from fastapi.testclient import TestClient
 from ogx_api.openai_responses import OpenAIResponseObject
 from ogx_client.types import ListModelsResponse, VersionInfo
 from ogx_client.types.model import Model
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
 from pydantic_ai import AgentRunResultEvent
 from pydantic_ai.messages import (
     ModelMessage,
@@ -441,9 +448,55 @@ def set_streaming_query_agent_run(
     )
 
 
+OTEL_INSTRUMENTED_MODULES = (
+    "app.endpoints.query",
+    "app.endpoints.responses",
+    "utils.quota_utils",
+    "utils.responses",
+    "utils.shields",
+    "utils.vector_search",
+)
+
+
+def install_integration_otel_provider(
+    exporter: InMemorySpanExporter,
+) -> TracerProvider:
+    """Install a global TracerProvider and refresh cached module tracers."""
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    trace._TRACER_PROVIDER_SET_ONCE._done = False  # pylint: disable=protected-access
+    trace._TRACER_PROVIDER = None  # pylint: disable=protected-access
+    trace.set_tracer_provider(provider)
+
+    for module_name in OTEL_INSTRUMENTED_MODULES:
+        module = importlib.import_module(module_name)
+        module.tracer = provider.get_tracer(module_name)
+
+    return provider
+
+
+def shutdown_integration_otel_provider(provider: TracerProvider) -> None:
+    """Shut down the integration OTEL provider and clear global state."""
+    provider.shutdown()
+    trace._TRACER_PROVIDER_SET_ONCE._done = False  # pylint: disable=protected-access
+    trace._TRACER_PROVIDER = None  # pylint: disable=protected-access
+
+
 # ==========================================
 # Fixtures
 # ==========================================
+
+
+@pytest.fixture(name="otel_collector", scope="module")
+def otel_collector_fixture() -> Generator[InMemorySpanExporter, None, None]:
+    """Module-scoped OTEL exporter for integration tests that opt in via fixture."""
+    exporter = InMemorySpanExporter()
+    provider = install_integration_otel_provider(exporter)
+
+    yield exporter
+
+    shutdown_integration_otel_provider(provider)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_otel_trace_propagation.py
+++ b/tests/integration/test_otel_trace_propagation.py
@@ -6,16 +6,9 @@ relationships when flowing through the query endpoint and its
 downstream components.
 """
 
-# pylint: disable=protected-access
-
-from collections.abc import Generator
-
 import pytest
 from fastapi import Request
 from opentelemetry import context as otel_context
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -28,39 +21,6 @@ from models.api.requests import QueryRequest
 KNOWN_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736"
 KNOWN_PARENT_SPAN_ID = "00f067aa0ba902b7"
 TRACEPARENT = f"00-{KNOWN_TRACE_ID}-{KNOWN_PARENT_SPAN_ID}-01"
-
-
-@pytest.fixture(name="otel_collector", scope="module")
-def otel_collector_fixture() -> Generator[InMemorySpanExporter, None, None]:
-    """Install a global TracerProvider backed by an InMemorySpanExporter.
-
-    Module-scoped so that every module-level ``trace.get_tracer(__name__)``
-    proxy resolves to the same real tracer across all tests in this file.
-    Shutting down the provider between tests would invalidate the cached
-    proxy and silently drop spans.
-
-    Why we reset ``_TRACER_PROVIDER_SET_ONCE`` instead of using
-    ``mock.patch("opentelemetry.trace.get_tracer_provider")``:
-    ``ProxyTracer._tracer`` reads the module-level ``_TRACER_PROVIDER``
-    variable directly — it never calls ``get_tracer_provider()``.
-    Patching the function leaves that variable ``None``, so the proxy
-    falls back to a noop tracer and no spans are captured.
-    ``set_tracer_provider()`` is the only way to populate the variable,
-    and the one-shot guard must be reset to allow re-installation.
-    """
-    exporter = InMemorySpanExporter()
-    provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-
-    trace._TRACER_PROVIDER_SET_ONCE._done = False
-    trace._TRACER_PROVIDER = None
-    trace.set_tracer_provider(provider)
-
-    yield exporter
-
-    provider.shutdown()
-    trace._TRACER_PROVIDER_SET_ONCE._done = False
-    trace._TRACER_PROVIDER = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_responses_otel_trace.py
+++ b/tests/integration/test_responses_otel_trace.py
@@ -1,0 +1,96 @@
+"""Integration tests for OpenTelemetry span tree on POST /v1/responses."""
+
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from pytest_mock import MockerFixture
+
+from app.endpoints.responses import responses_endpoint_handler
+from models.api.requests import ResponsesRequest
+from models.api.responses.successful import ResponsesResponse
+from tests.integration.endpoints.test_responses_integration import (
+    MOCK_AUTH,
+    _setup_test,
+)
+from tests.unit.app.endpoints.responses_otel_helpers import (
+    configure_streaming_client,
+    consume_streaming_response,
+)
+
+ROOT_SPAN_NAME = "responses.handle_request"
+EXPECTED_OPERATIONAL_SPANS = {
+    "quota.check",
+    "shield.moderate",
+    "rag.retrieve",
+    "llm.inference",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_spans(otel_collector: InMemorySpanExporter) -> None:
+    """Clear collected spans before each test."""
+    otel_collector.clear()
+
+
+def _assert_span_tree_parentage(spans: Sequence[Any], root_name: str) -> None:
+    """Assert expected operational spans exist and nest under the root."""
+    span_names = {span.name for span in spans}
+    missing = (EXPECTED_OPERATIONAL_SPANS | {root_name}) - span_names
+    assert not missing, f"Missing expected spans: {missing}"
+
+    root = next(span for span in spans if span.name == root_name)
+    assert root.context is not None
+
+    trace_ids = {span.context.trace_id for span in spans if span.context is not None}
+    assert len(trace_ids) == 1
+
+    child_spans = [span for span in spans if span.name != root_name]
+    assert child_spans, "Expected at least one child span"
+
+    for child in child_spans:
+        assert child.parent is not None, f"Span {child.name!r} should have a parent"
+        assert (
+            child.parent.span_id == root.context.span_id
+        ), f"Span {child.name!r} should be parented to {root_name}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.usefixtures("test_config")
+async def test_responses_span_tree_parentage(
+    stream: bool,
+    mocker: MockerFixture,
+    mock_request_with_auth: Request,
+    otel_collector: InMemorySpanExporter,
+) -> None:
+    """Responses emits expected spans with correct parentage for both stream modes."""
+    mock_client = _setup_test(mocker)
+    if stream:
+        configure_streaming_client(mocker, mock_client)
+
+    result = await responses_endpoint_handler(
+        request=mock_request_with_auth,
+        responses_request=ResponsesRequest(
+            input="What is Ansible?",
+            model="test-provider/test-model",
+            stream=stream,
+            store=False,
+            generate_topic_summary=False,
+        ),
+        auth=MOCK_AUTH,
+        mcp_headers={},
+    )
+
+    if stream:
+        assert isinstance(result, StreamingResponse)
+        await consume_streaming_response(result)
+    else:
+        assert isinstance(result, ResponsesResponse)
+
+    _assert_span_tree_parentage(otel_collector.get_finished_spans(), ROOT_SPAN_NAME)


### PR DESCRIPTION
## Description

Added integration tests for OTEL spans parentage checks in responses endpoint.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [x] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue #
- Closes # https://redhat.atlassian.net/browse/LCORE-2982

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for OpenTelemetry tracing in streaming and non-streaming Responses requests.
  * Verified operational spans share a single trace and attach correctly to the root request span.
  * Added reusable, opt-in tracing setup and cleanup for collecting spans during integration tests.
  * Improved test isolation by resetting tracing state after each integration test scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->