### PR TITLE
LCORE-3696: deprecate the built-in OpenAI provider in baseline default

### DIFF
--- a/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
+++ b/docs/design/llama-stack-config-merge/llama-stack-config-merge.md
@@ -267,6 +267,8 @@ llama_stack:
   config:
     # Baseline selection (backend-specific knobs stay here)
     baseline: default              # default | byo-llm | empty; ignored if `profile` is set
+                                   # DEPRECATED in 0.7: `default`'s built-in OpenAI
+                                   # provider is removed in 0.8 -- use `byo-llm`
     profile: ./my-profile.yaml     # optional; resolves relative to lightspeed-stack.yaml
 
     # Escape hatch — raw Llama Stack schema, deep-merged with list replacement
@@ -557,6 +559,7 @@ reference.
 | 2026-04-23 | Initial version | Spike completion |
 | 2026-08-20 | Default baseline openai provider is conditional on `OPENAI_API_KEY` | LCORE-3607: `baseline: default` must load when the key is unset |
 | 2026-08-21 | Add `baseline: byo-llm` (default_run.yaml minus the OpenAI row) | LCORE-3654: opt-in openai-free baseline |
+| 2026-08-25 | `baseline: default`'s built-in OpenAI provider deprecated in 0.7, removed in 0.8 | LCORE-3696: `default` shipped in 0.6.0 GA, so the ESA one-minor deprecation phase applies (confirmed by @sbunciak) |
 
 ## Appendix A — Worked example: legacy → unified migration
 

--- a/src/llama_stack_configuration.py
+++ b/src/llama_stack_configuration.py
@@ -1252,9 +1252,25 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     ls_config: dict[str, Any] = copy.deepcopy(baseline)
 
     # Profile and empty are unchanged. The shipped file either keeps OpenAI
-    # (default/omitted) or drops it (byo-llm).
-    if loaded_shipped_baseline and unified and unified.get("baseline") == "byo-llm":
-        _strip_default_openai_inference(ls_config)
+    # (default/omitted, with a deprecation WARN) or drops it (byo-llm).
+    #
+    # Deprecation schedule (confirmed by @sbunciak 2026-08-25): the built-in
+    # OpenAI row in baseline "default" is deprecated in 0.7 with this single
+    # startup WARN and removed in 0.8. "default" shipped in 0.6.0 GA, so the
+    # Engineering Support Agreement's one-minor deprecation phase applies.
+    if loaded_shipped_baseline:
+        if unified and unified.get("baseline") == "byo-llm":
+            _strip_default_openai_inference(ls_config)
+        else:
+            logger.warning(
+                "DEPRECATED: the built-in OpenAI inference provider in "
+                "llama_stack.config.baseline 'default' is deprecated and will "
+                "be removed in release 0.8. Set baseline to 'byo-llm' and "
+                "declare your LLM providers under inference.providers: "
+                "https://lightspeed-core.github.io/lightspeed-stack/design"
+                "/llama-stack-config-merge/llama-stack-config-merge.html"
+                "#configuration"
+            )
 
     # 3. Normalize duplicated vector_io providers in the baseline.
     dedupe_providers_vector_io(ls_config)

--- a/tests/unit/test_llama_stack_synthesize.py
+++ b/tests/unit/test_llama_stack_synthesize.py
@@ -8,6 +8,7 @@ write-to-file step (persistent path, mode 0600).
 
 # pylint: disable=too-many-lines
 
+import logging
 import os
 import stat
 from pathlib import Path
