### PR TITLE
LCORE-2547: rename llslibdev dependency group to ogxlibdev

### DIFF
--- a/.github/workflows/openapi_spectral.yaml
+++ b/.github/workflows/openapi_spectral.yaml
@@ -21,8 +21,8 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        # Same pattern as local dev (CONTRIBUTING.md): dev + llslibdev for a full app import.
-        run: uv sync --group dev --group llslibdev
+        # Same pattern as local dev (CONTRIBUTING.md): dev + ogxlibdev for a full app import.
+        run: uv sync --group dev --group ogxlibdev
       - name: Install PDM
         # scripts/generate_openapi_schema.py asserts OpenAPI info.version matches `pdm show --version`.
         run: uv pip install pdm

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -18,6 +18,6 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: uv sync --group llslibdev
+        run: uv sync --group ogxlibdev
       - name: Python linter
         run: uv run pylint src tests

--- a/.github/workflows/pyright.yaml
+++ b/.github/workflows/pyright.yaml
@@ -18,6 +18,6 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install dependencies
-        run: uv sync --group llslibdev
+        run: uv sync --group ogxlibdev
       - name: Run Pyright tests
         run: uv run pyright src

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: uv version
         run: uv --version
       - name: Install dependencies
-        run: uv pip install --python ${{ matrix.python-version }} --group llslibdev .
+        run: uv pip install --python ${{ matrix.python-version }} --group ogxlibdev .
       - name: Install pdm  # Required for dynamic version test
         run: uv pip install pdm
       - name: Run unit tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,7 +420,7 @@ Allowed prefixes: `LCORE-`, `RSPEED-`, `MGTM-`, `OLS-`, `RHIDP-`, `LEADS-`, `CWF
 - ❌ `feat(observability): add user_agent to ResponsesEventData`
 
 ## Development Workflow
-1. Use `uv sync --group dev --group llslibdev` for dependencies
+1. Use `uv sync --group dev --group ogxlibdev` for dependencies
 2. Always use `uv run` prefix for commands
 3. **ALWAYS** check `pyproject.toml` for existing dependencies and versions before adding new ones
 4. Follow existing code patterns in the module you're modifying

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To quickly get hands on LCS, we can run it using the default configurations prov
 
 0. install dependencies using [uv](https://docs.astral.sh/uv/getting-started/installation/)
    ```bash
-   uv sync --group dev --group llslibdev
+   uv sync --group dev --group ogxlibdev
    ```
 1. create OGX `run.yaml`. you can do this by running the local run generation script
    ```bash

--- a/deploy/lightspeed-stack/Containerfile
+++ b/deploy/lightspeed-stack/Containerfile
@@ -74,7 +74,7 @@ RUN if [ -f /cachi2/cachi2.env ]; then \
     pip install --no-cache-dir --ignore-installed --no-index --find-links ${PIP_FIND_LINKS} --no-deps -r requirements.hashes.wheel.txt -r requirements.hashes.wheel.pypi.txt -r requirements.hashes.source.txt && \
     pip check; \
     else \
-    uv sync --locked --no-dev --group llslibdev; \
+    uv sync --locked --no-dev --group ogxlibdev; \
     fi
 
 # Explicitly remove some packages to mitigate some CVEs

--- a/deploy/llama-stack/test.containerfile
+++ b/deploy/llama-stack/test.containerfile
@@ -19,7 +19,7 @@ COPY src ./src
 COPY providers ./providers
 
 # Install dependencies using uv sync
-RUN uv sync --locked --no-install-project --group llslibdev
+RUN uv sync --locked --no-install-project --group ogxlibdev
 
 # Add virtual environment to PATH for llama command
 # Add providers to PYTHONPATH so lightspeed_stack_providers modules can be imported

--- a/docs/devel_doc/container_orchestration.md
+++ b/docs/devel_doc/container_orchestration.md
@@ -53,7 +53,7 @@ The Makefile will auto-detect which runtime is available.
 
 ```bash
 # Install dependencies
-uv sync --group dev --group llslibdev
+uv sync --group dev --group ogxlibdev
 
 # Generate OGX config (run.yaml)
 ./scripts/generate_local_run.sh

--- a/docs/devel_doc/providers.md
+++ b/docs/devel_doc/providers.md
@@ -290,9 +290,9 @@ Shields are owned by LCORE (configured under `shields:` block), not as OGX `prov
     ```bash
     uv run llama stack list-providers
     ```
-    Edit your `pyproject.toml` and add the required pip packages for the provider into `llslibdev` section:
+    Edit your `pyproject.toml` and add the required pip packages for the provider into `ogxlibdev` section:
    ```toml
-   llslibdev = [
+   ogxlibdev = [
      "openai>=1.0.0",
      "pymilvus>=2.4.10",
      
@@ -304,7 +304,7 @@ Shields are owned by LCORE (configured under `shields:` block), not as OGX `prov
 
     Run the following command to update project dependencies:
     ```bash
-    uv sync --group llslibdev
+    uv sync --group ogxlibdev
     ```
 1. **Update OGX configuration**
     

