### PR TITLE
LCORE-2547: rename internal LlamaStack Python identifiers to Ogx

### DIFF
--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -13080,7 +13080,7 @@
                         "description": "This section contains Lightspeed Core Stack service configuration."
                     },
                     "llama_stack": {
-                        "$ref": "#/components/schemas/LlamaStackConfiguration",
+                        "$ref": "#/components/schemas/OgxConfiguration",
                         "title": "OGX configuration",
                         "description": "This section contains OGX configuration. Lightspeed Core Stack service can call OGX in library mode or in server mode."
                     },
@@ -15146,112 +15146,6 @@
                     }
                 ]
             },
-            "LlamaStackConfiguration": {
-                "properties": {
-                    "url": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "minLength": 1,
-                                "format": "uri"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "OGX URL",
-                        "description": "URL to OGX service; used when library mode is disabled. Must be a valid HTTP or HTTPS URL."
-                    },
-                    "api_key": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "format": "password",
-                                "writeOnly": true
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "API key",
-                        "description": "API key to access OGX service"
-                    },
-                    "use_as_library_client": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Use as library",
-                        "description": "When set to true OGX will be used in library mode, not in server mode (default)"
-                    },
-                    "library_client_config_path": {
-                        "anyOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "OGX configuration path (legacy, deprecated)",
-                        "description": "Path to configuration file used when OGX is run in library mode. DEPRECATED legacy two-file setup: logs a startup warning since 0.6 and is removed in 0.7 \u2014 use unified mode instead (the config block below, and/or the root-level inference.providers section); migrate with lightspeed-stack --migrate-config."
-                    },
-                    "timeout": {
-                        "type": "integer",
-                        "exclusiveMinimum": 0.0,
-                        "title": "Request timeout",
-                        "description": "Timeout in seconds for requests to OGX service. Default is 180 seconds (3 minutes) to accommodate long-running RAG queries.",
-                        "default": 180
-                    },
-                    "max_retries": {
-                        "type": "integer",
-                        "exclusiveMinimum": 0.0,
-                        "title": "Maximum number of connection attempts before giving up",
-                        "description": "Maximum number of connection attempts before giving up. Used on startup to connect to OGX and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where OGX is still starting up (e.g., when running as a sidecar in the same pod).",
-                        "default": 5
-                    },
-                    "retry_delay": {
-                        "type": "integer",
-                        "exclusiveMinimum": 0.0,
-                        "title": "Delay in seconds between retry attempts",
-                        "description": "Delay in seconds between retry attempts. Used on startup to connect to OGX and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where OGX is still starting up (e.g., when running as a sidecar in the same pod).",
-                        "default": 2
-                    },
-                    "allow_degraded_mode": {
-                        "anyOf": [
-                            {
-                                "type": "boolean"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Allow degraded mode",
-                        "description": "If enabled, Lightspeed Core can be started even when OGX is not accessible (valid for server mode only)",
-                        "default": false
-                    },
-                    "config": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/components/schemas/UnifiedLlamaStackConfig"
-                            },
-                            {
-                                "type": "null"
-                            }
-                        ],
-                        "title": "Unified OGX configuration",
-                        "description": "Backend-specific knobs for unified mode, where LCORE synthesizes the OGX run.yaml instead of reading an external file. Holds the baseline selector, an optional profile path, and a raw native_override escape hatch. Backend-agnostic high-level sections (e.g. inference.providers) live at the configuration root, not here. Mutually exclusive with library_client_config_path; that cross-field check lives on the root Configuration model. When set in library mode, library_client_config_path is not required."
-                    }
-                },
-                "additionalProperties": false,
-                "type": "object",
-                "title": "LlamaStackConfiguration",
-                "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://www.llama.com/products/llama-stack/)\n  - [Python OGX client](https://github.com/llamastack/llama-stack-client-python)\n  - [Build AI Applications with OGX](https://llamastack.github.io/)"
-            },
             "MCPClientAuthOptionsResponse": {
                 "properties": {
                     "servers": {
@@ -16008,6 +15902,112 @@
                 "type": "object",
                 "title": "ObservabilityConfiguration",
                 "description": "OpenTelemetry observability configuration.\n\nThis configuration is automatically populated from OTEL_* environment variables\nto provide visibility into the active tracing setup.\n\nAttributes:\n    otel: Dictionary of OTEL_* environment variables with secrets redacted."
+            },
+            "OgxConfiguration": {
+                "properties": {
+                    "url": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "minLength": 1,
+                                "format": "uri"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "OGX URL",
+                        "description": "URL to OGX service; used when library mode is disabled. Must be a valid HTTP or HTTPS URL."
+                    },
+                    "api_key": {
+                        "anyOf": [
+                            {
+                                "type": "string",
+                                "format": "password",
+                                "writeOnly": true
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "API key",
+                        "description": "API key to access OGX service"
+                    },
+                    "use_as_library_client": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Use as library",
+                        "description": "When set to true OGX will be used in library mode, not in server mode (default)"
+                    },
+                    "library_client_config_path": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "OGX configuration path (legacy, deprecated)",
+                        "description": "Path to configuration file used when OGX is run in library mode. DEPRECATED legacy two-file setup: logs a startup warning since 0.6 and is removed in 0.7 \u2014 use unified mode instead (the config block below, and/or the root-level inference.providers section); migrate with lightspeed-stack --migrate-config."
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Request timeout",
+                        "description": "Timeout in seconds for requests to OGX service. Default is 180 seconds (3 minutes) to accommodate long-running RAG queries.",
+                        "default": 180
+                    },
+                    "max_retries": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Maximum number of connection attempts before giving up",
+                        "description": "Maximum number of connection attempts before giving up. Used on startup to connect to OGX and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where OGX is still starting up (e.g., when running as a sidecar in the same pod).",
+                        "default": 5
+                    },
+                    "retry_delay": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0.0,
+                        "title": "Delay in seconds between retry attempts",
+                        "description": "Delay in seconds between retry attempts. Used on startup to connect to OGX and retrieve its version. Connection attempts are retried with a fixed delay to handle the case where OGX is still starting up (e.g., when running as a sidecar in the same pod).",
+                        "default": 2
+                    },
+                    "allow_degraded_mode": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Allow degraded mode",
+                        "description": "If enabled, Lightspeed Core can be started even when OGX is not accessible (valid for server mode only)",
+                        "default": false
+                    },
+                    "config": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/UnifiedOgxConfig"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ],
+                        "title": "Unified OGX configuration",
+                        "description": "Backend-specific knobs for unified mode, where LCORE synthesizes the OGX run.yaml instead of reading an external file. Holds the baseline selector, an optional profile path, and a raw native_override escape hatch. Backend-agnostic high-level sections (e.g. inference.providers) live at the configuration root, not here. Mutually exclusive with library_client_config_path; that cross-field check lives on the root Configuration model. When set in library mode, library_client_config_path is not required."
+                    }
+                },
+                "additionalProperties": false,
+                "type": "object",
+                "title": "OgxConfiguration",
+                "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://www.llama.com/products/llama-stack/)\n  - [Python OGX client](https://github.com/llamastack/llama-stack-client-python)\n  - [Build AI Applications with OGX](https://llamastack.github.io/)"
             },
             "OkpConfiguration": {
                 "properties": {
@@ -22250,7 +22250,7 @@
                 "title": "UnifiedInferenceProvider",
                 "description": "A high-level inference provider entry for unified-mode synthesis.\n\nOperators describe inference providers at this high level (backend-agnostic\nvocabulary) instead of authoring raw OGX provider blocks. The\nsynthesizer (`apply_high_level_inference`) expands each entry into an OGX\n`providers.inference` entry, mapping `type` to a `provider_type` and\nemitting `${env.<VAR>}` references for secrets (never literal values).\n\nAttributes:\n    type: Canonical provider identifier. Vendor-neutral so it survives a\n        future backend change; each backend-specific synthesizer maps it to\n        its own provider vocabulary.\n    id: Optional identifier emitted as the OGX provider_id. When\n        omitted, synthesized as type with underscores hyphenated. If set,\n        must be non-empty after stripping whitespace and may contain only\n        lowercase letters, digits, underscores, and hyphens.\n    api_key_env: Name of the environment variable holding the provider API\n        key. Emitted verbatim as `${env.<name>}` so the secret never lands\n        on disk resolved.\n    allowed_models: Optional allow-list of model identifiers passed through\n        to the synthesized provider config.\n    extra: Additional provider-config keys merged verbatim into the\n        synthesized provider's `config` block \u2014 an escape hatch for\n        provider-specific knobs not modeled here."
             },
-            "UnifiedLlamaStackConfig": {
+            "UnifiedOgxConfig": {
                 "properties": {
                     "baseline": {
                         "type": "string",
@@ -22284,7 +22284,7 @@
                 },
                 "additionalProperties": false,
                 "type": "object",
-                "title": "UnifiedLlamaStackConfig",
+                "title": "UnifiedOgxConfig",
                 "description": "Backend-specific knobs for unified-mode OGX synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the OGX-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml) including the\n        conditional OpenAI inference provider. \"byo-llm\" begins from the\n        same file with that OpenAI row removed. \"empty\" begins from an\n        empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw OGX schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express."
             },
             "UnprocessableEntityResponse": {

--- a/docs/user_doc/config.puml
+++ b/docs/user_doc/config.puml
@@ -188,7 +188,7 @@ class "LlamaStackConfiguration" as src.models.config.LlamaStackConfiguration {
   timeout
   url : Optional[AnyHttpUrl]
   use_as_library_client : Optional[bool]
-  check_llama_stack_model() -> Self
+  check_ogx_model() -> Self
 }
 class "ModelContextProtocolServer" as src.models.config.ModelContextProtocolServer {
   authorization_headers : dict[str, str]

--- a/docs/user_doc/config.svg
+++ b/docs/user_doc/config.svg
@@ -365,7 +365,7 @@
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="168.5454" x="3593.57" y="461.4514">url : Optional[AnyHttpUrl]</text>
       <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="240.6031" x="3593.57" y="480.5193">use_as_library_client : Optional[bool]</text>
       <line style="stroke:#181818;stroke-width:0.5;" x1="3588.57" x2="3887.7669" y1="488.6213" y2="488.6213"/>
-      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="219.8271" x="3593.57" y="507.5872">check_llama_stack_model() -&gt; Self</text>
+      <text fill="#000000" font-family="sans-serif" font-size="14" lengthAdjust="spacing" textLength="219.8271" x="3593.57" y="507.5872">check_ogx_model() -&gt; Self</text>
     </g>
     <!--class src.models.config.ModelContextProtocolServer-->
     <g id="elem_src.models.config.ModelContextProtocolServer">

--- a/src/app/endpoints/models.py
+++ b/src/app/endpoints/models.py
@@ -89,8 +89,8 @@ async def models_endpoint_handler(
     with tracer.start_as_current_span("models.list") as span:
         check_configuration_loaded(configuration)
 
-        llama_stack_configuration = configuration.llama_stack_configuration
-        logger.info("OGX config: %s", llama_stack_configuration)
+        ogx_configuration = configuration.ogx_configuration
+        logger.info("OGX config: %s", ogx_configuration)
 
         try:
             # try to get OGX client

--- a/src/app/endpoints/providers.py
+++ b/src/app/endpoints/providers.py
@@ -89,8 +89,8 @@ async def providers_endpoint_handler(
     with tracer.start_as_current_span("providers.list") as span:
         check_configuration_loaded(configuration)
 
-        llama_stack_configuration = configuration.llama_stack_configuration
-        logger.info("OGX config: %s", llama_stack_configuration)
+        ogx_configuration = configuration.ogx_configuration
+        logger.info("OGX config: %s", ogx_configuration)
 
         try:
             client = AsyncOgxClientHolder().get_client()
@@ -161,8 +161,8 @@ async def get_provider_endpoint_handler(
     with tracer.start_as_current_span("providers.get") as span:
         check_configuration_loaded(configuration)
 
-        llama_stack_configuration = configuration.llama_stack_configuration
-        logger.info("OGX config: %s", llama_stack_configuration)
+        ogx_configuration = configuration.ogx_configuration
+        logger.info("OGX config: %s", ogx_configuration)
 
         try:
             client = AsyncOgxClientHolder().get_client()

--- a/src/app/endpoints/rags.py
+++ b/src/app/endpoints/rags.py
@@ -89,8 +89,8 @@ async def rags_endpoint_handler(
         # make sure that the configuration is loaded
         check_configuration_loaded(configuration)
 
-        llama_stack_configuration = configuration.llama_stack_configuration
-        logger.info("OGX config: %s", llama_stack_configuration)
+        ogx_configuration = configuration.ogx_configuration
+        logger.info("OGX config: %s", ogx_configuration)
 
         try:
             # try to get OGX client
@@ -178,8 +178,8 @@ async def get_rag_endpoint_handler(
     with tracer.start_as_current_span("rags.get") as span:
         check_configuration_loaded(configuration)
 
-        llama_stack_configuration = configuration.llama_stack_configuration
-        logger.info("OGX config: %s", llama_stack_configuration)
+        ogx_configuration = configuration.ogx_configuration
+        logger.info("OGX config: %s", ogx_configuration)
 
         # Resolve user-facing rag_id to OGX vector_db_id
         vector_db_id = _resolve_rag_id_to_vector_db_id(

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -27,7 +27,7 @@ from metrics.utils import setup_model_metrics
 from models.api.responses.error import InternalServerErrorResponse
 from sentry import initialize_sentry
 from utils.degraded_mode import DegradedModeTracker
-from utils.llama_stack_version import check_llama_stack_version
+from utils.llama_stack_version import check_ogx_version
 
 logger = get_logger(__name__)
 
@@ -83,35 +83,35 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     initialize_sentry()
 
-    llama_stack_config = configuration.configuration.llama_stack
-    await AsyncOgxClientHolder().load(llama_stack_config)
+    ogx_config = configuration.configuration.llama_stack
+    await AsyncOgxClientHolder().load(ogx_config)
     client: AsyncOgxClient = AsyncOgxClientHolder().get_client()
     logger.debug("OGX client initialized, trying to connect to OGX")
     # Check connectivity to OGX and set degraded mode if unavailable
     degraded_tracker = DegradedModeTracker()
     try:
-        llama_stack_version = await check_llama_stack_version(
-            client, llama_stack_config.max_retries, llama_stack_config.retry_delay
+        ogx_version = await check_ogx_version(
+            client, ogx_config.max_retries, ogx_config.retry_delay
         )
-        if llama_stack_version is None:
+        if ogx_version is None:
             logger.error("Cannot retrieve OGX version, check connection")
-            if llama_stack_config.allow_degraded_mode:
+            if ogx_config.allow_degraded_mode:
                 degraded_tracker.set_degraded("OGX connection check failed")
         else:
-            logger.debug("OGX version: %s", llama_stack_version)
+            logger.debug("OGX version: %s", ogx_version)
             degraded_tracker.set_healthy()
     except APIConnectionError as e:
         # if degraded mode is allowed, simply ignore the exception
-        llama_stack_url = llama_stack_config.url
+        ogx_url = ogx_config.url
         logger.error(
             "Failed to connect to OGX at '%s'. "
             "Please verify that the 'llama_stack.url' configuration is correct "
             "and that the OGX service is running and accessible. "
             "Original error: %s",
-            llama_stack_url,
+            ogx_url,
             e,
         )
-        if llama_stack_config.allow_degraded_mode:
+        if ogx_config.allow_degraded_mode:
             logger.info("Entering degraded mode: LCORE running w/o OGX")
             degraded_tracker.set_degraded(f"Failed to connect to OGX: {e!s}")
         else:

--- a/src/client.py
+++ b/src/client.py
@@ -22,7 +22,7 @@ from llama_stack_configuration import (
 )
 from log import get_logger, setup_logging
 from models.api.responses.error import ServiceUnavailableResponse
-from models.config import LlamaStackConfiguration
+from models.config import OgxConfiguration
 from utils.model_list import parse_model_list_response
 from utils.types import Singleton
 
@@ -40,17 +40,17 @@ class AsyncOgxClientHolder(metaclass=Singleton):
         """Check if using library mode client."""
         return isinstance(self._lsc, AsyncOGXAsLibraryClient)
 
-    async def load(self, llama_stack_config: LlamaStackConfiguration) -> None:
+    async def load(self, ogx_config: OgxConfiguration) -> None:
         """Initialize the OGX client based on configuration."""
         if self._lsc is not None:  # early stopping - client already initialized
             return
 
-        if llama_stack_config.use_as_library_client:
-            await self._load_library_client(llama_stack_config)
+        if ogx_config.use_as_library_client:
+            await self._load_library_client(ogx_config)
         else:
-            self._load_service_client(llama_stack_config)
+            self._load_service_client(ogx_config)
 
-    async def _load_library_client(self, config: LlamaStackConfiguration) -> None:
+    async def _load_library_client(self, config: OgxConfiguration) -> None:
         """Initialize client in library mode.
 
         Forks on configuration shape: legacy mode (a library_client_config_path
@@ -118,7 +118,7 @@ class AsyncOgxClientHolder(metaclass=Singleton):
         logger.info("Using synthesized OGX config at %s", output_path)
         return output_path
 
-    def _load_service_client(self, config: LlamaStackConfiguration) -> None:
+    def _load_service_client(self, config: OgxConfiguration) -> None:
         """Initialize client in service mode (remote HTTP)."""
         logger.info("Using OGX running as a service")
         logger.info("Using timeout of %d seconds for OGX requests", config.timeout)

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -24,8 +24,8 @@ from models.config import (
     Customization,
     DatabaseConfiguration,
     InferenceConfiguration,
-    LlamaStackConfiguration,
     ModelContextProtocolServer,
+    OgxConfiguration,
     OkpConfiguration,
     QuotaHandlersConfiguration,
     RagConfiguration,
@@ -173,11 +173,11 @@ class AppConfig:  # pylint: disable=too-many-public-methods
         return self._configuration.service
 
     @property
-    def llama_stack_configuration(self) -> LlamaStackConfiguration:
+    def ogx_configuration(self) -> OgxConfiguration:
         """Return OGX configuration.
 
         Returns:
-            LlamaStackConfiguration: The configured OGX settings.
+            OgxConfiguration: The configured OGX settings.
 
         Raises:
             LogicError: If the application configuration has not been loaded.

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,8 +6,8 @@ from typing import Final, Literal
 # will be able to detect assignements to such constants.
 
 # Minimal and maximal supported OGX version
-MINIMAL_SUPPORTED_LLAMA_STACK_VERSION: Final[str] = "0.2.17"
-MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION: Final[str] = "1.0.2"
+MINIMAL_SUPPORTED_OGX_VERSION: Final[str] = "0.2.17"
+MAXIMAL_SUPPORTED_OGX_VERSION: Final[str] = "1.0.2"
 
 # Path to the lightspeed-stack.yaml, exported so uvicorn workers (separate
 # processes) can reload the configuration that the parent process selected.

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -185,11 +185,11 @@ def main() -> None:
 
     configuration.load_configuration(args.config_file)
     logger.info("Configuration: %s", configuration.configuration)
-    logger.info("OGX configuration: %s", configuration.llama_stack_configuration)
+    logger.info("OGX configuration: %s", configuration.ogx_configuration)
 
     # Deprecation schedule (Decision S2): the legacy two-file path keeps
     # working through 0.6 with this single startup WARN and is removed in 0.7.
-    if configuration.llama_stack_configuration.library_client_config_path is not None:
+    if configuration.ogx_configuration.library_client_config_path is not None:
         logger.warning(
             "DEPRECATED: the two-file configuration "
             "(llama_stack.library_client_config_path + external run.yaml) is "

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -761,7 +761,7 @@ class UnifiedInferenceProvider(ConfigurationBase):
         return stripped
 
 
-class UnifiedLlamaStackConfig(ConfigurationBase):
+class UnifiedOgxConfig(ConfigurationBase):
     """Backend-specific knobs for unified-mode OGX synthesis.
 
     Per Decision S5 of the design spike, backend-agnostic high-level sections
@@ -808,7 +808,7 @@ class UnifiedLlamaStackConfig(ConfigurationBase):
     )
 
 
-class LlamaStackConfiguration(ConfigurationBase):
+class OgxConfiguration(ConfigurationBase):
     """OGX configuration.
 
     OGX is a comprehensive system that provides a uniform set of tools
@@ -886,7 +886,7 @@ class LlamaStackConfiguration(ConfigurationBase):
         "OGX is not accessible (valid for server mode only)",
     )
 
-    config: Optional["UnifiedLlamaStackConfig"] = Field(
+    config: Optional["UnifiedOgxConfig"] = Field(
         None,
         title="Unified OGX configuration",
         description="Backend-specific knobs for unified mode, where LCORE synthesizes "
@@ -901,7 +901,7 @@ class LlamaStackConfiguration(ConfigurationBase):
     )
 
     @model_validator(mode="after")
-    def check_llama_stack_model(self) -> Self:
+    def check_ogx_model(self) -> Self:
         """
         Validate the OGX configuration and enforce mode-specific requirements.
 
@@ -920,7 +920,7 @@ class LlamaStackConfiguration(ConfigurationBase):
         (`check_unified_vs_legacy`).
 
         Returns:
-            Self: The validated LlamaStackConfiguration instance.
+            Self: The validated OgxConfiguration instance.
 
         Raises:
             ValueError: If no URL is provided and library-client mode is
@@ -3147,7 +3147,7 @@ class Configuration(ConfigurationBase):
         description="This section contains Lightspeed Core Stack service configuration.",
     )
 
-    llama_stack: LlamaStackConfiguration = Field(
+    llama_stack: OgxConfiguration = Field(
         ...,
         title="OGX configuration",
         description="This section contains OGX configuration. Lightspeed Core Stack service can "
@@ -3458,7 +3458,7 @@ class Configuration(ConfigurationBase):
         ``vector_store.providers``, and/or a ``llama_stack.config`` block. The
         legacy path is ``llama_stack.library_client_config_path`` pointing at an
         external run.yaml. Both checks live here on the root model rather than
-        on ``LlamaStackConfiguration`` (which cannot see root-level provider
+        on ``OgxConfiguration`` (which cannot see root-level provider
         lists):
 
         - A synthesis input and the legacy path are mutually exclusive — a

--- a/src/utils/llama_stack_version.py
+++ b/src/utils/llama_stack_version.py
@@ -10,19 +10,19 @@ from semver import Version
 from constants import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_RETRY_DELAY,
-    MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION,
-    MINIMAL_SUPPORTED_LLAMA_STACK_VERSION,
+    MAXIMAL_SUPPORTED_OGX_VERSION,
+    MINIMAL_SUPPORTED_OGX_VERSION,
 )
 from log import get_logger
 
 logger = get_logger(__name__)
 
 
-class InvalidLlamaStackVersionException(Exception):
+class InvalidOgxVersionException(Exception):
     """OGX version is not valid."""
 
 
-async def check_llama_stack_version(
+async def check_ogx_version(
     client: AsyncOgxClient,
     max_retries: int = DEFAULT_MAX_RETRIES,
     retry_delay: int = DEFAULT_RETRY_DELAY,
@@ -43,7 +43,7 @@ async def check_llama_stack_version(
 
     Raises:
         APIConnectionError: If OGX is unreachable after all retries.
-        InvalidLlamaStackVersionException: If the detected version is outside
+        InvalidOgxVersionException: If the detected version is outside
         the supported range or cannot be parsed.
     """
     if max_retries < 1:
@@ -54,8 +54,8 @@ async def check_llama_stack_version(
             version_info = await client.inspect.version()
             compare_versions(
                 version_info.version,
-                MINIMAL_SUPPORTED_LLAMA_STACK_VERSION,
-                MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION,
+                MINIMAL_SUPPORTED_OGX_VERSION,
+                MAXIMAL_SUPPORTED_OGX_VERSION,
             )
             return version_info.version
         except APIConnectionError:
@@ -78,7 +78,7 @@ def compare_versions(version_info: str, minimal: str, maximal: str) -> None:
 
     Parses `version_info`, `minimal`, and `maximal` with semver.Version.parse
     and compares them.  If the current version is lower than `minimal` or
-    higher than `maximal`, an InvalidLlamaStackVersionException is raised.
+    higher than `maximal`, an InvalidOgxVersionException is raised.
 
     Parameters:
     ----------
@@ -89,7 +89,7 @@ def compare_versions(version_info: str, minimal: str, maximal: str) -> None:
 
     Raises:
     ------
-        InvalidLlamaStackVersionException: If `version_info` is outside the
+        InvalidOgxVersionException: If `version_info` is outside the
         inclusive range defined by `minimal` and `maximal`.
     """
     version_pattern = r"\d+\.\d+\.\d+"
@@ -99,7 +99,7 @@ def compare_versions(version_info: str, minimal: str, maximal: str) -> None:
             "Failed to extract version pattern from '%s'. Skipping version check.",
             version_info,
         )
-        raise InvalidLlamaStackVersionException(
+        raise InvalidOgxVersionException(
             f"Failed to extract version pattern from '{version_info}'. Skipping version check."
         )
 
@@ -109,7 +109,7 @@ def compare_versions(version_info: str, minimal: str, maximal: str) -> None:
         current_version = Version.parse(normalized_version)
     except ValueError as e:
         logger.warning("Failed to parse OGX version '%s'.", version_info)
-        raise InvalidLlamaStackVersionException(
+        raise InvalidOgxVersionException(
             f"Failed to parse OGX version '{version_info}'."
         ) from e
 
@@ -120,11 +120,11 @@ def compare_versions(version_info: str, minimal: str, maximal: str) -> None:
     logger.debug("Maximal version: %s", maximal_version)
 
     if current_version < minimal_version:
-        raise InvalidLlamaStackVersionException(
+        raise InvalidOgxVersionException(
             f"OGX version >= {minimal_version} is required, but {current_version} is used"
         )
     if current_version > maximal_version:
-        raise InvalidLlamaStackVersionException(
+        raise InvalidOgxVersionException(
             f"OGX version <= {maximal_version} is required, but {current_version} is used"
         )
     logger.info("Correct OGX version: %s", current_version)

--- a/tests/benchmarks/data/python_10000_lines.py
+++ b/tests/benchmarks/data/python_10000_lines.py
@@ -58,7 +58,7 @@ def test_default_configuration() -> None:
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
-        _ = cfg.llama_stack_configuration  # pylint: disable=pointless-statement
+        _ = cfg.ogx_configuration  # pylint: disable=pointless-statement
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
@@ -135,18 +135,18 @@ def test_init_from_dict() -> None:
 
     # check for all subsections
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
     # check for configuration subsection
     assert cfg.configuration.name == "foo"
 
-    # check for llama_stack_configuration subsection
-    assert cfg.llama_stack_configuration.api_key is not None
-    assert cfg.llama_stack_configuration.api_key.get_secret_value() == "xyzzy"
-    assert str(cfg.llama_stack_configuration.url) == "http://x.y.com:1234/"
-    assert cfg.llama_stack_configuration.use_as_library_client is False
+    # check for ogx_configuration subsection
+    assert cfg.ogx_configuration.api_key is not None
+    assert cfg.ogx_configuration.api_key.get_secret_value() == "xyzzy"
+    assert str(cfg.ogx_configuration.url) == "http://x.y.com:1234/"
+    assert cfg.ogx_configuration.use_as_library_client is False
 
     # check for service_configuration subsection
     assert cfg.service_configuration.host == "localhost"
@@ -285,7 +285,7 @@ def test_load_proper_configuration(tmpdir: Path) -> None:
 
     Writes a YAML configuration to a temporary file, loads it with
     AppConfig.load_configuration, and asserts that `configuration`,
-    `llama_stack_configuration`, `service_configuration`, and
+    `ogx_configuration`, `service_configuration`, and
     `user_data_collection_configuration` are populated.
     """
     cfg_filename = tmpdir / "config.yaml"
@@ -311,7 +311,7 @@ mcp_servers: []
     cfg = AppConfig()
     cfg.load_configuration(str(cfg_filename))
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
@@ -441,11 +441,11 @@ def test_service_configuration_not_loaded() -> None:
         assert c is not None
 
 
-def test_llama_stack_configuration_not_loaded() -> None:
-    """Test that accessing llama_stack_configuration before loading raises an error."""
+def test_ogx_configuration_not_loaded() -> None:
+    """Test that accessing ogx_configuration before loading raises an error."""
     cfg = AppConfig()
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
-        c = cfg.llama_stack_configuration
+        c = cfg.ogx_configuration
         assert c is not None
 
 
@@ -3861,7 +3861,7 @@ def test_2_default_configuration() -> None:
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
-        _ = cfg.llama_stack_configuration  # pylint: disable=pointless-statement
+        _ = cfg.ogx_configuration  # pylint: disable=pointless-statement
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
@@ -3981,18 +3981,18 @@ def test_2_init_from_dict() -> None:
 
     # check for all subsections
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
     # check for configuration subsection
     assert cfg.configuration.name == "foo"
 
-    # check for llama_stack_configuration subsection
-    assert cfg.llama_stack_configuration.api_key is not None
-    assert cfg.llama_stack_configuration.api_key.get_secret_value() == "xyzzy"
-    assert str(cfg.llama_stack_configuration.url) == "http://x.y.com:1234/"
-    assert cfg.llama_stack_configuration.use_as_library_client is False
+    # check for ogx_configuration subsection
+    assert cfg.ogx_configuration.api_key is not None
+    assert cfg.ogx_configuration.api_key.get_secret_value() == "xyzzy"
+    assert str(cfg.ogx_configuration.url) == "http://x.y.com:1234/"
+    assert cfg.ogx_configuration.use_as_library_client is False
 
     # check for service_configuration subsection
     assert cfg.service_configuration.host == "localhost"
@@ -4131,7 +4131,7 @@ def test_2_load_proper_configuration(tmpdir: Path) -> None:
 
     Writes a YAML configuration to a temporary file, loads it with
     AppConfig.load_configuration, and asserts that `configuration`,
-    `llama_stack_configuration`, `service_configuration`, and
+    `ogx_configuration`, `service_configuration`, and
     `user_data_collection_configuration` are populated.
     """
     cfg_filename = tmpdir / "config.yaml"
@@ -4157,7 +4157,7 @@ mcp_servers: []
     cfg = AppConfig()
     cfg.load_configuration(str(cfg_filename))
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
@@ -4287,11 +4287,11 @@ def test_2_service_configuration_not_loaded() -> None:
         assert c is not None
 
 
-def test_2_llama_stack_configuration_not_loaded() -> None:
-    """Test that accessing llama_stack_configuration before loading raises an error."""
+def test_2_ogx_configuration_not_loaded() -> None:
+    """Test that accessing ogx_configuration before loading raises an error."""
     cfg = AppConfig()
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
-        c = cfg.llama_stack_configuration
+        c = cfg.ogx_configuration
         assert c is not None
 
 
@@ -7713,7 +7713,7 @@ def test_3_default_configuration() -> None:
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
-        _ = cfg.llama_stack_configuration  # pylint: disable=pointless-statement
+        _ = cfg.ogx_configuration  # pylint: disable=pointless-statement
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
@@ -7833,18 +7833,18 @@ def test_3_init_from_dict() -> None:
 
     # check for all subsections
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
     # check for configuration subsection
     assert cfg.configuration.name == "foo"
 
-    # check for llama_stack_configuration subsection
-    assert cfg.llama_stack_configuration.api_key is not None
-    assert cfg.llama_stack_configuration.api_key.get_secret_value() == "xyzzy"
-    assert str(cfg.llama_stack_configuration.url) == "http://x.y.com:1234/"
-    assert cfg.llama_stack_configuration.use_as_library_client is False
+    # check for ogx_configuration subsection
+    assert cfg.ogx_configuration.api_key is not None
+    assert cfg.ogx_configuration.api_key.get_secret_value() == "xyzzy"
+    assert str(cfg.ogx_configuration.url) == "http://x.y.com:1234/"
+    assert cfg.ogx_configuration.use_as_library_client is False
 
     # check for service_configuration subsection
     assert cfg.service_configuration.host == "localhost"
@@ -7983,7 +7983,7 @@ def test_3_load_proper_configuration(tmpdir: Path) -> None:
 
     Writes a YAML configuration to a temporary file, loads it with
     AppConfig.load_configuration, and asserts that `configuration`,
-    `llama_stack_configuration`, `service_configuration`, and
+    `ogx_configuration`, `service_configuration`, and
     `user_data_collection_configuration` are populated.
     """
     cfg_filename = tmpdir / "config.yaml"
@@ -8009,7 +8009,7 @@ mcp_servers: []
     cfg = AppConfig()
     cfg.load_configuration(str(cfg_filename))
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
@@ -8139,11 +8139,11 @@ def test_3_service_configuration_not_loaded() -> None:
         assert c is not None
 
 
-def test_3_llama_stack_configuration_not_loaded() -> None:
-    """Test that accessing llama_stack_configuration before loading raises an error."""
+def test_3_ogx_configuration_not_loaded() -> None:
+    """Test that accessing ogx_configuration before loading raises an error."""
     cfg = AppConfig()
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
-        c = cfg.llama_stack_configuration
+        c = cfg.ogx_configuration
         assert c is not None
 
 

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -43,7 +43,7 @@ def test_loading_proper_configuration(configuration_filename: str) -> None:
 
     # check that all configuration sections exist
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
     assert cfg.mcp_servers is not None
@@ -68,7 +68,7 @@ def test_loading_proper_configuration(configuration_filename: str) -> None:
     assert cors_config.allow_headers == ["foo_header", "bar_header", "baz_header"]
 
     # check 'llama_stack' section
-    ls_config = cfg.llama_stack_configuration
+    ls_config = cfg.ogx_configuration
     assert ls_config.use_as_library_client is False
     assert str(ls_config.url) == "http://localhost:8321/"
     assert ls_config.api_key is not None

--- a/tests/unit/app/endpoints/test_mcp_auth.py
+++ b/tests/unit/app/endpoints/test_mcp_auth.py
@@ -13,8 +13,8 @@ from configuration import AppConfig
 from models.api.responses.successful import MCPClientAuthOptionsResponse
 from models.config import (
     Configuration,
-    LlamaStackConfiguration,
     ModelContextProtocolServer,
+    OgxConfiguration,
     ServiceConfiguration,
     UserDataCollection,
 )
@@ -29,7 +29,7 @@ def mock_configuration_with_client_auth() -> Configuration:
     return Configuration(  # type: ignore[call-arg]
         name="test",
         service=ServiceConfiguration(),  # type: ignore[call-arg]
-        llama_stack=LlamaStackConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
+        llama_stack=OgxConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
         user_data_collection=UserDataCollection(feedback_enabled=False),  # type: ignore[call-arg]
         mcp_servers=[
             ModelContextProtocolServer(
@@ -57,7 +57,7 @@ def mock_configuration_mixed_auth() -> Configuration:
     return Configuration(  # type: ignore[call-arg]
         name="test",
         service=ServiceConfiguration(),  # type: ignore[call-arg]
-        llama_stack=LlamaStackConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
+        llama_stack=OgxConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
         user_data_collection=UserDataCollection(feedback_enabled=False),  # type: ignore[call-arg]
         mcp_servers=[
             ModelContextProtocolServer(
@@ -88,7 +88,7 @@ def mock_configuration_no_client_auth() -> Configuration:
     return Configuration(  # type: ignore[call-arg]
         name="test",
         service=ServiceConfiguration(),  # type: ignore[call-arg]
-        llama_stack=LlamaStackConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
+        llama_stack=OgxConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
         user_data_collection=UserDataCollection(feedback_enabled=False),  # type: ignore[call-arg]
         mcp_servers=[
             ModelContextProtocolServer(
@@ -215,7 +215,7 @@ async def test_get_mcp_client_auth_options_empty_config(
     mock_config = Configuration(  # type: ignore[call-arg]
         name="test",
         service=ServiceConfiguration(),  # type: ignore[call-arg]
-        llama_stack=LlamaStackConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
+        llama_stack=OgxConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
         user_data_collection=UserDataCollection(feedback_enabled=False),  # type: ignore[call-arg]
         mcp_servers=[],
     )  # type: ignore[call-arg]
@@ -249,7 +249,7 @@ async def test_get_mcp_client_auth_options_whitespace_handling(
     mock_config = Configuration(  # type: ignore[call-arg]
         name="test",
         service=ServiceConfiguration(),  # type: ignore[call-arg]
-        llama_stack=LlamaStackConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
+        llama_stack=OgxConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
         user_data_collection=UserDataCollection(feedback_enabled=False),  # type: ignore[call-arg]
         mcp_servers=[
             ModelContextProtocolServer(
@@ -297,7 +297,7 @@ async def test_get_mcp_client_auth_options_multiple_headers_single_server(
     mock_config = Configuration(  # type: ignore[call-arg]
         name="test",
         service=ServiceConfiguration(),  # type: ignore[call-arg]
-        llama_stack=LlamaStackConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
+        llama_stack=OgxConfiguration(url="http://localhost:8321"),  # type: ignore[call-arg]
         user_data_collection=UserDataCollection(feedback_enabled=False),  # type: ignore[call-arg]
         mcp_servers=[
             ModelContextProtocolServer(

--- a/tests/unit/app/endpoints/test_mcp_servers.py
+++ b/tests/unit/app/endpoints/test_mcp_servers.py
@@ -22,8 +22,8 @@ from models.api.responses.successful import (
 from models.config import (
     Configuration,
     CORSConfiguration,
-    LlamaStackConfiguration,
     ModelContextProtocolServer,
+    OgxConfiguration,
     ServiceConfiguration,
     TLSConfiguration,
     UserDataCollection,
@@ -58,7 +58,7 @@ def mock_configuration() -> Configuration:
             access_log=True,
             root_path="/.",
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             url=AnyHttpUrl("http://localhost:8321"),
             api_key=SecretStr("xyzzy"),
             use_as_library_client=False,

--- a/tests/unit/app/endpoints/test_tools.py
+++ b/tests/unit/app/endpoints/test_tools.py
@@ -22,8 +22,8 @@ from models.common.tools import ListedMcpTool
 from models.config import (
     Configuration,
     CORSConfiguration,
-    LlamaStackConfiguration,
     ModelContextProtocolServer,
+    OgxConfiguration,
     ServiceConfiguration,
     SkillsConfiguration,
     TLSConfiguration,
@@ -84,7 +84,7 @@ def mock_configuration() -> Configuration:
             access_log=True,
             root_path="/.",
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             url=AnyHttpUrl("http://localhost:8321"),
             api_key=SecretStr("xyzzy"),
             use_as_library_client=False,

--- a/tests/unit/models/config/test_approvals_configuration.py
+++ b/tests/unit/models/config/test_approvals_configuration.py
@@ -10,7 +10,7 @@ from models.config import (
     ApprovalsConfiguration,
     CompactionConfiguration,
     Configuration,
-    LlamaStackConfiguration,
+    OgxConfiguration,
     ServiceConfiguration,
     UserDataCollection,
 )
@@ -107,7 +107,7 @@ def test_root_configuration_default_includes_approvals() -> None:
     cfg = Configuration(
         name="test",
         service=ServiceConfiguration(),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),

--- a/tests/unit/models/config/test_authentication_configuration.py
+++ b/tests/unit/models/config/test_authentication_configuration.py
@@ -19,7 +19,7 @@ from models.config import (
     AuthenticationConfiguration,
     Configuration,
     JwkConfiguration,
-    LlamaStackConfiguration,
+    OgxConfiguration,
     RHIdentityConfiguration,
     ServiceConfiguration,
     UserDataCollection,
@@ -307,7 +307,7 @@ def test_authentication_configuration_in_config_noop() -> None:
             workers=1,
             root_path="/.",
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             url=AnyHttpUrl("http://localhost"),
@@ -347,7 +347,7 @@ def test_authentication_configuration_skip_readiness_probe() -> None:
             workers=1,
             root_path="/.",
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             url=AnyHttpUrl("http://localhost"),
@@ -403,7 +403,7 @@ def test_authentication_configuration_in_config_k8s() -> None:
             workers=1,
             root_path="/.",
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             url=AnyHttpUrl("http://localhost"),
@@ -461,7 +461,7 @@ def test_authentication_configuration_in_config_rh_identity() -> None:
             workers=1,
             root_path="/.",
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             url=AnyHttpUrl("http://localhost"),
@@ -509,7 +509,7 @@ def test_authentication_configuration_in_config_jwktoken() -> None:
             workers=1,
             root_path="/.",
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             url=AnyHttpUrl("http://localhost"),

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -21,8 +21,8 @@ from models.config import (
     FaissVectorStoreProvider,
     FaissVectorStoreProviderConfig,
     InferenceConfiguration,
-    LlamaStackConfiguration,
     ModelContextProtocolServer,
+    OgxConfiguration,
     PostgreSQLDatabaseConfiguration,
     QuotaHandlersConfiguration,
     QuotaLimiterConfiguration,
@@ -32,7 +32,7 @@ from models.config import (
     ServiceConfiguration,
     SkillsConfiguration,
     TLSConfiguration,
-    UnifiedLlamaStackConfig,
+    UnifiedOgxConfig,
     UserDataCollection,
     VectorStoreConfiguration,
 )
@@ -97,7 +97,7 @@ def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
             ),
             cors=CORSConfiguration(),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -302,7 +302,7 @@ def test_dump_configuration_valid_values(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -532,7 +532,7 @@ def test_dump_configuration_with_one_mcp_server(tmp_path: Path) -> None:
     cfg = Configuration(
         name="test_name",
         service=ServiceConfiguration(),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
@@ -584,7 +584,7 @@ def test_dump_configuration_with_more_mcp_servers(tmp_path: Path) -> None:
     cfg = Configuration(
         name="test_name",
         service=ServiceConfiguration(),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
@@ -658,7 +658,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -931,7 +931,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -1194,9 +1194,9 @@ def test_dump_configuration_with_vector_store(tmp_path: Path) -> None:
             ),
             cors=CORSConfiguration(),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
-            config=UnifiedLlamaStackConfig(baseline="default"),
+            config=UnifiedOgxConfig(baseline="default"),
             api_key=SecretStr("whatever"),
         ),
         user_data_collection=UserDataCollection(
@@ -1255,7 +1255,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -1519,7 +1519,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -1753,7 +1753,7 @@ def test_dump_configuration_with_one_skill(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -1828,7 +1828,7 @@ def test_dump_configuration_with_skills(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -1912,7 +1912,7 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=False,
             url="http://localhost",
             api_key=SecretStr("whatever"),
@@ -2153,7 +2153,7 @@ def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -2394,7 +2394,7 @@ def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),
@@ -2635,7 +2635,7 @@ def test_dump_configuration_specific_compaction_values(tmp_path: Path) -> None:
                 allow_headers=["foo_header", "bar_header", "baz_header"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             api_key=SecretStr("whatever"),

--- a/tests/unit/models/config/test_llama_stack_configuration.py
+++ b/tests/unit/models/config/test_llama_stack_configuration.py
@@ -1,4 +1,4 @@
-"""Unit tests for LlamaStackConfiguration model."""
+"""Unit tests for OgxConfiguration model."""
 
 import copy
 from typing import Any
@@ -11,8 +11,8 @@ from pytest_subtests import SubTests
 import constants
 from models.config import (
     Configuration,
-    LlamaStackConfiguration,
-    UnifiedLlamaStackConfig,
+    OgxConfiguration,
+    UnifiedOgxConfig,
 )
 from utils.checks import InvalidConfigurationError
 
@@ -30,12 +30,12 @@ def _base_config_dict() -> dict[str, Any]:
 
 def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
     """
-    Verify that the LlamaStackConfiguration constructor accepts
+    Verify that the OgxConfiguration constructor accepts
     valid combinations of parameters and creates instances
     successfully.
     """
     with subtests.test(msg="Configuration for library mode"):
-        llama_stack_configuration = LlamaStackConfiguration(
+        llama_stack_configuration = OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             url=None,
@@ -48,7 +48,7 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Configuration for server mode"):
-        llama_stack_configuration = LlamaStackConfiguration(
+        llama_stack_configuration = OgxConfiguration(
             use_as_library_client=False,
             url=AnyHttpUrl("http://localhost"),
             library_client_config_path=None,
@@ -61,7 +61,7 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Minimal configuration for server mode"):
-        llama_stack_configuration = LlamaStackConfiguration(
+        llama_stack_configuration = OgxConfiguration(
             url="http://localhost"
         )  # pyright: ignore[reportCallIssue]
         assert llama_stack_configuration is not None
@@ -70,7 +70,7 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Full configuration for server mode"):
-        llama_stack_configuration = LlamaStackConfiguration(
+        llama_stack_configuration = OgxConfiguration(
             use_as_library_client=False, url="http://localhost", api_key="foo"
         )  # pyright: ignore[reportCallIssue]
         assert llama_stack_configuration is not None
@@ -79,7 +79,7 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
         assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Degraded mode enabled"):
-        llama_stack_configuration = LlamaStackConfiguration(
+        llama_stack_configuration = OgxConfiguration(
             url="http://localhost",
             allow_degraded_mode=True,
         )  # pyright: ignore[reportCallIssue]
@@ -91,7 +91,7 @@ def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
 
 def test_llama_stack_configuration_no_run_yaml() -> None:
     """
-    Verify that constructing a LlamaStackConfiguration with a
+    Verify that constructing a OgxConfiguration with a
     non-existent or invalid library_client_config_path raises
     InvalidConfigurationError.
     """
@@ -99,7 +99,7 @@ def test_llama_stack_configuration_no_run_yaml() -> None:
         InvalidConfigurationError,
         match="OGX configuration file 'not a file' is not a file",
     ):
-        LlamaStackConfiguration(
+        OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="not a file",
         )  # pyright: ignore[reportCallIssue]
@@ -107,7 +107,7 @@ def test_llama_stack_configuration_no_run_yaml() -> None:
 
 def test_llama_stack_wrong_configuration_constructor_no_url() -> None:
     """
-    Verify that constructing a LlamaStackConfiguration without
+    Verify that constructing a OgxConfiguration without
     specifying either a URL or enabling library client mode raises
     a ValueError.
     """
@@ -115,16 +115,16 @@ def test_llama_stack_wrong_configuration_constructor_no_url() -> None:
         ValueError,
         match="OGX URL is not specified and library client mode is not specified",
     ):
-        LlamaStackConfiguration()  # pyright: ignore[reportCallIssue]
+        OgxConfiguration()  # pyright: ignore[reportCallIssue]
 
 
 def test_llama_stack_wrong_configuration_constructor_library_mode_off() -> None:
-    """Test the LlamaStackConfiguration constructor."""
+    """Test the OgxConfiguration constructor."""
     with pytest.raises(
         ValueError,
         match="OGX URL is not specified and library client mode is not enabled",
     ):
-        LlamaStackConfiguration(
+        OgxConfiguration(
             use_as_library_client=False
         )  # pyright: ignore[reportCallIssue]
 
@@ -138,7 +138,7 @@ def test_llama_stack_library_mode_without_source_is_allowed_on_nested_model() ->
     test_root_rejects_library_mode_without_run_source). Constructing the nested
     model alone with neither a path nor a config block must therefore succeed.
     """
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         use_as_library_client=True
     )  # pyright: ignore[reportCallIssue]
     assert cfg.use_as_library_client is True
@@ -148,7 +148,7 @@ def test_llama_stack_library_mode_without_source_is_allowed_on_nested_model() ->
 
 def test_llama_stack_configuration_valid_http_url() -> None:
     """Test that valid HTTP URLs are accepted."""
-    config = LlamaStackConfiguration(
+    config = OgxConfiguration(
         url="http://localhost:8321"
     )  # pyright: ignore[reportCallIssue]
     assert config is not None
@@ -157,7 +157,7 @@ def test_llama_stack_configuration_valid_http_url() -> None:
 
 def test_llama_stack_configuration_valid_https_url() -> None:
     """Test that valid HTTPS URLs are accepted."""
-    config = LlamaStackConfiguration(
+    config = OgxConfiguration(
         url="https://llama-stack.example.com:8321"
     )  # pyright: ignore[reportCallIssue]
     assert config is not None
@@ -167,30 +167,26 @@ def test_llama_stack_configuration_valid_https_url() -> None:
 def test_llama_stack_configuration_malformed_url_rejected() -> None:
     """Test that malformed URLs are rejected with a ValidationError."""
     with pytest.raises(ValidationError, match="Input should be a valid URL"):
-        LlamaStackConfiguration(
-            url="not-a-valid-url"
-        )  # pyright: ignore[reportCallIssue]
+        OgxConfiguration(url="not-a-valid-url")  # pyright: ignore[reportCallIssue]
 
 
 def test_llama_stack_configuration_invalid_scheme_rejected() -> None:
     """Test that URLs without http/https scheme are rejected."""
     with pytest.raises(ValidationError, match="URL scheme should be 'http' or 'https'"):
-        LlamaStackConfiguration(
-            url="ftp://localhost:8321"
-        )  # pyright: ignore[reportCallIssue]
+        OgxConfiguration(url="ftp://localhost:8321")  # pyright: ignore[reportCallIssue]
 
 
 def test_llama_stack_configuration_wrong_max_retries_count(subtests: SubTests) -> None:
     """Test that malformed URLs are rejected with a ValidationError."""
     with subtests.test(msg="Configuration with zero max_retries count"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
-            LlamaStackConfiguration(
+            OgxConfiguration(
                 url="https://llama-stack.example.com:8321",
                 max_retries=0,
             )  # pyright: ignore[reportCallIssue]
     with subtests.test(msg="Configuration with negative max_retries count"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
-            LlamaStackConfiguration(
+            OgxConfiguration(
                 url="https://llama-stack.example.com:8321",
                 max_retries=-1,
             )  # pyright: ignore[reportCallIssue]
@@ -200,13 +196,13 @@ def test_llama_stack_configuration_wrong_retry_delay_value(subtests: SubTests) -
     """Test that malformed URLs are rejected with a ValidationError."""
     with subtests.test(msg="Configuration with zero retry_delay value"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
-            LlamaStackConfiguration(
+            OgxConfiguration(
                 url="https://llama-stack.example.com:8321",
                 retry_delay=0,
             )  # pyright: ignore[reportCallIssue]
     with subtests.test(msg="Configuration with negative retry_delay value"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
-            LlamaStackConfiguration(
+            OgxConfiguration(
                 url="https://llama-stack.example.com:8321",
                 retry_delay=-1,
             )  # pyright: ignore[reportCallIssue]
@@ -219,23 +215,23 @@ def test_llama_stack_configuration_wrong_retry_delay_value(subtests: SubTests) -
 
 def test_library_mode_with_unified_config_no_path_is_valid() -> None:
     """Library mode driven by llama_stack.config needs no library_client_config_path."""
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         use_as_library_client=True,
-        config=UnifiedLlamaStackConfig(),
+        config=UnifiedOgxConfig(),
     )  # pyright: ignore[reportCallIssue]
     assert cfg.config is not None
     assert cfg.library_client_config_path is None
 
 
 def test_unified_config_rejects_unknown_fields() -> None:
-    """UnifiedLlamaStackConfig forbids extra keys (extra='forbid', R9)."""
+    """UnifiedOgxConfig forbids extra keys (extra='forbid', R9)."""
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
-        UnifiedLlamaStackConfig(bogus=True)  # pyright: ignore[reportCallIssue]
+        UnifiedOgxConfig(bogus=True)  # pyright: ignore[reportCallIssue]
 
 
 def test_unified_config_accepts_byo_llm_baseline() -> None:
     """byo-llm is a valid baseline selector (LCORE-3654)."""
-    cfg = UnifiedLlamaStackConfig(baseline="byo-llm")
+    cfg = UnifiedOgxConfig(baseline="byo-llm")
     assert cfg.baseline == "byo-llm"
 
 

--- a/tests/unit/models/config/test_model_context_protocol_server.py
+++ b/tests/unit/models/config/test_model_context_protocol_server.py
@@ -11,8 +11,8 @@ from models.config import (  # type: ignore[import-not-found]
     ApprovalFilter,
     AuthenticationConfiguration,
     Configuration,
-    LlamaStackConfiguration,
     ModelContextProtocolServer,
+    OgxConfiguration,
     ServiceConfiguration,
     UserDataCollection,
 )
@@ -106,7 +106,7 @@ def test_configuration_empty_mcp_servers() -> None:
     cfg = Configuration(
         name="test_name",
         service=ServiceConfiguration(),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
@@ -131,7 +131,7 @@ def test_configuration_single_mcp_server() -> None:
     cfg = Configuration(
         name="test_name",
         service=ServiceConfiguration(),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
@@ -163,7 +163,7 @@ def test_configuration_multiple_mcp_servers() -> None:
     cfg = Configuration(
         name="test_name",
         service=ServiceConfiguration(),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),
@@ -283,7 +283,7 @@ def test_configuration_mcp_servers_with_mixed_auth_headers(tmp_path: Path) -> No
     cfg = Configuration(
         name="test_name",
         service=ServiceConfiguration(),
-        llama_stack=LlamaStackConfiguration(
+        llama_stack=OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),

--- a/tests/unit/models/config/test_shields_configuration.py
+++ b/tests/unit/models/config/test_shields_configuration.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 from models.config import (
     CompactionConfiguration,
     Configuration,
-    LlamaStackConfiguration,
+    OgxConfiguration,
     QuestionValidityConfig,
     QuestionValidityShieldConfiguration,
     RedactionConfig,
@@ -103,7 +103,7 @@ def _minimal_configuration_kwargs() -> dict:
     return {
         "name": "test",
         "service": ServiceConfiguration(),
-        "llama_stack": LlamaStackConfiguration(
+        "llama_stack": OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
         ),

--- a/tests/unit/models/responses/test_successful_responses.py
+++ b/tests/unit/models/responses/test_successful_responses.py
@@ -46,7 +46,7 @@ from models.common.turn_summary import (
 )
 from models.config import (
     Configuration,
-    LlamaStackConfiguration,
+    OgxConfiguration,
     ServiceConfiguration,
     UserDataCollection,
 )
@@ -1102,7 +1102,7 @@ class TestConfigurationResponse:
                 access_log=True,
                 root_path="/.",
             ),
-            llama_stack=LlamaStackConfiguration(
+            llama_stack=OgxConfiguration(
                 url=AnyHttpUrl("http://localhost:8321"),
                 use_as_library_client=False,
                 api_key=None,

--- a/tests/unit/telemetry/conftest.py
+++ b/tests/unit/telemetry/conftest.py
@@ -32,8 +32,8 @@ from models.config import (
     JwkConfiguration,
     JwtConfiguration,
     JwtRoleRule,
-    LlamaStackConfiguration,
     ModelContextProtocolServer,
+    OgxConfiguration,
     OkpConfiguration,
     PgvectorVectorStoreProvider,
     PgvectorVectorStoreProviderConfig,
@@ -59,7 +59,7 @@ from models.config import (
     TrustedProxyConfiguration,
     TrustedProxyServiceAccount,
     UnifiedInferenceProvider,
-    UnifiedLlamaStackConfig,
+    UnifiedOgxConfig,
     UserDataCollection,
     VectorStoreConfiguration,
 )
@@ -336,7 +336,7 @@ def build_fully_populated_config() -> Configuration:
                 allow_headers=["Authorization", "Content-Type"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration.model_construct(
+        llama_stack=OgxConfiguration.model_construct(
             url=PII_LLAMA_URL,
             api_key=SecretStr(PII_API_KEY),
             use_as_library_client=False,
@@ -345,7 +345,7 @@ def build_fully_populated_config() -> Configuration:
             max_retries=5,
             retry_delay=2,
             allow_degraded_mode=True,
-            config=UnifiedLlamaStackConfig.model_construct(
+            config=UnifiedOgxConfig.model_construct(
                 baseline="default",
                 profile=PII_LS_PROFILE,
                 native_override={"key": PII_LS_NATIVE_OVERRIDE},
@@ -685,7 +685,7 @@ def build_minimal_config() -> Configuration:
                 allow_headers=["*"],
             ),
         ),
-        llama_stack=LlamaStackConfiguration.model_construct(
+        llama_stack=OgxConfiguration.model_construct(
             url=None,
             api_key=None,
             use_as_library_client=True,

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -17,8 +17,8 @@ from pytest_mock import MockerFixture
 
 from authorization.azure_token_manager import AzureEntraIDManager
 from client import AsyncOgxClientHolder
-from configuration import AzureEntraIdConfiguration
-from models.config import LlamaStackConfiguration
+from configuration import AppConfig, AzureEntraIdConfiguration
+from models.config import OgxConfiguration
 from utils.types import Singleton
 
 
@@ -26,6 +26,12 @@ from utils.types import Singleton
 def reset_singleton() -> None:
     """Reset singleton state between tests."""
     Singleton._instances = {}
+
+
+@pytest.fixture(autouse=True)
+def load_app_config_for_enrichment(minimal_config: AppConfig) -> None:
+    """Ensure AppConfig is loaded for library client enrichment."""
+    _ = minimal_config
 
 
 def test_async_client_get_client_method() -> None:
@@ -45,7 +51,7 @@ def test_async_client_get_client_method() -> None:
 @pytest.mark.asyncio
 async def test_get_async_llama_stack_library_client() -> None:
     """Test the initialization of asynchronous OGX client in library mode."""
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         url=None,
         api_key=None,
         use_as_library_client=True,
@@ -66,7 +72,7 @@ async def test_get_async_llama_stack_library_client() -> None:
 @pytest.mark.asyncio
 async def test_get_async_llama_stack_remote_client() -> None:
     """Test the initialization of asynchronous OGX client in server mode."""
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         url=AnyHttpUrl("http://localhost:8321"),
         api_key=None,
         use_as_library_client=False,
@@ -94,7 +100,7 @@ async def test_get_async_llama_stack_wrong_configuration(
     source" guarantee itself lives on the root Configuration validator.)
     """
     monkeypatch.delenv("LIGHTSPEED_STACK_CONFIG_PATH", raising=False)
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         url=None,
         api_key=None,
         use_as_library_client=True,
@@ -126,7 +132,7 @@ async def test_update_azure_token_service_client() -> None:
     manager.set_base_url("https://api.example.com")
     manager._update_access_token("fresh-token", int(time.time()) + 3600)
 
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         url=AnyHttpUrl("http://localhost:8321"),
         api_key=None,
         use_as_library_client=False,
@@ -163,7 +169,7 @@ async def test_load_service_client_defers_azure_provider_data() -> None:
     manager.set_base_url("https://ols-test.openai.azure.com/openai/v1")
     manager._update_access_token("startup-token", int(time.time()) + 3600)
 
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         url=AnyHttpUrl("http://localhost:8321"),
         api_key=None,
         use_as_library_client=False,
@@ -189,7 +195,7 @@ async def test_load_service_client_defers_azure_provider_data() -> None:
 @pytest.mark.asyncio
 async def test_reload_library_client() -> None:
     """Test that reload_library_client reloads and returns new client."""
-    cfg = LlamaStackConfiguration(
+    cfg = OgxConfiguration(
         url=None,
         api_key=None,
         use_as_library_client=True,

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -62,7 +62,7 @@ def test_default_configuration() -> None:
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
-        _ = cfg.llama_stack_configuration  # pylint: disable=pointless-statement
+        _ = cfg.ogx_configuration  # pylint: disable=pointless-statement
 
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
         # try to read property
@@ -186,18 +186,18 @@ def test_init_from_dict() -> None:
 
     # check for all subsections
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
     # check for configuration subsection
     assert cfg.configuration.name == "foo"
 
-    # check for llama_stack_configuration subsection
-    assert cfg.llama_stack_configuration.api_key is not None
-    assert cfg.llama_stack_configuration.api_key.get_secret_value() == "xyzzy"
-    assert str(cfg.llama_stack_configuration.url) == "http://x.y.com:1234/"
-    assert cfg.llama_stack_configuration.use_as_library_client is False
+    # check for ogx_configuration subsection
+    assert cfg.ogx_configuration.api_key is not None
+    assert cfg.ogx_configuration.api_key.get_secret_value() == "xyzzy"
+    assert str(cfg.ogx_configuration.url) == "http://x.y.com:1234/"
+    assert cfg.ogx_configuration.use_as_library_client is False
 
     # check for service_configuration subsection
     assert cfg.service_configuration.host == "localhost"
@@ -400,7 +400,7 @@ def test_load_proper_configuration(tmpdir: Path) -> None:
 
     Writes a YAML configuration to a temporary file, loads it with
     AppConfig.load_configuration, and asserts that `configuration`,
-    `llama_stack_configuration`, `service_configuration`, and
+    `ogx_configuration`, `service_configuration`, and
     `user_data_collection_configuration` are populated.
     """
     cfg_filename = tmpdir / "config.yaml"
@@ -426,7 +426,7 @@ mcp_servers: []
     cfg = AppConfig()
     cfg.load_configuration(str(cfg_filename))
     assert cfg.configuration is not None
-    assert cfg.llama_stack_configuration is not None
+    assert cfg.ogx_configuration is not None
     assert cfg.service_configuration is not None
     assert cfg.user_data_collection_configuration is not None
 
@@ -556,11 +556,11 @@ def test_service_configuration_not_loaded() -> None:
         assert c is not None
 
 
-def test_llama_stack_configuration_not_loaded() -> None:
-    """Test that accessing llama_stack_configuration before loading raises an error."""
+def test_ogx_configuration_not_loaded() -> None:
+    """Test that accessing ogx_configuration before loading raises an error."""
     cfg = AppConfig()
     with pytest.raises(LogicError, match="logic error: configuration is not loaded"):
-        c = cfg.llama_stack_configuration
+        c = cfg.ogx_configuration
         assert c is not None
 
 

--- a/tests/unit/test_llama_stack_configuration.py
+++ b/tests/unit/test_llama_stack_configuration.py
@@ -24,7 +24,7 @@ from llama_stack_configuration import (
 from models.config import (
     Configuration,
     InferenceConfiguration,
-    LlamaStackConfiguration,
+    OgxConfiguration,
     ServiceConfiguration,
     UserDataCollection,
 )
@@ -713,7 +713,7 @@ def test_generate_configuration_with_pydantic_model(tmp_path: Path) -> None:
     cfg = Configuration(  # type: ignore[call-arg]
         name="test",
         service=ServiceConfiguration(),  # type: ignore[call-arg]
-        llama_stack=LlamaStackConfiguration(  # type: ignore[call-arg]
+        llama_stack=OgxConfiguration(  # type: ignore[call-arg]
             use_as_library_client=True,
             library_client_config_path="run.yaml",
         ),

--- a/tests/unit/utils/test_config_dumper.py
+++ b/tests/unit/utils/test_config_dumper.py
@@ -94,7 +94,7 @@ def test_dump_schema(tmpdir: Path) -> None:
             "JwkConfiguration",
             "JwtConfiguration",
             "JwtRoleRule",
-            "LlamaStackConfiguration",
+            "OgxConfiguration",
             "ModelContextProtocolServer",
             "OkpConfiguration",
             "PostgreSQLDatabaseConfiguration",

--- a/tests/unit/utils/test_llama_stack_version.py
+++ b/tests/unit/utils/test_llama_stack_version.py
@@ -10,50 +10,50 @@ from pytest_subtests import SubTests
 from semver import Version
 
 from constants import (
-    MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION,
-    MINIMAL_SUPPORTED_LLAMA_STACK_VERSION,
+    MAXIMAL_SUPPORTED_OGX_VERSION,
+    MINIMAL_SUPPORTED_OGX_VERSION,
 )
 from utils.llama_stack_version import (
-    InvalidLlamaStackVersionException,
-    check_llama_stack_version,
+    InvalidOgxVersionException,
+    check_ogx_version,
 )
 
 
 @pytest.mark.asyncio
-async def test_check_llama_stack_version_minimal_supported_version(
+async def test_check_ogx_version_minimal_supported_version(
     mocker: MockerFixture,
 ) -> None:
-    """Test the check_llama_stack_version function."""
+    """Test the check_ogx_version function."""
     # mock the OGX client
     mock_client = mocker.AsyncMock()
     mock_client.inspect.version.return_value = VersionInfo(
-        version=MINIMAL_SUPPORTED_LLAMA_STACK_VERSION
+        version=MINIMAL_SUPPORTED_OGX_VERSION
     )
 
     # test if the version is checked
-    await check_llama_stack_version(mock_client)
+    await check_ogx_version(mock_client)
 
 
 @pytest.mark.asyncio
-async def test_check_llama_stack_version_maximal_supported_version(
+async def test_check_ogx_version_maximal_supported_version(
     mocker: MockerFixture,
 ) -> None:
-    """Test the check_llama_stack_version function."""
+    """Test the check_ogx_version function."""
     # mock the OGX client
     mock_client = mocker.AsyncMock()
     mock_client.inspect.version.return_value = VersionInfo(
-        version=MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION
+        version=MAXIMAL_SUPPORTED_OGX_VERSION
     )
 
     # test if the version is checked
-    await check_llama_stack_version(mock_client)
+    await check_ogx_version(mock_client)
 
 
 @pytest.mark.asyncio
-async def test_check_llama_stack_version_too_small_version(
+async def test_check_ogx_version_too_small_version(
     mocker: MockerFixture,
 ) -> None:
-    """Test the check_llama_stack_version function."""
+    """Test the check_ogx_version function."""
     # mock the OGX client
     mock_client = mocker.AsyncMock()
 
@@ -61,12 +61,12 @@ async def test_check_llama_stack_version_too_small_version(
     mock_client.inspect.version.return_value = VersionInfo(version="0.0.0")
 
     expected_exception_msg = (
-        f"OGX version >= {MINIMAL_SUPPORTED_LLAMA_STACK_VERSION} "
+        f"OGX version >= {MINIMAL_SUPPORTED_OGX_VERSION} "
         + "is required, but 0.0.0 is used"
     )
     # test if the version is checked
-    with pytest.raises(InvalidLlamaStackVersionException, match=expected_exception_msg):
-        await check_llama_stack_version(mock_client)
+    with pytest.raises(InvalidOgxVersionException, match=expected_exception_msg):
+        await check_ogx_version(mock_client)
 
 
 async def _check_version_must_fail(mock_client: Any, bigger_version: Version) -> None:
@@ -77,29 +77,29 @@ async def _check_version_must_fail(mock_client: Any, bigger_version: Version) ->
         bigger_version: A version object representing a version higher than the supported version.
 
     Raises:
-        InvalidLlamaStackVersionException: If the OGX version is greater than the
+        InvalidOgxVersionException: If the OGX version is greater than the
         maximal supported version.
     """
     mock_client.inspect.version.return_value = VersionInfo(version=str(bigger_version))
 
     expected_exception_msg = (
-        f"OGX version <= {MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION} is required, "
+        f"OGX version <= {MAXIMAL_SUPPORTED_OGX_VERSION} is required, "
         + f"but {bigger_version} is used"
     )
     # test if the version is checked
-    with pytest.raises(InvalidLlamaStackVersionException, match=expected_exception_msg):
-        await check_llama_stack_version(mock_client)
+    with pytest.raises(InvalidOgxVersionException, match=expected_exception_msg):
+        await check_ogx_version(mock_client)
 
 
 @pytest.mark.asyncio
-async def test_check_llama_stack_version_too_big_version(
+async def test_check_ogx_version_too_big_version(
     mocker: MockerFixture, subtests: SubTests
 ) -> None:
-    """Test the check_llama_stack_version function."""
+    """Test the check_ogx_version function."""
     # mock the OGX client
     mock_client = mocker.AsyncMock()
 
-    max_version = Version.parse(MAXIMAL_SUPPORTED_LLAMA_STACK_VERSION)
+    max_version = Version.parse(MAXIMAL_SUPPORTED_OGX_VERSION)
 
     with subtests.test(msg="Increased patch number"):
         bigger_version = max_version.bump_patch()
@@ -119,10 +119,10 @@ async def test_check_llama_stack_version_too_big_version(
 
 
 @pytest.mark.asyncio
-async def test_check_llama_stack_version_retries_on_connection_error(
+async def test_check_ogx_version_retries_on_connection_error(
     mocker: MockerFixture,
 ) -> None:
-    """Test that check_llama_stack_version retries on APIConnectionError."""
+    """Test that check_ogx_version retries on APIConnectionError."""
     mock_client = mocker.AsyncMock()
     mock_sleep = mocker.patch("utils.llama_stack_version.asyncio.sleep")
 
@@ -130,20 +130,20 @@ async def test_check_llama_stack_version_retries_on_connection_error(
     mock_client.inspect.version.side_effect = [
         APIConnectionError(request=mocker.MagicMock()),
         APIConnectionError(request=mocker.MagicMock()),
-        VersionInfo(version=MINIMAL_SUPPORTED_LLAMA_STACK_VERSION),
+        VersionInfo(version=MINIMAL_SUPPORTED_OGX_VERSION),
     ]
 
-    await check_llama_stack_version(mock_client, max_retries=5, retry_delay=1)
+    await check_ogx_version(mock_client, max_retries=5, retry_delay=1)
 
     assert mock_client.inspect.version.call_count == 3
     assert mock_sleep.call_count == 2
 
 
 @pytest.mark.asyncio
-async def test_check_llama_stack_version_raises_after_max_retries(
+async def test_check_ogx_version_raises_after_max_retries(
     mocker: MockerFixture,
 ) -> None:
-    """Test that check_llama_stack_version raises after all retries are exhausted."""
+    """Test that check_ogx_version raises after all retries are exhausted."""
     mock_client = mocker.AsyncMock()
     mock_sleep = mocker.patch("utils.llama_stack_version.asyncio.sleep")
 
@@ -152,7 +152,7 @@ async def test_check_llama_stack_version_raises_after_max_retries(
     )
 
     with pytest.raises(APIConnectionError):
-        await check_llama_stack_version(mock_client, max_retries=3, retry_delay=1)
+        await check_ogx_version(mock_client, max_retries=3, retry_delay=1)
 
     assert mock_client.inspect.version.call_count == 3
     assert mock_sleep.call_count == 2

--- a/tests/unit/utils/test_models_dumper.py
+++ b/tests/unit/utils/test_models_dumper.py
@@ -872,7 +872,7 @@ def test_dump_models(tmpdir: Path) -> None:
                             "title": "Service configuration"
                         },
                         "llama_stack": {
-                            "$ref": "`#/components/schemas/`LlamaStackConfiguration",
+                            "$ref": "`#/components/schemas/`OgxConfiguration",
                             "description": "This section contains OGX configuration. Lightspeed Core Stack service can call OGX in library mode or in server mode.",
                             "title": "OGX configuration"
                         },
@@ -2885,7 +2885,7 @@ def test_dump_models(tmpdir: Path) -> None:
                     "title": "LivenessResponse",
                     "type": "object"
                 },
-                "LlamaStackConfiguration": {
+                "OgxConfiguration": {
                     "additionalProperties": false,
                     "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://www.llama.com/products/llama-stack/)\n  - [Python OGX client](https://github.com/llamastack/llama-stack-client-python)\n  - [Build AI Applications with OGX](https://llamastack.github.io/)",
                     "properties": {
@@ -2948,7 +2948,7 @@ def test_dump_models(tmpdir: Path) -> None:
                         "config": {
                             "anyOf": [
                                 {
-                                    "$ref": "`#/components/schemas/`UnifiedLlamaStackConfig"
+                                    "$ref": "`#/components/schemas/`UnifiedOgxConfig"
                                 },
                                 {
                                     "type": "null"
@@ -2959,7 +2959,7 @@ def test_dump_models(tmpdir: Path) -> None:
                             "title": "Unified OGX configuration"
                         }
                     },
-                    "title": "LlamaStackConfiguration",
+                    "title": "OgxConfiguration",
                     "type": "object"
                 },
                 "MCPClientAuthOptionsResponse": {
@@ -9282,7 +9282,7 @@ def test_dump_models(tmpdir: Path) -> None:
                     "title": "UnifiedInferenceProvider",
                     "type": "object"
                 },
-                "UnifiedLlamaStackConfig": {
+                "UnifiedOgxConfig": {
                     "additionalProperties": false,
                     "description": "Backend-specific knobs for unified-mode OGX synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the OGX-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml); \"empty\" begins from\n        an empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw ogx schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
                     "properties": {
@@ -9311,7 +9311,7 @@ def test_dump_models(tmpdir: Path) -> None:
                             "type": "object"
                         }
                     },
-                    "title": "UnifiedLlamaStackConfig",
+                    "title": "UnifiedOgxConfig",
                     "type": "object"
                 },
                 "UnprocessableEntityResponse": {
@@ -10120,7 +10120,7 @@ def test_dump_models(tmpdir: Path) -> None:
             "JwtConfiguration",
             "JwtRoleRule",
             "LivenessResponse",
-            "LlamaStackConfiguration",
+            "OgxConfiguration",
             "MCPClientAuthOptionsResponse",
             "MCPListToolsSummary",
             "MCPListToolsTool",
@@ -10259,7 +10259,7 @@ def test_dump_models(tmpdir: Path) -> None:
             "TurnSummary",
             "UnauthorizedResponse",
             "UnifiedInferenceProvider",
-            "UnifiedLlamaStackConfig",
+            "UnifiedOgxConfig",
             "UnprocessableEntityResponse",
             "UserDataCollection",
             "VectorStoreConfiguration",


### PR DESCRIPTION
## Description

Rename internal Python symbols from LlamaStack to Ogx (`OgxConfiguration`, `UnifiedOgxConfig`, `ogx_configuration`, `check_ogx_version`, `InvalidOgxVersionException`, supported-version constants).
Update `src/` and unit/integration tests to use the new names.
No external contract changes: YAML key remains `llama_stack:`, `/info` still returns `llama_stack_version`, module filenames unchanged.


## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2547
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API schema terminology to use OGX configuration names.

- **Refactor**
  - Renamed configuration models, properties, version checks, and related error terminology from Llama Stack to OGX.
  - Updated model, provider, RAG, startup, and client configuration handling to use the new naming consistently.

- **Tests**
  - Updated configuration, endpoint, client, telemetry, schema, and version-validation tests to reflect the OGX terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->