### PR TITLE
LCORE-3295: Raise an exception, not a string

### DIFF
--- a/scripts/vulnerability_report.py
+++ b/scripts/vulnerability_report.py
@@ -149,7 +149,8 @@ def check_args(args: Namespace) -> None:
     if args.generate_graphs:
         # when graphs should be generated, output format need to be specified too
         if not args.svg_output and not args.png_output:
-            raise "Graphs generation was requested: you need to select the PNG and/or SVG output."
+            msg = "Graphs generation was requested: you need to select the PNG and/or SVG output."
+            raise ValueError(msg)
 
 
 def dependabot_file_name(args: Namespace) -> str:


### PR DESCRIPTION
## Description

LCORE-3295: Raise an exception, not a string

## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error that prevented vulnerability graph generation from reporting a clear validation message when no output format was selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->