### PR TITLE
LCORE-3883: persist compacted-mode turns on query, streaming and A2A

### DIFF
--- a/src/app/endpoints/a2a.py
+++ b/src/app/endpoints/a2a.py
@@ -60,9 +60,14 @@ from configuration import configuration
 from constants import MEDIA_TYPE_EVENT_STREAM
 from log import get_logger
 from models.api.requests import QueryRequest
+from models.common.responses.responses_api_params import ResponsesApiParams
 from models.config import Action
 from utils.agents.error_handler import map_agent_inference_error
-from utils.conversation_compaction import apply_compaction_blocking
+from utils.conversation_compaction import (
+    CompactionResult,
+    apply_compaction_blocking,
+    store_compacted_turn,
+)
 from utils.mcp_headers import McpHeaders, mcp_headers_dependency
 from utils.otel_tracing import (
     SpanAttributes,
@@ -71,7 +76,7 @@ from utils.otel_tracing import (
     anonymize_value,
     set_span_attributes,
 )
-from utils.pydantic_ai_helpers import build_agent
+from utils.pydantic_ai_helpers import build_agent, captured_output_items
 from utils.query import extract_provider_and_model_from_model_id
 from utils.responses import prepare_responses_params
 from utils.suid import normalize_conversation_id
@@ -199,6 +204,46 @@ def _record_execution_span(
         output_text = run_result.response.text
         if output_text:
             span.set_attribute(SpanAttributes.OUTPUT, anonymize_value(output_text))
+
+
+async def _persist_compacted_a2a_turn(
+    client: Any,
+    responses_params: ResponsesApiParams,
+    compaction: CompactionResult,
+    agent: Any,
+    task_id: str,
+) -> None:
+    """Append a completed compacted A2A turn to the conversation (LCORE-3883).
+
+    In compacted mode the ``conversation`` parameter is not sent, so OGX does
+    not store the turn and lightspeed-stack must append it itself, keeping the
+    recent-turn buffer and audit history intact for the next turn in this A2A
+    context.
+
+    Parameters:
+        client: OGX client used to write the conversation items.
+        responses_params: Prepared Responses API parameters.
+        compaction: Outcome of applying compaction. Nothing is written unless
+            the request was served in compacted mode.
+        agent: The pydantic-ai agent whose model captured the output items.
+        task_id: A2A task identifier, used for error reporting.
+    """
+    if not compaction.compacted or compaction.original_input is None:
+        return
+    try:
+        await store_compacted_turn(
+            client,
+            responses_params.conversation,
+            compaction.original_input,
+            captured_output_items(agent),
+        )
+    except Exception:  # pylint: disable=broad-except
+        # The caller already has its answer; the cost of the failure is that the
+        # next turn in this context loses this one.
+        logger.exception(
+            "Failed to append compacted turn to conversation for A2A task %s",
+            task_id,
+        )
 
 
 class TaskResultAggregator:
@@ -528,6 +573,10 @@ class A2AAgentExecutor(AgentExecutor):
                     final=True,
                 )
                 return
+
+            await _persist_compacted_a2a_turn(
+                client, responses_params, compaction, agent, task_id
+            )
 
             _record_execution_span(span, self._tool_call_names, self._run_result)
 

--- a/src/pydantic_ai_lightspeed/ogx/_model.py
+++ b/src/pydantic_ai_lightspeed/ogx/_model.py
@@ -20,7 +20,7 @@ from the include parameter, which OGX / OGX doesn't support.
 from __future__ import annotations as _annotations
 
 from collections import defaultdict
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import Any, Final, Optional, cast
 
@@ -118,13 +118,22 @@ class _FilteredResponseStream:
     a closing ``}`` to complete the outer JSON object that pydantic_ai opens.
     """
 
-    def __init__(self, source: AsyncStream[responses.ResponseStreamEvent]) -> None:
+    def __init__(
+        self,
+        source: AsyncStream[responses.ResponseStreamEvent],
+        on_completed: Optional[Callable[[Any], None]] = None,
+    ) -> None:
         """Wrap an existing stream with reordering logic.
 
         Args:
             source: The raw OpenAI AsyncStream to reorder.
