### PR TITLE
LCORE-2547: address OGX rename review findings

### DIFF
--- a/docs/design/ogx-config-merge/ogx-config-merge-spike.md
+++ b/docs/design/ogx-config-merge/ogx-config-merge-spike.md
@@ -200,7 +200,7 @@ backend-specific synthesizer translates the canonical LCORE vocabulary to
 its target shape; we do not adopt either backend's surface verbatim.
 
 **Pydantic AI research findings** (full report:
-[`pydantic-ai-research.md`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/ogx-config-merge/poc-results/pydantic-ai-research.md),
+[`pydantic-ai-research.md`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/llama-stack-config-merge/poc-results/pydantic-ai-research.md),
 pass dated 2026-05-20 against `pydantic-ai 1.98.0`):
 
 - Pydantic AI's per-Agent `<provider>:<model>` string + `Provider(...)`
@@ -884,13 +884,13 @@ removed from the tree after merge (PoC validation results aren't kept on
 `main`); the links below are permalinks to the files at the merge commit,
 where they remain in history:
 
-- [`lightspeed-stack-unified-library.yaml`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/ogx-config-merge/poc-results/lightspeed-stack-unified-library.yaml)
+- [`lightspeed-stack-unified-library.yaml`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/llama-stack-config-merge/poc-results/lightspeed-stack-unified-library.yaml)
   — the unified-mode config used.
-- [`library-mode/synthesized-run.yaml`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/ogx-config-merge/poc-results/library-mode/synthesized-run.yaml)
+- [`library-mode/synthesized-run.yaml`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/llama-stack-config-merge/poc-results/library-mode/synthesized-run.yaml)
   — what LCORE produced (3.7 KB).
-- [`library-mode/query-response.json`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/ogx-config-merge/poc-results/library-mode/query-response.json)
+- [`library-mode/query-response.json`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/llama-stack-config-merge/poc-results/library-mode/query-response.json)
   — a real `/v1/query` round-trip.
-- [`library-mode/README.md`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/ogx-config-merge/poc-results/library-mode/README.md)
+- [`library-mode/README.md`](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/llama-stack-config-merge/poc-results/library-mode/README.md)
   — walkthrough.
 
 Summary of validation:
@@ -943,7 +943,7 @@ Summary of validation:
   query. The implementation JIRAs' e2e coverage must exercise a real
   Llama Guard model (e.g. `meta-llama/Llama-Guard-3-8B`) end-to-end.
   Caught by CodeRabbit on the PoC artifact at
-  [`synthesized-run.yaml` L110](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/ogx-config-merge/poc-results/library-mode/synthesized-run.yaml#L110).
+  [`synthesized-run.yaml` L110](https://github.com/lightspeed-core/lightspeed-stack/blob/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/llama-stack-config-merge/poc-results/library-mode/synthesized-run.yaml#L110).
 
 ---
 
@@ -1175,7 +1175,7 @@ adjust it for your environment before running.)
 # 0. Fetch the PoC config from the merge commit (removed from the tree post-merge)
 mkdir -p /tmp/lcore-836-poc
 curl -sSL -o /tmp/lcore-836-poc/lightspeed-stack-unified-library.yaml \
-  https://raw.githubusercontent.com/lightspeed-core/lightspeed-stack/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/ogx-config-merge/poc-results/lightspeed-stack-unified-library.yaml
+  https://raw.githubusercontent.com/lightspeed-core/lightspeed-stack/42844d068b488cc7d72928068b5606a7941f8c15/docs/design/llama-stack-config-merge/poc-results/lightspeed-stack-unified-library.yaml
 
 # 1. Start LCORE in library mode with the unified config
 export OPENAI_API_KEY=<your-key>

--- a/docs/design/prompt-guardrails/prompt-guardrails-spike.md
+++ b/docs/design/prompt-guardrails/prompt-guardrails-spike.md
@@ -404,7 +404,7 @@ refusals. Every hard part of LCORE-230 is precisely what it does not do,
 and LCS's own capabilities are better fitted on all five axes (real LLM
 detector, refusal-string semantics, true redaction, careful multimodal
 handling, Pydantic config). This also matches the precedent already set
