### PR TITLE
LCORE-2547: re-run black after the OGX rename

### DIFF
--- a/tests/unit/telemetry/test_configuration_snapshot.py
+++ b/tests/unit/telemetry/test_configuration_snapshot.py
@@ -1194,9 +1194,7 @@ class TestPiiLeakPrevention:
             ), f"PII leaked in lightspeed-stack snapshot: '{pii_value}'"
 
     @pytest.mark.asyncio
-    async def test_no_pii_in_ogx_snapshot(
-        self, ogx_config_file: str
-    ) -> None:
+    async def test_no_pii_in_ogx_snapshot(self, ogx_config_file: str) -> None:
         """Verify no PII leaks in OGX snapshot JSON."""
         json_str = json.dumps(await build_ogx_snapshot(ogx_config_file))
         for pii_value in LLAMA_STACK_PII_VALUES:
@@ -1205,9 +1203,7 @@ class TestPiiLeakPrevention:
             ), f"PII leaked in llama-stack snapshot: '{pii_value}'"
 
     @pytest.mark.asyncio
-    async def test_no_pii_in_combined_snapshot(
-        self, ogx_config_file: str
-    ) -> None:
+    async def test_no_pii_in_combined_snapshot(self, ogx_config_file: str) -> None:
         """Verify no PII leaks in the combined snapshot JSON."""
         snapshot = await build_configuration_snapshot(
             build_fully_populated_config(), ogx_config_file
@@ -1228,9 +1224,7 @@ class TestPiiLeakPrevention:
         ), f"Snapshot contains unexpected top-level keys: {unexpected}"
 
     @pytest.mark.asyncio
-    async def test_provider_config_not_leaked(
-        self, ogx_config_file: str
-    ) -> None:
+    async def test_provider_config_not_leaked(self, ogx_config_file: str) -> None:
         """Verify provider config sections (with secrets) are not included."""
         json_str = json.dumps(await build_ogx_snapshot(ogx_config_file))
         assert "api_key" not in json_str


### PR DESCRIPTION
## Description

`main` currently fails `black --check`, so every PR opened against it goes red on the black job regardless of its contents (for example #2592).

The OGX rename shortened `llama_stack_config_file` to `ogx_config_file` in `tests/unit/telemetry/test_configuration_snapshot.py`, so two test signatures now fit on one line. The rename commit (`d991c7bb`) did not re-run the formatter.

This is the formatter's output, nothing else — three lines.

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement

## Tools used to create PR

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-2547
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

```
uv run black --check src tests
```

Fails on `main`, passes on this branch. No behaviour change — formatting only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted three telemetry configuration tests for improved readability.
  * No test behavior, assertions, or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->