### PR TITLE
LCORE-3653: Add immutable vector db seed

### DIFF
--- a/docker-compose-library.yaml
+++ b/docker-compose-library.yaml
@@ -18,11 +18,14 @@ services:
       - ./lightspeed-stack.yaml:/app-root/lightspeed-stack.yaml:Z
       - ./run.yaml:/app-root/run.yaml:Z
       - ${GCP_KEYS_PATH:-./tmp/.gcp-keys-dummy}:/opt/app-root/.gcp-keys:ro
-      - ./tests/e2e/rag:/opt/app-root/src/.llama/storage/rag:Z
-      - ${HF_CACHE_PATH:-./tmp/.hf-cache}:/opt/app-root/src/.cache/huggingface
+      # Read-only e2e FAISS fixtures — never use as the live KV_RAG_PATH
+      - ./tests/e2e/rag:/opt/app-root/src/.llama/storage/.e2e-rag-seed:ro,Z
+      - ${HF_CACHE_PATH:-./tmp/.hf-cache}:/opt/app-root/src/.cache/huggingface:z
       - ./tests/e2e/skills:/app-root/skills:ro,Z
       - ./tests/e2e/secrets/mcp-token:/tmp/mcp-token:ro,z
       - ./tests/e2e/secrets/invalid-mcp-token:/tmp/invalid-mcp-token:ro,z
+      # Host copy so seed-restore entrypoint changes apply without rebuilding
+      - ./scripts/entrypoint.sh:/app-root/entrypoint.sh:ro,z
     environment:
       # LLM Provider API Keys
       - BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY:-}
@@ -59,6 +62,9 @@ services:
       - OGX_LOGGING=${OGX_LOGGING:-}
       # FAISS test and inline RAG config
       - FAISS_VECTOR_STORE_ID=${FAISS_VECTOR_STORE_ID:-}
+      - RAG_SEED_DIR=/opt/app-root/src/.llama/storage/.e2e-rag-seed
+      - KV_RAG_PATH=/tmp/e2e-rag-work/kv_store.db
+      - PDF_KV_RAG_PATH=/tmp/e2e-rag-work/pdf_kv_store.db
       # Prevent HuggingFace Hub update checks (HTTP 429 rate-limiting in CI from parallel jobs).
       - HF_HUB_OFFLINE=1
       # OpenTelemetry configuration (tracing disabled by default)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,10 +18,12 @@ services:
       - ./src/llama_stack_configuration.py:/opt/app-root/llama_stack_configuration.py:ro,z
       - ${GCP_KEYS_PATH:-./tmp/.gcp-keys-dummy}:/opt/app-root/.gcp-keys:ro
       - ./lightspeed-stack.yaml:/opt/app-root/lightspeed-stack.yaml:ro,z
+      # Writable OGX storage (rag/ work copy is re-seeded by entrypoint each start)
       - llama-storage:/opt/app-root/src/.llama/storage
-      - ./tests/e2e/rag:/opt/app-root/src/.llama/storage/rag:z
+      # Read-only e2e FAISS fixtures — never mount these as the live KV_RAG_PATH
+      - ./tests/e2e/rag:/opt/app-root/src/.llama/storage/.e2e-rag-seed:ro,z
       - mock-tls-certs:/certs:ro
-      - ${HF_CACHE_PATH:-./tmp/.hf-cache}:/opt/app-root/src/.cache/huggingface
+      - ${HF_CACHE_PATH:-./tmp/.hf-cache}:/opt/app-root/src/.cache/huggingface:z
     environment:
       - BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY:-}
       - TAVILY_SEARCH_API_KEY=${TAVILY_SEARCH_API_KEY:-}
@@ -57,6 +59,10 @@ services:
       - OGX_LOGGING=${OGX_LOGGING:-}
       # FAISS test
       - FAISS_VECTOR_STORE_ID=${FAISS_VECTOR_STORE_ID:-}
