### PR TITLE
LCORE-3754: Add WebP as supported attachment/image content type

### DIFF
--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -12402,7 +12402,8 @@
                         "examples": [
                             "text/plain",
                             "image/jpeg",
-                            "image/png"
+                            "image/png",
+                            "image/webp"
                         ]
                     },
                     "content": {

--- a/src/constants.py
+++ b/src/constants.py
@@ -53,11 +53,14 @@ ATTACHMENT_CONTENT_TYPES: Final[frozenset[str]] = frozenset(
         "application/xml",
         "image/jpeg",
         "image/png",
+        "image/webp",
     }
 )
 
 # Image content types (subset of ATTACHMENT_CONTENT_TYPES)
-IMAGE_CONTENT_TYPES: Final[frozenset[str]] = frozenset({"image/jpeg", "image/png"})
+IMAGE_CONTENT_TYPES: Final[frozenset[str]] = frozenset(
+    {"image/jpeg", "image/png", "image/webp"}
+)
 
 # Default system prompt used only when no other system prompt is specified in
 # configuration file nor in the query request

--- a/src/models/common/query.py
+++ b/src/models/common/query.py
@@ -2,6 +2,7 @@
 
 import base64
 import binascii
+import re
 from typing import Any, Literal, Optional, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -15,11 +16,11 @@ from log import get_logger
 
 logger = get_logger(__name__)
 
