### PR TITLE
LCORE-3507 - Do not catch blind exception: Exception src/utils/vector_search.py:625:12

### DIFF
--- a/src/utils/vector_search.py
+++ b/src/utils/vector_search.py
@@ -641,7 +641,9 @@ async def _fetch_okp_rag(  # pylint: disable=too-many-locals
                     len(rag_chunks),
                 )
 
-    except Exception as e:  # pylint: disable=broad-exception-caught
+    except (
+        Exception  # pylint: disable=broad-exception-caught
+    ) as e:  # noqa: BLE001 RUF100
         logger.warning("Failed to query OKP for chunks: %s", e)
         logger.debug("OKP query error details: %s", traceback.format_exc())
 


### PR DESCRIPTION
## Description

LCORE-3507: Do not catch blind exception
In this case there are so many exception types to catch, that it is needed to disable the rule for this line.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted internal exception-handling code for improved readability.
  * No user-visible behavior or functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->