### PR TITLE
LCORE-3791: refactor to use matching instead of if-else-chain

### DIFF
--- a/src/authentication/rh_identity.py
+++ b/src/authentication/rh_identity.py
@@ -80,15 +80,16 @@ class RHIdentityData:
             raise HTTPException(status_code=400, detail="Invalid identity data")
 
         identity_type = identity["type"]
-        if identity_type == "User":
-            self._validate_user_fields(identity)
-        elif identity_type == "System":
-            self._validate_system_fields(identity)
-        elif identity_type == "ServiceAccount":
-            self._validate_service_account_fields(identity)
-        else:
-            logger.warning("Identity validation failed: unsupported identity type")
-            raise HTTPException(status_code=400, detail="Invalid identity data")
+        match identity_type:
+            case "User":
+                self._validate_user_fields(identity)
+            case "System":
+                self._validate_system_fields(identity)
+            case "ServiceAccount":
+                self._validate_service_account_fields(identity)
+            case _:
+                logger.warning("Identity validation failed: unsupported identity type")
+                raise HTTPException(status_code=400, detail="Invalid identity data")
 
         # Validate org_id if present and non-empty
         org_id = identity.get("org_id")

--- a/src/utils/mcp_auth_headers.py
+++ b/src/utils/mcp_auth_headers.py
@@ -46,52 +46,53 @@ def resolve_authorization_headers(
     for header_name, value in authorization_headers.items():
         value = value.strip()
         try:
-            if value == constants.MCP_AUTH_KUBERNETES:
-                # Special case: Keep kubernetes keyword for later substitution
-                resolved[header_name] = constants.MCP_AUTH_KUBERNETES
-                logger.debug(
-                    "Header %s will use Kubernetes token (resolved at request time)",
-                    header_name,
-                )
-            elif value == constants.MCP_AUTH_CLIENT:
-                # Special case: Keep client keyword for later substitution
-                resolved[header_name] = constants.MCP_AUTH_CLIENT
-                logger.debug(
-                    "Header %s will use client-provided token (resolved at request time)",
-                    header_name,
-                )
-            elif value == constants.MCP_AUTH_OAUTH:
-                # Special case: Keep oauth keyword; if no token provided, probe endpoint
-                # and forward 401 WWW-Authenticate for client-driven OAuth flow
-                resolved[header_name] = constants.MCP_AUTH_OAUTH
-                logger.debug(
-                    "Header %s will use OAuth token (resolved at request time or 401)",
-                    header_name,
-                )
-            else:
-                # Regular case: Read secret from file path
-                secret_path = Path(value).expanduser()
-                if secret_path.exists() and secret_path.is_file():
-                    secret_value = secret_path.read_text(encoding="utf-8").strip()
-                    if not secret_value:
-                        logger.warning(
-                            "Secret file %s for header %s is empty",
-                            secret_path,
-                            header_name,
-                        )
-                    else:
-                        resolved[header_name] = secret_value
-                        logger.debug(
-                            "Resolved header %s from secret file %s",
-                            header_name,
-                            secret_path,
-                        )
-                else:
-                    logger.warning(
-                        "Secret file not found or not a file: %s for header %s",
-                        secret_path,
+            match value:
+                case constants.MCP_AUTH_KUBERNETES:
+                    # Special case: Keep kubernetes keyword for later substitution
+                    resolved[header_name] = constants.MCP_AUTH_KUBERNETES
+                    logger.debug(
+                        "Header %s will use Kubernetes token (resolved at request time)",
                         header_name,
                     )
+                case constants.MCP_AUTH_CLIENT:
+                    # Special case: Keep client keyword for later substitution
+                    resolved[header_name] = constants.MCP_AUTH_CLIENT
+                    logger.debug(
+                        "Header %s will use client-provided token (resolved at request time)",
+                        header_name,
+                    )
+                case constants.MCP_AUTH_OAUTH:
+                    # Special case: Keep oauth keyword; if no token provided, probe endpoint
+                    # and forward 401 WWW-Authenticate for client-driven OAuth flow
+                    resolved[header_name] = constants.MCP_AUTH_OAUTH
+                    logger.debug(
+                        "Header %s will use OAuth token (resolved at request time or 401)",
+                        header_name,
+                    )
+                case _:
+                    # Regular case: Read secret from file path
+                    secret_path = Path(value).expanduser()
+                    if secret_path.exists() and secret_path.is_file():
+                        secret_value = secret_path.read_text(encoding="utf-8").strip()
+                        if not secret_value:
+                            logger.warning(
+                                "Secret file %s for header %s is empty",
+                                secret_path,
+                                header_name,
+                            )
+                        else:
+                            resolved[header_name] = secret_value
+                            logger.debug(
+                                "Resolved header %s from secret file %s",
+                                header_name,
+                                secret_path,
+                            )
+                    else:
+                        logger.warning(
+                            "Secret file not found or not a file: %s for header %s",
+                            secret_path,
+                            header_name,
+                        )
         except Exception:  # pylint: disable=broad-except
             # Don't log value: it might be a literal token.
             logger.exception(

--- a/src/utils/responses.py
+++ b/src/utils/responses.py
@@ -1619,18 +1619,19 @@ def _extract_text_from_content(
     text_fragments: list[str] = []
     for part in content:
         part_type = getattr(part, "type", None)
-        if part_type == "input_text":
-            input_text_part = cast(InputTextPart, part)
-            if input_text_part.text:
-                text_fragments.append(input_text_part.text.strip())
-        elif part_type == "output_text":
-            output_text_part = cast(OutputTextPart, part)
-            if output_text_part.text:
-                text_fragments.append(output_text_part.text.strip())
-        elif part_type == "refusal":
-            refusal_part = cast(ContentPartRefusal, part)
-            if refusal_part.refusal:
-                text_fragments.append(refusal_part.refusal.strip())
+        match part_type:
+            case "input_text":
+                input_text_part = cast(InputTextPart, part)
+                if input_text_part.text:
+                    text_fragments.append(input_text_part.text.strip())
+            case "output_text":
+                output_text_part = cast(OutputTextPart, part)
+                if output_text_part.text:
+                    text_fragments.append(output_text_part.text.strip())
+            case "refusal":
+                refusal_part = cast(ContentPartRefusal, part)
+                if refusal_part.refusal:
+                    text_fragments.append(refusal_part.refusal.strip())
 
     return " ".join(text_fragments)
 


### PR DESCRIPTION
## Description

LCORE-3791: refactor to use matching instead of if-else-chain

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of identity validation, authorization headers, and response text extraction.
  * Existing behavior remains unchanged, including validation outcomes, credential handling, warnings, and text processing.
* **Reliability**
  * Maintained consistent error handling for unsupported identity types, missing credential files, empty secrets, and other exceptional conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->