-_IMAGE_SIGNATURES: dict[str, tuple[tuple[int, bytes], ...]] = {
-    "image/png": ((0, b"\x89PNG"),),
-    "image/jpeg": ((0, b"\xff\xd8\xff"),),
-    # WebP is a RIFF container: 4-byte "RIFF", 4-byte size, then "WEBP".
-    "image/webp": ((0, b"RIFF"), (8, b"WEBP")),
+_IMAGE_SIGNATURES: dict[str, re.Pattern[bytes]] = {
+    "image/png": re.compile(rb"^\x89PNG"),
+    "image/jpeg": re.compile(rb"^\xff\xd8\xff"),
+    # WebP is a RIFF container: "RIFF", a 4-byte size, then "WEBP".
+    "image/webp": re.compile(rb"^RIFF.{4}WEBP", re.DOTALL),
 }
 
 
@@ -33,11 +34,8 @@ def _validate_image_magic_bytes(data: bytes, content_type: str) -> None:
     Raises:
         ValueError: If the data does not match the expected image format.
     """
-    signatures = _IMAGE_SIGNATURES.get(content_type)
-    if signatures and any(
-        data[offset : offset + len(expected)] != expected
-        for offset, expected in signatures
-    ):
+    pattern = _IMAGE_SIGNATURES.get(content_type)
+    if pattern and not pattern.match(data):
         raise ValueError(
             f"Image content does not match declared content_type "
             f"'{content_type}': invalid image data"

--- a/src/models/common/query.py
+++ b/src/models/common/query.py
@@ -15,14 +15,16 @@ from log import get_logger
 
 logger = get_logger(__name__)
 
-_IMAGE_SIGNATURES: dict[str, bytes] = {
-    "image/png": b"\x89PNG",
-    "image/jpeg": b"\xff\xd8\xff",
+_IMAGE_SIGNATURES: dict[str, tuple[tuple[int, bytes], ...]] = {
+    "image/png": ((0, b"\x89PNG"),),
+    "image/jpeg": ((0, b"\xff\xd8\xff"),),
+    # WebP is a RIFF container: 4-byte "RIFF", 4-byte size, then "WEBP".
+    "image/webp": ((0, b"RIFF"), (8, b"WEBP")),
 }
 
 
 def _validate_image_magic_bytes(data: bytes, content_type: str) -> None:
-    """Verify that decoded image data starts with the expected magic bytes.
+    """Verify that decoded image data matches the expected magic bytes.
 
     Parameters:
         data: Raw decoded image bytes.
@@ -31,8 +33,11 @@ def _validate_image_magic_bytes(data: bytes, content_type: str) -> None:
     Raises:
         ValueError: If the data does not match the expected image format.
     """
-    expected = _IMAGE_SIGNATURES.get(content_type)
-    if expected and not data.startswith(expected):
+    signatures = _IMAGE_SIGNATURES.get(content_type)
+    if signatures and any(
+        data[offset : offset + len(expected)] != expected
+        for offset, expected in signatures
+    ):
         raise ValueError(
             f"Image content does not match declared content_type "
             f"'{content_type}': invalid image data"
@@ -56,7 +61,7 @@ class Attachment(BaseModel):
     )
     content_type: str = Field(
         description="The content type as defined in MIME standard",
-        examples=["text/plain", "image/jpeg", "image/png"],
+        examples=["text/plain", "image/jpeg", "image/png", "image/webp"],
     )
     content: str = Field(
         description="The actual attachment content (text or base64-encoded image data)",

--- a/tests/e2e/features/query.feature
+++ b/tests/e2e/features/query.feature
@@ -180,6 +180,48 @@ Scenario: Check if LLM responds for query request with error for missing query
           | Fragments in LLM response |
           | image                     |
 
+  @flaky
+  Scenario: Check if LLM responds properly when a valid WebP image attachment is sent
+    When I use "query" to ask question with authorization header
+    """
+    {
+      "query": "Describe this image",
+      "attachments": [
+        {
+          "attachment_type": "image",
+          "content": "UklGRjwAAABXRUJQVlA4IDAAAADQAQCdASoBAAEAAUAmJaACdLoB+AADsAD+8ut//NgVzXPv9//S4P0uD9Lg/9KQAAA=",
+          "content_type": "image/webp"
+        }
+      ],
+      "model": "{MODEL}",
+      "provider": "{PROVIDER}",
+      "system_prompt": "You are a helpful assistant"
+    }
+    """
+    Then The status code of the response is 200
+      And The response contains following fragments
+          | Fragments in LLM response |
+          | image                     |
+
+  Scenario: Check if query rejects WebP-declared attachment with mismatched magic bytes
+    When I use "query" to ask question with authorization header
+    """
+    {
+      "query": "Describe this image",
+      "attachments": [
+        {
+          "attachment_type": "image",
+          "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+          "content_type": "image/webp"
+        }
+      ],
+      "model": "{MODEL}",
+      "provider": "{PROVIDER}"
+    }
+    """
+    Then The status code of the response is 422
+      And The body of the response contains invalid image data
+
   Scenario: Check if query rejects image attachment with mismatched attachment_type and content_type
     When I use "query" to ask question with authorization header
     """

--- a/tests/e2e/features/streaming_query.feature
+++ b/tests/e2e/features/streaming_query.feature
@@ -170,6 +170,25 @@ Feature: streaming_query endpoint API tests
           | Fragments in LLM response |
           | image                     |
 
+  Scenario: Check if streaming_query rejects WebP-declared attachment with mismatched magic bytes
+    When I use "streaming_query" to ask question with authorization header
+    """
+    {
+      "query": "Describe this image",
+      "attachments": [
+        {
+          "attachment_type": "image",
+          "content": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+          "content_type": "image/webp"
+        }
+      ],
+      "model": "{MODEL}",
+      "provider": "{PROVIDER}"
+    }
+    """
+    Then The status code of the response is 422
+      And The body of the response contains invalid image data
+
   Scenario: Check if streaming_query rejects image attachment with mismatched attachment_type and content_type
     When I use "streaming_query" to ask question with authorization header
     """

--- a/tests/unit/models/requests/test_attachment.py
+++ b/tests/unit/models/requests/test_attachment.py
@@ -64,6 +64,31 @@ class TestAttachment:
         assert a.attachment_type == "image"
         assert a.content_type == "image/png"
 
+    def test_valid_image_attachment_webp(self) -> None:
+        """Test that a valid WebP image attachment is accepted."""
+        image_data = base64.b64encode(
+            b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 100
+        ).decode()
+        a = Attachment(
+            attachment_type="image",
+            content_type="image/webp",
+            content=image_data,
+        )
+        assert a.attachment_type == "image"
+        assert a.content_type == "image/webp"
+
+    def test_image_attachment_riff_but_not_webp_rejected(self) -> None:
+        """Test that a non-WebP RIFF file (e.g. WAV) declared as WebP is rejected."""
+        wav_data = base64.b64encode(
+            b"RIFF" + b"\x00\x00\x00\x00" + b"WAVE" + b"\x00" * 100
+        ).decode()
+        with pytest.raises(ValidationError, match="invalid image data"):
+            Attachment(
+                attachment_type="image",
+                content_type="image/webp",
+                content=wav_data,
+            )
+
     def test_image_content_type_requires_image_attachment_type(self) -> None:
         """Test that image content_type requires attachment_type='image'."""
         image_data = base64.b64encode(b"\xff\xd8\xff\xe0").decode()


### PR DESCRIPTION
## Jira
https://redhat.atlassian.net/browse/LCORE-3754
Related: https://redhat.atlassian.net/browse/RHIDP-16178

## Summary
- Add `image/webp` alongside the existing `image/jpeg` and `image/png` attachment types (`ATTACHMENT_CONTENT_TYPES`, `IMAGE_CONTENT_TYPES` in `src/constants.py`).
- WebP's magic bytes aren't a simple prefix like JPEG/PNG — it's a RIFF container (`"RIFF"` + 4-byte size + `"WEBP"`). `_validate_image_magic_bytes` now matches a compiled regex per content type instead of `bytes.startswith()`, so the variable-length RIFF size field is just `.{4}` in the pattern.
- Checked whether this needs an upstream contribution elsewhere in the dependency stack (per the linked RHIDP ticket): `pydantic_ai`'s `ImageUrl`/`_image_format_lookup` already supports `image/webp` natively (`ImageFormat: TypeAlias = Literal['jpeg', 'png', 'gif', 'webp']`) — no changes needed downstream of attachment validation.

## Test plan
- [x] `make format` / `make verify` (black, pylint 10.00/10, pyright, ruff, pydocstyle) — all clean
- [x] `make test-unit` — 3462 passed, 1 skipped, 91.28% coverage
- [x] New unit tests: valid WebP attachment accepted; a non-WebP RIFF container (WAV) declared as WebP correctly rejected (proves both signature offsets are checked, not just the RIFF prefix)
- [x] New e2e scenarios (`query.feature`, `streaming_query.feature`): deterministic rejection of a WebP-declared attachment with mismatched magic bytes (no live LLM needed); end-to-end `@flaky` scenario sending a real, valid 1x1 WebP image (generated with Pillow) through `query`, mirroring the existing PNG scenario
- [x] `behave --dry-run` confirms both feature files parse correctly with all steps resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for WebP image attachments in queries and streaming queries.
  * Added WebP to supported image types and API documentation examples.

* **Bug Fixes**
  * Improved image validation to verify that attachment content matches its declared image type.
  * Invalid or mismatched WebP attachments now return a clear validation error.

* **Tests**
  * Added coverage for valid WebP uploads and rejection of invalid image data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->