+            on_completed: Optional callback invoked with the final response
+                object when OGX emits ``response.completed``. Used to capture
+                the structured output items for compacted-mode persistence
+                (LCORE-3883).
         """
         self._source = source
+        self._on_completed = on_completed
         self._announced_item_ids: set[str] = set()
         self._buffered_deltas: dict[
             str, list[responses.ResponseFunctionCallArgumentsDeltaEvent]
@@ -143,6 +152,10 @@ class _FilteredResponseStream:
     ) -> AsyncIterator[responses.ResponseStreamEvent]:
         """Yield events, buffering early argument deltas until their item is announced."""
         async for event in self._source:
+            if self._on_completed is not None and isinstance(
+                event, responses.ResponseCompletedEvent
+            ):
+                self._on_completed(event.response)
             if isinstance(event, responses.ResponseOutputItemAddedEvent):
                 if (
                     isinstance(event.item, responses.ResponseFunctionToolCall)
@@ -244,6 +257,37 @@ class OgxResponsesModel(OpenAIResponsesModel):
     OGX doesn't support it.
     """
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize the model and its per-request output-item capture.
+
+        Args:
+            *args: Positional arguments forwarded to ``OpenAIResponsesModel``.
+            **kwargs: Keyword arguments forwarded to ``OpenAIResponsesModel``.
+        """
+        super().__init__(*args, **kwargs)
+        self._last_output_items: list[Any] = []
+
+    @property
+    def last_output_items(self) -> list[Any]:
+        """Structured output items from the most recent Responses API call.
+
+        Captured verbatim from the OGX response so that compacted-mode turn
+        persistence stores exactly what OGX would have stored itself, rather
+        than a reconstruction mapped back from pydantic-ai messages
+        (LCORE-3883). Empty until a response completes.
+        """
+        return getattr(self, "_last_output_items", [])
+
+    def _capture_output_items(self, response: Any) -> None:
+        """Record the structured output items of a completed response.
+
+        Args:
+            response: The OGX Responses API object for the completed call.
+        """
+        items = getattr(response, "output", None)
+        if items:
+            self._last_output_items = list(items)
+
     async def _responses_create(
         self,
         messages: list[ModelMessage],
@@ -276,12 +320,14 @@ class OgxResponsesModel(OpenAIResponsesModel):
                 model_settings,
                 model_request_parameters,
             )
-        return await super()._responses_create(
+        response = await super()._responses_create(
             messages,
             False,
             model_settings,
             model_request_parameters,
         )
+        self._capture_output_items(response)
+        return response
 
     async def request(  # pylint: disable=unused-argument
         self,
@@ -406,7 +452,9 @@ class OgxResponsesModel(OpenAIResponsesModel):
             messages, True, model_settings_cast, model_request_parameters
         )
 
-        filtered_stream = _FilteredResponseStream(response)
+        filtered_stream = _FilteredResponseStream(
+            response, on_completed=self._capture_output_items
+        )
 
         async with response:
             peekable: PeekableAsyncStream[

--- a/src/utils/agents/query.py
+++ b/src/utils/agents/query.py
@@ -39,6 +39,7 @@ from utils.agents.tool_processor import (
 from utils.conversation_compaction import (
     agent_prompt_text,
     reject_image_attachments_in_compacted_mode,
+    store_compacted_turn,
 )
 from utils.conversations import append_turn_items_to_conversation
 from utils.otel_tracing import (
@@ -47,7 +48,7 @@ from utils.otel_tracing import (
     add_span_event,
     set_span_attributes,
 )
-from utils.pydantic_ai_helpers import build_agent
+from utils.pydantic_ai_helpers import build_agent, captured_output_items
 from utils.query import (
     build_multimodal_input,
     extract_provider_and_model_from_model_id,
@@ -237,7 +238,7 @@ async def retrieve_agent_response(
     responses_params: ResponsesApiParams,
     moderation_result: ShieldModerationResult,
     endpoint_path: str,
-    _original_input: Optional[ResponseInput] = None,
+    original_input: Optional[ResponseInput] = None,
     no_tools: bool = False,
     image_attachments: Optional[list[Attachment]] = None,
     shield_ids: Optional[list[str]] = None,
@@ -249,7 +250,9 @@ async def retrieve_agent_response(
         responses_params: Prepared Responses API parameters.
         moderation_result: Shield moderation outcome for the turn.
         endpoint_path: Endpoint path used for metric labeling.
-        _original_input: Original user input before the explicit-input rewrite.
+        original_input: Original user input before the explicit-input rewrite.
+            Set only in compacted mode; when set, the completed turn is
+            appended to the conversation explicitly (LCORE-3883).
         no_tools: Whether to skip tool processing.
         image_attachments: Image attachments for multimodal prompt construction.
         shield_ids: Optional list of shield names to run for this turn, mirroring
@@ -334,8 +337,22 @@ async def retrieve_agent_response(
             vector_store_ids=vector_store_ids,
             rag_id_mapping=rag_id_mapping,
         )
+        # Capture the structured output items OGX returned so compacted mode can
+        # persist the turn exactly as OGX would have (LCORE-3883).
+        turn_summary.output_items = captured_output_items(agent)
 
         # Emit inference completed event after successful summary build
         add_span_event(span, SpanEvents.LLM_INFERENCE_COMPLETED)
+
+        # In compacted mode the conversation parameter was not sent, so OGX did
+        # not persist this turn. Append it ourselves to keep the recent-turn
+        # buffer and the audit history intact for the next request (LCORE-3883).
+        if original_input is not None:
+            await store_compacted_turn(
+                client,
+                responses_params.conversation,
+                original_input,
+                turn_summary.output_items,
+            )
 
         return turn_summary

--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -63,6 +63,7 @@ from utils.agents.tool_processor import (
 from utils.conversation_compaction import (
     agent_prompt_text,
     reject_image_attachments_in_compacted_mode,
+    store_compacted_turn,
 )
 from utils.conversations import append_turn_items_to_conversation
 from utils.otel_tracing import (
@@ -72,7 +73,7 @@ from utils.otel_tracing import (
     anonymize_value,
     set_span_attributes,
 )
-from utils.pydantic_ai_helpers import build_agent
+from utils.pydantic_ai_helpers import build_agent, captured_output_items
 from utils.query import (
     build_multimodal_input,
     consume_query_tokens,
@@ -163,6 +164,47 @@ async def retrieve_agent_response_generator(
     except (AgentRunError, ApiException, RuntimeError) as exc:
         response = map_agent_inference_error(exc, responses_params.model)
         raise HTTPException(**response.model_dump()) from exc
+
+
+async def _persist_compacted_turn(
+    context: ResponseGeneratorContext,
+    responses_params: ResponsesApiParams,
+    turn_summary: TurnSummary,
+    original_input: Optional[ResponseInput],
+    persist_guard: list[bool],
+) -> None:
+    """Append a completed compacted turn to the conversation (LCORE-3883).
+
+    In compacted mode the ``conversation`` parameter is not sent, so OGX does
+    not store the turn and lightspeed-stack must append it itself, keeping the
+    recent-turn buffer and the audit history intact for the next request.
+
+    Parameters:
+        context: Streaming request context, providing the OGX client.
+        responses_params: Prepared Responses API parameters.
+        turn_summary: Completed turn, carrying the captured output items.
+        original_input: The user input before the explicit-input rewrite. When
+            ``None`` the request was not compacted and nothing is written.
+        persist_guard: Single-element flag shared with the interrupt path, so a
+            turn is persisted at most once.
+    """
+    if original_input is None or persist_guard[0]:
+        return
+    persist_guard[0] = True
+    try:
+        await store_compacted_turn(
+            context.client,
+            responses_params.conversation,
+            original_input,
+            turn_summary.output_items,
+        )
+    except Exception:  # pylint: disable=broad-except
+        # The client already has its answer, so the stream still succeeds; the
+        # cost of the failure is that the next request loses this turn.
+        logger.exception(
+            "Failed to append compacted turn to conversation for request %s",
+            context.request_id,
+        )
 
 
 async def generate_agent_response(  # pylint: disable=too-many-statements
@@ -263,6 +305,10 @@ async def generate_agent_response(  # pylint: disable=too-many-statements
         if root_span is not None:
             root_span.end()
         return
+
+    await _persist_compacted_turn(
+        context, responses_params, turn_summary, original_input, persist_guard
+    )
 
     should_generate_topic_summary = (
         context.query_request.conversation_id is None
@@ -404,6 +450,10 @@ async def agent_response_generator(
         async for event in stream:
             if payload := dispatch_stream_event(event, dispatch_state):
                 yield serialize_event(payload, media_type)
+
+    # Capture the structured output items OGX returned so compacted mode can
+    # persist the turn exactly as OGX would have (LCORE-3883).
+    turn_summary.output_items = captured_output_items(agent)
 
     if dispatch_state.run_result is None:
         logger.error("No final result received from agent run")

--- a/src/utils/pydantic_ai_helpers.py
+++ b/src/utils/pydantic_ai_helpers.py
@@ -12,6 +12,7 @@ from pydantic_ai.capabilities import AbstractCapability, AgentCapability
 from pydantic_ai_skills import SkillsCapability
 
 from configuration import AppConfig
+from log import get_logger
 from models.common.responses.responses_api_params import ResponsesApiParams
 from models.common.skills import SkillMetadata
 from models.common.tools import CatalogTool, CatalogToolParameter
@@ -212,6 +213,38 @@ def _agent_capabilities(
             )
         ]
     return capabilities or None
+
+
+logger = get_logger(__name__)
+
+
+def captured_output_items(agent: Any) -> list[Any]:
+    """Return the structured output items captured from the last OGX call.
+
+    In compacted mode the ``conversation`` parameter is not sent, so OGX does
+    not persist the turn and lightspeed-stack must append it itself. The items
+    are captured verbatim from the OGX response by
+    :class:`OgxResponsesModel`, so the stored turn matches what OGX would have
+    stored (LCORE-3883).
+
+    Parameters:
+        agent: The pydantic-ai agent whose model performed the call.
+
+    Returns:
+        The captured output items, or an empty list when the model did not
+        capture any (for example a non-OGX model in a test double).
+    """
+    model = getattr(agent, "model", None)
+    items = getattr(model, "last_output_items", None)
+    if not isinstance(items, list):
+        # Either the model captured nothing yet, or it is not an
+        # OgxResponsesModel (a test double, or a future backend). Persisting an
+        # empty output is preferable to raising on an otherwise good turn.
+        logger.debug(
+            "No captured output items available from model %s", type(model).__name__
+        )
+        return []
+    return list(items)
 
 
 def build_agent(

--- a/tests/unit/pydantic_ai_lightspeed/ogx/test_model.py
+++ b/tests/unit/pydantic_ai_lightspeed/ogx/test_model.py
@@ -846,3 +846,95 @@ class TestFilteredResponseStream:
         result = [e async for e in stream]
 
         assert result == [announcement, delta]
+
+
+class TestOutputItemCapture:
+    """Capture of OGX output items for compacted-mode persistence (LCORE-3883)."""
+
+    @staticmethod
+    def _completed_event(text: str) -> responses.ResponseCompletedEvent:
+        """Build a ``response.completed`` event carrying one output message."""
+        return responses.ResponseCompletedEvent(
+            response=responses.Response(
+                id="resp-1",
+                created_at=0,
+                model="test",
+                object="response",
+                output=[
+                    responses.ResponseOutputMessage(
+                        id="msg-1",
+                        type="message",
+                        role="assistant",
+                        status="completed",
+                        content=[
+                            responses.ResponseOutputText(
+                                type="output_text", text=text, annotations=[]
+                            )
+                        ],
+                    )
+                ],
+                parallel_tool_calls=False,
+                tool_choice="auto",
+                tools=[],
+                status="completed",
+            ),
+            sequence_number=0,
+            type="response.completed",
+        )
+
+    def test_last_output_items_is_empty_before_any_call(self) -> None:
+        """A fresh model has captured nothing."""
+        model = OgxResponsesModel.__new__(OgxResponsesModel)
+
+        assert not model.last_output_items
+
+    def test_capture_records_output_items_verbatim(self) -> None:
+        """Captured items are the OGX objects themselves, not a reconstruction."""
+        model = OgxResponsesModel.__new__(OgxResponsesModel)
+        response = self._completed_event("hello").response
+
+        model._capture_output_items(response)  # pylint: disable=protected-access
+
+        assert model.last_output_items == list(response.output)
+        assert model.last_output_items[0] is response.output[0]
+
+    def test_capture_ignores_a_response_without_output(self) -> None:
+        """An empty output must not clobber previously captured items."""
+        model = OgxResponsesModel.__new__(OgxResponsesModel)
+        response = self._completed_event("hello").response
+        model._capture_output_items(response)  # pylint: disable=protected-access
+
+        empty = self._completed_event("hello").response
+        empty.output = []
+        model._capture_output_items(empty)  # pylint: disable=protected-access
+
+        assert len(model.last_output_items) == 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_captures_on_completed_event(
+        self, mocker: MockerFixture
+    ) -> None:
+        """The filtered stream hands the completed response to the callback."""
+        captured: list[Any] = []
+        event = self._completed_event("streamed answer")
+        source = mocker.Mock()
+        source.__aiter__ = lambda _: _async_iter([event])
+
+        stream = _FilteredResponseStream(source, on_completed=captured.append)
+        result = [e async for e in stream]
+
+        assert result == [event]
+        assert captured == [event.response]
+
+    @pytest.mark.asyncio
+    async def test_filtered_stream_without_callback_still_works(
+        self, mocker: MockerFixture
+    ) -> None:
+        """The callback is optional, so existing callers are unaffected."""
+        event = self._completed_event("x")
+        source = mocker.Mock()
+        source.__aiter__ = lambda _: _async_iter([event])
+
+        stream = _FilteredResponseStream(source)
+
+        assert [e async for e in stream] == [event]

--- a/tests/unit/utils/agents/test_query.py
+++ b/tests/unit/utils/agents/test_query.py
@@ -664,3 +664,94 @@ class TestRetrieveAgentResponse:
             )
 
         assert exc_info.value.status_code == 429
+
+
+class TestQueryCompactedTurnPersistence:
+    """Compacted-mode turn persistence on /v1/query (LCORE-3883).
+
+    Asserts against the conversation items that actually land rather than the
+    arguments of a mocked helper, so a break in the write path is caught.
+    """
+
+    @staticmethod
+    def _client_capturing_writes(mocker: MockerFixture) -> tuple[Any, list[Any]]:
+        """Return a client whose conversation writes are recorded."""
+        stored: list[Any] = []
+
+        async def _create(
+            conversation_id: str, *, add_items_request: Any = None, **_: Any
+        ) -> None:
+            _ = conversation_id
+            stored.extend(getattr(add_items_request, "items", add_items_request) or [])
+
+        client = mocker.AsyncMock()
+        client.items.create = _create
+        return client, stored
+
+    @pytest.mark.asyncio
+    async def test_compacted_success_appends_turn_with_captured_output(
+        self,
+        mocker: MockerFixture,
+        make_agent_run_result: Callable[..., Any],
+        make_responses_params: Callable[..., ResponsesApiParams],
+        patch_recording_metrics: None,
+    ) -> None:
+        """A compacted turn is written back using the items OGX returned."""
+        explicit = [
+            OpenAIResponseMessage(role="user", content="Summary:\nS1"),
+            OpenAIResponseMessage(role="user", content="new question"),
+        ]
+        params = make_responses_params(input_text="ignored").model_copy(
+            update={"input": explicit, "omit_conversation": True}
+        )
+        mock_agent = mocker.AsyncMock()
+        mock_agent.run = mocker.AsyncMock(
+            return_value=make_agent_run_result(content="Answer")
+        )
+        # The model captured the genuine OGX output items for this call.
+        mock_agent.model.last_output_items = [
+            OpenAIResponseMessage(role="assistant", content="Answer")
+        ]
+        mocker.patch("utils.agents.query.build_agent", return_value=mock_agent)
+        client, stored = self._client_capturing_writes(mocker)
+
+        await retrieve_agent_response(
+            client=client,
+            responses_params=params,
+            moderation_result=ShieldModerationPassed(),
+            endpoint_path=ENDPOINT_PATH_QUERY,
+            original_input="new question",
+        )
+
+        texts = [str(item) for item in stored]
+        assert len(stored) == 2, f"expected user turn + output, got {texts}"
+        assert any("new question" in t for t in texts)
+        assert any("Answer" in t for t in texts)
+
+    @pytest.mark.asyncio
+    async def test_non_compacted_success_does_not_append_turn(
+        self,
+        mocker: MockerFixture,
+        make_agent_run_result: Callable[..., Any],
+        make_responses_params: Callable[..., ResponsesApiParams],
+        patch_recording_metrics: None,
+    ) -> None:
+        """Without compaction OGX persists the turn, so we must not duplicate it."""
+        mock_agent = mocker.AsyncMock()
+        mock_agent.run = mocker.AsyncMock(
+            return_value=make_agent_run_result(content="Answer")
+        )
+        mock_agent.model.last_output_items = [
+            OpenAIResponseMessage(role="assistant", content="Answer")
+        ]
+        mocker.patch("utils.agents.query.build_agent", return_value=mock_agent)
+        client, stored = self._client_capturing_writes(mocker)
+
+        await retrieve_agent_response(
+            client=client,
+            responses_params=make_responses_params(input_text="hi"),
+            moderation_result=ShieldModerationPassed(),
+            endpoint_path=ENDPOINT_PATH_QUERY,
+        )
+
+        assert stored == []

--- a/tests/unit/utils/agents/test_streaming.py
+++ b/tests/unit/utils/agents/test_streaming.py
@@ -1649,3 +1649,196 @@ def _mock_run_stream(
             return None
 
     return _RunStreamCtx()
+
+
+class TestCompactedTurnPersistence:
+    """Compacted-mode turn persistence (LCORE-3883).
+
+    In compacted mode the ``conversation`` parameter is not sent, so OGX does
+    not store the turn and lightspeed-stack must append it explicitly. These
+    tests assert against the conversation items that actually land, not against
+    the arguments of a mocked helper.
+    """
+
+    @staticmethod
+    def _capture_conversation_writes(context: Any) -> list[Any]:
+        """Wire a stateful fake onto the client and return the captured items."""
+        stored: list[Any] = []
+
+        async def _create(
+            conversation_id: str, *, add_items_request: Any = None, **_: Any
+        ) -> None:
+            _ = conversation_id
+            stored.extend(getattr(add_items_request, "items", add_items_request) or [])
+
+        context.client.items.create = _create
+        return stored
+
+    @staticmethod
+    def _patch_finalizers(mocker: MockerFixture) -> None:
+        """Stub the post-stream finalization the persistence test does not exercise."""
+        mocker.patch("utils.agents.streaming.consume_query_tokens")
+        mocker.patch(
+            "utils.agents.streaming.get_available_quotas", return_value={"daily": 1}
+        )
+        mocker.patch(
+            "utils.agents.streaming.maybe_get_topic_summary",
+            new=mocker.AsyncMock(return_value=None),
+        )
+        mocker.patch("utils.agents.streaming.store_query_results")
+        mock_config = mocker.Mock()
+        mock_config.quota_limiters = []
+        mocker.patch("utils.agents.streaming.configuration", mock_config)
+
+    @pytest.mark.asyncio
+    async def test_compacted_success_appends_turn_to_conversation(
+        self,
+        mocker: MockerFixture,
+        make_generator_context: Callable[..., ResponseGeneratorContext],
+        responses_params: ResponsesApiParams,
+    ) -> None:
+        """A completed compacted stream writes the user turn and the LLM output."""
+        context = make_generator_context()
+        stored = self._capture_conversation_writes(context)
+        self._patch_finalizers(mocker)
+
+        turn_summary = TurnSummary()
+        turn_summary.token_usage = TokenCounter(input_tokens=1, output_tokens=1)
+        turn_summary.output_items = [
+            OpenAIResponseMessage(role="assistant", content="The answer.")
+        ]
+
+        async def inner() -> AsyncIterator[str]:
+            yield serialize_event(
+                TokenStreamPayload.create(chunk_id=0, token="The answer."),
+                MEDIA_TYPE_JSON,
+            )
+
+        events = [
+            event
+            async for event in generate_agent_response(
+                inner(),
+                context,
+                responses_params,
+                turn_summary,
+                [],
+                original_input="the original question",
+            )
+        ]
+
+        assert _sse_event_types(events) == ["start", "token", "end"]
+        texts = [str(item) for item in stored]
+        assert len(stored) == 2, f"expected user turn + output, got {texts}"
+        assert any("the original question" in t for t in texts)
+        assert any("The answer." in t for t in texts)
+
+    @pytest.mark.asyncio
+    async def test_non_compacted_success_does_not_append_turn(
+        self,
+        mocker: MockerFixture,
+        make_generator_context: Callable[..., ResponseGeneratorContext],
+        responses_params: ResponsesApiParams,
+    ) -> None:
+        """Without compaction OGX stores the turn, so we must not duplicate it."""
+        context = make_generator_context()
+        stored = self._capture_conversation_writes(context)
+        self._patch_finalizers(mocker)
+
+        turn_summary = TurnSummary()
+        turn_summary.token_usage = TokenCounter(input_tokens=1, output_tokens=1)
+
+        async def inner() -> AsyncIterator[str]:
+            yield serialize_event(
+                TokenStreamPayload.create(chunk_id=0, token="Hi"), MEDIA_TYPE_JSON
+            )
+
+        _ = [
+            event
+            async for event in generate_agent_response(
+                inner(), context, responses_params, turn_summary, []
+            )
+        ]
+
+        assert stored == []
+
+    @pytest.mark.asyncio
+    async def test_interrupt_guard_prevents_double_persistence(
+        self,
+        mocker: MockerFixture,
+        make_generator_context: Callable[..., ResponseGeneratorContext],
+        responses_params: ResponsesApiParams,
+    ) -> None:
+        """An interrupt that already persisted the turn blocks the success path."""
+        context = make_generator_context()
+        stored = self._capture_conversation_writes(context)
+        self._patch_finalizers(mocker)
+        # Simulate the interrupt path having already persisted this turn.
+        mocker.patch(
+            "utils.agents.streaming.register_interrupt_callback", return_value=[True]
+        )
+
+        turn_summary = TurnSummary()
+        turn_summary.token_usage = TokenCounter(input_tokens=1, output_tokens=1)
+        turn_summary.output_items = [
+            OpenAIResponseMessage(role="assistant", content="The answer.")
+        ]
+
+        async def inner() -> AsyncIterator[str]:
+            yield serialize_event(
+                TokenStreamPayload.create(chunk_id=0, token="x"), MEDIA_TYPE_JSON
+            )
+
+        _ = [
+            event
+            async for event in generate_agent_response(
+                inner(),
+                context,
+                responses_params,
+                turn_summary,
+                [],
+                original_input="the original question",
+            )
+        ]
+
+        assert stored == []
+
+    @pytest.mark.asyncio
+    async def test_persistence_failure_does_not_fail_the_stream(
+        self,
+        mocker: MockerFixture,
+        make_generator_context: Callable[..., ResponseGeneratorContext],
+        responses_params: ResponsesApiParams,
+    ) -> None:
+        """The client keeps its answer even when the conversation write fails."""
+        context = make_generator_context()
+        self._patch_finalizers(mocker)
+
+        async def _boom(_conversation_id: str, **_: Any) -> None:
+            raise RuntimeError("conversation store unavailable")
+
+        context.client.items.create = _boom
+
+        turn_summary = TurnSummary()
+        turn_summary.token_usage = TokenCounter(input_tokens=1, output_tokens=1)
+        turn_summary.output_items = [
+            OpenAIResponseMessage(role="assistant", content="A")
+        ]
+
+        async def inner() -> AsyncIterator[str]:
+            yield serialize_event(
+                TokenStreamPayload.create(chunk_id=0, token="A"), MEDIA_TYPE_JSON
+            )
+
+        events = [
+            event
+            async for event in generate_agent_response(
+                inner(),
+                context,
+                responses_params,
+                turn_summary,
+                [],
+                original_input="q",
+            )
+        ]
+
+        assert _sse_event_types(events) == ["start", "token", "end"]


### PR DESCRIPTION
## Description

Fixes LCORE-3883. In compacted mode the `conversation` parameter is dropped from the OGX call, so OGX does not store the turn and lightspeed-stack must append it itself. That wiring was lost: `29bd62d7` removed the A2A call site while refactoring the executor onto pydantic-ai agents, and `16c17d44` removed the query and streaming call sites along with the deprecated helpers they lived in. `/v1/responses` was unaffected because it has its own `_append_previous_response_turn`.

The effect is silent data loss: once a conversation enters compacted mode, no further turn is recorded. History stops growing, and because the recent-turn buffer is derived from the conversation items after the last marker, the model loses all context after the compaction point. Nothing raises. It was masked until LCORE-3582 landed, since compacted requests previously failed with HTTP 500 before reaching the point where the turn would be stored.

Restoring the call sites alone is not sufficient. `TurnSummary.output_items` — the field the persistence writes — is no longer populated on any success path either; the only writer left is the blocked-moderation branch. Wiring without it would append the user message with an empty assistant reply.

Rather than reconstruct output items by mapping pydantic-ai messages back to the OGX shapes, they are captured where the genuine objects already exist: `OgxResponsesModel` now records `response.output` from the non-streaming call and from the `response.completed` event on the streaming path. A compacted turn is therefore stored exactly as OGX itself would have stored it.

Keeping the `conversation` parameter so that OGX persists the turn was tested against a local OGX 1.0.2 stack and rejected. OGX does honour the explicit input and does not inject conversation history, but it persists the whole input list, so every replayed buffer turn is duplicated into the conversation on each request (a one-turn buffer grew a conversation from 2 to 7 items in a single request, and the duplication compounds because the buffer is read back from those same items).

Notes for reviewers:

1. The streaming success path shares the existing interrupt `persist_guard`, so a turn is persisted at most once if an interrupt fires while the stream is finishing.
2. A persistence failure is logged rather than failing an otherwise successful stream — the client already has its answer, and the cost is that the next request loses that turn. Happy to invert this if you would rather it surface.
3. The comment at `streaming_query.py:491` claiming the shared generator handles compacted-turn storage needed no edit: this change makes it true again.
4. Tool-call and tool-result items are now preserved in compacted history, because the captured items are the real OGX output rather than a flattened assistant message.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-3582
- Closes # LCORE-3883

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

Reproduce the OGX persistence behaviour that motivates the design (requires a local OGX stack):

1. Start OGX: `OPENSSL_CONF=/dev/null OPENAI_API_KEY=... ogx stack run tests/e2e/configs/run-ci.yaml --port 8321`
2. Create a conversation, seed two turns, then `POST /v1/responses` with `conversation` set and an explicit input list containing a summary plus one replayed turn pair plus a new query.
3. Expected, and observed: the model answers from the explicit input (conversation history is not injected), but the conversation grows by 5 items rather than 2 — the replayed pair is duplicated. This is why the fix appends the turn explicitly instead of letting OGX store it.

Run the unit tests covering the three endpoints:

```
uv run python -m pytest tests/unit/utils/agents/ tests/unit/pydantic_ai_lightspeed/ tests/unit/app/endpoints/test_a2a.py -q
```

Result: `346 passed`. Full unit run across the touched areas: `1268 passed`.

The new tests assert against the conversation items that actually land rather than the arguments of a mocked helper. Confirmed non-vacuous: reverting `src/utils/agents/streaming.py` fails `test_compacted_success_appends_turn_to_conversation`, and reverting `src/utils/agents/query.py` fails `test_compacted_success_appends_turn_with_captured_output`.

Linters:

```
uv run make format && uv run make verify
```

black, ruff, pylint, pyright and docstyle pass. `check-types-src` reports `Success: no issues found in 223 source files`. `check-types-tests` reports 38 errors, all pre-existing on `main` and none in the files touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compacted A2A, query, and streaming turns are now saved to the conversation after completion.
  * Structured model output is captured and included when persisting completed turns.
  * Persistence is protected against duplicate writes and does not interrupt successful responses if saving fails.

* **Bug Fixes**
  * Prevented compacted turns from being omitted from conversation history.
  * Non-compacted requests continue without adding unnecessary conversation entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->