@@ -740,6 +741,15 @@ def test_synthesize_vllm_appends_and_keeps_conditional_openai(
     assert any(entry["provider_id"] == "vllm" for entry in _inference_entries(resolved))
 
 
+def _byo_llm_deprecation_warnings(caplog: pytest.LogCaptureFixture) -> list[str]:
+    """Return WARN records that name the byo-llm baseline replacement."""
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING and "byo-llm" in record.getMessage()
+    ]
+
+
 @pytest.mark.parametrize(
     "lcs",
     [
@@ -749,10 +759,16 @@ def test_synthesize_vllm_appends_and_keeps_conditional_openai(
     ],
 )
 def test_synthesize_default_path_keeps_conditional_openai(
-    lcs: dict[str, Any],
+    lcs: dict[str, Any], caplog: pytest.LogCaptureFixture
 ) -> None:
-    """default or omitted baseline keeps the OpenAI row."""
-    result = synthesize_configuration(lcs)
+    """default or omitted baseline keeps the OpenAI row and warns naming byo-llm."""
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    warnings = _byo_llm_deprecation_warnings(caplog)
+    assert len(warnings) == 1
+    assert "removed in release 0.8" in warnings[0]
     openai_entries = _openai_inference_entries(result)
     assert len(openai_entries) == 1
     assert openai_entries[0]["provider_id"] == OPENAI_CONDITIONAL_PROVIDER_ID
@@ -760,10 +776,14 @@ def test_synthesize_default_path_keeps_conditional_openai(
     assert "sentence-transformers" in ids
 
 
-def test_synthesize_byo_llm_strips_openai() -> None:
-    """byo-llm drops the built-in OpenAI row and keeps the embedder."""
+def test_synthesize_byo_llm_strips_openai(caplog: pytest.LogCaptureFixture) -> None:
+    """byo-llm drops the OpenAI row, keeps the embedder, and does not warn."""
     lcs = {"llama_stack": {"config": {"baseline": "byo-llm"}}}
-    result = synthesize_configuration(lcs)
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    assert _byo_llm_deprecation_warnings(caplog) == []
     assert _openai_inference_entries(result) == []
     ids = [entry["provider_id"] for entry in _inference_entries(result)]
     assert ids == ["sentence-transformers"]
@@ -810,8 +830,10 @@ def test_synthesize_byo_llm_with_openai_appends_one_row() -> None:
     assert openai_entries[0]["config"]["api_key"] == "${env.OPENAI_API_KEY}"
 
 
-def test_synthesize_empty_baseline_does_not_strip_openai() -> None:
-    """baseline: empty is unchanged: no OpenAI strip."""
+def test_synthesize_empty_baseline_does_not_strip_openai(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """baseline: empty is unchanged: no OpenAI strip and no deprecation WARN."""
     lcs = {
         "llama_stack": {
             "config": {
@@ -820,12 +842,18 @@ def test_synthesize_empty_baseline_does_not_strip_openai() -> None:
             }
         }
     }
-    result = synthesize_configuration(lcs)
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs)
+    assert _byo_llm_deprecation_warnings(caplog) == []
     assert result == {"version": 2, "apis": ["inference"]}
 
 
-def test_synthesize_profile_ignores_byo_llm(tmp_path: Path) -> None:
-    """profile: wins over baseline: byo-llm; no OpenAI strip."""
+def test_synthesize_profile_ignores_byo_llm(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """profile: wins over baseline: byo-llm; no OpenAI strip and no WARN."""
     profile = {
         "version": 2,
         "apis": ["inference"],
@@ -849,7 +877,11 @@ def test_synthesize_profile_ignores_byo_llm(tmp_path: Path) -> None:
             }
         }
     }
-    result = synthesize_configuration(lcs, config_file_dir=str(tmp_path))
+    with caplog.at_level(
+        "WARNING", logger="lightspeed_stack.llama_stack_configuration"
+    ):
+        result = synthesize_configuration(lcs, config_file_dir=str(tmp_path))
+    assert _byo_llm_deprecation_warnings(caplog) == []
     assert result["marker"] == "from-profile"
     openai_entries = _openai_inference_entries(result)
     assert len(openai_entries) == 1


### PR DESCRIPTION
## Description

Emits a single startup WARN when unified-mode synthesis starts from the shipped baseline as `default` (or with the selector omitted), naming `byo-llm` as the replacement, the release the built-in OpenAI provider is removed in, and the configuration documentation.

```
DEPRECATED: the built-in OpenAI inference provider in llama_stack.config.baseline
'default' is deprecated and will be removed in release 0.8. Set baseline to
'byo-llm' and declare your LLM providers under inference.providers: <docs link>
```

**Schedule: deprecate in 0.7, remove in 0.8.** `baseline: default` and the shipped `src/data/default_run.yaml` went GA in 0.6.0 — not only in an 0.7 release candidate — so the Engineering Support Agreement's mandatory one-minor-release deprecation phase applies before the OpenAI row can be dropped. Confirmed by @sbunciak.

The concrete breakage this protects against: a user on 0.6.x can be running

```yaml
inference:
  default_model: gpt-4o-mini
  default_provider: openai
llama_stack:
  config:
    baseline: default
```

and removing openai from `default` without a deprecation window would silently leave them with no model configured.

The warning is scoped to the shipped baseline: `byo-llm`, `empty` and `profile:` stay silent. The tests assert that alongside the existing behavioural checks, so the scoping cannot regress.

**Credit:** the warning was originally written and container-tested by @Jdubrick in #2498, and removed there at my review so the additive `byo-llm` baseline could land without carrying a release commitment that had not been made yet. This restores it now the release is decided.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [x] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-3696
- Closes # LCORE-3696

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

1. `baseline: default`, omitted `baseline`, and an omitted `config` block each emit exactly one WARN naming `byo-llm` and release 0.8.
2. `baseline: byo-llm`, `baseline: empty` and `profile:` emit none — asserted in the same tests that check their synthesis behaviour.

```
uv run python -m pytest tests/unit/test_llama_stack_synthesize.py \
    tests/integration/test_unified_synthesis.py \
    tests/unit/test_llama_stack_configuration.py -q
```

Result: 147 passed, 1 xfailed (the pre-existing LCORE-3370 xfail).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design and planning documentation for native PDF support, unified configuration, conversation compaction, and related testing and deployment work.
  * Documented the transition toward unified single-file configuration and added migration, profile, and reference guidance.
  * Added a deprecation note for the built-in default OpenAI provider.

* **Bug Fixes**
  * Added a startup warning when the deprecated default OpenAI provider is used, while preserving existing behavior.
  * Clarified that the `byo-llm` configuration avoids this warning.

* **Chores**
  * Added development tooling permissions and project tracking metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->