--- a/docs/user_doc/deployment_guide.md
+++ b/docs/user_doc/deployment_guide.md
@@ -627,7 +627,7 @@ It is possible to run Lightspeed Core Stack service with OGX "embedded" as a Pyt
 1. Clone LCS repository
 1. Add and install all required dependencies
     ```bash
-    uv sync --group llslibdev
+    uv sync --group ogxlibdev
     ```
 
 #### OGX configuration

--- a/docs/user_doc/okp_guide.md
+++ b/docs/user_doc/okp_guide.md
@@ -79,7 +79,7 @@ podman run --rm -d -p 8081:8080 registry.redhat.io/offline-knowledge-portal/rhok
 Install dependencies:
 
 ```bash
-uv sync --group dev --group llslibdev
+uv sync --group dev --group ogxlibdev
 ```
 
 Set required environment variables:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ explicit = true
 
 [tool.uv.sources]
 torch = [
-    { index = "pytorch-cpu", group = "llslibdev" },
+    { index = "pytorch-cpu", group = "ogxlibdev" },
 ]
 
 [dependency-groups]
@@ -151,7 +151,7 @@ dev = [
     "pip==26.1",
     "pytest-benchmark>=5.2.3",
 ]
-llslibdev = [
+ogxlibdev = [
     # To check OGX API provider dependecies:
     #
     #    $ uv run ogx stack list-providers

--- a/scripts/konflux_requirements.sh
+++ b/scripts/konflux_requirements.sh
@@ -22,7 +22,7 @@ NO_WHEEL_PACKAGES="markupsafe"
 
 # Generate requirements list from pyproject.toml from both indexes
 uv pip compile pyproject.toml -o "$RAW_REQ_FILE" \
-		--group llslibdev \
+		--group ogxlibdev \
 		--python-platform x86_64-unknown-linux-gnu \
 		--python-version 3.12 \
 		--refresh \

--- a/scripts/konflux_resolve.py
+++ b/scripts/konflux_resolve.py
@@ -1030,7 +1030,7 @@ def uv_resolve(
         "--emit-index-annotation",
         "--no-sources",
         "--group",
-        "llslibdev",
+        "ogxlibdev",
     ]
     if os.path.exists(overrides_file):
         cmd += ["--override", overrides_file]

--- a/tests/e2e-prow/rhoai/manifests/lightspeed/llama-stack-openai.yaml
+++ b/tests/e2e-prow/rhoai/manifests/lightspeed/llama-stack-openai.yaml
@@ -75,7 +75,7 @@ spec:
           export GIT_TERMINAL_PROMPT=0
           git clone -q "${REPO_URL}" /opt/app-root/repo
           cd /opt/app-root/repo && git fetch origin "${REPO_REVISION}" 2>/dev/null || true && git checkout -q "${REPO_REVISION}"
-          uv sync --locked --no-install-project --group llslibdev
+          uv sync --locked --no-install-project --group ogxlibdev
           (cd /opt/app-root/repo && tar cf - .) | (cd /opt/app-root && tar xf -)
           rm -rf /opt/app-root/repo
           sed -i 's|/opt/app-root/repo/.venv|/opt/app-root/.venv|g' /opt/app-root/.venv/bin/* 2>/dev/null || true

--- a/uv.lock
+++ b/uv.lock
@@ -1876,7 +1876,7 @@ dev = [
     { name = "types-pyyaml" },
     { name = "types-requests" },
 ]
-llslibdev = [
+ogxlibdev = [
     { name = "aiosqlite" },
     { name = "autoevals" },
     { name = "azure-identity" },
@@ -1988,7 +1988,7 @@ dev = [
     { name = "types-pyyaml", specifier = ">=6.0.2" },
     { name = "types-requests", specifier = ">=2.28.0" },
 ]
-llslibdev = [
+ogxlibdev = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "autoevals", specifier = ">=0.0.129" },
     { name = "azure-identity", specifier = ">=1.21.0" },
@@ -2017,7 +2017,7 @@ llslibdev = [
     { name = "pythainlp", specifier = ">=3.0.10" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "sentence-transformers", specifier = ">=5.0.0" },
-    { name = "torch", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "lightspeed-stack", group = "llslibdev" } },
+    { name = "torch", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "lightspeed-stack", group = "ogxlibdev" } },
     { name = "transformers", specifier = ">=4.34.0" },
     { name = "tree-sitter", specifier = ">=0.24.0" },
     { name = "trl", specifier = ">=0.18.2" },


### PR DESCRIPTION
## Description

Renames the llslibdev uv dependency group to ogxlibdev across build tooling, CI, container builds, Konflux scripts, and docs. No runtime or API changes.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2547
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