+      # Live RAG DBs under /tmp (writable for UID 1001); seeded from .e2e-rag-seed
+      - RAG_SEED_DIR=/opt/app-root/src/.llama/storage/.e2e-rag-seed
+      - KV_RAG_PATH=/tmp/e2e-rag-work/kv_store.db
+      - PDF_KV_RAG_PATH=/tmp/e2e-rag-work/pdf_kv_store.db
       # Prevent HuggingFace Hub update checks (HTTP 429 rate-limiting in CI from parallel jobs).
       - HF_HUB_OFFLINE=1
       # OKP/Solr RAG

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
 set -e
 
+# Copy read-only e2e FAISS fixtures to a writable work path (OGX writes on register).
+# cp preserves source mode, so chmod so the work copy stays owner-writable.
+RAG_SEED_DIR="${RAG_SEED_DIR:-/opt/app-root/src/.llama/storage/.e2e-rag-seed}"
+KV_RAG_PATH="${KV_RAG_PATH:-/tmp/e2e-rag-work/kv_store.db}"
+PDF_KV_RAG_PATH="${PDF_KV_RAG_PATH:-/tmp/e2e-rag-work/pdf_kv_store.db}"
+
+if [ -d "$RAG_SEED_DIR" ]; then
+    mkdir -p "$(dirname "$KV_RAG_PATH")" "$(dirname "$PDF_KV_RAG_PATH")"
+    if [ -f "$RAG_SEED_DIR/kv_store.db" ]; then
+        cp -f "$RAG_SEED_DIR/kv_store.db" "$KV_RAG_PATH"
+        chmod u+w "$KV_RAG_PATH"
+    fi
+    if [ -f "$RAG_SEED_DIR/pdf_kv_store.db" ]; then
+        cp -f "$RAG_SEED_DIR/pdf_kv_store.db" "$PDF_KV_RAG_PATH"
+        chmod u+w "$PDF_KV_RAG_PATH"
+    fi
+fi
+
 # Only use OpenTelemetry instrumentation if explicitly enabled
 # Use explicit venv paths to ensure dependencies are found
 if [ "${OTEL_SDK_DISABLED:-true}" = "false" ]; then

--- a/scripts/llama-stack-entrypoint.sh
+++ b/scripts/llama-stack-entrypoint.sh
@@ -8,6 +8,24 @@ INPUT_CONFIG="${LLAMA_STACK_CONFIG:-/opt/app-root/run.yaml}"
 ENRICHED_CONFIG="/tmp/enriched-run.yaml"
 LIGHTSPEED_CONFIG="${LIGHTSPEED_CONFIG:-/opt/app-root/lightspeed-stack.yaml}"
 
+# Copy read-only e2e FAISS fixtures to a writable work path (OGX writes on register).
+# cp preserves source mode, so chmod so the work copy stays owner-writable.
+RAG_SEED_DIR="${RAG_SEED_DIR:-/opt/app-root/src/.llama/storage/.e2e-rag-seed}"
+KV_RAG_PATH="${KV_RAG_PATH:-/tmp/e2e-rag-work/kv_store.db}"
+PDF_KV_RAG_PATH="${PDF_KV_RAG_PATH:-/tmp/e2e-rag-work/pdf_kv_store.db}"
+
+if [ -d "$RAG_SEED_DIR" ]; then
+    mkdir -p "$(dirname "$KV_RAG_PATH")" "$(dirname "$PDF_KV_RAG_PATH")"
+    if [ -f "$RAG_SEED_DIR/kv_store.db" ]; then
+        cp -f "$RAG_SEED_DIR/kv_store.db" "$KV_RAG_PATH"
+        chmod u+w "$KV_RAG_PATH"
+    fi
+    if [ -f "$RAG_SEED_DIR/pdf_kv_store.db" ]; then
+        cp -f "$RAG_SEED_DIR/pdf_kv_store.db" "$PDF_KV_RAG_PATH"
+        chmod u+w "$PDF_KV_RAG_PATH"
+    fi
+fi
+
 # Enrich config if lightspeed config exists
 if [ -f "$LIGHTSPEED_CONFIG" ]; then
     echo "Enriching llama-stack config..."

