### PR TITLE
LCORE-: Fix missing refusal message in conversation/v2 when using streaming query

### DIFF
--- a/src/utils/agents/streaming.py
+++ b/src/utils/agents/streaming.py
@@ -516,6 +516,11 @@ def _(
     )
     state.chunk_id += 1
     state.turn_summary.next_chunk_id = state.chunk_id
+
+    # Fix the missing refusal message issue in conversation/v2
+    if not state.turn_summary.partial_tokens:
+        state.turn_summary.llm_response = final_text
+
     return payload
 
 


### PR DESCRIPTION
## Description

When streaming completes without partial tokens, the LLM response was not being captured in the turn summary, causing refusal messages to be lost in conversation/v2 history.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: (e.g., Claude, CodeRabbit, Ollama, etc., N/A if not used)
- Generated by: (e.g., tool name and version; N/A if not used)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] PR has passed all pre-merge test jobs.
- [x] If it is a core feature, I have added thorough tests.

## Testing
It's better to verify the bug first.
1. Configure a shield - question validity should be the easiest to set up
2. Ask a question that will be blocked by the shield through `/streaming_query`
3. Check the conversation history with the conversation_id from the response in `/conversation/v2`
4. The assistant message should be an empty string

Now apply the patch and redo the above steps, but this time the refusal message should show up in `conversation/v2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Turn summaries now capture the final response when no streamed tokens were received, including content-filter refusals and other non-streamed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->