-in `docs/design/ogx-config-merge/ogx-config-merge-spike.md:220`
+in `docs/design/ogx-config-merge/ogx-config-merge-spike.md#decision-s5-where-do-backend-agnostic-high-level-keys-sit`
 ("Do not preemptively abstract `safety.*`").
 
 **Already taken from it**: the `AsyncGuardrail` blocking/concurrent/

--- a/docs/devel_doc/openapi.json
+++ b/docs/devel_doc/openapi.json
@@ -16076,7 +16076,7 @@
                 "additionalProperties": false,
                 "type": "object",
                 "title": "OgxConfiguration",
-                "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://ogx-ai.github.io/)\n  - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)\n  - [Build AI Applications with OGX](https://ogx-ai.github.io/)"
+                "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://ogx-ai.github.io/)\n  - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)\n  - [Build AI Applications with OGX](https://ogx-ai.github.io/docs/building_applications)"
             },
             "OkpConfiguration": {
                 "properties": {

--- a/docs/devel_doc/openapi.md
+++ b/docs/devel_doc/openapi.md
@@ -260,7 +260,7 @@ Lightspeed Core Stack (LCS) service API specification.
     * [JwtConfiguration](#jwtconfiguration)
     * [JwtRoleRule](#jwtrolerule)
     * [LivenessResponse](#livenessresponse)
-    * [LlamaStackConfiguration](#llamastackconfiguration)
+    * [OgxConfiguration](#ogxconfiguration)
     * [MCPClientAuthOptionsResponse](#mcpclientauthoptionsresponse)
     * [MCPListToolsTool](#mcplisttoolstool)
     * [MCPServerAuthInfo](#mcpserverauthinfo)
@@ -6728,7 +6728,7 @@ Attributes:
 | alive | boolean | Flag indicating that the app is alive |
 
 
-## LlamaStackConfiguration
+## OgxConfiguration
 
 
 OGX configuration.
@@ -6742,7 +6742,7 @@ Useful resources:
 
   - [OGX](https://ogx-ai.github.io/)
   - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)
-  - [Build AI Applications with OGX](https://ogx-ai.github.io/)
+  - [Build AI Applications with OGX](https://ogx-ai.github.io/docs/building_applications)
 
 
 | Field | Type | Description |

--- a/docs/migrations/v0.7.0.md
+++ b/docs/migrations/v0.7.0.md
@@ -10,8 +10,9 @@
 ## OGX naming (`llama_stack` → `ogx`)
 
 In v0.7.0, Lightspeed Core Stack adopts `ogx` as the canonical name for the
-OGX configuration section and related API fields. The old `llama_stack` names
-remain available as **deprecated aliases** with a startup warning.
+OGX configuration section in `lightspeed-stack.yaml`. The deprecated
+`llama_stack:` top-level YAML key remains accepted with a startup warning.
+API response fields were renamed without backward-compatible aliases.
 
 ### Configuration YAML
 
@@ -51,9 +52,13 @@ Migrate configs to `ogx:` when convenient.
 
 ### `/info` API
 
+The `/info` response field was renamed; the old name is not returned:
+
 | v0.6.x | v0.7.0 |
 |---|---|
 | `llama_stack_version` | `ogx_version` |
+
+Update clients that read `/info` to use `ogx_version`.
 
 ---
 

--- a/docs/user_doc/config.html
+++ b/docs/user_doc/config.html
@@ -1220,7 +1220,7 @@ Web Tokens</a>
         </tr>
       </tbody>
     </table>
-    <h2 id="llamastackconfiguration">LlamaStackConfiguration</h2>
+    <h2 id="ogxconfiguration">OgxConfiguration</h2>
     <p>OGX configuration.</p>
     <p>OGX is a comprehensive system that provides a uniform set of
 tools for building, scaling, and deploying generative AI applications,
@@ -1229,15 +1229,14 @@ services and capabilities into an adaptable setup.</p>
     <p>Useful resources:</p>
     <ul>
       <li>
-        <a href="https://ogx-ai.github.io/">Llama
-Stack</a>
+        <a href="https://ogx-ai.github.io/">OGX</a>
       </li>
       <li>
         <a href="https://github.com/ogx-ai/ogx-client-python">Python
 OGX client</a>
       </li>
       <li>
-        <a href="https://ogx-ai.github.io/">Build AI Applications with
+        <a href="https://ogx-ai.github.io/docs/building_applications">Build AI Applications with
 OGX</a>
       </li>
     </ul>
@@ -2690,7 +2689,7 @@ provider&#x2019;s config block.</td>
         </tr>
       </tbody>
     </table>
-    <h2 id="unifiedllamastackconfig">UnifiedLlamaStackConfig</h2>
+    <h2 id="unifiedogxconfig">UnifiedOgxConfig</h2>
     <p>Backend-specific knobs for unified-mode OGX synthesis.</p>
     <p>Per Decision S5 of the design spike, backend-agnostic high-level
 sections (inference, &#x2026;) live at the configuration root, not here. This

--- a/docs/user_doc/config.json
+++ b/docs/user_doc/config.json
@@ -449,7 +449,7 @@
             "title": "Service configuration"
           },
           "ogx": {
-            "$ref": "`#/components/schemas/`LlamaStackConfiguration",
+            "$ref": "`#/components/schemas/`OgxConfiguration",
             "description": "This section contains OGX configuration. Lightspeed Core Stack service can call OGX in library mode or in server mode.",
             "title": "OGX configuration"
           },
@@ -1037,9 +1037,9 @@
         "title": "JwtRoleRule",
         "type": "object"
       },
-      "LlamaStackConfiguration": {
+      "OgxConfiguration": {
         "additionalProperties": false,
-        "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://ogx-ai.github.io/)\n  - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)\n  - [Build AI Applications with OGX](https://ogx-ai.github.io/)",
+        "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://ogx-ai.github.io/)\n  - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)\n  - [Build AI Applications with OGX](https://ogx-ai.github.io/docs/building_applications)",
         "properties": {
           "url": {
             "type": "string",
@@ -1100,7 +1100,7 @@
           "config": {
             "anyOf": [
               {
-                "$ref": "`#/components/schemas/`UnifiedLlamaStackConfig"
+                "$ref": "`#/components/schemas/`UnifiedOgxConfig"
               },
               {
                 "type": "null"
@@ -1111,7 +1111,7 @@
             "title": "Unified OGX configuration"
           }
         },
-        "title": "LlamaStackConfiguration",
+        "title": "OgxConfiguration",
         "type": "object"
       },
       "ModelContextProtocolServer": {
@@ -2247,7 +2247,7 @@
         "title": "UnifiedInferenceProvider",
         "type": "object"
       },
-      "UnifiedLlamaStackConfig": {
+      "UnifiedOgxConfig": {
         "additionalProperties": false,
         "description": "Backend-specific knobs for unified-mode OGX synthesis.\n\nPer Decision S5 of the design spike, backend-agnostic high-level sections\n(inference, ...) live at the configuration root, not here. This block holds\nonly the Llama-Stack-specific synthesis controls: which baseline to start\nfrom, an optional profile file, and a raw native_override escape hatch.\n\nAttributes:\n    baseline: Synthesis starting point. \"default\" begins from LCORE's\n        built-in baseline (src/data/default_run.yaml); \"empty\" begins from\n        an empty dict (used by the migration tool for an exact round-trip).\n        Ignored when `profile` is set.\n    profile: Optional path to a user-authored run.yaml-shaped file used as\n        the synthesis baseline. Relative paths resolve against the directory\n        of the loaded lightspeed-stack.yaml.\n    native_override: Raw OGX schema deep-merged last (maps merge\n        recursively, lists and scalars replace). The escape hatch for\n        anything the high-level sections do not express.",
         "properties": {
@@ -2276,7 +2276,7 @@
             "type": "object"
           }
         },
-        "title": "UnifiedLlamaStackConfig",
+        "title": "UnifiedOgxConfig",
         "type": "object"
       },
       "UserDataCollection": {

--- a/docs/user_doc/config.md
+++ b/docs/user_doc/config.md
@@ -432,7 +432,7 @@ Rule for extracting roles from JWT claims.
 | roles    | array   | Roles to be assigned if the rule matches                |
 
 
-## LlamaStackConfiguration
+## OgxConfiguration
 
 
 OGX configuration.
@@ -446,7 +446,7 @@ Useful resources:
 
   - [OGX](https://ogx-ai.github.io/)
   - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)
-  - [Build AI Applications with OGX](https://ogx-ai.github.io/)
+  - [Build AI Applications with OGX](https://ogx-ai.github.io/docs/building_applications)
 
 
 | Field                      | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
@@ -1036,7 +1036,7 @@ Attributes:
 | extra          | object | Additional provider-config keys merged verbatim into the synthesized provider's config block.                                                                                                                                                             |
 
 
-## UnifiedLlamaStackConfig
+## UnifiedOgxConfig
 
 
 Backend-specific knobs for unified-mode OGX synthesis.

--- a/src/lightspeed_stack.py
+++ b/src/lightspeed_stack.py
@@ -32,10 +32,10 @@ def create_argument_parser() -> ArgumentParser:
                       error_responses,common,agents,common_responses}
                       dump schemas for selected models group into OpenAPI-compatible file and quit
     - -c / --config: path to the configuration file (default "lightspeed-stack.yaml")
-    - -g / --generate-ogx-configuration: generate an OGX
-                                                 configuration from the service configuration
-    - -i / --input-config-file: OGX input configuration filename (default "run.yaml")
-    - -o / --output-config-file: OGX output configuration filename (default "run_.yaml")
+    - --synthesized-config-output: path for synthesized OGX run.yaml in unified library mode
+    - --migrate-config: migrate legacy two-file config to unified single file and exit
+    - --run-yaml: legacy OGX run.yaml path (with --migrate-config)
+    - --migrate-output: unified config output path (with --migrate-config)
 
     Returns:
         Configured ArgumentParser for parsing the service CLI options.
@@ -154,8 +154,7 @@ def main() -> None:
       the quota scheduler, and starts the Uvicorn web service.
 
     Raises:
-        SystemExit: when configuration dumping or OGX generation fails
-                    (exits with status 1).
+        SystemExit: when configuration dumping or migration fails (exits with status 1).
     """
     logger.info("Lightspeed Core Stack startup")
     parser = create_argument_parser()

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -854,7 +854,7 @@ class OgxConfiguration(ConfigurationBase):
 
       - [OGX](https://ogx-ai.github.io/)
       - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)
-      - [Build AI Applications with OGX](https://ogx-ai.github.io/)
+      - [Build AI Applications with OGX](https://ogx-ai.github.io/docs/building_applications)
     """
 
     url: Optional[AnyHttpUrl] = Field(

--- a/tests/unit/utils/dumpers/test_models_dumper.py
+++ b/tests/unit/utils/dumpers/test_models_dumper.py
@@ -2887,7 +2887,7 @@ def test_dump_models(tmpdir: Path) -> None:
                 },
                 "OgxConfiguration": {
                     "additionalProperties": false,
-                    "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://ogx-ai.github.io/)\n  - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)\n  - [Build AI Applications with OGX](https://ogx-ai.github.io/)",
+                    "description": "OGX configuration.\n\nOGX is a comprehensive system that provides a uniform set of tools\nfor building, scaling, and deploying generative AI applications, enabling\ndevelopers to create, integrate, and orchestrate multiple AI services and\ncapabilities into an adaptable setup.\n\nUseful resources:\n\n  - [OGX](https://ogx-ai.github.io/)\n  - [Python OGX client](https://github.com/ogx-ai/ogx-client-python)\n  - [Build AI Applications with OGX](https://ogx-ai.github.io/docs/building_applications)",
                     "properties": {
                         "url": {
                             "type": "string",


### PR DESCRIPTION
## Description

Follow-up fixes from the LCORE-2547 OGX rename review: correct broken PoC permalinks in the config-merge spike (`llama-stack-config-merge` path at merge SHA), fix published schema naming (`OgxConfiguration` / `UnifiedOgxConfig`), update the `building_applications` resource link, clarify v0.7.0 migration notes (`llama_stack:` YAML alias only; `/info` field rename is breaking), fix the prompt-guardrails cross-reference anchor, and align the stale `lightspeed_stack.py` CLI docstring with actual flags.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [x] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-2547
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

- `uv run black --check src tests`
- `uv run make verify`
- `uv run make test-unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated configuration terminology throughout the documentation and schemas to use “OGX,” including `OgxConfiguration` and `UnifiedOgxConfig`.
  - Updated links to point directly to the OGX application-building documentation.
  - Clarified configuration migration guidance, including the deprecated `llama_stack` alias and updated `/info` response.
  - Replaced fixed line references with stable heading links.
- **CLI**
  - Replaced legacy configuration-generation options with unified-configuration migration and synthesized-output options.
  - Updated migration error descriptions for clearer messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->