### PR TITLE
LCORE-3503: Do not catch blind exception

### DIFF
--- a/src/utils/vector_search.py
+++ b/src/utils/vector_search.py
@@ -289,7 +289,9 @@ async def _query_store_for_byok_rag(  # pylint: disable=too-many-arguments,too-m
             },
         )
         return _extract_byok_rag_chunks(search_response, vector_store_id, weight)
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except (
+        Exception  # pylint: disable=broad-exception-caught
+    ) as e:  # noqa: BLE001 RUF100
         logger.warning("Failed to search '%s': %s", vector_store_id, e)
         return []
 


### PR DESCRIPTION
## Description

LCORE-3503: Do not catch blind exception
In this case there are so many exception types to catch, that it is needed to disable the rule for this line.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3503


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality annotations for improved static analysis compatibility.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->