### PR TITLE
LCORE-3514: Do not catch blind exception

### DIFF
--- a/tests/e2e/features/steps/shields.py
+++ b/tests/e2e/features/steps/shields.py
@@ -31,7 +31,7 @@ def shields_are_disabled_for_scenario(context: Context) -> None:
         context.llama_guard_provider_shield_id = saved[1] if saved else None
         context.shields_disabled_for_scenario = True
         print("Unregistered shield llama-guard for this scenario")
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except (RuntimeError, ValueError, AttributeError) as e:
         context.scenario.skip(
             f"Could not unregister shield (is Llama Stack reachable?): {e}"
         )


### PR DESCRIPTION
## Description

LCORE-3514: Do not catch blind exception

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3514


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when disabling the `llama-guard` shield by handling expected runtime, value, and attribute errors explicitly, helping unexpected issues surface more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->