### PR TITLE
LCORE-3756: fix question_validity shield on responses and infer endpoints

### DIFF
--- a/src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py
+++ b/src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py
@@ -217,8 +217,9 @@ class QuestionValidity(AbstractSafetyCapability):
 
     async def run(self, input_text: str) -> ShieldModerationResult:
         """Run question-validity check and return a moderation result."""
+        prompt = self._build_prompt(input_text)
         result = await model_request(
-            model=self._model, messages=[ModelRequest.user_text_prompt(input_text)]
+            model=self._model, messages=[ModelRequest.user_text_prompt(prompt)]
         )
 
         if result.text is not None and result.text.strip() == SUBJECT_ALLOWED:

--- a/tests/e2e/features/shields_question_validity.feature
+++ b/tests/e2e/features/shields_question_validity.feature
@@ -23,15 +23,10 @@ Feature: question_validity shield functional tests
       | endpoint  | request_body                                                                                                              | expected_fragment                            |
       | query     | {"query": "What is OpenShift and how do I deploy an application on it?", "model": "{MODEL}", "provider": "{PROVIDER}"}   | deploy                                       |
       | query     | {"query": "What is the best topping for a pizza?", "model": "{MODEL}", "provider": "{PROVIDER}"}                         | I can only answer questions about OpenShift. |
+      | responses | {"input": "What is OpenShift and how do I deploy an application on it?", "model": "{PROVIDER}/{MODEL}", "stream": false} | deploy                                       |
       | responses | {"input": "What is the best topping for a pizza?", "model": "{PROVIDER}/{MODEL}", "stream": false}                       | I can only answer questions about OpenShift. |
+      | infer     | {"question": "What is OpenShift and how do I deploy an application on it?"}                                              | deploy                                       |
       | infer     | {"question": "What is the best topping for a pizza?"}                                                                    | I can only answer questions about OpenShift. |
-
-    # disabled due to https://redhat.atlassian.net/browse/LCORE-3756
-    @skip
-    Examples:
-      | endpoint  | request_body                                                                                                              | expected_fragment |
-      | responses | {"input": "What is OpenShift and how do I deploy an application on it?", "model": "{PROVIDER}/{MODEL}", "stream": false} | deploy             |
-      | infer     | {"question": "What is OpenShift and how do I deploy an application on it?"}                                              | deploy             |
 
   @cfg_shields @flaky
   Scenario Outline: question_validity allows in-topic and rejects off-topic questions via streaming_query

--- a/tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
+++ b/tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
@@ -681,6 +681,32 @@ class TestQuestionValidityRun:
         mocker.patch(f"{_MODULE}.OgxResponsesModel.from_ogx_client")
 
     @pytest.mark.asyncio
+    async def test_run_applies_model_prompt_template(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test that run() applies model_prompt template before model_request."""
+        mock_model_request = mocker.patch(
+            f"{_MODULE}.model_request",
+            return_value=ModelResponse(
+                parts=[TextPart(content=SUBJECT_ALLOWED)],
+                usage=RequestUsage(),
+            ),
+        )
+
+        custom_prompt = "Classify: $message (reply $allowed or $rejected)"
+        config = QuestionValidityConfig(
+            model_id="test",
+            model_prompt=custom_prompt,
+        )
+        qv = QuestionValidity(config=config)
+        await qv.run("How do I create a pod?")
+
+        messages = mock_model_request.call_args.kwargs["messages"]
+        prompt_str = str(messages[0])
+        assert "Classify: How do I create a pod?" in prompt_str
+        assert "reply ALLOWED or REJECTED" in prompt_str
+
+    @pytest.mark.asyncio
     async def test_allowed_returns_passed(self, mocker: MockerFixture) -> None:
         """Test that an allowed response returns ShieldModerationPassed."""
         mock_response = ModelResponse(


### PR DESCRIPTION
## Description

`QuestionValidity.run()` (used by the shield interface on `/v1/responses` and `/v1/infer`) was sending raw user input to the validity model instead of applying the configured `model_prompt` template. `wrap_run()` already called `_build_prompt()`, but `run()` did not, so shields behaved incorrectly on responses and infer endpoints.

This change applies `_build_prompt()` in `run()` before `model_request`, matching the agent path. A unit test verifies template substitution, and the previously skipped e2e examples for in-topic allow cases on `responses` and `infer` are re-enabled.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [x] Unit tests improvement
- [ ] Integration tests improvement
- [x] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #
- Closes  https://redhat.atlassian.net/browse/LCORE-3756

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing

- Unit tests:
  ```bash
  uv run pytest tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py tests/unit/utils/test_shields.py -q
  ```
- Lint (changed files):
  ```bash
  uv run black --check --line-length 88 \
    src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py \
    tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
  uv run ruff check \
    src/pydantic_ai_lightspeed/capabilities/question_validity/_capability.py \
    tests/unit/pydantic_ai_lightspeed/capabilities/question_validity/test_capability.py
  ```
- E2E (requires local stack + model backend):
  ```bash
  uv run behave tests/e2e/features/shields_question_validity.feature
  ```

Verification:
- `test_run_applies_model_prompt_template` confirms `$message`, `$allowed`, and `$rejected` are substituted in the prompt sent to the model.
- E2E scenario `question_validity allows in-topic and rejects off-topic questions` now includes previously skipped `responses` and `infer` in-topic examples (off-topic cases were already active).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Question validity checks now consistently apply the configured prompt template before classification.
  * Valid and off-topic requests are now correctly covered across supported response and inference endpoints.

* **Tests**
  * Added coverage confirming custom prompt values are substituted correctly during question validity checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->