--- a/tests/e2e/features/steps/common.py
+++ b/tests/e2e/features/steps/common.py
@@ -8,7 +8,6 @@ from behave.runner import Context
 
 from tests.e2e.utils.utils import (
     absolute_repo_path,
-    clear_llama_stack_storage,
     create_config_backup,
     is_prow_environment,
     restart_container,
@@ -171,20 +170,16 @@ def configure_service(context: Context, config_name: str) -> None:
 @given("MCP configuration is reset for a new scenario")
 @given("MCP toolgroups are reset for a new MCP configuration")
 def reset_mcp_configuration_for_new_scenario(context: Context) -> None:
-    """Reset MCP-related state before applying a different MCP config.
+    """Force a Lightspeed restart before applying a different MCP config.
 
-    Llama Stack 0.7 no longer registers MCP servers as toolgroups. In library
-    mode, clear embedded Llama Stack storage so the next config applies cleanly.
-    In server mode, only force a Lightspeed restart on the next config apply.
-
-    Sets ``force_lightspeed_restart_after_mcp_config_reset`` so the next
+    MCP servers live in Lightspeed configuration only (not OGX toolgroups), so a
+    process restart is enough to load the next per-auth YAML. Sets
+    ``force_lightspeed_restart_after_mcp_config_reset`` so the next
     ``The service uses ...`` step cannot skip ``The service is restarted`` when
     the YAML basename is unchanged.
     """
     context.force_lightspeed_restart_after_mcp_config_reset = True
     context.lightspeed_stack_skip_restart = False
-    if context.is_library_mode:
-        clear_llama_stack_storage()
 
 
 @given("The service is restarted")

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -417,37 +417,6 @@ def remove_config_backup(backup_path: str) -> None:
             print(f"Warning: Could not remove backup file {backup_path}: {e}")
 
 
-def clear_llama_stack_storage(container_name: str = "lightspeed-stack") -> None:
-    """Clear Llama Stack storage in library mode (embedded Llama Stack).
-
-    Removes the ~/.llama directory so embedded Llama Stack persisted state is
-    reset. Used before MCP config scenarios in library mode.
-    Only runs when using Docker (skipped in Prow).
-
-    Parameters:
-    ----------
-        container_name (str): Docker container name (default "lightspeed-stack").
-
-    Returns:
-    -------
-        None
-    """
-    if is_prow_environment():
-        return
-
-    try:
-        subprocess.run(
-            ["docker", "exec", container_name, "sh", "-c", "rm -rf ~/.llama"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as e:
-        print(f"Failed to clear Llama Stack storage: {e}")
-        raise
-
-
 def restart_container(container_name: str) -> None:
     """Restart a Docker container by name and wait until it is healthy.
 


### PR DESCRIPTION
## Description

Prevent e2e FAISS fixtures from being used as the live OGX vector DB. Mount them read-only as a seed, copy into a writable work path (`KV_RAG_PATH` under `/tmp`) on container start, and point docker-compose at that copy so `register_vector_store` cannot empty the committed fixture (server-mode inline RAG).

Also drop the obsolete `rm -rf ~/.llama` MCP reset wipe; MCP lives in Lightspeed config only, and a forced Lightspeed restart is enough between per-auth MCP YAMLs.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue # 
- Closes # https://redhat.atlassian.net/browse/LCORE-3653

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- Server mode: start stack via `docker-compose.yaml`, confirm entrypoint copies seed → `/tmp/e2e-rag-work/`, run `inline_rag.feature` (and restart container once to confirm RAG still works).
- Library mode: same with `docker-compose-library.yaml`.
- MCP: run `mcp.feature` scenarios that switch per-auth configs; confirm forced restart still applies without wiping FAISS.