### PR TITLE
LCORE-2547: finish OGX runtime naming cleanup

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -54,8 +54,7 @@ jobs:
       E2E_OPENAI_MODEL: ${{ vars.E2E_OPENAI_MODEL }}
       E2E_DEPLOYMENT_MODE: ${{ matrix.mode }}
       FAISS_VECTOR_STORE_ID: ${{ vars.FAISS_VECTOR_STORE_ID }}
-      # Override via repo Actions variable E2E_LLAMA_HOSTNAME; default matches server-mode lightspeed-stack.yaml
-      E2E_LLAMA_HOSTNAME: ${{ vars.E2E_LLAMA_HOSTNAME || 'llama-stack' }}
+      E2E_OGX_HOSTNAME: ogx
 
     steps:
       - uses: actions/checkout@v7
@@ -289,8 +288,8 @@ jobs:
           echo "=== Test failure logs ==="
           
           if [ "${{ matrix.mode }}" == "server" ]; then
-            echo "=== llama-stack logs ==="
-            docker compose logs llama-stack
+            echo "=== OGX logs ==="
+            docker compose logs ogx
             echo ""
             echo "=== lightspeed-stack logs ==="
             docker compose logs lightspeed-stack

--- a/.github/workflows/e2e_tests_providers.yaml
+++ b/.github/workflows/e2e_tests_providers.yaml
@@ -355,8 +355,8 @@ jobs:
           echo "=== Test failure logs ==="
           
           if [ "${{ matrix.mode }}" == "server" ]; then
-            echo "=== llama-stack logs ==="
-            docker compose logs llama-stack
+            echo "=== OGX logs ==="
+            docker compose logs ogx
             echo ""
             echo "=== lightspeed-stack logs ==="
             docker compose logs lightspeed-stack

--- a/.github/workflows/e2e_tests_rhaiis.yaml
+++ b/.github/workflows/e2e_tests_rhaiis.yaml
@@ -249,8 +249,8 @@ jobs:
           echo "=== Test failure logs ==="
 
           if [ "${{ matrix.mode }}" == "server" ]; then
-            echo "=== llama-stack logs ==="
-            docker compose logs llama-stack
+            echo "=== OGX logs ==="
+            docker compose logs ogx
             echo ""
             echo "=== lightspeed-stack logs ==="
             docker compose logs lightspeed-stack

--- a/.gitignore
+++ b/.gitignore
@@ -183,7 +183,7 @@ dev/
 # VSCode
 .vscode/
 
-# Llama related - when running the stack as lib client
+# OGX related - when running the stack as lib client
 .llama
 
 # Database files
@@ -195,7 +195,7 @@ requirements.*.backup
 # Local run files
 local-run.yaml
 
-# Synthesized Llama Stack run.yaml written by unified library mode (LCORE-2336)
+# Synthesized OGX run.yaml written by unified library mode (LCORE-2336)
 .generated/
 
 # Sisyphus planning files

--- a/.tekton/integration-tests/pipeline/lightspeed-stack-integration-test.yaml
+++ b/.tekton/integration-tests/pipeline/lightspeed-stack-integration-test.yaml
@@ -15,7 +15,7 @@ spec:
       default: '{"components": [{"name":"lightspeed-stack-0-8", "containerImage": "quay.io/example/lightspeed-stack-0-8:latest"}]}'
       type: string
     - name: llama-stack-image
-      description: 'Llama Stack runs from source on UBI (init container clones repo and installs deps). Kept for logging/backwards compatibility.'
+      description: 'OGX runs from source on UBI (init container clones repo and installs deps). Parameter name kept for backwards compatibility.'
       default: 'run-from-source (UBI)'
       type: string
     - name: test-name
@@ -81,7 +81,7 @@ spec:
               - name: instanceType
                 value: "m5.large"
     - name: get-stack-images
-      description: Extract lightspeed-stack image and commit from SNAPSHOT (Llama Stack runs from source in-pod)
+      description: Extract lightspeed-stack image and commit from SNAPSHOT (OGX runs from source in-pod)
       runAfter:
         - provision-cluster
       params:

--- a/deploy/ogx/README.md
+++ b/deploy/ogx/README.md
@@ -1,9 +1,9 @@
-# Llama Stack container image
+# OGX container image
 
-`test.containerfile` builds the Llama Stack server image used by
-`docker-compose.yaml` (server mode, e.g. for the e2e suite). Besides the
-Llama Stack distribution itself, the image bundles the pieces needed to
-generate its run configuration at container start:
+`test.containerfile` builds the OGX server image used by `docker-compose.yaml`
+(server mode, e.g. for the e2e suite). Besides the OGX distribution itself, the
+image bundles the pieces needed to generate its run configuration at container
+start:
 
 - `/opt/app-root/ogx_configuration.py` — the config-generation
   script (copied from `src/ogx_configuration.py`).
@@ -21,11 +21,12 @@ shape:
 
 - **Unified mode** — the `lightspeed-stack.yaml` carries a *synthesis
   input* (a non-empty `inference.providers` or `vector_store.providers`,
-  or a `llama_stack.config` block). The full `run.yaml` is synthesized
-  from it; no external `run.yaml` mount is needed.
+  or an `ogx.config` block). The full `run.yaml` is synthesized from it;
+  no external `run.yaml` mount is needed.
 - **Legacy mode** — no synthesis input present. The mounted `run.yaml`
-  (`$LLAMA_STACK_CONFIG`, default `/opt/app-root/run.yaml`) is enriched
-  with lightspeed dynamic values (BYOK RAG, Solr/OKP, Azure Entra ID).
+  (`$OGX_CONFIG`, with deprecated fallback `$LLAMA_STACK_CONFIG`, default
+  `/opt/app-root/run.yaml`) is enriched with lightspeed dynamic values
+  (BYOK RAG, Solr/OKP, Azure Entra ID).
 
 The repository `docker-compose.yaml` mounts both files and works for
 either mode — with a unified `lightspeed-stack.yaml` the `run.yaml`
@@ -33,7 +34,7 @@ mount is simply ignored. A unified-only deployment needs just:
 
 ```yaml
 services:
-  llama-stack:
+  ogx:
     build:
       context: .
       dockerfile: deploy/ogx/test.containerfile
@@ -48,5 +49,5 @@ services:
 The compose file also mounts host copies of the script, the baseline
 data directory, and the entrypoint over their baked-in counterparts, so
 `docker compose up` picks up local changes to any of them without an
-image rebuild. Rebuild (`docker compose build llama-stack`) when
+image rebuild. Rebuild (`docker compose build ogx`) when
 dependencies (`pyproject.toml` / `uv.lock`) or the providers change.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,11 @@
 services:
   # Red Hat OGX distribution with FAISS
-  llama-stack:
+  ogx:
     build:
       context: .
       dockerfile: deploy/ogx/test.containerfile
     platform: linux/amd64
-    container_name: llama-stack
+    container_name: ogx
     ports:
       - "8321:8321"  # Expose OGX on 8321 (adjust if needed)
     depends_on:
@@ -14,7 +14,7 @@ services:
     volumes:
       # Used in legacy mode only: with a unified lightspeed-stack.yaml (one
       # carrying inference.providers / vector_store.providers / a
-      # llama_stack.config block) the entrypoint synthesizes the run config
+      # ogx.config block) the entrypoint synthesizes the run config
       # from lightspeed-stack.yaml and this mount is ignored
       - ./run.yaml:/opt/app-root/run.yaml:z
       # Host copies so `docker compose up` picks up script changes without rebuilding OGX
@@ -24,7 +24,7 @@ services:
       - ${GCP_KEYS_PATH:-./tmp/.gcp-keys-dummy}:/opt/app-root/.gcp-keys:ro
       - ./lightspeed-stack.yaml:/opt/app-root/lightspeed-stack.yaml:ro,z
       # Writable OGX storage (rag/ work copy is re-seeded by entrypoint each start)
-      - llama-storage:/opt/app-root/src/.llama/storage
+      - ogx-storage:/opt/app-root/src/.llama/storage
       # Read-only e2e FAISS fixtures — never mount these as the live KV_RAG_PATH
       - ./tests/e2e/rag:/opt/app-root/src/.llama/storage/.e2e-rag-seed:ro,z
       - mock-tls-certs:/certs:ro
@@ -80,8 +80,8 @@ services:
       - SOLR_CONTENT_FIELD=${SOLR_CONTENT_FIELD:-}
       - SOLR_EMBEDDING_MODEL=${SOLR_EMBEDDING_MODEL:-}
       - SOLR_EMBEDDING_DIM=${SOLR_EMBEDDING_DIM:-}
-      #required for enrichment
-      - E2E_LLAMA_HOSTNAME=${E2E_LLAMA_HOSTNAME:-llama-stack}
+      # Required for enrichment; E2E_LLAMA_HOSTNAME is the external/GitHub Actions name
+      - E2E_OGX_HOSTNAME=${E2E_OGX_HOSTNAME:-${E2E_LLAMA_HOSTNAME:-ogx}}
     networks:
       - lightspeednet
     healthcheck:
@@ -111,9 +111,9 @@ services:
       - CLIENT_SECRET=${CLIENT_SECRET:-}
       # FAISS vector store ID (used by inline RAG config)
       - FAISS_VECTOR_STORE_ID=${FAISS_VECTOR_STORE_ID:-}
-      # Substituted in mounted lightspeed-stack.yaml (llama_stack.url); GitHub Actions sets via vars
-      - E2E_LLAMA_HOSTNAME=${E2E_LLAMA_HOSTNAME:-llama-stack}
-      - E2E_LLAMA_PORT=${E2E_LLAMA_PORT:-8321}
+      # Substituted in mounted lightspeed-stack.yaml (ogx.url); GitHub Actions sets E2E_LLAMA_HOSTNAME
+      - E2E_OGX_HOSTNAME=${E2E_OGX_HOSTNAME:-${E2E_LLAMA_HOSTNAME:-ogx}}
+      - E2E_OGX_PORT=${E2E_OGX_PORT:-${E2E_LLAMA_PORT:-8321}}
       # OpenTelemetry configuration (tracing disabled by default)
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       - OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL:-}
@@ -121,7 +121,7 @@ services:
       - OTEL_ANONYMIZATION_SECRET=${OTEL_ANONYMIZATION_SECRET:-lightspeed-stack-otel-anonymization-dev-default}
       - OTEL_SDK_DISABLED=${OTEL_SDK_DISABLED:-true}
     depends_on:
-        llama-stack:
+        ogx:
           condition: service_healthy
         mock-mcp:
           condition: service_healthy
@@ -186,7 +186,7 @@ services:
 
 
 volumes:
-  llama-storage:
+  ogx-storage:
   mock-tls-certs:
 
 networks:

--- a/docs/design/ogx-config-merge/ogx-config-merge.md
+++ b/docs/design/ogx-config-merge/ogx-config-merge.md
@@ -351,7 +351,7 @@ None at the REST API surface. Internal API additions in
 - `migrate_config_dumb(run_yaml_path, lightspeed_yaml_path, output_path)
   -> None` — dumb-mode migration (lossless round-trip).
 - `deep_merge_list_replace(base, overlay) -> dict` — merge helper.
-- `apply_high_level_inference(ls_config, inference)` — high-level expansion.
+- `apply_high_level_inference(ogx_config, inference)` — high-level expansion.
 - `load_default_baseline() -> dict` — loads `src/data/default_run.yaml`.
 
 CLI additions in `src/lightspeed_stack.py`:
@@ -474,11 +474,11 @@ not have had a full release with a working migration path. Releases:
 3. Run `dedupe_providers_vector_io` on the baseline.
 4. Apply existing enrichment: `enrich_byok_rag`, `enrich_solr` (Azure
    Entra ID intentionally stays separate because it's a `.env`
-   side-effect, not an `ls_config` mutation).
+   side-effect, not an `ogx_config` mutation).
 5. If top-level `inference.providers` is non-empty →
-   `apply_high_level_inference(ls_config, lcs_config["inference"])`.
+   `apply_high_level_inference(ogx_config, lcs_config["inference"])`.
 6. If `unified` and `unified.native_override` non-empty →
-   `deep_merge_list_replace(ls_config, native_override)`.
+   `deep_merge_list_replace(ogx_config, native_override)`.
 7. `dedupe_providers_vector_io` again for good measure.
 8. Return the final dict.
 

--- a/docs/devel_doc/conversations_api.md
+++ b/docs/devel_doc/conversations_api.md
@@ -115,9 +115,9 @@ When a user makes a query **without** providing a `conversation_id`:
 ```python
 # No conversation_id provided - create a new conversation first
 conversation = await client.conversations.create(metadata={})
-llama_stack_conv_id = conversation.id
+ogx_conv_id = conversation.id
 # Store the normalized version
-conversation_id = normalize_conversation_id(llama_stack_conv_id)
+conversation_id = normalize_conversation_id(ogx_conv_id)
 
 # Use the conversation in responses.create()
 response = await client.responses.create(
@@ -125,7 +125,7 @@ response = await client.responses.create(
     model=model_id,
     instructions=system_prompt,
     store=True,
-    conversation=llama_stack_conv_id,  # Use OGX format
+    conversation=ogx_conv_id,  # Use OGX format
     # ... other parameters
 )
 ```
@@ -151,7 +151,7 @@ ogx_conv_id = to_ogx_conversation_id(conversation_id)
 response = await client.responses.create(
     input=input_text,
     model=model_id,
-    conversation=llama_stack_conv_id,  # Existing conversation
+    conversation=ogx_conv_id,  # Existing conversation
     # ... other parameters
 )
 ```
@@ -166,7 +166,7 @@ Conversations are stored in **two databases**:
 - `openai_conversations`: Stores conversation metadata
 - `conversation_items`: Stores individual messages/turns in conversations
 
-**Configuration (in `config/llama_stack_client_config.yaml`):**
+**Configuration (in OGX `run.yaml` / library client config):**
 ```yaml
 storage:
   stores:

--- a/docs/testing/e2e_testing.md
+++ b/docs/testing/e2e_testing.md
@@ -142,10 +142,10 @@ uv run behave tests/e2e/features/health.feature --tags=-skip-in-library-mode
 | `E2E_DEPLOYMENT_MODE`           | `server`    | `server` or `library`. Drives config paths and which scenarios run (e.g. `@skip-in-library-mode`).                                        |
 | `E2E_LSC_HOSTNAME`              | `localhost` | Host of the Lightspeed Core Stack API.                                                                                                    |
 | `E2E_LSC_PORT`                  | `8080`      | Port of the Lightspeed Core Stack API.                                                                                                    |
-| `E2E_LLAMA_HOSTNAME`            | `localhost` | Host of the OGX service (server mode).                                                                                            |
-| `E2E_LLAMA_PORT`                | `8321`      | Port of the OGX service.                                                                                                          |
-| `E2E_LLAMA_STACK_URL`           | —           | Full base URL for OGX (overrides host/port if set). Used by shield helpers.                                                       |
-| `E2E_LLAMA_STACK_API_KEY`       | `xyzzy`     | API key for OGX client (e.g. shield API).                                                                                         |
+| `E2E_OGX_HOSTNAME`            | `localhost` | Host of the OGX service (server mode). GitHub Actions repo variable: `E2E_LLAMA_HOSTNAME` (compose maps it here). |
+| `E2E_OGX_PORT`                | `8321`      | Port of the OGX service.                                                                                                          |
+| `E2E_OGX_STACK_URL`           | —           | Full base URL for OGX (overrides host/port if set). Used by shield helpers.                                                       |
+| `E2E_OGX_STACK_API_KEY`       | `xyzzy`     | API key for OGX client (e.g. shield API).                                                                                         |
 | `E2E_DEFAULT_MODEL_OVERRIDE`    | —           | Override default LLM model id (e.g. `gpt-4o-mini`).                                                                                       |
 | `E2E_DEFAULT_PROVIDER_OVERRIDE` | —           | Override default provider id (e.g. `openai`).                                                                                             |
 | `FAISS_VECTOR_STORE_ID`         | —           | Vector store id for FAISS-related scenarios.                                                                                              |

--- a/lightspeed-stack.yaml
+++ b/lightspeed-stack.yaml
@@ -7,11 +7,11 @@ service:
   workers: 1
   color_log: true
   access_log: true
-# llama_stack configuration
+# ogx configuration
 # When using 'make run', a container is ALWAYS launched at http://localhost:8321 (hardcoded in Makefile).
-# This llama_stack section controls where lightspeed-core connects to OGX.
-# To use a different port: override with 'make run LLAMA_STACK_PORT=<port>' and update the url below,
-# or run ogx manually and don't use 'make run'.
+# This ogx section controls where lightspeed-core connects to OGX.
+# To use a different port: override with 'make run OGX_PORT=<port>' and update the url below,
+# or run OGX manually and don't use 'make run'.
 ogx:
   use_as_library_client: false
   url: http://localhost:8321

--- a/scripts/ogx-entrypoint.sh
+++ b/scripts/ogx-entrypoint.sh
@@ -6,12 +6,12 @@
 # configuration shape:
 #   - unified mode: the lightspeed config carries a synthesis input (a
 #     non-empty inference.providers or vector_store.providers, or a
-#     llama_stack.config / ogx.config block). The full run.yaml is synthesized
+#     ogx.config block (deprecated alias: llama_stack.config). The full run.yaml is synthesized
 #     from it — no external run.yaml mount is needed, and $OGX_CONFIG /
-#     $LLAMA_STACK_CONFIG is ignored. The shipped default baseline is read from
+#     $LLAMA_STACK_CONFIG (deprecated) is ignored. The shipped default baseline is read from
 #     /opt/app-root/data/default_run.yaml.
-#   - legacy mode: the mounted run.yaml ($OGX_CONFIG, falling back to
-#     $LLAMA_STACK_CONFIG) is enriched with lightspeed dynamic values
+#   - legacy mode: the mounted run.yaml ($OGX_CONFIG, falling back to the
+#     deprecated $LLAMA_STACK_CONFIG) is enriched with lightspeed dynamic values
 #     (BYOK RAG, Solr/OKP, Azure Entra ID).
 
 set -e

--- a/src/client/ogx.py
+++ b/src/client/ogx.py
@@ -159,7 +159,7 @@ class AsyncOgxClientHolder(metaclass=Singleton):
         """Enrich OGX config with BYOK RAG and OKP Solr settings."""
         try:
             with open(input_config_path, encoding="utf-8") as f:
-                ls_config = yaml.safe_load(f)
+                ogx_config = yaml.safe_load(f)
         except (OSError, yaml.YAMLError) as e:
             logger.warning("Failed to read OGX config: %s", e)
             return input_config_path
@@ -167,26 +167,26 @@ class AsyncOgxClientHolder(metaclass=Singleton):
         config = configuration.configuration
 
         # Enrichment: BYOK RAG
-        enrich_byok_rag(ls_config, [s.model_dump() for s in config.rag.byok.stores])
+        enrich_byok_rag(ogx_config, [s.model_dump() for s in config.rag.byok.stores])
 
         # Enrichment: Solr - enabled when "okp" appears in either inline or tool list
         rag_config_for_solr = {
             "inline": config.rag.retrieval.inline.sources,
             "tool": config.rag.retrieval.tool.sources,
         }
-        enrich_solr(ls_config, rag_config_for_solr, config.rag.okp.model_dump())
+        enrich_solr(ogx_config, rag_config_for_solr, config.rag.okp.model_dump())
 
         # Enrichment: Azure Entra ID deferred auth
         entra_id_config = (
             config.azure_entra_id.model_dump() if config.azure_entra_id else None
         )
-        enrich_azure_entra_id_inference(ls_config, entra_id_config)
+        enrich_azure_entra_id_inference(ogx_config, entra_id_config)
 
         enriched_path = os.path.join(tempfile.gettempdir(), "ogx_enriched_config.yaml")
 
         try:
             with open(enriched_path, "w", encoding="utf-8") as f:
-                yaml.dump(ls_config, f, Dumper=YamlDumper, default_flow_style=False)
+                yaml.dump(ogx_config, f, Dumper=YamlDumper, default_flow_style=False)
             logger.info("Wrote enriched OGX config to %s", enriched_path)
             return enriched_path
         except OSError as e:

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -73,14 +73,14 @@ def replace_env_vars_preserving_native_override(
     ogx_section = config_dict.get("ogx")
     if ogx_section is None:
         ogx_section = config_dict.get("llama_stack")
-    ls_config = ogx_section.get("config") if isinstance(ogx_section, dict) else None
-    if not (isinstance(ls_config, dict) and "native_override" in ls_config):
+    ogx_config = ogx_section.get("config") if isinstance(ogx_section, dict) else None
+    if not (isinstance(ogx_config, dict) and "native_override" in ogx_config):
         return replace_env_vars(config_dict)
 
-    raw_override = ls_config["native_override"]
-    ls_config["native_override"] = {}  # keep secrets out of env resolution
+    raw_override = ogx_config["native_override"]
+    ogx_config["native_override"] = {}  # keep secrets out of env resolution
     resolved = replace_env_vars(config_dict)
-    ls_config["native_override"] = raw_override  # restore source dict if reused
+    ogx_config["native_override"] = raw_override  # restore source dict if reused
     resolved_ogx = (resolved.get("ogx") or resolved.get("llama_stack") or {}).get(
         "config"
     )

--- a/src/ogx_configuration.py
+++ b/src/ogx_configuration.py
@@ -155,7 +155,7 @@ class YamlDumper(yaml.Dumper):  # pylint: disable=too-many-ancestors
 
 
 def enrich_azure_entra_id_inference(
-    ls_config: dict[str, Any],
+    ogx_config: dict[str, Any],
     azure_entra_id: Optional[dict[str, Any]],
 ) -> None:
     """Enrich remote::azure inference provider for Entra ID authentication.
@@ -164,7 +164,7 @@ def enrich_azure_entra_id_inference(
     with model_validation=false to defer model validation to runtime.
 
     Parameters:
-        ls_config (dict[str, Any]): Mutable OGX configuration dictionary to update.
+        ogx_config (dict[str, Any]): Mutable OGX configuration dictionary to update.
         azure_entra_id (Optional[dict[str, Any]]): Lightspeed azure_entra_id block,
             or None.
 
@@ -174,7 +174,7 @@ def enrich_azure_entra_id_inference(
     if azure_entra_id is None:
         return
 
-    inference_providers = ls_config.get("providers", {}).get("inference", [])
+    inference_providers = ogx_config.get("providers", {}).get("inference", [])
 
     for provider in inference_providers:
         if provider.get("provider_type") != "remote::azure":
@@ -215,18 +215,18 @@ def _dedupe_vector_io_list(entries: list[Any]) -> list[dict[str, Any]]:
     return out
 
 
-def dedupe_providers_vector_io(ls_config: dict[str, Any]) -> None:
+def dedupe_providers_vector_io(ogx_config: dict[str, Any]) -> None:
     """Collapse ``providers.vector_io`` to one entry per ``provider_id``."""
-    if "providers" not in ls_config or "vector_io" not in ls_config["providers"]:
+    if "providers" not in ogx_config or "vector_io" not in ogx_config["providers"]:
         return
-    raw = ls_config["providers"]["vector_io"]
+    raw = ogx_config["providers"]["vector_io"]
     if not isinstance(raw, list):
         return
-    ls_config["providers"]["vector_io"] = _dedupe_vector_io_list(raw)
+    ogx_config["providers"]["vector_io"] = _dedupe_vector_io_list(raw)
 
 
 def construct_storage_backends_section(
-    ls_config: dict[str, Any], byok_rag: list[dict[str, Any]]
+    ogx_config: dict[str, Any], byok_rag: list[dict[str, Any]]
 ) -> dict[str, Any]:
     """Construct storage.backends section in OGX configuration file.
 
@@ -235,7 +235,7 @@ def construct_storage_backends_section(
 
     Parameters:
     ----------
-        ls_config (dict[str, Any]): Existing OGX configuration mapping.
+        ogx_config (dict[str, Any]): Existing OGX configuration mapping.
         byok_rag (list[dict[str, Any]]): List of BYOK RAG definitions.
 
     Returns:
@@ -245,8 +245,8 @@ def construct_storage_backends_section(
     output: dict[str, Any] = {}
 
     # preserve existing backends
-    if "storage" in ls_config and "backends" in ls_config["storage"]:
-        output = ls_config["storage"]["backends"].copy()
+    if "storage" in ogx_config and "backends" in ogx_config["storage"]:
+        output = ogx_config["storage"]["backends"].copy()
 
     # add new backends for each BYOK RAG (skip types that don't need one)
     added = 0
@@ -273,7 +273,7 @@ def construct_storage_backends_section(
 
 
 def construct_vector_stores_section(
-    ls_config: dict[str, Any], byok_rag: list[dict[str, Any]]
+    ogx_config: dict[str, Any], byok_rag: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     """Construct registered_resources.vector_stores section in OGX config.
 
@@ -281,7 +281,7 @@ def construct_vector_stores_section(
 
     Parameters:
     ----------
-        ls_config (dict[str, Any]): Existing OGX configuration mapping
+        ogx_config (dict[str, Any]): Existing OGX configuration mapping
         used as the base; existing `registered_resources.vector_stores` entries
         are preserved if present.
         byok_rag (list[dict[str, Any]]): List of BYOK RAG definitions to be added to
@@ -299,9 +299,9 @@ def construct_vector_stores_section(
     output = []
 
     # fill-in existing vector_stores entries from registered_resources
-    if "registered_resources" in ls_config:
-        if "vector_stores" in ls_config["registered_resources"]:
-            output = ls_config["registered_resources"]["vector_stores"].copy()
+    if "registered_resources" in ogx_config:
+        if "vector_stores" in ogx_config["registered_resources"]:
+            output = ogx_config["registered_resources"]["vector_stores"].copy()
 
     # append new vector_stores entries, skipping duplicates
     # Resolve ${env.VAR} patterns so comparisons work when existing entries
@@ -342,7 +342,7 @@ def construct_vector_stores_section(
 
 
 def construct_models_section(
-    ls_config: dict[str, Any], byok_rag: list[dict[str, Any]]
+    ogx_config: dict[str, Any], byok_rag: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     """Construct registered_resources.models section with embedding models.
 
@@ -350,7 +350,7 @@ def construct_models_section(
 
     Parameters:
     ----------
-        ls_config (dict[str, Any]): Existing OGX configuration mapping.
+        ogx_config (dict[str, Any]): Existing OGX configuration mapping.
         byok_rag (list[dict[str, Any]]): List of BYOK RAG definitions.
 
     Returns:
@@ -360,9 +360,9 @@ def construct_models_section(
     output: list[dict[str, Any]] = []
 
     # preserve existing models
-    if "registered_resources" in ls_config:
-        if "models" in ls_config["registered_resources"]:
-            output = ls_config["registered_resources"]["models"].copy()
+    if "registered_resources" in ogx_config:
+        if "models" in ogx_config["registered_resources"]:
+            output = ogx_config["registered_resources"]["models"].copy()
 
     # add embedding models for each BYOK RAG
     for brag in byok_rag:
@@ -448,7 +448,7 @@ def _build_vector_io_config(
 
 
 def construct_vector_io_providers_section(
-    ls_config: dict[str, Any], byok_rag: list[dict[str, Any]]
+    ogx_config: dict[str, Any], byok_rag: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     """Construct providers/vector_io section in OGX configuration file.
 
@@ -458,7 +458,7 @@ def construct_vector_io_providers_section(
 
     Parameters:
     ----------
-        ls_config (dict[str, Any]): Existing OGX configuration
+        ogx_config (dict[str, Any]): Existing OGX configuration
         dictionary; if it contains providers.vector_io, those entries are used
         as the starting list.
         byok_rag (list[dict[str, Any]]): List of BYOK RAG specifications to convert
@@ -474,8 +474,8 @@ def construct_vector_io_providers_section(
     """
     output: list[dict[str, Any]] = []
 
-    if "providers" in ls_config and "vector_io" in ls_config["providers"]:
-        raw = ls_config["providers"]["vector_io"]
+    if "providers" in ogx_config and "vector_io" in ogx_config["providers"]:
+        raw = ogx_config["providers"]["vector_io"]
         if isinstance(raw, list):
             output = _dedupe_vector_io_list(raw)
         else:
@@ -515,44 +515,44 @@ def construct_vector_io_providers_section(
     return output
 
 
-def enrich_byok_rag(ls_config: dict[str, Any], byok_rag: list[dict[str, Any]]) -> None:
+def enrich_byok_rag(ogx_config: dict[str, Any], byok_rag: list[dict[str, Any]]) -> None:
     """Enrich OGX config with BYOK RAG settings.
 
     Args:
-        ls_config: OGX configuration dict (modified in place)
+        ogx_config: OGX configuration dict (modified in place)
         byok_rag: List of BYOK RAG configurations
     """
     if len(byok_rag) == 0:
         logger.info("BYOK RAG is not configured: skipping")
-        dedupe_providers_vector_io(ls_config)
+        dedupe_providers_vector_io(ogx_config)
         return
 
     logger.info("Enriching OGX config with BYOK RAG")
 
     # Add storage backends
-    if "storage" not in ls_config:
-        ls_config["storage"] = {}
-    ls_config["storage"]["backends"] = construct_storage_backends_section(
-        ls_config, byok_rag
+    if "storage" not in ogx_config:
+        ogx_config["storage"] = {}
+    ogx_config["storage"]["backends"] = construct_storage_backends_section(
+        ogx_config, byok_rag
     )
 
     # Add vector_io providers
-    if "providers" not in ls_config:
-        ls_config["providers"] = {}
-    ls_config["providers"]["vector_io"] = construct_vector_io_providers_section(
-        ls_config, byok_rag
+    if "providers" not in ogx_config:
+        ogx_config["providers"] = {}
+    ogx_config["providers"]["vector_io"] = construct_vector_io_providers_section(
+        ogx_config, byok_rag
     )
 
     # Add registered vector stores
-    if "registered_resources" not in ls_config:
-        ls_config["registered_resources"] = {}
-    ls_config["registered_resources"]["vector_stores"] = (
-        construct_vector_stores_section(ls_config, byok_rag)
+    if "registered_resources" not in ogx_config:
+        ogx_config["registered_resources"] = {}
+    ogx_config["registered_resources"]["vector_stores"] = (
+        construct_vector_stores_section(ogx_config, byok_rag)
     )
 
     # Add embedding models
-    ls_config["registered_resources"]["models"] = construct_models_section(
-        ls_config, byok_rag
+    ogx_config["registered_resources"]["models"] = construct_models_section(
+        ogx_config, byok_rag
     )
 
 
@@ -585,7 +585,7 @@ def _vector_store_provider_by_id(
 
 
 def _upsert_vsprov_embedding_model(
-    ls_config: dict[str, Any],
+    ogx_config: dict[str, Any],
     provider_id: str,
     embedding_model: str,
     embedding_dimension: int,
@@ -598,13 +598,13 @@ def _upsert_vsprov_embedding_model(
     ``model_id`` already exists.
 
     Parameters:
-        ls_config: OGX configuration modified in place.
+        ogx_config: OGX configuration modified in place.
         provider_id: Dynamic provider id used to name the model row.
         embedding_model: Configured embedding model path or id.
         embedding_dimension: Embedding vector dimensionality (required on
             validated ``vector_store.providers`` entries).
     """
-    models = ls_config.setdefault("registered_resources", {}).setdefault("models", [])
+    models = ogx_config.setdefault("registered_resources", {}).setdefault("models", [])
     model_id = f"vsprov_{provider_id}_embedding"
     provider_model_id = embedding_model.removeprefix("sentence-transformers/")
     entry = {
@@ -693,18 +693,18 @@ def _replace_or_append_vector_io(
 
 
 def _apply_vector_stores_defaults(
-    ls_config: dict[str, Any], designated: dict[str, Any]
+    ogx_config: dict[str, Any], designated: dict[str, Any]
 ) -> None:
     """Write vector_stores.default_* from the designated provider entry.
 
     Parameters:
-        ls_config: OGX configuration modified in place.
+        ogx_config: OGX configuration modified in place.
         designated: Provider entry selected by ``vector_store.default_provider``.
     """
-    vector_stores = ls_config.get("vector_stores")
+    vector_stores = ogx_config.get("vector_stores")
     if not isinstance(vector_stores, dict):
         vector_stores = {}
-        ls_config["vector_stores"] = vector_stores
+        ogx_config["vector_stores"] = vector_stores
     provider_id = str(designated["id"]).strip()
     vector_stores["default_provider_id"] = provider_id
     # Match _upsert_vsprov_embedding_model model_id; OGX validates
@@ -721,7 +721,7 @@ def _enrich_one_vector_store_provider(
     backends: dict[str, Any],
     vector_io: list[Any],
     existing_ids: set[str],
-    ls_config: dict[str, Any],
+    ogx_config: dict[str, Any],
 ) -> None:
     """Enrich LS config for a single ``vector_store.providers`` entry.
 
@@ -730,11 +730,11 @@ def _enrich_one_vector_store_provider(
         backends: ``storage.backends`` map (modified in place for faiss).
         vector_io: ``providers.vector_io`` list (modified in place).
         existing_ids: Known ``provider_id`` values already in ``vector_io``.
-        ls_config: Full OGX config (for embedding model registration).
+        ogx_config: Full OGX config (for embedding model registration).
     """
     provider_id = str(entry["id"]).strip()
     product_type = entry["type"]
-    ls_type = BACKEND_TO_PROVIDER_TYPE[product_type]
+    ogx_provider_type = BACKEND_TO_PROVIDER_TYPE[product_type]
     extra_fields, backend_name, backend_entry = _vsprov_fields_and_backend(
         product_type, provider_id, entry.get("config") or {}
     )
@@ -746,8 +746,10 @@ def _enrich_one_vector_store_provider(
         existing_ids,
         {
             "provider_id": provider_id,
-            "provider_type": ls_type,
-            "config": _build_vector_io_config(ls_type, backend_name, extra_fields),
+            "provider_type": ogx_provider_type,
+            "config": _build_vector_io_config(
+                ogx_provider_type, backend_name, extra_fields
+            ),
         },
     )
 
@@ -755,7 +757,7 @@ def _enrich_one_vector_store_provider(
     embedding_dimension = entry.get("embedding_dimension")
     if embedding_model and embedding_dimension is not None:
         _upsert_vsprov_embedding_model(
-            ls_config,
+            ogx_config,
             provider_id=provider_id,
             embedding_model=embedding_model,
             embedding_dimension=embedding_dimension,
@@ -763,7 +765,7 @@ def _enrich_one_vector_store_provider(
 
 
 def enrich_vector_store(
-    ls_config: dict[str, Any],
+    ogx_config: dict[str, Any],
     vector_store: Optional[dict[str, Any]] = None,
 ) -> None:
     """Enrich LS config with dynamic vector-store provider capacity.
@@ -775,7 +777,7 @@ def enrich_vector_store(
     ``registered_resources.vector_stores``.
 
     Parameters:
-        ls_config: OGX configuration dictionary (modified in place).
+        ogx_config: OGX configuration dictionary (modified in place).
         vector_store: High-level ``vector_store`` section
             (``default_provider`` + ``providers``) as a dict.
     """
@@ -783,16 +785,16 @@ def enrich_vector_store(
     providers = vector_store.get("providers") or []
     if not providers:
         logger.debug("vector_store.providers not configured: skipping")
-        dedupe_providers_vector_io(ls_config)
+        dedupe_providers_vector_io(ogx_config)
         return
 
-    backends = ls_config.setdefault("storage", {}).setdefault("backends", {})
-    providers_section = ls_config.setdefault("providers", {})
+    backends = ogx_config.setdefault("storage", {}).setdefault("backends", {})
+    providers_section = ogx_config.setdefault("providers", {})
     vector_io = providers_section.get("vector_io")
     if not isinstance(vector_io, list):
         vector_io = []
         providers_section["vector_io"] = vector_io
-    ls_config.setdefault("registered_resources", {}).setdefault("models", [])
+    ogx_config.setdefault("registered_resources", {}).setdefault("models", [])
 
     existing_ids = {
         str(entry.get("provider_id")).strip()
@@ -802,16 +804,16 @@ def enrich_vector_store(
 
     for entry in providers:
         _enrich_one_vector_store_provider(
-            entry, backends, vector_io, existing_ids, ls_config
+            entry, backends, vector_io, existing_ids, ogx_config
         )
 
     designated = _vector_store_provider_by_id(
         providers, vector_store.get("default_provider")
     )
     if designated is not None:
-        _apply_vector_stores_defaults(ls_config, designated)
+        _apply_vector_stores_defaults(ogx_config, designated)
 
-    dedupe_providers_vector_io(ls_config)
+    dedupe_providers_vector_io(ogx_config)
 
 
 # =============================================================================
@@ -820,14 +822,14 @@ def enrich_vector_store(
 
 
 def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
-    ls_config: dict[str, Any],
+    ogx_config: dict[str, Any],
     rag_config: dict[str, Any],
     okp_config: dict[str, Any],
 ) -> None:
     """Enrich OGX config with Solr settings.
 
     Parameters:
-        ls_config: OGX configuration dict (modified in place)
+        ogx_config: OGX configuration dict (modified in place)
         rag_config: RAG configuration dict. Used keys:
             - inline (list[str]): inline RAG IDs
             - tool (list[str]): tool RAG IDs
@@ -861,14 +863,14 @@ def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
     logger.info("Enriching OGX config with OKP")
 
     # Add vector_io provider for Solr
-    if "providers" not in ls_config:
-        ls_config["providers"] = {}
-    if "vector_io" not in ls_config["providers"]:
-        ls_config["providers"]["vector_io"] = []
+    if "providers" not in ogx_config:
+        ogx_config["providers"] = {}
+    if "vector_io" not in ogx_config["providers"]:
+        ogx_config["providers"]["vector_io"] = []
 
     # Add Solr provider if not already present
     existing_providers = [
-        p.get("provider_id") for p in ls_config["providers"]["vector_io"]
+        p.get("provider_id") for p in ogx_config["providers"]["vector_io"]
     ]
     if constants.SOLR_PROVIDER_ID not in existing_providers:
         collection_env = (
@@ -886,7 +888,7 @@ def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
         embedding_dim_env = (
             f"${{env.SOLR_EMBEDDING_DIM:={constants.SOLR_DEFAULT_EMBEDDING_DIMENSION}}}"
         )
-        ls_config["providers"]["vector_io"].append(
+        ogx_config["providers"]["vector_io"].append(
             {
                 "provider_id": constants.SOLR_PROVIDER_ID,
                 "provider_type": "remote::solr_vector_io",
@@ -919,18 +921,18 @@ def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
         logger.info("Added OKP provider to providers/vector_io")
 
     # Add vector store registration for Solr
-    if "registered_resources" not in ls_config:
-        ls_config["registered_resources"] = {}
-    if "vector_stores" not in ls_config["registered_resources"]:
-        ls_config["registered_resources"]["vector_stores"] = []
+    if "registered_resources" not in ogx_config:
+        ogx_config["registered_resources"] = {}
+    if "vector_stores" not in ogx_config["registered_resources"]:
+        ogx_config["registered_resources"]["vector_stores"] = []
 
     # Add Solr vector store if not already present
     existing_stores = [
         vs.get("vector_store_id")
-        for vs in ls_config["registered_resources"]["vector_stores"]
+        for vs in ogx_config["registered_resources"]["vector_stores"]
     ]
     if constants.SOLR_DEFAULT_VECTOR_STORE_ID not in existing_stores:
-        ls_config["registered_resources"]["vector_stores"].append(
+        ogx_config["registered_resources"]["vector_stores"].append(
             {
                 "vector_store_id": constants.SOLR_DEFAULT_VECTOR_STORE_ID,
                 "provider_id": constants.SOLR_PROVIDER_ID,
@@ -944,21 +946,21 @@ def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
         )
 
     # Add Solr embedding model to registered_resources.models if not already present
-    if "models" not in ls_config["registered_resources"]:
-        ls_config["registered_resources"]["models"] = []
+    if "models" not in ogx_config["registered_resources"]:
+        ogx_config["registered_resources"]["models"] = []
 
     # Strip sentence-transformers/ prefix from constant for provider_model_id
     provider_model_id = constants.SOLR_DEFAULT_EMBEDDING_MODEL
     provider_model_id = provider_model_id.removeprefix("sentence-transformers/")
 
     # Check if already registered
-    registered_models = ls_config["registered_resources"]["models"]
+    registered_models = ogx_config["registered_resources"]["models"]
     existing_model_ids = [m.get("provider_model_id") for m in registered_models]
     if provider_model_id not in existing_model_ids:
         # Build environment variable expression
         provider_model_env = f"${{env.SOLR_EMBEDDING_MODEL:={provider_model_id}}}"
 
-        ls_config["registered_resources"]["models"].append(
+        ogx_config["registered_resources"]["models"].append(
             {
                 "model_id": constants.SOLR_EMBEDDING_MODEL_ID,
                 "model_type": "embedding",
@@ -981,9 +983,9 @@ def enrich_solr(  # pylint: disable=too-many-locals,too-many-statements
         # LCORE uses "semantic"; OGX uses "vector"
         if ogx_mode == "semantic":
             ogx_mode = "vector"
-        if "vector_stores" not in ls_config:
-            ls_config["vector_stores"] = {}
-        chunk_params = ls_config["vector_stores"].setdefault(
+        if "vector_stores" not in ogx_config:
+            ogx_config["vector_stores"] = {}
+        chunk_params = ogx_config["vector_stores"].setdefault(
             "chunk_retrieval_params", {}
         )
         chunk_params["default_search_mode"] = ogx_mode
@@ -1059,17 +1061,17 @@ def _matchable_provider_id(provider_id: Any) -> Any:
     return provider_id
 
 
-def _strip_default_openai_inference(ls_config: dict[str, Any]) -> None:
+def _strip_default_openai_inference(ogx_config: dict[str, Any]) -> None:
     """Remove the OpenAI inference provider from the default baseline.
 
     Parameters:
-        ls_config: The Llama Stack configuration being synthesized (modified
+        ogx_config: The OGX configuration being synthesized (modified
             in place).
 
     Returns:
-        None: ``ls_config`` is modified in place.
+        None: ``ogx_config`` is modified in place.
     """
-    providers = ls_config.get("providers")
+    providers = ogx_config.get("providers")
     if not isinstance(providers, dict):
         return
     inference = providers.get("inference")
@@ -1086,7 +1088,7 @@ def _strip_default_openai_inference(ls_config: dict[str, Any]) -> None:
 
 
 def apply_high_level_inference(
-    ls_config: dict[str, Any], inference: dict[str, Any]
+    ogx_config: dict[str, Any], inference: dict[str, Any]
 ) -> None:
     """Expand high-level ``inference.providers`` into OGX provider entries.
 
@@ -1104,35 +1106,35 @@ def apply_high_level_inference(
     values (R6).
 
     Parameters:
-        ls_config: The OGX configuration being synthesized (modified in
+        ogx_config: The OGX configuration being synthesized (modified in
             place).
         inference: The root ``inference`` section as a dict; only its
             ``providers`` list is consumed here.
 
     Returns:
-        None: ``ls_config`` is modified in place.
+        None: ``ogx_config`` is modified in place.
     """
     providers = inference.get("providers") or []
     if not providers:
         return
 
-    providers_section = ls_config.setdefault("providers", {})
+    providers_section = ogx_config.setdefault("providers", {})
     inference_list = providers_section.setdefault("inference", [])
 
     for provider in providers:
         provider_type = provider["type"]
         emitted_id = provider.get("id") or provider_type.replace("_", "-")
-        ls_provider_type = PROVIDER_TYPE_MAP[provider_type]
+        ogx_provider_type = PROVIDER_TYPE_MAP[provider_type]
         entry: dict[str, Any] = {
             "provider_id": emitted_id,
-            "provider_type": ls_provider_type,
+            "provider_type": ogx_provider_type,
         }
 
         provider_config: dict[str, Any] = {}
         if provider.get("extra"):
             provider_config.update(provider["extra"])
         if provider.get("api_key_env"):
-            key_field = API_KEY_FIELD_MAP.get(ls_provider_type, "api_key")
+            key_field = API_KEY_FIELD_MAP.get(ogx_provider_type, "api_key")
             provider_config[key_field] = "${env." + provider["api_key_env"] + "}"
         if provider.get("allowed_models"):
             provider_config["allowed_models"] = provider["allowed_models"]
@@ -1162,8 +1164,8 @@ def apply_high_level_inference(
     )
 
 
-def ensure_mcp_tool_runtime(ls_config: dict[str, Any]) -> None:
-    """Ensure the default MCP tool_runtime provider exists in ``ls_config``.
+def ensure_mcp_tool_runtime(ogx_config: dict[str, Any]) -> None:
+    """Ensure the default MCP tool_runtime provider exists in ``ogx_config``.
 
     Adds ``tool_runtime`` to ``apis`` when missing, then appends the default
     ``model-context-protocol`` provider under ``providers.tool_runtime`` when
@@ -1171,17 +1173,17 @@ def ensure_mcp_tool_runtime(ls_config: dict[str, Any]) -> None:
     (including ``rag-runtime``) are left untouched.
 
     Parameters:
-        ls_config: The OGX configuration being synthesized (modified
+        ogx_config: The OGX configuration being synthesized (modified
             in place).
 
     Returns:
-        None: ``ls_config`` is modified in place.
+        None: ``ogx_config`` is modified in place.
     """
-    apis = ls_config.setdefault("apis", [])
+    apis = ogx_config.setdefault("apis", [])
     if "tool_runtime" not in apis:
         apis.append("tool_runtime")
 
-    providers_section = ls_config.setdefault("providers", {})
+    providers_section = ogx_config.setdefault("providers", {})
     tool_runtime = providers_section.setdefault("tool_runtime", [])
     for existing in tool_runtime:
         if (
@@ -1272,7 +1274,7 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
             else load_default_baseline()
         )
 
-    ls_config: dict[str, Any] = copy.deepcopy(baseline)
+    ogx_config: dict[str, Any] = copy.deepcopy(baseline)
 
     # Profile and empty are unchanged. The shipped file either keeps OpenAI
     # (default/omitted, with a deprecation WARN) or drops it (byo-llm).
@@ -1283,7 +1285,7 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     # Engineering Support Agreement's one-minor deprecation phase applies.
     if loaded_shipped_baseline:
         if unified and unified.get("baseline") == "byo-llm":
-            _strip_default_openai_inference(ls_config)
+            _strip_default_openai_inference(ogx_config)
         else:
             logger.warning(
                 "DEPRECATED: the built-in OpenAI inference provider in "
@@ -1296,23 +1298,23 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
             )
 
     # 3. Normalize duplicated vector_io providers in the baseline.
-    dedupe_providers_vector_io(ls_config)
+    dedupe_providers_vector_io(ogx_config)
 
     # 4. High-level inference providers (Decision S5 — a root-level section).
     inference = lcs_config.get("inference") or {}
     if inference.get("providers"):
-        apply_high_level_inference(ls_config, inference)
+        apply_high_level_inference(ogx_config, inference)
 
     # 5. Ensure MCP tool_runtime for default/profile baselines (skipped for
     #    baseline: empty so migrate round-trips stay lossless).
     if not baseline_was_empty:
-        ensure_mcp_tool_runtime(ls_config)
+        ensure_mcp_tool_runtime(ogx_config)
 
     # 6. Raw escape hatch, deep-merged with list replacement. It wins over the
     #    baseline and the high-level expansion (R5) but deliberately NOT over
     #    enrichment (step 7).
     if unified and unified.get("native_override"):
-        ls_config = deep_merge_list_replace(ls_config, unified["native_override"])
+        ogx_config = deep_merge_list_replace(ogx_config, unified["native_override"])
 
     # 7. Existing enrichment — same calls as legacy generate_configuration so
     #    unified output matches legacy output for equivalent inputs (R7).
@@ -1322,23 +1324,23 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     #    get the same treatment or list-shaped enrichment artifacts
     #    (vector_io providers, registered models, azure model_validation) are
     #    replaced wholesale by the lifted lists and silently lost.
-    enrich_azure_entra_id_inference(ls_config, lcs_config.get("azure_entra_id"))
+    enrich_azure_entra_id_inference(ogx_config, lcs_config.get("azure_entra_id"))
     rag_section = lcs_config.get("rag", {})
     byok_stores = rag_section.get("byok", {}).get("stores", [])
-    enrich_byok_rag(ls_config, byok_stores)
+    enrich_byok_rag(ogx_config, byok_stores)
     retrieval = rag_section.get("retrieval", {})
     rag_config_for_solr = {
         "inline": retrieval.get("inline", {}).get("sources", []),
         "tool": retrieval.get("tool", {}).get("sources", []),
     }
     okp_config = rag_section.get("okp", {})
-    enrich_solr(ls_config, rag_config_for_solr, okp_config)
-    enrich_vector_store(ls_config, lcs_config.get("vector_store"))
+    enrich_solr(ogx_config, rag_config_for_solr, okp_config)
+    enrich_vector_store(ogx_config, lcs_config.get("vector_store"))
 
     # 8. Dedupe again in case native_override or enrichment reintroduced dupes.
-    dedupe_providers_vector_io(ls_config)
+    dedupe_providers_vector_io(ogx_config)
 
-    return ls_config
+    return ogx_config
 
 
 def synthesize_to_file(
@@ -1364,7 +1366,7 @@ def synthesize_to_file(
     Returns:
         None.
     """
-    ls_config = synthesize_configuration(lcs_config, config_file_dir, default_baseline)
+    ogx_config = synthesize_configuration(lcs_config, config_file_dir, default_baseline)
 
     path = Path(output_file)
     if path.parent != Path(""):
@@ -1374,7 +1376,7 @@ def synthesize_to_file(
     # the write guarantees 0600 even when overwriting a pre-existing file.
     fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as file:
-        yaml.dump(ls_config, file, Dumper=YamlDumper, default_flow_style=False)
+        yaml.dump(ogx_config, file, Dumper=YamlDumper, default_flow_style=False)
     os.chmod(str(path), 0o600)
 
     logger.info("Wrote synthesized OGX configuration to %s (mode 0600)", path)
@@ -1480,17 +1482,17 @@ def generate_configuration(
     logger.info("Reading OGX configuration from file %s", input_file)
 
     with open(input_file, encoding="utf-8") as file:
-        ls_config = yaml.safe_load(file)
+        ogx_config = yaml.safe_load(file)
 
-    dedupe_providers_vector_io(ls_config)
+    dedupe_providers_vector_io(ogx_config)
 
     # Enrichment: Azure Entra ID deferred auth
-    enrich_azure_entra_id_inference(ls_config, config.get("azure_entra_id"))
+    enrich_azure_entra_id_inference(ogx_config, config.get("azure_entra_id"))
 
     # Enrichment: BYOK RAG
     rag_section = config.get("rag", {})
     byok_stores = rag_section.get("byok", {}).get("stores", [])
-    enrich_byok_rag(ls_config, byok_stores)
+    enrich_byok_rag(ogx_config, byok_stores)
 
     # Enrichment: Solr - enabled when "okp" appears in either inline or tool list
     retrieval = rag_section.get("retrieval", {})
@@ -1499,14 +1501,14 @@ def generate_configuration(
         "tool": retrieval.get("tool", {}).get("sources", []),
     }
     okp_config = rag_section.get("okp", {})
-    enrich_solr(ls_config, rag_config_for_solr, okp_config)
+    enrich_solr(ogx_config, rag_config_for_solr, okp_config)
 
-    dedupe_providers_vector_io(ls_config)
+    dedupe_providers_vector_io(ogx_config)
 
     logger.info("Writing OGX configuration into file %s", output_file)
 
     with open(output_file, "w", encoding="utf-8") as file:
-        yaml.dump(ls_config, file, Dumper=YamlDumper, default_flow_style=False)
+        yaml.dump(ogx_config, file, Dumper=YamlDumper, default_flow_style=False)
 
 
 # =============================================================================

--- a/src/telemetry/configuration_snapshot.py
+++ b/src/telemetry/configuration_snapshot.py
@@ -647,7 +647,7 @@ def _extract_snapshot_fields(
 # =============================================================================
 
 
-def _extract_store_info(ls_config: dict[str, Any], store_name: str) -> dict[str, Any]:
+def _extract_store_info(ogx_config: dict[str, Any], store_name: str) -> dict[str, Any]:
     """Extract store type and db_path from OGX storage configuration.
 
     Resolves the store → backend → type/db_path chain in the OGX
@@ -655,14 +655,14 @@ def _extract_store_info(ls_config: dict[str, Any], store_name: str) -> dict[str,
 
     Parameters:
     ----------
-        ls_config: The parsed OGX configuration dict.
+        ogx_config: The parsed OGX configuration dict.
         store_name: Name of the store to look up (e.g., "inference", "metadata").
 
     Returns:
     -------
         A dict with 'type' and 'db_path' keys, plus 'namespace' for metadata store.
     """
-    store = get_nested_value(ls_config, f"storage.stores.{store_name}")
+    store = get_nested_value(ogx_config, f"storage.stores.{store_name}")
     if store is None or not isinstance(store, dict):
         return {"type": NOT_CONFIGURED, "db_path": NOT_CONFIGURED}
 
@@ -670,7 +670,7 @@ def _extract_store_info(ls_config: dict[str, Any], store_name: str) -> dict[str,
     if backend_name is None:
         return {"type": NOT_CONFIGURED, "db_path": NOT_CONFIGURED}
 
-    backends = get_nested_value(ls_config, "storage.backends") or {}
+    backends = get_nested_value(ogx_config, "storage.backends") or {}
     backend = backends.get(backend_name, {})
 
     result: dict[str, Any] = {
@@ -750,15 +750,15 @@ async def build_ogx_snapshot(
     if config_path is None:
         return {"status": NOT_AVAILABLE}
 
-    ls_config = await asyncio.to_thread(_read_yaml_file, config_path)
+    ogx_config = await asyncio.to_thread(_read_yaml_file, config_path)
 
-    if not isinstance(ls_config, dict):
+    if not isinstance(ogx_config, dict):
         logger.warning("OGX config is not a dict, skipping snapshot")
         return {"status": NOT_AVAILABLE}
 
-    snapshot = _extract_snapshot_fields(ls_config, OGX_FIELDS)
-    snapshot["inference_store"] = _extract_store_info(ls_config, "inference")
-    snapshot["metadata_store"] = _extract_store_info(ls_config, "metadata")
+    snapshot = _extract_snapshot_fields(ogx_config, OGX_FIELDS)
+    snapshot["inference_store"] = _extract_store_info(ogx_config, "inference")
+    snapshot["metadata_store"] = _extract_store_info(ogx_config, "metadata")
     return snapshot
 
 

--- a/src/utils/conversations.py
+++ b/src/utils/conversations.py
@@ -564,7 +564,7 @@ async def append_turn_items_to_conversation(
 
 async def get_all_conversation_items(
     client: AsyncOgxClient,
-    conversation_id_llama_stack: str,
+    conversation_id_ogx: str,
 ) -> list[ConversationItem]:
     """Fetch all items for a conversation (Conversations API), paginating as needed.
 
@@ -581,7 +581,7 @@ async def get_all_conversation_items(
     try:
         while has_more:
             page = await client.items.list(
-                conversation_id=conversation_id_llama_stack,
+                conversation_id=conversation_id_ogx,
                 order="asc",
                 after=after,
             )

--- a/tests/e2e-prow/rhoai/manifests/lightspeed/lightspeed-stack.yaml
+++ b/tests/e2e-prow/rhoai/manifests/lightspeed/lightspeed-stack.yaml
@@ -43,7 +43,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       env:
-        - name: E2E_LLAMA_HOSTNAME
+        - name: E2E_OGX_HOSTNAME
           valueFrom:
             secretKeyRef:
               name: llama-stack-ip-secret

--- a/tests/e2e-prow/rhoai/manifests/lightspeed/ogx-openai.yaml
+++ b/tests/e2e-prow/rhoai/manifests/lightspeed/ogx-openai.yaml
@@ -183,7 +183,7 @@ spec:
             secretKeyRef:
               name: faiss-vector-store-secret
               key: id
-        - name: E2E_LLAMA_HOSTNAME
+        - name: E2E_OGX_HOSTNAME
           valueFrom:
             secretKeyRef:
               name: llama-stack-ip-secret

--- a/tests/e2e-prow/rhoai/manifests/lightspeed/ogx-prow.yaml
+++ b/tests/e2e-prow/rhoai/manifests/lightspeed/ogx-prow.yaml
@@ -126,7 +126,7 @@ spec:
             secretKeyRef:
               name: faiss-vector-store-secret
               key: id
-        - name: E2E_LLAMA_HOSTNAME
+        - name: E2E_OGX_HOSTNAME
           valueFrom:
             secretKeyRef:
               name: llama-stack-ip-secret
@@ -155,7 +155,7 @@ spec:
           ENRICHED_CONFIG="/opt/app-root/run.yaml"
           LIGHTSPEED_CONFIG="${LIGHTSPEED_CONFIG:-/opt/app-root/lightspeed-stack.yaml}"
           if [[ -f "$LIGHTSPEED_CONFIG" ]]; then
-            echo "Enriching llama-stack config..."
+            echo "Enriching OGX config..."
             ENRICHMENT_FAILED=0
             /opt/app-root/.venv/bin/python3 /opt/app-root/src/ogx_configuration.py \
               -c "$LIGHTSPEED_CONFIG" \

--- a/tests/e2e-prow/rhoai/pipeline-konflux.sh
+++ b/tests/e2e-prow/rhoai/pipeline-konflux.sh
@@ -296,9 +296,9 @@ fi
 # So behave/e2e-ops can kill this listener before rebinding 8080 (restart-lightspeed hooks).
 # Debug hook/port churn: export E2E_OPS_VERBOSE=1 before running pipeline.sh
 export E2E_LSC_PORT_FORWARD_PID_FILE="${E2E_LSC_PORT_FORWARD_PID_FILE:-/tmp/e2e-lightspeed-port-forward.pid}"
-export E2E_LLAMA_PORT_FORWARD_PID_FILE="${E2E_LLAMA_PORT_FORWARD_PID_FILE:-/tmp/e2e-llama-port-forward.pid}"
+export E2E_OGX_PORT_FORWARD_PID_FILE="${E2E_OGX_PORT_FORWARD_PID_FILE:-/tmp/e2e-ogx-port-forward.pid}"
 rm -f "$E2E_LSC_PORT_FORWARD_PID_FILE"
-rm -f "$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+rm -f "$E2E_OGX_PORT_FORWARD_PID_FILE"
 
 oc label pod lightspeed-stack-service pod=lightspeed-stack-service -n $NAMESPACE
 
@@ -336,8 +336,8 @@ PF_JWKS_PID=$!
 # OGX directly — mirror LCS and forward llama-stack-service-svc to localhost:8321.
 log "Starting port-forward for llama-stack (MCP / ogx_client hooks)..."
 oc port-forward svc/llama-stack-service-svc 8321:8321 -n $NAMESPACE &
-PF_LLAMA_PID=$!
-echo "$PF_LLAMA_PID" >"$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+PF_OGX_PID=$!
+echo "$PF_OGX_PID" >"$E2E_OGX_PORT_FORWARD_PID_FILE"
 
 # Wait for port-forward to be usable (app may not be listening immediately; port-forward can drop)
 log "Waiting for port-forward to lightspeed-stack to be ready..."
@@ -358,7 +358,7 @@ for i in $(seq 1 36); do
     done < <(oc get events -n "$NAMESPACE" --sort-by='.lastTimestamp' 2>&1 | tail -40) || true
     kill $PF_LCS_PID 2>/dev/null || true
     kill $PF_JWKS_PID 2>/dev/null || true
-    kill $PF_LLAMA_PID 2>/dev/null || true
+    kill $PF_OGX_PID 2>/dev/null || true
     exit 1
   fi
   # If port-forward process died, restart it (e.g. "connection refused" / "lost connection to pod")
@@ -384,22 +384,22 @@ for i in $(seq 1 36); do
     e2e_echo_pod_logs 250
     kill $PF_LCS_PID 2>/dev/null || true
     kill $PF_JWKS_PID 2>/dev/null || true
-    kill $PF_LLAMA_PID 2>/dev/null || true
+    kill $PF_OGX_PID 2>/dev/null || true
     exit 1
   fi
-  if ! kill -0 $PF_LLAMA_PID 2>/dev/null; then
+  if ! kill -0 $PF_OGX_PID 2>/dev/null; then
     log "Llama port-forward died, restarting (attempt $i)..."
     oc port-forward svc/llama-stack-service-svc 8321:8321 -n $NAMESPACE &
-    PF_LLAMA_PID=$!
-    echo "$PF_LLAMA_PID" >"$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+    PF_OGX_PID=$!
+    echo "$PF_OGX_PID" >"$E2E_OGX_PORT_FORWARD_PID_FILE"
   fi
   sleep 5
 done
 
 export E2E_LSC_HOSTNAME="localhost"
 export E2E_JWKS_HOSTNAME="localhost"
-export E2E_LLAMA_HOSTNAME="localhost"
-export E2E_LLAMA_PORT="8321"
+export E2E_OGX_HOSTNAME="localhost"
+export E2E_OGX_PORT="8321"
 # Same pattern as tests/e2e-prow/rhoai/pipeline.sh and .github/workflows/e2e_tests_*.yaml:
 # Behave {MODEL}/{PROVIDER} use these when set; avoids wrong fallbacks if /v1/models
 # discovery in before_all is empty (matches run-ci.yaml openai + E2E_OPENAI_MODEL).
@@ -413,7 +413,7 @@ fi
 export E2E_DEFAULT_PROVIDER_OVERRIDE E2E_DEFAULT_MODEL_OVERRIDE
 log "LCS accessible at: http://$E2E_LSC_HOSTNAME:8080"
 log "Mock JWKS accessible at: http://$E2E_JWKS_HOSTNAME:8000"
-log "OGX (e2e client hooks) at: http://$E2E_LLAMA_HOSTNAME:$E2E_LLAMA_PORT"
+log "OGX (e2e client hooks) at: http://$E2E_OGX_HOSTNAME:$E2E_OGX_PORT"
 
 #========================================
 # 7. RUN TESTS
@@ -441,20 +441,20 @@ if [[ -n "${E2E_LSC_PORT_FORWARD_PID_FILE:-}" && -f "$E2E_LSC_PORT_FORWARD_PID_F
   fi
   rm -f "$E2E_LSC_PORT_FORWARD_PID_FILE"
 fi
-if [[ -n "${E2E_LLAMA_PORT_FORWARD_PID_FILE:-}" && -f "$E2E_LLAMA_PORT_FORWARD_PID_FILE" ]]; then
-  read -r _ll_pf <"$E2E_LLAMA_PORT_FORWARD_PID_FILE" 2>/dev/null || true
+if [[ -n "${E2E_OGX_PORT_FORWARD_PID_FILE:-}" && -f "$E2E_OGX_PORT_FORWARD_PID_FILE" ]]; then
+  read -r _ll_pf <"$E2E_OGX_PORT_FORWARD_PID_FILE" 2>/dev/null || true
   if [[ "${_ll_pf:-}" =~ ^[0-9]+$ ]]; then
     kill -9 "$_ll_pf" 2>/dev/null || true
   fi
-  rm -f "$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+  rm -f "$E2E_OGX_PORT_FORWARD_PID_FILE"
 fi
 
 kill $PF_LCS_PID 2>/dev/null || true
 kill $PF_JWKS_PID 2>/dev/null || true
-kill $PF_LLAMA_PID 2>/dev/null || true
+kill $PF_OGX_PID 2>/dev/null || true
 wait $PF_LCS_PID 2>/dev/null || true
 wait $PF_JWKS_PID 2>/dev/null || true
-wait $PF_LLAMA_PID 2>/dev/null || true
+wait $PF_OGX_PID 2>/dev/null || true
 set -e
 trap 'echo "❌ Pipeline failed at line $LINENO"; exit 1' ERR
 

--- a/tests/e2e-prow/rhoai/pipeline-services-konflux.sh
+++ b/tests/e2e-prow/rhoai/pipeline-services-konflux.sh
@@ -19,7 +19,7 @@ if [ -f "$REPO_ROOT/tests/e2e/secrets/invalid-mcp-token" ]; then
 fi
 
 # 1. OGX (run from source). Cluster DNS name matches oc expose --name=llama-stack-service-svc.
-# Secret must exist before the pod: both LCS and OGX-container use E2E_LLAMA_HOSTNAME from it.
+# Secret must exist before the pod: both LCS and OGX-container use E2E_OGX_HOSTNAME from it.
 _LLAMA_SVC_FQDN="llama-stack-service-svc.${NAMESPACE}.svc.cluster.local"
 oc create secret generic llama-stack-ip-secret \
   --from-literal=key="$_LLAMA_SVC_FQDN" \

--- a/tests/e2e-prow/rhoai/pipeline-services.sh
+++ b/tests/e2e-prow/rhoai/pipeline-services.sh
@@ -4,9 +4,9 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAMESPACE="${NAMESPACE:-e2e-rhoai-dsc}"
 
 # Create OGX-ip-secret before deploying the pod (it references the secret as an env var)
-export E2E_LLAMA_HOSTNAME="llama-stack-service-svc.${NAMESPACE}.svc.cluster.local"
+export E2E_OGX_HOSTNAME="llama-stack-service-svc.${NAMESPACE}.svc.cluster.local"
 oc create secret generic llama-stack-ip-secret \
-    --from-literal=key="$E2E_LLAMA_HOSTNAME" \
+    --from-literal=key="$E2E_OGX_HOSTNAME" \
     -n "$NAMESPACE" 2>/dev/null || echo "Secret llama-stack-ip-secret exists"
 
 # Deploy OGX (substitute only LLAMA_STACK_IMAGE, leave other ${} intact)

--- a/tests/e2e-prow/rhoai/pipeline.sh
+++ b/tests/e2e-prow/rhoai/pipeline.sh
@@ -356,10 +356,10 @@ oc describe pod llama-stack-service -n "$NAMESPACE" || true
 # Export PID file paths so e2e-ops.sh can find and kill stale port-forwards
 # during test-triggered pod restarts (matches pipeline-konflux.sh).
 export E2E_LSC_PORT_FORWARD_PID_FILE="${E2E_LSC_PORT_FORWARD_PID_FILE:-/tmp/e2e-lightspeed-port-forward.pid}"
-export E2E_LLAMA_PORT_FORWARD_PID_FILE="${E2E_LLAMA_PORT_FORWARD_PID_FILE:-/tmp/e2e-llama-port-forward.pid}"
+export E2E_OGX_PORT_FORWARD_PID_FILE="${E2E_OGX_PORT_FORWARD_PID_FILE:-/tmp/e2e-ogx-port-forward.pid}"
 export E2E_JWKS_PORT_FORWARD_PID_FILE="${E2E_JWKS_PORT_FORWARD_PID_FILE:-/tmp/e2e-jwks-port-forward.pid}"
 rm -f "$E2E_LSC_PORT_FORWARD_PID_FILE"
-rm -f "$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+rm -f "$E2E_OGX_PORT_FORWARD_PID_FILE"
 rm -f "$E2E_JWKS_PORT_FORWARD_PID_FILE"
 
 oc label pod lightspeed-stack-service pod=lightspeed-stack-service -n $NAMESPACE
@@ -398,8 +398,8 @@ echo "$PF_JWKS_PID" >"$E2E_JWKS_PORT_FORWARD_PID_FILE"
 # need localhost:8321. Without this forward those tests hit "Connection refused".
 echo "Starting port-forward for llama-stack..."
 oc port-forward svc/llama-stack-service-svc 8321:8321 -n $NAMESPACE &
-PF_LLAMA_PID=$!
-echo "$PF_LLAMA_PID" >"$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+PF_OGX_PID=$!
+echo "$PF_OGX_PID" >"$E2E_OGX_PORT_FORWARD_PID_FILE"
 
 # Wait for port-forward to be usable (app may not be listening immediately; port-forward can drop)
 echo "Waiting for port-forward to lightspeed-stack to be ready..."
@@ -421,7 +421,7 @@ for i in $(seq 1 36); do
     oc get pods -n "$NAMESPACE" -o wide || true
     kill $PF_LCS_PID 2>/dev/null || true
     kill $PF_JWKS_PID 2>/dev/null || true
-    kill $PF_LLAMA_PID 2>/dev/null || true
+    kill $PF_OGX_PID 2>/dev/null || true
     exit 1
   fi
   # If port-forward process died, restart it (e.g. "connection refused" / "lost connection to pod")
@@ -446,14 +446,14 @@ for i in $(seq 1 36); do
     oc logs llama-stack-service -n "$NAMESPACE" --tail=100 || true
     kill $PF_LCS_PID 2>/dev/null || true
     kill $PF_JWKS_PID 2>/dev/null || true
-    kill $PF_LLAMA_PID 2>/dev/null || true
+    kill $PF_OGX_PID 2>/dev/null || true
     exit 1
   fi
-  if ! kill -0 $PF_LLAMA_PID 2>/dev/null; then
+  if ! kill -0 $PF_OGX_PID 2>/dev/null; then
     echo "Llama port-forward died, restarting (attempt $i)..."
     oc port-forward svc/llama-stack-service-svc 8321:8321 -n $NAMESPACE &
-    PF_LLAMA_PID=$!
-    echo "$PF_LLAMA_PID" >"$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+    PF_OGX_PID=$!
+    echo "$PF_OGX_PID" >"$E2E_OGX_PORT_FORWARD_PID_FILE"
   fi
   sleep 5
 done
@@ -487,11 +487,11 @@ TEST_EXIT_CODE=$(cat "$E2E_EXIT_CODE_FILE" 2>/dev/null || echo 1)
 # Kill first so wait doesn't block (if a port-forward is still running, wait would hang)
 kill $PF_LCS_PID 2>/dev/null || true
 kill $PF_JWKS_PID 2>/dev/null || true
-kill $PF_LLAMA_PID 2>/dev/null || true
+kill $PF_OGX_PID 2>/dev/null || true
 wait $PF_LCS_PID 2>/dev/null || true
 wait $PF_JWKS_PID 2>/dev/null || true
-wait $PF_LLAMA_PID 2>/dev/null || true
-rm -f "$E2E_LSC_PORT_FORWARD_PID_FILE" "$E2E_LLAMA_PORT_FORWARD_PID_FILE" "$E2E_JWKS_PORT_FORWARD_PID_FILE"
+wait $PF_OGX_PID 2>/dev/null || true
+rm -f "$E2E_LSC_PORT_FORWARD_PID_FILE" "$E2E_OGX_PORT_FORWARD_PID_FILE" "$E2E_JWKS_PORT_FORWARD_PID_FILE"
 set -e
 trap 'echo "❌ Pipeline failed at line $LINENO"; exit 1' ERR
 

--- a/tests/e2e-prow/rhoai/scripts/e2e-ops.sh
+++ b/tests/e2e-prow/rhoai/scripts/e2e-ops.sh
@@ -12,21 +12,21 @@
 #   Behave steps that call OGX directly (MCP toolgroups, shields). When the llama
 #   pod is recreated, that forward must be restarted or you get "PodSandbox ... not found" /
 #   APIConnectionError on subsequent scenarios.
-# - E2E_LLAMA_PORT_FORWARD_PID_FILE coordinates killing/restarting the 8321 forward.
+# - E2E_OGX_PORT_FORWARD_PID_FILE coordinates killing/restarting the 8321 forward.
 # - restart-lightspeed ensures Llama is running before LCS recreate when needed.
-# - restart-both-services is available explicitly; restart-lightspeed / restart-llama-stack
+# - restart-both-services is available explicitly; restart-lightspeed / restart-ogx
 #   do not auto-trigger a full stack restart on failure.
 #
 # Commands:
 #   restart-lightspeed              - Restart lightspeed-stack pod and port-forward
-#   restart-llama-stack             - Restart/restore OGX pod and localhost:8321 forward
+#   restart-ogx             - Restart/restore OGX pod and localhost:8321 forward
 #   restart-both-services           - Full OGX then lightspeed-stack restart (explicit only)
 #   restart-port-forward            - Re-establish port-forward for lightspeed
-#   restart-llama-port-forward      - Re-establish port-forward for OGX (8321)
+#   restart-ogx-port-forward      - Re-establish port-forward for OGX (8321)
 #   wait-for-pod <name> [attempts]  - Wait for a pod to be ready
 #   update-configmap <name> <file>  - Update ConfigMap from file
 #   get-configmap-content <name>    - Get ConfigMap content (outputs to stdout)
-#   disrupt-llama-stack             - Delete OGX pod to disrupt connection
+#   disrupt-ogx             - Delete OGX pod to disrupt connection
 #   deploy-e2e-tunnel-proxy         - Deploy in-cluster tunnel proxy (proxy.feature step)
 #   deploy-e2e-interception-proxy   - Deploy in-cluster interception proxy (proxy.feature step)
 #   deploy-e2e-mock-tls-inference   - Deploy mock HTTPS inference server (tls-*.feature)
@@ -41,7 +41,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 MANIFEST_DIR="$SCRIPT_DIR/../manifests/lightspeed"
 # Written by pipeline.sh when it starts LCS port-forward; e2e-ops kills this PID before rebinding 8080.
 E2E_LSC_PORT_FORWARD_PID_FILE="${E2E_LSC_PORT_FORWARD_PID_FILE:-/tmp/e2e-lightspeed-port-forward.pid}"
-E2E_LLAMA_PORT_FORWARD_PID_FILE="${E2E_LLAMA_PORT_FORWARD_PID_FILE:-/tmp/e2e-llama-port-forward.pid}"
+E2E_OGX_PORT_FORWARD_PID_FILE="${E2E_OGX_PORT_FORWARD_PID_FILE:-/tmp/e2e-ogx-port-forward.pid}"
 E2E_JWKS_PORT_FORWARD_PID_FILE="${E2E_JWKS_PORT_FORWARD_PID_FILE:-/tmp/e2e-jwks-port-forward.pid}"
 
 # ============================================================================
@@ -177,8 +177,8 @@ kill_stale_lightspeed_forward() {
 kill_stale_llama_forward() {
     local port="${1:-8321}"
     local saved_pf
-    if [[ -f "$E2E_LLAMA_PORT_FORWARD_PID_FILE" ]]; then
-        read -r saved_pf <"$E2E_LLAMA_PORT_FORWARD_PID_FILE" 2>/dev/null || true
+    if [[ -f "$E2E_OGX_PORT_FORWARD_PID_FILE" ]]; then
+        read -r saved_pf <"$E2E_OGX_PORT_FORWARD_PID_FILE" 2>/dev/null || true
         if [[ "$saved_pf" =~ ^[0-9]+$ ]]; then
             kill -9 "$saved_pf" 2>/dev/null || true
         fi
@@ -225,7 +225,7 @@ e2e_ops_diagnose_forward_failure() {
         tail -30 /tmp/port-forward.log 2>/dev/null | sed 's/^/[e2e-ops] /' || true
     fi
     e2e_ops_dump_pod_logs "lightspeed-stack-service" 10000
-    if [[ "${E2E_COPY_MOCK_TLS_CERTS_TO_LLAMA:-0}" == "1" ]]; then
+    if [[ "${E2E_COPY_MOCK_TLS_CERTS_TO_OGX:-0}" == "1" ]]; then
         e2e_ops_dump_pod_logs "llama-stack-service" 10000
     fi
 }
@@ -333,14 +333,14 @@ _restart_llama_stack_core() {
 
     echo "Applying pod manifest..."
     if [[ "${E2E_KONFLUX_E2E:-0}" == "1" ]]; then
-        if [[ "${E2E_COPY_INTERCEPTION_CA_TO_LLAMA:-0}" == "1" ]]; then
+        if [[ "${E2E_COPY_INTERCEPTION_CA_TO_OGX:-0}" == "1" ]]; then
             echo "[e2e-ops] Syncing e2e-interception-proxy-ca secret before llama-stack apply..."
             if ! cmd_sync_interception_proxy_ca_secret; then
                 echo "===== Llama-stack restore FAILED (interception CA secret sync) ====="
                 return 1
             fi
         fi
-        if [[ "${E2E_COPY_MOCK_TLS_CERTS_TO_LLAMA:-0}" == "1" ]] \
+        if [[ "${E2E_COPY_MOCK_TLS_CERTS_TO_OGX:-0}" == "1" ]] \
             && [[ "${E2E_SYNC_MOCK_TLS_CERTS:-0}" == "1" ]]; then
             echo "[e2e-ops] Syncing e2e-mock-tls-certs secret before llama-stack apply..."
             if ! cmd_sync_mock_tls_certs_secret; then
@@ -365,7 +365,7 @@ _restart_llama_stack_core() {
         fi
         echo "Labeling pod for service..."
         oc label pod llama-stack-service pod=llama-stack-service -n "$NAMESPACE" --overwrite
-        if [[ "${E2E_COPY_INTERCEPTION_CA_TO_LLAMA:-0}" == "1" ]]; then
+        if [[ "${E2E_COPY_INTERCEPTION_CA_TO_OGX:-0}" == "1" ]]; then
             if ! _verify_interception_ca_mounted_in_llama; then
                 echo "===== Llama-stack restore FAILED (interception CA not mounted) ====="
                 return 1
@@ -387,7 +387,7 @@ _restart_llama_stack_core() {
     fi
 
     if ! cmd_restart_llama_port_forward; then
-        echo "ERROR: Llama pod is up but localhost:${LOCAL_LLAMA_PORT:-8321} port-forward failed"
+        echo "ERROR: Llama pod is up but localhost:${LOCAL_OGX_PORT:-8321} port-forward failed"
         e2e_ops_dump_pod_logs "llama-stack-service" 200
         return 1
     fi
@@ -401,10 +401,10 @@ _restart_lightspeed_core() {
     echo "Restarting lightspeed-stack service..."
 
     # Degraded-mode e2e must start LCS while llama is down. Default path restores
-    # llama first so pods can come up; set E2E_SKIP_LLAMA_RESTORE_ON_LCS_RESTART=1
+    # llama first so pods can come up; set E2E_SKIP_OGX_RESTORE_ON_LCS_RESTART=1
     # to keep llama disrupted for allow_degraded_mode startup checks.
-    if [[ "${E2E_SKIP_LLAMA_RESTORE_ON_LCS_RESTART:-0}" == "1" ]]; then
-        echo "⚠️  Skipping llama restore before LCS restart (E2E_SKIP_LLAMA_RESTORE_ON_LCS_RESTART=1)"
+    if [[ "${E2E_SKIP_OGX_RESTORE_ON_LCS_RESTART:-0}" == "1" ]]; then
+        echo "⚠️  Skipping llama restore before LCS restart (E2E_SKIP_OGX_RESTORE_ON_LCS_RESTART=1)"
     elif ! _llama_stack_http_health_once 2>/dev/null; then
         echo "⚠️  OGX not healthy — restoring before LCS restart..."
         if ! _restart_llama_stack_core; then
@@ -555,8 +555,8 @@ verify_llama_local_forward() {
 }
 
 cmd_restart_llama_port_forward() {
-    local local_port="${LOCAL_LLAMA_PORT:-8321}"
-    local remote_port="${REMOTE_LLAMA_PORT:-8321}"
+    local local_port="${LOCAL_OGX_PORT:-8321}"
+    local remote_port="${REMOTE_OGX_PORT:-8321}"
     local max_attempts=6
     local pf_pid
     local pf_resource
@@ -594,7 +594,7 @@ cmd_restart_llama_port_forward() {
         sleep 4
 
         if verify_llama_local_forward 12; then
-            echo "$pf_pid" >"$E2E_LLAMA_PORT_FORWARD_PID_FILE"
+            echo "$pf_pid" >"$E2E_OGX_PORT_FORWARD_PID_FILE"
             echo "[e2e-ops] Llama through port-forward: GET http://127.0.0.1:$local_port/v1/health -> OK"
             echo "✓ OGX port-forward established (PID: $pf_pid, $pf_resource)"
             return 0
@@ -972,7 +972,7 @@ cmd_dump_pod_logs() {
     e2e_ops_dump_pod_logs "${1:?pod name required}" "${2:-150}"
 }
 
-cmd_disrupt_llama_stack() {
+cmd_disrupt_ogx() {
     local pod_name="llama-stack-service"
 
     local phase
@@ -1000,13 +1000,13 @@ case "$COMMAND" in
     restart-lightspeed)
         cmd_restart_lightspeed
         ;;
-    restart-llama-stack)
+    restart-ogx)
         cmd_restart_llama_stack
         ;;
     restart-both-services)
         cmd_restart_both_services
         ;;
-    restart-llama-port-forward)
+    restart-ogx-port-forward)
         cmd_restart_llama_port_forward
         ;;
     restart-jwks-port-forward)
@@ -1024,8 +1024,8 @@ case "$COMMAND" in
     get-configmap-content)
         cmd_get_configmap_content "$@"
         ;;
-    disrupt-llama-stack)
-        cmd_disrupt_llama_stack
+    disrupt-ogx)
+        cmd_disrupt_ogx
         ;;
     tunnel-proxy-stats)
         cmd_tunnel_proxy_stats
@@ -1065,14 +1065,14 @@ case "$COMMAND" in
         echo ""
         echo "Commands:"
         echo "  restart-lightspeed              - Restart lightspeed-stack pod and port-forward"
-        echo "  restart-llama-stack             - Restart/restore llama-stack pod"
+        echo "  restart-ogx             - Restart/restore llama-stack pod"
         echo "  restart-both-services           - Full llama-stack + lightspeed-stack restart (explicit)"
-        echo "  restart-llama-port-forward      - Re-establish port-forward for OGX (8321)"
+        echo "  restart-ogx-port-forward      - Re-establish port-forward for OGX (8321)"
         echo "  restart-port-forward            - Re-establish port-forward for lightspeed"
         echo "  wait-for-pod <name> [attempts]  - Wait for a pod to be ready"
         echo "  update-configmap <name> <file>  - Update ConfigMap from file"
         echo "  get-configmap-content <name>    - Get ConfigMap content (outputs to stdout)"
-        echo "  disrupt-llama-stack             - Delete llama-stack pod to disrupt connection"
+        echo "  disrupt-ogx             - Delete llama-stack pod to disrupt connection"
         echo "  tunnel-proxy-stats              - JSON stats from in-cluster e2e-tunnel-proxy"
         echo "  interception-proxy-stats        - JSON stats from in-cluster e2e-interception-proxy"
         echo "  copy-interception-proxy-ca-to-llama - Alias for sync-interception-proxy-ca-secret"

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-shields-empty.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-shields-empty.yaml
@@ -10,7 +10,7 @@ service:
   color_log: true
   access_log: true
 llama_stack:
-  # Library mode - embeds llama-stack as library
+  # Library mode - embeds OGX as library
   use_as_library_client: true
   # Unified mode: run.yaml (materialized per provider by CI/the harness)
   # is consumed as the synthesis profile instead of the legacy two-file path.

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-shields-override-disabled.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-shields-override-disabled.yaml
@@ -12,7 +12,7 @@ service:
   color_log: true
   access_log: true
 llama_stack:
-  # Library mode - embeds llama-stack as library
+  # Library mode - embeds OGX as library
   use_as_library_client: true
   # Unified mode: run.yaml (materialized per provider by CI/the harness)
   # is consumed as the synthesis profile instead of the legacy two-file path.

--- a/tests/e2e/configuration/library-mode/lightspeed-stack-shields.yaml
+++ b/tests/e2e/configuration/library-mode/lightspeed-stack-shields.yaml
@@ -12,7 +12,7 @@ service:
   color_log: true
   access_log: true
 llama_stack:
-  # Library mode - embeds llama-stack as library
+  # Library mode - embeds OGX as library
   use_as_library_client: true
   # Unified mode: run.yaml (materialized per provider by CI/the harness)
   # is consumed as the synthesis profile instead of the legacy two-file path.

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-authorized.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-authorized.yaml
@@ -17,7 +17,7 @@ ogx:
   # Alternative for "as library use"
   # use_as_library_client: true
   # library_client_config_path: <path-to-llama-stack-run.yaml-file>
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-default.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-default.yaml
@@ -13,7 +13,7 @@ service:
   access_log: true
 ogx:
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-degraded.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-degraded.yaml
@@ -11,7 +11,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
   # Enable degraded mode to allow startup without OGX
   allow_degraded_mode: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-api-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-api-auth.yaml
@@ -11,7 +11,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-client-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-client-auth.yaml
@@ -9,7 +9,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-file-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-file-auth.yaml
@@ -9,7 +9,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-invalid.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-invalid.yaml
@@ -12,7 +12,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-kubernetes-auth.yaml
@@ -9,7 +9,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-oauth-auth.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp-oauth-auth.yaml
@@ -9,7 +9,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-mcp.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-mcp.yaml
@@ -15,7 +15,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-negative.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-negative.yaml
@@ -18,7 +18,7 @@ ogx:
   # Alternative for "as library use"
   # use_as_library_client: true
   # library_client_config_path: <path-to-llama-stack-run.yaml-file>
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-rbac.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-rbac.yaml
@@ -11,7 +11,7 @@ service:
 
 ogx:
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 
 user_data_collection:

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-rh-identity.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-rh-identity.yaml
@@ -10,7 +10,7 @@ service:
   access_log: true
 ogx:
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-rhelai.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-rhelai.yaml
@@ -9,7 +9,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-rhoai.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-rhoai.yaml
@@ -9,7 +9,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-shields-empty.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-shields-empty.yaml
@@ -10,9 +10,9 @@ service:
   color_log: true
   access_log: true
 llama_stack:
-  # Server mode - connects to separate llama-stack service
+  # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-shields-override-disabled.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-shields-override-disabled.yaml
@@ -12,9 +12,9 @@ service:
   color_log: true
   access_log: true
 llama_stack:
-  # Server mode - connects to separate llama-stack service
+  # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-shields.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-shields.yaml
@@ -12,9 +12,9 @@ service:
   color_log: true
   access_log: true
 llama_stack:
-  # Server mode - connects to separate llama-stack service
+  # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-skills-directory.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-skills-directory.yaml
@@ -10,7 +10,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-skills.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-skills.yaml
@@ -10,7 +10,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack-tls.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack-tls.yaml
@@ -10,7 +10,7 @@ service:
   access_log: true
 ogx:
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/configuration/server-mode/lightspeed-stack.yaml
+++ b/tests/e2e/configuration/server-mode/lightspeed-stack.yaml
@@ -9,7 +9,7 @@ service:
 ogx:
   # Server mode - connects to separate OGX service
   use_as_library_client: false
-  url: http://${env.E2E_LLAMA_HOSTNAME}:8321
+  url: http://${env.E2E_OGX_HOSTNAME}:8321
   api_key: xyzzy
 user_data_collection:
   feedback_enabled: true

--- a/tests/e2e/features/degraded_mode_startup.feature
+++ b/tests/e2e/features/degraded_mode_startup.feature
@@ -1,7 +1,7 @@
 @cfg_degraded @skip-in-library-mode @Authorized
 Feature: Degraded mode startup
 
-  End-to-end scenarios that test LCORE startup behavior when llama-stack
+  End-to-end scenarios that test LCORE startup behavior when ogx
   is NOT available at startup time and allow_degraded_mode is enabled.
 
   These tests verify that LCORE metrics correctly reflect startup state
@@ -13,26 +13,26 @@ Feature: Degraded mode startup
       And REST API service prefix is /v1
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
 
-  Scenario: Degraded mode metric is set to 0.0 when started with llama-stack
+  Scenario: Degraded mode metric is set to 0.0 when started with ogx
     Given The service uses the lightspeed-stack-degraded.yaml configuration
       And The service is restarted
     When I access endpoint "metrics" using HTTP GET method
     Then The status code of the response is 200
     And The response body contains "ls_started_in_degraded_mode 0.0"
 
-  Scenario: Degraded mode metric is set to 1.0 when started without llama-stack
-    Given The llama-stack connection is disrupted
+  Scenario: Degraded mode metric is set to 1.0 when started without ogx
+    Given The ogx connection is disrupted
       And The service uses the lightspeed-stack-degraded.yaml configuration
-      # Konflux restart-lightspeed otherwise restores llama before LCS boots.
-      And The service is restarted without restoring llama-stack
+      # Konflux restart-lightspeed otherwise restores OGX before LCS boots.
+      And The service is restarted without restoring ogx
     When I access endpoint "metrics" using HTTP GET method
     Then The status code of the response is 200
     And The response body contains "ls_started_in_degraded_mode 1.0"
 
-  Scenario: Readiness endpoint reports degraded state when started without llama-stack
-    Given The llama-stack connection is disrupted
+  Scenario: Readiness endpoint reports degraded state when started without ogx
+    Given The ogx connection is disrupted
       And The service uses the lightspeed-stack-degraded.yaml configuration
-      And The service is restarted without restoring llama-stack
+      And The service is restarted without restoring ogx
     When I access endpoint "readiness" using HTTP GET method
     Then The status code of the response is 200
     And The body of the response, ignoring the "providers" field, is the following

--- a/tests/e2e/features/environment.py
+++ b/tests/e2e/features/environment.py
@@ -18,13 +18,13 @@ from behave.model import Feature, Scenario
 from behave.runner import Context
 
 from tests.e2e.features.steps.common import (
-    get_llama_stack_hostname,
-    get_llama_stack_port,
+    get_ogx_hostname,
+    get_ogx_port,
     reset_active_lightspeed_stack_config_basename,
 )
 from tests.e2e.features.steps.health import (
     get_ogx_was_running,
-    reset_llama_stack_disrupt_once_tracking,
+    reset_ogx_disrupt_once_tracking,
     reset_ogx_was_running,
 )
 from tests.e2e.features.steps.tls import (
@@ -159,10 +159,10 @@ def _ensure_prow_port_forward(context: Context) -> None:
     restart-port-forward to re-establish the tunnel before the scenario runs.
 
     Treat HTTP 503 like 200/401 here: it means the tunnel reached Lightspeed and the
-    app responded. ``ogx_disrupted`` leaves Llama stopped on purpose; readiness
+    app responded. ``ogx_disrupted`` leaves OGX stopped on purpose; readiness
     then returns 503. Previously we treated 503 as a dead tunnel and ran
-    ``restart-lightspeed``, which restores Llama via e2e-ops and breaks later scenarios
-    that skip disruption (once-per-feature) while expecting Llama to stay down.
+    ``restart-lightspeed``, which restores OGX via e2e-ops and breaks later scenarios
+    that skip disruption (once-per-feature) while expecting OGX to stay down.
     """
     host = os.getenv("E2E_LSC_HOSTNAME", "localhost")
     port = os.getenv("E2E_LSC_PORT", "8080")
@@ -187,7 +187,7 @@ def _ensure_prow_port_forward(context: Context) -> None:
 
     # Port-forward alone failed — the pod itself may be dead (e.g. OGX
     # was never restored after a disruption feature). Attempt a full restart,
-    # which also checks Llama health before recreating LCS.
+    # which also checks OGX health before recreating LCS.
     print("[before_scenario] Port-forward failed; attempting full pod restart...")
     try:
         result = run_e2e_ops("restart-lightspeed", timeout=200)
@@ -222,7 +222,7 @@ def before_scenario(context: Context, scenario: Scenario) -> None:
 
     # Skip scenarios that require separate OGX container in library mode
     if context.is_library_mode and "skip-in-library-mode" in scenario.effective_tags:
-        scenario.skip("Skipped in library mode (no separate llama-stack container)")
+        scenario.skip("Skipped in library mode (no separate OGX container)")
         return
 
     # Skip scenarios that rely on a non-default BYOK store. Only library mode
@@ -232,7 +232,7 @@ def before_scenario(context: Context, scenario: Scenario) -> None:
     if not context.is_library_mode and "skip-in-server-mode" in scenario.effective_tags:
         scenario.skip(
             "Skipped in server mode (feature-specific BYOK store is not loaded "
-            "into the external llama-stack)"
+            "into the external OGX service)"
         )
         return
 
@@ -255,8 +255,8 @@ def before_scenario(context: Context, scenario: Scenario) -> None:
     # Clear shield unregister state from previous scenarios (see ``shields_are_disabled_for_scenario``).
     for _attr in (
         "shields_disabled_for_scenario",
-        "llama_guard_provider_id",
-        "llama_guard_provider_shield_id",
+        "ogx_guard_provider_id",
+        "ogx_guard_provider_shield_id",
     ):
         if hasattr(context, _attr):
             delattr(context, _attr)
@@ -302,7 +302,7 @@ def after_scenario(context: Context, scenario: Scenario) -> None:
             - is_library_mode (bool): whether tests run in library mode.
             - ogx_was_running (bool, optional): whether OGX was
               running before the scenario.
-            - hostname_llama, port_llama (str/int, optional): host and port
+            - hostname_ogx, port_ogx (str/int, optional): host and port
               used for the OGX health check.
         scenario (Scenario): Behave scenario (unused; shield restore uses context flags).
     """
@@ -316,8 +316,8 @@ def after_scenario(context: Context, scenario: Scenario) -> None:
 
     # Re-register shield if ``Given shields are disabled for this scenario`` unregistered it.
     if getattr(context, "shields_disabled_for_scenario", False):
-        provider_id = getattr(context, "llama_guard_provider_id", None)
-        provider_shield_id = getattr(context, "llama_guard_provider_shield_id", None)
+        provider_id = getattr(context, "ogx_guard_provider_id", None)
+        provider_shield_id = getattr(context, "ogx_guard_provider_shield_id", None)
         if provider_id is not None and provider_shield_id is not None:
             try:
                 register_shield(
@@ -332,10 +332,10 @@ def after_scenario(context: Context, scenario: Scenario) -> None:
 
 def _print_ogx_diagnostics() -> None:
     """Print container state, health, and recent logs to diagnose why OGX did not recover."""
-    print("--- llama-stack diagnostics ---")
+    print("--- ogx diagnostics ---")
     for label, cmd in [
-        ("State", ["docker", "inspect", "--format={{.State}}", "llama-stack"]),
-        ("Health", ["docker", "inspect", "--format={{.State.Health}}", "llama-stack"]),
+        ("State", ["docker", "inspect", "--format={{.State}}", "ogx"]),
+        ("Health", ["docker", "inspect", "--format={{.State.Health}}", "ogx"]),
     ]:
         try:
             r = subprocess.run(
@@ -346,7 +346,7 @@ def _print_ogx_diagnostics() -> None:
             print(f"  {label}: (inspect timed out)")
     try:
         r = subprocess.run(
-            ["docker", "logs", "--tail", "40", "llama-stack"],
+            ["docker", "logs", "--tail", "40", "ogx"],
             capture_output=True,
             text=True,
             timeout=10,
@@ -361,10 +361,10 @@ def _print_ogx_diagnostics() -> None:
     print("--- end diagnostics ---")
 
 
-def _restore_llama_stack() -> None:
+def _restore_ogx_service() -> None:
     """Restore OGX connection after disruption."""
     if is_prow_environment():
-        # Recreate llama pod, then restart LCS so in-process clients reconnect (Llama IP/pod changed).
+        # Recreate OGX pod, then restart LCS so in-process clients reconnect (OGX IP/pod changed).
         try:
             restore_ogx_pod()
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
@@ -380,7 +380,7 @@ def _restore_llama_stack() -> None:
                     "✓ Prow: OGX restored and lightspeed-stack restarted "
                     "for clean reconnect"
                 )
-                reset_llama_stack_disrupt_once_tracking()
+                reset_ogx_disrupt_once_tracking()
                 return
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
                 last_lcs_err = e
@@ -398,9 +398,7 @@ def _restore_llama_stack() -> None:
 
     try:
         # Start the OGX container again
-        subprocess.run(
-            ["docker", "start", "llama-stack"], check=True, capture_output=True
-        )
+        subprocess.run(["docker", "start", "ogx"], check=True, capture_output=True)
 
         # Wait for the service to be healthy
         print("Restoring OGX connection...")
@@ -411,10 +409,10 @@ def _restore_llama_stack() -> None:
                     [
                         "docker",
                         "exec",
-                        "llama-stack",
+                        "ogx",
                         "curl",
                         "-sf",
-                        f"http://{get_llama_stack_hostname()}:{get_llama_stack_port()}/v1/health",
+                        f"http://{get_ogx_hostname()}:{get_ogx_port()}/v1/health",
                     ],
                     capture_output=True,
                     timeout=5,
@@ -422,7 +420,7 @@ def _restore_llama_stack() -> None:
                 )
                 if result.returncode == 0:
                     print("✓ OGX connection restored successfully")
-                    reset_llama_stack_disrupt_once_tracking()
+                    reset_ogx_disrupt_once_tracking()
                     break
             except subprocess.TimeoutExpired:
                 print(
@@ -468,8 +466,8 @@ def before_feature(context: Context, feature: Feature) -> None:
     context.feature_config = None
     context.scenario_lightspeed_override_active = False
     context.active_lightspeed_stack_config_basename = None
-    # One real Llama disruption per feature (module-level flag; survives context resets)
-    reset_llama_stack_disrupt_once_tracking()
+    # One real OGX disruption per feature (module-level flag; survives context resets)
+    reset_ogx_disrupt_once_tracking()
     if feature.filename and is_tls_feature_file(feature.filename):
         reset_tls_prow_state()
         prepare_tls_feature_entry_on_prow(feature.filename)
@@ -510,7 +508,7 @@ def after_feature(context: Context, feature: Feature) -> None:
     # Read from module-level state — Behave clears custom context attributes
     # between scenarios, so context.ogx_was_running is unreliable here.
     if get_ogx_was_running():
-        _restore_llama_stack()
+        _restore_ogx_service()
         reset_ogx_was_running()
 
     if getattr(context, "feedback_e2e_conversation_cleanup", False):
@@ -531,7 +529,7 @@ def after_feature(context: Context, feature: Feature) -> None:
             switch_config(backup_path)
             remove_config_backup(backup_path)
             if not context.is_library_mode:
-                restart_container("llama-stack")
+                restart_container("ogx")
             restart_container("lightspeed-stack")
             reset_active_lightspeed_stack_config_basename()
         else:

--- a/tests/e2e/features/ogx_disrupted.feature
+++ b/tests/e2e/features/ogx_disrupted.feature
@@ -1,7 +1,7 @@
 @skip-in-library-mode @Authorized
-Feature: Llama Stack connection disrupted
+Feature: OGX connection disrupted
 
-  End-to-end scenarios that stop the Llama Stack container (or simulate disconnect) and
+  End-to-end scenarios that stop the OGX container (or simulate disconnect) and
   assert degraded responses (503, readiness, etc.). Config order matches test_list.txt:
   default stack, then noop-token (query/conversations/…), then rbac (rlsapi errors).
   Skipped in library mode.
@@ -18,11 +18,11 @@ Feature: Llama Stack connection disrupted
 # --- @cfg_default ---
 
   @cfg_default
-  Scenario: Check if models endpoint reports error when llama-stack is unreachable
+  Scenario: Check if models endpoint reports error when ogx is unreachable
     Given The service uses the lightspeed-stack-default.yaml configuration
       And The service is restarted
     Given The system is in default state
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "models" using HTTP GET method
     Then The status code of the response is 503
     And The body of the response is the following
@@ -32,11 +32,11 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_default
-  Scenario: Check if service report proper readiness state when llama stack is not available
+  Scenario: Check if service report proper readiness state when OGX is not available
     Given The service uses the lightspeed-stack-default.yaml configuration
       And The service is restarted
     Given The system is in default state
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access endpoint "readiness" using HTTP GET method
     Then The status code of the response is 503
     And The body of the response, ignoring the "providers" field, is the following
@@ -46,11 +46,11 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_default
-  Scenario: Check if service report proper liveness state even when llama stack is not available
+  Scenario: Check if service report proper liveness state even when OGX is not available
     Given The service uses the lightspeed-stack-default.yaml configuration
       And The service is restarted
     Given The system is in default state
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access endpoint "liveness" using HTTP GET method
     Then The status code of the response is 200
     And The body of the response is the following
@@ -60,10 +60,10 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_default
-  Scenario: Check if info endpoint reports error when llama-stack connection is not working
+  Scenario: Check if info endpoint reports error when ogx connection is not working
     Given The service uses the lightspeed-stack-default.yaml configuration
       And The service is restarted
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "info" using HTTP GET method
     Then The status code of the response is 503
     And The body of the response is the following
@@ -75,10 +75,10 @@ Feature: Llama Stack connection disrupted
 # --- @cfg_default (noop auth; tools list needs no bearer) ---
 
   @cfg_default
-  Scenario: Check if tools endpoint reports error when llama-stack is unreachable
+  Scenario: Check if tools endpoint reports error when ogx is unreachable
     Given The service uses the lightspeed-stack-default.yaml configuration
       And The service is restarted
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "tools" using HTTP GET method
     Then The status code of the response is 503
     And The body of the response is the following
@@ -90,12 +90,12 @@ Feature: Llama Stack connection disrupted
   # --- lightspeed-stack-authorized.yaml (aligned with query, responses, conversations, …) ---
 
   @cfg_authorized
-  Scenario: Check if LLM responds for query request with error for inability to connect to llama-stack
-    Given Llama Stack is restarted
+  Scenario: Check if LLM responds for query request with error for inability to connect to ogx
+    Given OGX is restarted
     And The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I use "query" to ask question with authorization header
     """
     {"query": "Say hello"}
@@ -105,11 +105,11 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_authorized
-  Scenario: Responses returns error when unable to connect to llama-stack
+  Scenario: Responses returns error when unable to connect to ogx
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     Given The system is in default state
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
     When I use "responses" to ask question with authorization header
     """
@@ -120,11 +120,11 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_authorized
-  Scenario: Streaming responses returns error when unable to connect to llama-stack
+  Scenario: Streaming responses returns error when unable to connect to ogx
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I use "responses" to ask question with authorization header
     """
     {"input": "Say hello", "model": "{PROVIDER}/{MODEL}", "stream": true}
@@ -134,33 +134,33 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_authorized
-  Scenario: Check if rags endpoint fails when llama-stack is unavailable
+  Scenario: Check if rags endpoint fails when ogx is unavailable
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint rags using HTTP GET method
     Then The status code of the response is 503
     And The body of the response contains Unable to connect to OGX
 
 
   @cfg_authorized
-  Scenario: Check if prompts list endpoint fails when llama-stack is unavailable
+  Scenario: Check if prompts list endpoint fails when ogx is unavailable
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "prompts" using HTTP GET method
     Then The status code of the response is 503
     And The body of the response contains Unable to connect to OGX
 
 
   @cfg_authorized
-  Scenario: Check if prompts create endpoint fails when llama-stack is unavailable
+  Scenario: Check if prompts create endpoint fails when ogx is unavailable
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "prompts" using HTTP POST method
     """
     {"prompt": "Summarize: {{text}}", "variables": ["text"]}
@@ -170,22 +170,22 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_authorized
-  Scenario: Check if prompts get by id endpoint fails when llama-stack is unavailable
+  Scenario: Check if prompts get by id endpoint fails when ogx is unavailable
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "prompts/pmpt_5c76d7f7c633ef97477adeb2f642150d8d08e8a6526e9909" using HTTP GET method
     Then The status code of the response is 503
     And The body of the response contains Unable to connect to OGX
 
 
   @cfg_authorized
-  Scenario: Check if prompts update endpoint fails when llama-stack is unavailable
+  Scenario: Check if prompts update endpoint fails when ogx is unavailable
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "prompts/pmpt_5c76d7f7c633ef97477adeb2f642150d8d08e8a6526e9909" using HTTP PUT method
     """
     {"prompt": "Summarize in bullets: {{text}}", "version": 1, "set_as_default": true, "variables": ["text"]}
@@ -195,19 +195,19 @@ Feature: Llama Stack connection disrupted
 
 
   @cfg_authorized
-  Scenario: Check if prompts delete endpoint fails when llama-stack is unavailable
+  Scenario: Check if prompts delete endpoint fails when ogx is unavailable
     Given The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I access REST API endpoint "prompts/pmpt_5c76d7f7c633ef97477adeb2f642150d8d08e8a6526e9909" using HTTP DELETE method
     Then The status code of the response is 503
     And The body of the response contains Unable to connect to OGX
 
 
   @cfg_authorized
-  Scenario: Check if conversations/{conversation_id} GET endpoint fails when llama-stack is unavailable
-    Given Llama Stack is restarted
+  Scenario: Check if conversations/{conversation_id} GET endpoint fails when ogx is unavailable
+    Given OGX is restarted
     And The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
@@ -217,15 +217,15 @@ Feature: Llama Stack connection disrupted
     """
     And The status code of the response is 200
     And I store conversation details
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I use REST API conversation endpoint with conversation_id from above using HTTP GET method
     Then The status code of the response is 503
     And The body of the response contains Unable to connect to OGX
 
 
   @cfg_authorized
-  Scenario: Check if conversations/{conversation_id} DELETE endpoint fails when llama-stack is unavailable
-    Given Llama Stack is restarted
+  Scenario: Check if conversations/{conversation_id} DELETE endpoint fails when ogx is unavailable
+    Given OGX is restarted
     And The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
@@ -235,15 +235,15 @@ Feature: Llama Stack connection disrupted
     """
     And The status code of the response is 200
     And I store conversation details
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I use REST API conversation endpoint with conversation_id from above using HTTP DELETE method
     Then The status code of the response is 503
     And The body of the response contains Unable to connect to OGX
 
 
   @cfg_authorized
-  Scenario: Check conversations/{conversation_id} works when llama-stack is down
-    Given Llama Stack is restarted
+  Scenario: Check conversations/{conversation_id} works when ogx is down
+    Given OGX is restarted
     And The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
@@ -254,7 +254,7 @@ Feature: Llama Stack connection disrupted
     """
     And The status code of the response is 200
     And I store conversation details
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     And REST API service prefix is /v2
     When I access REST API endpoint "conversations" using HTTP GET method
     Then The status code of the response is 200
@@ -268,8 +268,8 @@ Feature: Llama Stack connection disrupted
 # --- still @cfg_authorized (noop-with-token; not RBAC) ---
 
   @cfg_authorized
-  Scenario: V2 conversations DELETE endpoint works even when llama-stack is down
-    Given Llama Stack is restarted
+  Scenario: V2 conversations DELETE endpoint works even when ogx is down
+    Given OGX is restarted
     And The service uses the lightspeed-stack-authorized.yaml configuration
       And The service is restarted
     And I set the Authorization header to Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva
@@ -280,7 +280,7 @@ Feature: Llama Stack connection disrupted
     """
     And The status code of the response is 200
     And I store conversation details
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     And REST API service prefix is /v2
     When I use REST API conversation endpoint with conversation_id from above using HTTP DELETE method
     Then The status code of the response is 200
@@ -297,12 +297,12 @@ Feature: Llama Stack connection disrupted
   # --- lightspeed-stack-rbac.yaml (aligned with rbac.feature / rlsapi_v1_errors.feature) ---
 
   @RBAC @cfg_rbac
-  Scenario: Returns 503 when llama-stack connection is broken
-    Given Llama Stack is restarted
+  Scenario: Returns 503 when ogx connection is broken
+    Given OGX is restarted
     And The service uses the lightspeed-stack-rbac.yaml configuration
       And The service is restarted
     And I authenticate as "user" user
-    And The llama-stack connection is disrupted
+    And The ogx connection is disrupted
     When I use "infer" to ask question with authorization header
     """
     {"question": "How do I list files?"}

--- a/tests/e2e/features/okp_rag.feature
+++ b/tests/e2e/features/okp_rag.feature
@@ -38,7 +38,7 @@ Feature: OKP(Solr) RAG retrieval tests
 
   Scenario: Online mode streaming query with inline RAG returns referenced_documents
     Given The service uses the lightspeed-stack-okp-online.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And The service is restarted
     When I use "streaming_query" to ask question with authorization header
     """

--- a/tests/e2e/features/proxy.feature
+++ b/tests/e2e/features/proxy.feature
@@ -1,12 +1,12 @@
 @cfg_default @skip-in-library-mode @skip-in-prow
-Feature: Proxy and TLS networking tests for Llama Stack providers
+Feature: Proxy and TLS networking tests for OGX providers
 
-  Verify that the Lightspeed Stack works correctly when Llama Stack's
+  Verify that the Lightspeed Stack works correctly when OGX's
   remote inference providers are configured with proxy and TLS settings
   via the run.yaml NetworkConfig.
 
   Query bodies use shield_ids: [] because Llama Guard moderation can issue
-  separate provider calls inside Llama Stack that may not inherit the same
+  separate provider calls inside OGX that may not inherit the same
   proxy/TLS CA trust as the scenario's remote inference provider.
 
   Background:
@@ -16,7 +16,7 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
       And The service uses the lightspeed-stack-default.yaml configuration
       And The service is restarted
-      And The original Llama Stack config is restored if modified
+      And The original OGX config is restored if modified
 
 
   # --- AC1: Tunnel proxy routing ---
@@ -24,8 +24,8 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
   @TunnelProxy
   Scenario: LLM traffic is routed through a configured tunnel proxy
     Given A tunnel proxy is running on port 8888
-      And Llama Stack is configured to route inference through the tunnel proxy
-      And Llama Stack is restarted
+      And OGX is configured to route inference through the tunnel proxy
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -40,8 +40,8 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
 
   @TunnelProxy
   Scenario: LLM query fails gracefully when proxy is unreachable
-    Given Llama Stack is configured to route inference through proxy "http://127.0.0.1:19999"
-      And Llama Stack is restarted
+    Given OGX is configured to route inference through proxy "http://127.0.0.1:19999"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -56,8 +56,8 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
   @InterceptionProxy @flaky
   Scenario: LLM traffic works through interception proxy with correct CA
     Given An interception proxy with trustme CA is running on port 8889
-      And Llama Stack is configured to route inference through the interception proxy with CA cert
-      And Llama Stack is restarted
+      And OGX is configured to route inference through the interception proxy with CA cert
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -69,8 +69,8 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
   @InterceptionProxy
   Scenario: LLM query fails when interception proxy CA is not provided
     Given An interception proxy with trustme CA is running on port 8890
-      And Llama Stack is configured to route inference through the interception proxy without CA cert
-      And Llama Stack is restarted
+      And OGX is configured to route inference through the interception proxy without CA cert
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -84,8 +84,8 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
 
   @TLSVersion @flaky
   Scenario: TLS minimum version TLSv1.2 is respected
-    Given Llama Stack is configured with minimum TLS version "TLSv1.2"
-      And Llama Stack is restarted
+    Given OGX is configured with minimum TLS version "TLSv1.2"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -95,8 +95,8 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
 
   @TLSVersion @flaky
   Scenario: TLS minimum version TLSv1.3 is respected
-    Given Llama Stack is configured with minimum TLS version "TLSv1.3"
-      And Llama Stack is restarted
+    Given OGX is configured with minimum TLS version "TLSv1.3"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -106,8 +106,8 @@ Feature: Proxy and TLS networking tests for Llama Stack providers
 
   @TLSCipher @flaky
   Scenario: Custom cipher suite configuration is respected
-    Given Llama Stack is configured with ciphers "ECDHE+AESGCM:DHE+AESGCM"
-      And Llama Stack is restarted
+    Given OGX is configured with ciphers "ECDHE+AESGCM:DHE+AESGCM"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """

--- a/tests/e2e/features/shields.feature
+++ b/tests/e2e/features/shields.feature
@@ -2,7 +2,7 @@ Feature: Shields endpoint tests
 
   Tests for the LCORE-owned GET /v1/shields catalog endpoint. These shields
   (question_validity, redaction) are configured directly in
-  lightspeed-stack.yaml; they are not Llama Stack / OGX Safety API resources.
+  lightspeed-stack.yaml; they are not OGX Safety API resources.
   See docs/user_doc/shields_guide.md for the full shield configuration and
   runtime-behavior reference.
 

--- a/tests/e2e/features/steps/common.py
+++ b/tests/e2e/features/steps/common.py
@@ -23,7 +23,7 @@ _active_lightspeed_stack_config_basename: dict[str, Optional[str]] = {"basename"
 
 # Behave clears user attributes on ``context`` between scenarios; store
 # OGX endpoint info at module level so ``after_feature`` can see it.
-_llama_stack_endpoint: dict[str, str] = {"hostname": "localhost", "port": "8321"}
+_ogx_endpoint: dict[str, str] = {"hostname": "localhost", "port": "8321"}
 
 
 def reset_active_lightspeed_stack_config_basename() -> None:
@@ -40,14 +40,14 @@ def get_active_lightspeed_stack_config_basename() -> Optional[str]:
     return _active_lightspeed_stack_config_basename["basename"]
 
 
-def get_llama_stack_hostname() -> str:
+def get_ogx_hostname() -> str:
     """Return the OGX hostname surviving per-scenario context clearing."""
-    return _llama_stack_endpoint["hostname"]
+    return _ogx_endpoint["hostname"]
 
 
-def get_llama_stack_port() -> str:
+def get_ogx_port() -> str:
     """Return the OGX port surviving per-scenario context clearing."""
-    return _llama_stack_endpoint["port"]
+    return _ogx_endpoint["port"]
 
 
 @given("The service is started locally")
@@ -65,12 +65,12 @@ def service_is_started_locally(context: Context) -> None:
     context.hostname = os.getenv("E2E_LSC_HOSTNAME", "localhost")
     context.port = os.getenv("E2E_LSC_PORT", "8080")
     if is_prow_environment():
-        context.hostname_llama = os.getenv("E2E_LLAMA_HOSTNAME", "localhost")
+        context.hostname_ogx = os.getenv("E2E_OGX_HOSTNAME", "localhost")
     else:
-        context.hostname_llama = "localhost"
-    context.port_llama = os.getenv("E2E_LLAMA_PORT", "8321")
-    _llama_stack_endpoint["hostname"] = context.hostname_llama
-    _llama_stack_endpoint["port"] = context.port_llama
+        context.hostname_ogx = "localhost"
+    context.port_ogx = os.getenv("E2E_OGX_PORT", "8321")
+    _ogx_endpoint["hostname"] = context.hostname_ogx
+    _ogx_endpoint["port"] = context.port_ogx
 
 
 @given('the Lightspeed stack configuration directory is "{directory}"')
@@ -120,7 +120,7 @@ def configure_service(context: Context, config_name: str) -> None:
     """
     config_name = config_name.strip()
     if _active_lightspeed_stack_config_basename["basename"] == config_name:
-        # MCP reset or llama disrupt: do not skip the next restart.
+        # MCP reset or OGX disrupt: do not skip the next restart.
         if getattr(context, "force_lightspeed_restart_after_mcp_config_reset", False):
             context.lightspeed_stack_skip_restart = False
             context.force_lightspeed_restart_after_mcp_config_reset = False
@@ -201,19 +201,19 @@ def restart_service(context: Context) -> None:
     restart_container("lightspeed-stack")
 
 
-@given("The service is restarted without restoring llama-stack")
-def restart_service_without_restoring_llama(context: Context) -> None:
-    """Restart LCS while leaving llama disrupted (degraded-mode startup e2e).
+@given("The service is restarted without restoring ogx")
+def restart_service_without_restoring_ogx(context: Context) -> None:
+    """Restart LCS while leaving OGX disrupted (degraded-mode startup e2e).
 
-    On Prow/Konflux, the default ``restart-lightspeed`` path restores llama when
+    On Prow/Konflux, the default ``restart-lightspeed`` path restores OGX when
     it is unhealthy so LCS can come up. Degraded-mode scenarios need the
-    opposite: LCS must boot with llama still down. Docker Compose already
+    opposite: LCS must boot with OGX still down. Docker Compose already
     restarts only the LCS container, so this matches local server-mode behavior.
     """
     if getattr(context, "lightspeed_stack_skip_restart", False):
         context.lightspeed_stack_skip_restart = False
         return
-    restart_lightspeed_stack_service(skip_llama_restore=True, wait_http=False)
+    restart_lightspeed_stack_service(skip_ogx_restore=True, wait_http=False)
 
 
 @given("The system is in default state")

--- a/tests/e2e/features/steps/health.py
+++ b/tests/e2e/features/steps/health.py
@@ -11,7 +11,7 @@ from tests.e2e.utils.utils import is_prow_environment
 # Behave may clear user attributes on ``context`` between scenarios; keep this
 # in module scope so "disrupt once per feature" survives per-scenario resets.
 # Mutate one dict entry so we need not reassign a module-level bool (no global).
-_llama_stack_disrupt_once: dict[str, bool] = {"applied": False}
+_ogx_disrupt_once: dict[str, bool] = {"applied": False}
 
 # Behave clears user attributes on ``context`` between scenarios; store
 # ``was_running`` at module level so ``after_feature`` can still see it.
@@ -28,40 +28,34 @@ def reset_ogx_was_running() -> None:
     _ogx_was_running["value"] = False
 
 
-def reset_llama_stack_disrupt_once_tracking() -> None:
+def reset_ogx_disrupt_once_tracking() -> None:
     """Reset before each feature; see ``environment.before_feature``."""
-    _llama_stack_disrupt_once["applied"] = False
+    _ogx_disrupt_once["applied"] = False
     _ogx_was_running["value"] = False
 
 
-def _force_lightspeed_restart_after_llama_disrupt(context: Context) -> None:
+def _force_lightspeed_restart_after_ogx_disrupt(context: Context) -> None:
     """Do not skip the next Lightspeed restart after OGX is disrupted."""
     context.force_lightspeed_restart_after_mcp_config_reset = True
     context.lightspeed_stack_skip_restart = False
 
 
-def _force_lightspeed_restart_after_llama_disrupt(context: Context) -> None:
-    """Do not skip the next Lightspeed restart after Llama is disrupted."""
-    context.force_lightspeed_restart_after_mcp_config_reset = True
-    context.lightspeed_stack_skip_restart = False
-
-
-@given("The llama-stack connection is disrupted")
-def llama_stack_connection_broken(context: Context) -> None:
-    """Break llama_stack connection by stopping the container.
+@given("The ogx connection is disrupted")
+def ogx_connection_broken(context: Context) -> None:
+    """Break the OGX connection by stopping the container.
 
     Disrupts the OGX service by stopping its Docker container and
     records whether it was running.
 
     The real disruption runs only once per feature until OGX is running again:
     the first invocation performs Docker/Prow disruption; later invocations no-op.
-    ``reset_llama_stack_disrupt_once_tracking`` clears the skip flag from
+    ``reset_ogx_disrupt_once_tracking`` clears the skip flag from
     ``before_feature`` and after OGX is restored (``restart_container``,
-    ``_restore_llama_stack``) so the next disrupt step stops the container again.
+    ``_restore_ogx_service``) so the next disrupt step stops the container again.
     Tracking uses module state (not ``context`` alone) because Behave can clear
     custom attributes on ``context`` between scenarios.
 
-    Checks whether the Docker container named "llama-stack" is running; if it
+    Checks whether the Docker container named "ogx" is running; if it
     is, stops the container, waits briefly for the disruption to take effect,
     and sets `context.ogx_was_running` to True so callers can restore
     state later. If the container is not running, the flag remains False. On
@@ -73,9 +67,9 @@ def llama_stack_connection_broken(context: Context) -> None:
         context (behave.runner.Context): Behave context used to store
         `ogx_was_running` and share state between steps.
     """
-    if _llama_stack_disrupt_once["applied"]:
+    if _ogx_disrupt_once["applied"]:
         print("OGX disruption skipped (already applied once this feature)")
-        _force_lightspeed_restart_after_llama_disrupt(context)
+        _force_lightspeed_restart_after_ogx_disrupt(context)
         return
 
     # Store original state for restoration (only on the real disruption path).
@@ -85,19 +79,19 @@ def llama_stack_connection_broken(context: Context) -> None:
     _ogx_was_running["value"] = False
 
     if is_prow_environment():
-        from tests.e2e.utils.prow_utils import disrupt_llama_stack_pod
+        from tests.e2e.utils.prow_utils import disrupt_ogx_pod
 
-        was_running = disrupt_llama_stack_pod()
+        was_running = disrupt_ogx_pod()
         context.ogx_was_running = was_running
         _ogx_was_running["value"] = was_running
-        _llama_stack_disrupt_once["applied"] = True
-        _force_lightspeed_restart_after_llama_disrupt(context)
+        _ogx_disrupt_once["applied"] = True
+        _force_lightspeed_restart_after_ogx_disrupt(context)
         return
 
     # Docker-based disruption
     try:
         result = subprocess.run(
-            ["docker", "inspect", "-f", "{{.State.Running}}", "llama-stack"],
+            ["docker", "inspect", "-f", "{{.State.Running}}", "ogx"],
             capture_output=True,
             text=True,
             check=True,
@@ -106,9 +100,7 @@ def llama_stack_connection_broken(context: Context) -> None:
         if result.stdout.strip():
             context.ogx_was_running = True
             _ogx_was_running["value"] = True
-            subprocess.run(
-                ["docker", "stop", "llama-stack"], check=True, capture_output=True
-            )
+            subprocess.run(["docker", "stop", "ogx"], check=True, capture_output=True)
 
             # Wait a moment for the connection to be fully disrupted
             time.sleep(2)
@@ -121,5 +113,5 @@ def llama_stack_connection_broken(context: Context) -> None:
         print(f"Warning: Could not disrupt OGX connection: {e}")
         return
 
-    _llama_stack_disrupt_once["applied"] = True
-    _force_lightspeed_restart_after_llama_disrupt(context)
+    _ogx_disrupt_once["applied"] = True
+    _force_lightspeed_restart_after_ogx_disrupt(context)

--- a/tests/e2e/features/steps/proxy.py
+++ b/tests/e2e/features/steps/proxy.py
@@ -34,9 +34,9 @@ from tests.e2e.proxy.interception_proxy import (
 from tests.e2e.proxy.tunnel_proxy import DEFAULT_PROXY_PORT
 from tests.e2e.utils.ogx_config_utils import (
     backup_ogx_config,
-    load_llama_config,
-    restore_llama_config_if_modified,
-    write_llama_config,
+    load_ogx_config,
+    restore_ogx_config_if_modified,
+    write_ogx_config,
 )
 from tests.e2e.utils.prow_utils import get_namespace, run_e2e_ops
 from tests.e2e.utils.utils import (
@@ -55,12 +55,12 @@ def _is_docker_mode() -> bool:
     if is_prow_environment():
         return False
     result = subprocess.run(
-        ["docker", "ps", "--filter", "name=llama-stack", "--format", "{{.Names}}"],
+        ["docker", "ps", "--filter", "name=ogx", "--format", "{{.Names}}"],
         capture_output=True,
         text=True,
         check=False,
     )
-    return "llama-stack" in result.stdout
+    return "ogx" in result.stdout
 
 
 def _host_special_dns_from_container(hostname: str) -> Optional[str]:
@@ -89,7 +89,7 @@ def _host_special_dns_from_container(hostname: str) -> Optional[str]:
         [
             "docker",
             "exec",
-            "llama-stack",
+            "ogx",
             "python3",
             "-c",
             probe,
@@ -188,11 +188,11 @@ def _fetch_cluster_interception_proxy_stats() -> dict[str, Any]:
     return stats
 
 
-_INTERCEPTION_CA_LLAMA_PATH = "/tmp/interception-proxy-ca.pem"
+_INTERCEPTION_CA_OGX_PATH = "/tmp/interception-proxy-ca.pem"
 
 
 def _sync_interception_proxy_ca_secret() -> None:
-    """Publish trustme CA to Secret ``e2e-interception-proxy-ca`` (mounted by llama pod)."""
+    """Publish trustme CA to Secret ``e2e-interception-proxy-ca`` (mounted by OGX pod)."""
     result = run_e2e_ops("sync-interception-proxy-ca-secret", timeout=90)
     print(result.stdout, end="")
     if result.returncode != 0:
@@ -298,7 +298,7 @@ def _stop_proxy(context: Context, attr: str, loop_attr: str) -> None:
         delattr(context, loop_attr)
 
 
-@given("The original Llama Stack config is restored if modified")
+@given("The original OGX config is restored if modified")
 def restore_if_modified(context: Context) -> None:
     """Restore original run.yaml if a previous scenario modified it.
 
@@ -309,30 +309,30 @@ def restore_if_modified(context: Context) -> None:
     # Stop any leftover proxy servers from previous scenario
     _stop_proxy(context, "tunnel_proxy", "proxy_loop")
     _stop_proxy(context, "interception_proxy", "interception_proxy_loop")
-    os.environ.pop("E2E_COPY_INTERCEPTION_CA_TO_LLAMA", None)
-    os.environ.pop("E2E_COPY_MOCK_TLS_CERTS_TO_LLAMA", None)
-    if hasattr(context, "needs_interception_ca_on_llama"):
-        delattr(context, "needs_interception_ca_on_llama")
+    os.environ.pop("E2E_COPY_INTERCEPTION_CA_TO_OGX", None)
+    os.environ.pop("E2E_COPY_MOCK_TLS_CERTS_TO_OGX", None)
+    if hasattr(context, "needs_interception_ca_on_ogx"):
+        delattr(context, "needs_interception_ca_on_ogx")
 
-    if restore_llama_config_if_modified():
+    if restore_ogx_config_if_modified():
         print("Restoring original OGX config from backup...")
 
 
 # --- Service Restart Steps ---
 
 
-@given("Llama Stack is restarted")
+@given("OGX is restarted")
 def restart_ogx(context: Context) -> None:
     """Restart the OGX container."""
     from tests.e2e.features.steps.tls import (
         is_tls_configuration_feature,
-        restart_llama_for_tls_feature,
+        restart_ogx_for_tls_feature,
     )
 
     if is_tls_configuration_feature(context):
-        restart_llama_for_tls_feature(context)
+        restart_ogx_for_tls_feature(context)
         return
-    restart_container("llama-stack")
+    restart_container("ogx")
 
 
 @given("Lightspeed Stack is restarted")
@@ -392,8 +392,8 @@ def start_tunnel_proxy(context: Context, port: int) -> None:
     time.sleep(1)
 
 
-@given("Llama Stack is configured to route inference through the tunnel proxy")
-def configure_llama_tunnel_proxy(context: Context) -> None:
+@given("OGX is configured to route inference through the tunnel proxy")
+def configure_ogx_tunnel_proxy(context: Context) -> None:
     """Modify run.yaml with proxy config pointing to the tunnel proxy."""
     backup_ogx_config()
     if is_prow_environment():
@@ -402,7 +402,7 @@ def configure_llama_tunnel_proxy(context: Context) -> None:
         proxy = context.tunnel_proxy
         proxy_port = proxy.port
     proxy_host = _get_proxy_host(context.is_docker_mode)
-    config = load_llama_config()
+    config = load_ogx_config()
     provider = _find_inference_provider(context, config)
 
     if "config" not in provider:
@@ -413,14 +413,14 @@ def configure_llama_tunnel_proxy(context: Context) -> None:
         }
     }
 
-    write_llama_config(config)
+    write_ogx_config(config)
 
 
-@given('Llama Stack is configured to route inference through proxy "{proxy_url}"')
-def configure_llama_unreachable_proxy(context: Context, proxy_url: str) -> None:
+@given('OGX is configured to route inference through proxy "{proxy_url}"')
+def configure_ogx_unreachable_proxy(context: Context, proxy_url: str) -> None:
     """Modify run.yaml with a proxy URL (may be unreachable)."""
     backup_ogx_config()
-    config = load_llama_config()
+    config = load_ogx_config()
     provider = _find_inference_provider(context, config)
 
     if "config" not in provider:
@@ -431,7 +431,7 @@ def configure_llama_unreachable_proxy(context: Context, proxy_url: str) -> None:
         }
     }
 
-    write_llama_config(config)
+    write_ogx_config(config)
 
 
 # --- Interception Proxy Steps ---
@@ -444,7 +444,7 @@ def start_interception_proxy(context: Context, port: int) -> None:
         cluster_port = _cluster_interception_proxy_port(port)
         context.interception_proxy = None
         context.cluster_interception_proxy_port = cluster_port
-        context.ca_cert_path_for_config = _INTERCEPTION_CA_LLAMA_PATH
+        context.ca_cert_path_for_config = _INTERCEPTION_CA_OGX_PATH
         _deploy_cluster_interception_proxy()
         print(
             f"Using in-cluster interception proxy at "
@@ -466,7 +466,7 @@ def start_interception_proxy(context: Context, port: int) -> None:
     if context.is_docker_mode:
         container_cert_path = "/tmp/interception-proxy-ca.pem"
         subprocess.run(
-            ["docker", "cp", str(ca_cert_path), f"llama-stack:{container_cert_path}"],
+            ["docker", "cp", str(ca_cert_path), f"ogx:{container_cert_path}"],
             check=True,
         )
         context.ca_cert_path_for_config = container_cert_path
@@ -499,15 +499,15 @@ def start_interception_proxy(context: Context, port: int) -> None:
 
 
 @given(
-    "Llama Stack is configured to route inference through "
+    "OGX is configured to route inference through "
     "the interception proxy with CA cert"
 )
-def configure_llama_interception_with_ca(context: Context) -> None:
+def configure_ogx_interception_with_ca(context: Context) -> None:
     """Modify run.yaml with interception proxy and CA cert config."""
     backup_ogx_config()
-    context.needs_interception_ca_on_llama = True
+    context.needs_interception_ca_on_ogx = True
     if is_prow_environment():
-        os.environ["E2E_COPY_INTERCEPTION_CA_TO_LLAMA"] = "1"
+        os.environ["E2E_COPY_INTERCEPTION_CA_TO_OGX"] = "1"
     if is_prow_environment():
         proxy_port = getattr(
             context, "cluster_interception_proxy_port", DEFAULT_INTERCEPTION_PROXY_PORT
@@ -517,7 +517,7 @@ def configure_llama_interception_with_ca(context: Context) -> None:
         proxy = context.interception_proxy
         proxy_port = proxy.port
         proxy_host = _get_proxy_host(context.is_docker_mode)
-    config = load_llama_config()
+    config = load_ogx_config()
     provider = _find_inference_provider(context, config)
 
     if "config" not in provider:
@@ -532,20 +532,20 @@ def configure_llama_interception_with_ca(context: Context) -> None:
         },
     }
 
-    write_llama_config(config)
+    write_ogx_config(config)
     if is_prow_environment():
         _sync_interception_proxy_ca_secret()
 
 
 @given(
-    "Llama Stack is configured to route inference through "
+    "OGX is configured to route inference through "
     "the interception proxy without CA cert"
 )
-def configure_llama_interception_no_ca(context: Context) -> None:
+def configure_ogx_interception_no_ca(context: Context) -> None:
     """Modify run.yaml with interception proxy but NO CA cert."""
     backup_ogx_config()
-    context.needs_interception_ca_on_llama = False
-    os.environ.pop("E2E_COPY_INTERCEPTION_CA_TO_LLAMA", None)
+    context.needs_interception_ca_on_ogx = False
+    os.environ.pop("E2E_COPY_INTERCEPTION_CA_TO_OGX", None)
     if is_prow_environment():
         proxy_port = getattr(
             context, "cluster_interception_proxy_port", DEFAULT_INTERCEPTION_PROXY_PORT
@@ -555,7 +555,7 @@ def configure_llama_interception_no_ca(context: Context) -> None:
         proxy = context.interception_proxy
         proxy_port = proxy.port
         proxy_host = _get_proxy_host(context.is_docker_mode)
-    config = load_llama_config()
+    config = load_ogx_config()
     provider = _find_inference_provider(context, config)
 
     if "config" not in provider:
@@ -566,17 +566,17 @@ def configure_llama_interception_no_ca(context: Context) -> None:
         },
     }
 
-    write_llama_config(config)
+    write_ogx_config(config)
 
 
 # --- TLS Steps ---
 
 
-@given('Llama Stack is configured with minimum TLS version "{version}"')
-def configure_llama_tls_version(context: Context, version: str) -> None:
+@given('OGX is configured with minimum TLS version "{version}"')
+def configure_ogx_tls_version(context: Context, version: str) -> None:
     """Modify run.yaml with TLS version config."""
     backup_ogx_config()
-    config = load_llama_config()
+    config = load_ogx_config()
     provider = _find_inference_provider(context, config)
 
     if "config" not in provider:
@@ -587,14 +587,14 @@ def configure_llama_tls_version(context: Context, version: str) -> None:
         }
     }
 
-    write_llama_config(config)
+    write_ogx_config(config)
 
 
-@given('Llama Stack is configured with ciphers "{ciphers}"')
-def configure_llama_ciphers(context: Context, ciphers: str) -> None:
+@given('OGX is configured with ciphers "{ciphers}"')
+def configure_ogx_ciphers(context: Context, ciphers: str) -> None:
     """Modify run.yaml with cipher suite config."""
     backup_ogx_config()
-    config = load_llama_config()
+    config = load_ogx_config()
     provider = _find_inference_provider(context, config)
 
     if "config" not in provider:
@@ -605,7 +605,7 @@ def configure_llama_ciphers(context: Context, ciphers: str) -> None:
         }
     }
 
-    write_llama_config(config)
+    write_ogx_config(config)
 
 
 # --- Proxy Verification Steps ---

--- a/tests/e2e/features/steps/shields.py
+++ b/tests/e2e/features/steps/shields.py
@@ -27,8 +27,8 @@ def shields_are_disabled_for_scenario(context: Context) -> None:
 
     try:
         saved = unregister_shield("llama-guard")
-        context.llama_guard_provider_id = saved[0] if saved else None
-        context.llama_guard_provider_shield_id = saved[1] if saved else None
+        context.ogx_guard_provider_id = saved[0] if saved else None
+        context.ogx_guard_provider_shield_id = saved[1] if saved else None
         context.shields_disabled_for_scenario = True
         print("Unregistered shield llama-guard for this scenario")
     except Exception as e:  # pylint: disable=broad-exception-caught

--- a/tests/e2e/features/steps/tls.py
+++ b/tests/e2e/features/steps/tls.py
@@ -17,10 +17,10 @@ from behave.runner import Context
 
 from tests.e2e.utils.ogx_config_utils import (
     backup_ogx_config,
-    clear_llama_config_backup,
-    load_llama_config,
-    reset_llama_run_config_to_pipeline_default,
-    write_llama_config,
+    clear_ogx_config_backup,
+    load_ogx_config,
+    reset_ogx_run_config_to_pipeline_default,
+    write_ogx_config,
 )
 from tests.e2e.utils.prow_utils import get_namespace, restart_pod, run_e2e_ops
 from tests.e2e.utils.utils import is_prow_environment
@@ -38,10 +38,10 @@ _TLS_MODEL_RESOURCE: dict[str, str] = {
 
 def reset_tls_prow_state() -> None:
     """Reset per-feature TLS test state (call from ``before_feature``)."""
-    os.environ.pop("E2E_COPY_MOCK_TLS_CERTS_TO_LLAMA", None)
+    os.environ.pop("E2E_COPY_MOCK_TLS_CERTS_TO_OGX", None)
     os.environ.pop("E2E_SYNC_MOCK_TLS_CERTS", None)
     os.environ.pop("E2E_MOCK_TLS_INFERENCE_HOST", None)
-    clear_llama_config_backup()
+    clear_ogx_config_backup()
 
 
 def is_tls_feature_file(feature_filename: Optional[str]) -> bool:
@@ -64,11 +64,11 @@ def prepare_tls_feature_entry_on_prow(feature_filename: Optional[str] = None) ->
         return
     label = os.path.basename(feature_filename or "tls.feature")
     print(f"[{label}] Prow/Konflux entry: ensure mock TLS, reset run.yaml, warm OGX...")
-    reset_llama_run_config_to_pipeline_default()
+    reset_ogx_run_config_to_pipeline_default()
     _ensure_cluster_mock_tls_inference()
-    _prepare_tls_prow_llama_restart_env()
+    _prepare_tls_prow_ogx_restart_env()
     os.environ.pop("E2E_SYNC_MOCK_TLS_CERTS", None)
-    restart_pod("llama-stack")
+    restart_pod("ogx")
     print(f"[{label}] Prow/Konflux entry baseline complete", flush=True)
 
 
@@ -84,12 +84,12 @@ def is_tls_configuration_feature(context: Context) -> bool:
     return "TLS configuration" in name
 
 
-def _prepare_tls_prow_llama_restart_env() -> None:
-    """Set env for full llama pod recreate with mock TLS certs mounted."""
-    os.environ["E2E_COPY_MOCK_TLS_CERTS_TO_LLAMA"] = "1"
+def _prepare_tls_prow_ogx_restart_env() -> None:
+    """Set env for full OGX pod recreate with mock TLS certs mounted."""
+    os.environ["E2E_COPY_MOCK_TLS_CERTS_TO_OGX"] = "1"
 
 
-def _restart_lightspeed_after_llama_tls(context: Context) -> None:
+def _restart_lightspeed_after_ogx_tls(context: Context) -> None:
     """Restart LCS after OGX recreate so the in-process OGX client reconnects.
 
     TLS scenarios only change OGX run.yaml; LCS yaml is unchanged. Without this,
@@ -114,12 +114,12 @@ def _restart_lightspeed_after_llama_tls(context: Context) -> None:
     wait_for_lightspeed_stack_http_ready()
 
 
-def restart_llama_for_tls_feature(context: Context) -> None:
+def restart_ogx_for_tls_feature(context: Context) -> None:
     """Restart OGX for TLS tests (full pod recreate on Prow/Konflux)."""
     from tests.e2e.utils.utils import restart_container
 
     if is_prow_environment():
-        _prepare_tls_prow_llama_restart_env()
+        _prepare_tls_prow_ogx_restart_env()
         os.environ.pop("E2E_SYNC_MOCK_TLS_CERTS", None)
     scenario = getattr(getattr(context, "scenario", None), "name", "") or "?"
     feature_file = os.path.basename(
@@ -129,7 +129,7 @@ def restart_llama_for_tls_feature(context: Context) -> None:
         f"[{feature_file}] OGX restart: full recreate scenario={scenario!r}",
         flush=True,
     )
-    restart_container("llama-stack")
+    restart_container("ogx")
 
 
 def _cluster_mock_tls_inference_host() -> str:
@@ -173,7 +173,7 @@ def _ensure_cluster_mock_tls_inference() -> None:
     """Deploy mock TLS on Prow if missing; keep one pod for the whole tls suite.
 
     ``deploy-e2e-mock-tls-inference`` copies all PEMs into Secret ``e2e-mock-tls-certs``
-    once. Scenarios only change which cert path Llama uses in run.yaml.
+    once. Scenarios only change which cert path OGX uses in run.yaml.
     """
     if _mock_tls_inference_pod_ready():
         print("Using existing e2e-mock-tls-inference deployment")
@@ -239,7 +239,7 @@ def _configure_tls(tls_config: dict[str, Any], base_url: Optional[str] = None) -
         base_url: Optional base URL override for the provider.
     """
     backup_ogx_config()
-    config = load_llama_config()
+    config = load_ogx_config()
     provider = _ensure_tls_provider(config)
     provider.setdefault("config", {}).setdefault("network", {})
     if base_url is not None:
@@ -248,9 +248,9 @@ def _configure_tls(tls_config: dict[str, Any], base_url: Optional[str] = None) -
         provider["config"]["base_url"] = _mock_tls_base_url(_MOCK_TLS_PORT_TLS)
     provider.setdefault("config", {})["refresh_models"] = False
     provider["config"]["network"]["tls"] = tls_config
-    write_llama_config(config)
+    write_ogx_config(config)
     if is_prow_environment():
-        _prepare_tls_prow_llama_restart_env()
+        _prepare_tls_prow_ogx_restart_env()
 
 
 # --- Background Steps ---
@@ -270,25 +270,25 @@ def deploy_mock_tls_inference_server(context: Context) -> None:
 # --- TLS Configuration Steps ---
 
 
-@given("Llama Stack is configured with TLS verification disabled")
+@given("OGX is configured with TLS verification disabled")
 def configure_tls_verify_false(context: Context) -> None:
     """Configure run.yaml with TLS verify: false."""
     _configure_tls({"verify": False})
 
 
-@given("Llama Stack is configured with CA certificate verification")
+@given("OGX is configured with CA certificate verification")
 def configure_tls_verify_ca(context: Context) -> None:
     """Configure run.yaml with TLS verify: /certs/ca.crt."""
     _configure_tls({"verify": "/certs/ca.crt", "min_version": "TLSv1.2"})
 
 
-@given("Llama Stack is configured with TLS verification enabled")
+@given("OGX is configured with TLS verification enabled")
 def configure_tls_verify_true(context: Context) -> None:
     """Configure run.yaml with TLS verify: true (fails with self-signed certs)."""
     _configure_tls({"verify": True})
 
 
-@given("Llama Stack is configured with mutual TLS authentication")
+@given("OGX is configured with mutual TLS authentication")
 def configure_tls_mtls(context: Context) -> None:
     """Configure run.yaml with mutual TLS (client cert and key)."""
     _configure_tls(
@@ -302,7 +302,7 @@ def configure_tls_mtls(context: Context) -> None:
     )
 
 
-@given("Llama Stack is configured for mTLS without client certificate")
+@given("OGX is configured for mTLS without client certificate")
 def configure_tls_mtls_no_client_cert(context: Context) -> None:
     """Configure run.yaml for mTLS port without client cert (should fail)."""
     _configure_tls(
@@ -311,7 +311,7 @@ def configure_tls_mtls_no_client_cert(context: Context) -> None:
     )
 
 
-@given("Llama Stack is configured for mTLS with wrong client certificate")
+@given("OGX is configured for mTLS with wrong client certificate")
 def configure_tls_mtls_wrong_client_cert(context: Context) -> None:
     """Configure run.yaml for mTLS with invalid client cert (CA cert as client cert)."""
     _configure_tls(
@@ -324,7 +324,7 @@ def configure_tls_mtls_wrong_client_cert(context: Context) -> None:
     )
 
 
-@given("Llama Stack is configured for mTLS with untrusted client certificate")
+@given("OGX is configured for mTLS with untrusted client certificate")
 def configure_tls_mtls_untrusted_client_cert(context: Context) -> None:
     """Configure run.yaml with untrusted client certificate."""
     _configure_tls(
@@ -338,7 +338,7 @@ def configure_tls_mtls_untrusted_client_cert(context: Context) -> None:
     )
 
 
-@given("Llama Stack is configured for mTLS with expired client certificate")
+@given("OGX is configured for mTLS with expired client certificate")
 def configure_tls_mtls_expired_client_cert(context: Context) -> None:
     """Configure run.yaml with expired client certificate."""
     _configure_tls(
@@ -352,7 +352,7 @@ def configure_tls_mtls_expired_client_cert(context: Context) -> None:
     )
 
 
-@given("Llama Stack is configured with CA certificate and hostname mismatch server")
+@given("OGX is configured with CA certificate and hostname mismatch server")
 def configure_tls_ca_hostname_mismatch(context: Context) -> None:
     """Configure run.yaml to connect to hostname-mismatch server (should fail)."""
     _configure_tls(
@@ -361,7 +361,7 @@ def configure_tls_ca_hostname_mismatch(context: Context) -> None:
     )
 
 
-@given("Llama Stack is configured with mutual TLS and hostname mismatch server")
+@given("OGX is configured with mutual TLS and hostname mismatch server")
 def configure_tls_mtls_hostname_mismatch(context: Context) -> None:
     """Configure run.yaml with mTLS against hostname-mismatch server."""
     _configure_tls(
@@ -375,14 +375,14 @@ def configure_tls_mtls_hostname_mismatch(context: Context) -> None:
     )
 
 
-@given('Llama Stack is configured with CA certificate path "{path}"')
+@given('OGX is configured with CA certificate path "{path}"')
 def configure_tls_ca_path(context: Context, path: str) -> None:
     """Configure run.yaml with TLS verify pointing to a specific CA cert path."""
     _configure_tls({"verify": path})
 
 
 @given(
-    'Llama Stack is configured with TLS minimum version "{version}" and CA certificate path "{path}"'
+    'OGX is configured with TLS minimum version "{version}" and CA certificate path "{path}"'
 )
 def configure_tls_min_version_and_ca(context: Context, version: str, path: str) -> None:
     """Configure run.yaml with TLS minimum version and a specific CA cert path."""
@@ -390,7 +390,7 @@ def configure_tls_min_version_and_ca(context: Context, version: str, path: str) 
 
 
 @given(
-    'Llama Stack is configured with TLS minimum version "{version}" and hostname mismatch server'
+    'OGX is configured with TLS minimum version "{version}" and hostname mismatch server'
 )
 def configure_tls_min_version_hostname_mismatch(context: Context, version: str) -> None:
     """Configure run.yaml with TLS min version against hostname-mismatch server."""

--- a/tests/e2e/features/tls-ca.feature
+++ b/tests/e2e/features/tls-ca.feature
@@ -1,6 +1,6 @@
 @cfg_tls @skip-in-library-mode @skip-in-prow
 Feature: TLS configuration — CA certificate verification
-  Validate Llama Stack NetworkConfig.tls CA trust settings against the mock HTTPS
+  Validate OGX NetworkConfig.tls CA trust settings against the mock HTTPS
   inference provider (standard TLS port).
 
   Background:
@@ -8,14 +8,14 @@ Feature: TLS configuration — CA certificate verification
       And The system is in default state
       And REST API service prefix is /v1
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
-      And The original Llama Stack config is restored if modified
+      And The original OGX config is restored if modified
       And The mock TLS inference server is deployed
       And The service uses the lightspeed-stack-tls.yaml configuration
       And The service is restarted
 
   Scenario: Inference succeeds with TLS verification disabled
-    Given Llama Stack is configured with TLS verification disabled
-      And Llama Stack is restarted
+    Given OGX is configured with TLS verification disabled
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -25,8 +25,8 @@ Feature: TLS configuration — CA certificate verification
       And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference succeeds with CA certificate verification
-    Given Llama Stack is configured with CA certificate verification
-      And Llama Stack is restarted
+    Given OGX is configured with CA certificate verification
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -36,8 +36,8 @@ Feature: TLS configuration — CA certificate verification
       And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference fails with an untrusted CA certificate
-    Given Llama Stack is configured with CA certificate path "/certs/untrusted-ca.crt"
-      And Llama Stack is restarted
+    Given OGX is configured with CA certificate path "/certs/untrusted-ca.crt"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -47,8 +47,8 @@ Feature: TLS configuration — CA certificate verification
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails with an expired CA certificate
-    Given Llama Stack is configured with CA certificate path "/certs/expired-ca.crt"
-      And Llama Stack is restarted
+    Given OGX is configured with CA certificate path "/certs/expired-ca.crt"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -58,8 +58,8 @@ Feature: TLS configuration — CA certificate verification
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails when TLS verify is true against self-signed cert
-    Given Llama Stack is configured with TLS verification enabled
-      And Llama Stack is restarted
+    Given OGX is configured with TLS verification enabled
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -69,8 +69,8 @@ Feature: TLS configuration — CA certificate verification
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails with CA certificate verification and hostname mismatch
-    Given Llama Stack is configured with CA certificate and hostname mismatch server
-      And Llama Stack is restarted
+    Given OGX is configured with CA certificate and hostname mismatch server
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """

--- a/tests/e2e/features/tls-mtls.feature
+++ b/tests/e2e/features/tls-mtls.feature
@@ -1,6 +1,6 @@
 @cfg_tls @skip-in-library-mode @skip-in-prow
 Feature: TLS configuration — mutual TLS authentication
-  Validate Llama Stack NetworkConfig.tls client certificate settings against the
+  Validate OGX NetworkConfig.tls client certificate settings against the
   mock HTTPS inference provider (mTLS port).
 
   Background:
@@ -8,14 +8,14 @@ Feature: TLS configuration — mutual TLS authentication
       And The system is in default state
       And REST API service prefix is /v1
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
-      And The original Llama Stack config is restored if modified
+      And The original OGX config is restored if modified
       And The mock TLS inference server is deployed
       And The service uses the lightspeed-stack-tls.yaml configuration
       And The service is restarted
 
   Scenario: Inference succeeds with mutual TLS authentication
-    Given Llama Stack is configured with mutual TLS authentication
-      And Llama Stack is restarted
+    Given OGX is configured with mutual TLS authentication
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -25,8 +25,8 @@ Feature: TLS configuration — mutual TLS authentication
       And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference fails when mTLS is required but no client certificate is provided
-    Given Llama Stack is configured for mTLS without client certificate
-      And Llama Stack is restarted
+    Given OGX is configured for mTLS without client certificate
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -36,8 +36,8 @@ Feature: TLS configuration — mutual TLS authentication
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails when mTLS is required but wrong client certificate is provided
-    Given Llama Stack is configured for mTLS with wrong client certificate
-      And Llama Stack is restarted
+    Given OGX is configured for mTLS with wrong client certificate
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -47,8 +47,8 @@ Feature: TLS configuration — mutual TLS authentication
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails when mTLS is required but untrusted client certificate is provided
-    Given Llama Stack is configured for mTLS with untrusted client certificate
-      And Llama Stack is restarted
+    Given OGX is configured for mTLS with untrusted client certificate
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -58,8 +58,8 @@ Feature: TLS configuration — mutual TLS authentication
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails when mTLS is required but expired client certificate is provided
-    Given Llama Stack is configured for mTLS with expired client certificate
-      And Llama Stack is restarted
+    Given OGX is configured for mTLS with expired client certificate
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -69,8 +69,8 @@ Feature: TLS configuration — mutual TLS authentication
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails with mutual TLS and hostname mismatch
-    Given Llama Stack is configured with mutual TLS and hostname mismatch server
-      And Llama Stack is restarted
+    Given OGX is configured with mutual TLS and hostname mismatch server
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """

--- a/tests/e2e/features/tls-tlsv13.feature
+++ b/tests/e2e/features/tls-tlsv13.feature
@@ -1,6 +1,6 @@
 @cfg_tls @skip-in-library-mode @skip-in-prow
 Feature: TLS configuration — TLS minimum version 1.3
-  Validate Llama Stack NetworkConfig.tls min_version TLSv1.3 against the mock
+  Validate OGX NetworkConfig.tls min_version TLSv1.3 against the mock
   HTTPS inference provider.
 
   Background:
@@ -8,14 +8,14 @@ Feature: TLS configuration — TLS minimum version 1.3
       And The system is in default state
       And REST API service prefix is /v1
       And the Lightspeed stack configuration directory is "tests/e2e/configuration"
-      And The original Llama Stack config is restored if modified
+      And The original OGX config is restored if modified
       And The mock TLS inference server is deployed
       And The service uses the lightspeed-stack-tls.yaml configuration
       And The service is restarted
 
   Scenario: Inference succeeds with TLS minimum version TLSv1.3
-    Given Llama Stack is configured with TLS minimum version "TLSv1.3" and CA certificate path "/certs/ca.crt"
-      And Llama Stack is restarted
+    Given OGX is configured with TLS minimum version "TLSv1.3" and CA certificate path "/certs/ca.crt"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -25,8 +25,8 @@ Feature: TLS configuration — TLS minimum version 1.3
      And The body of the response contains Hello from the TLS mock inference server
 
   Scenario: Inference fails with TLS minimum version TLSv1.3 and untrusted CA certificate
-    Given Llama Stack is configured with TLS minimum version "TLSv1.3" and CA certificate path "/certs/untrusted-ca.crt"
-      And Llama Stack is restarted
+    Given OGX is configured with TLS minimum version "TLSv1.3" and CA certificate path "/certs/untrusted-ca.crt"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -36,8 +36,8 @@ Feature: TLS configuration — TLS minimum version 1.3
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails with TLS minimum version TLSv1.3 and hostname mismatch
-    Given Llama Stack is configured with TLS minimum version "TLSv1.3" and hostname mismatch server
-      And Llama Stack is restarted
+    Given OGX is configured with TLS minimum version "TLSv1.3" and hostname mismatch server
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """
@@ -47,8 +47,8 @@ Feature: TLS configuration — TLS minimum version 1.3
       And The body of the response does not contain Hello from the TLS mock inference server
 
   Scenario: Inference fails with TLS minimum version TLSv1.3 and expired CA certificate
-    Given Llama Stack is configured with TLS minimum version "TLSv1.3" and CA certificate path "/certs/expired-ca.crt"
-      And Llama Stack is restarted
+    Given OGX is configured with TLS minimum version "TLSv1.3" and CA certificate path "/certs/expired-ca.crt"
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I use "query" to ask question
     """

--- a/tests/e2e/features/unified-mode-boot.feature
+++ b/tests/e2e/features/unified-mode-boot.feature
@@ -32,7 +32,7 @@ Feature: Unified mode configuration boot
 
 
   @skip-in-server-mode
-  Scenario: Unified config with llama_stack.config only boots and serves requests in library mode
+  Scenario: Unified config with ogx.config only boots and serves requests in library mode
     Given The service uses the lightspeed-stack-unified-config-only.yaml configuration
       And The service is restarted
      When I access endpoint "readiness" using HTTP GET method
@@ -65,7 +65,7 @@ Feature: Unified mode configuration boot
   @skip-in-library-mode
   Scenario: Unified config with inference.providers boots and serves requests in server mode
     Given The service uses the lightspeed-stack-unified-providers.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I access endpoint "readiness" using HTTP GET method
      Then The status code of the response is 200
@@ -85,9 +85,9 @@ Feature: Unified mode configuration boot
 
 
   @skip-in-library-mode
-  Scenario: Unified config with llama_stack.config only boots and serves requests in server mode
+  Scenario: Unified config with ogx.config only boots and serves requests in server mode
     Given The service uses the lightspeed-stack-unified-config-only.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I access endpoint "readiness" using HTTP GET method
      Then The status code of the response is 200
@@ -101,7 +101,7 @@ Feature: Unified mode configuration boot
   @skip-in-library-mode
   Scenario: Unified config with relative profile path boots in server mode
     Given The service uses the lightspeed-stack-unified-relative-profile.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I access endpoint "readiness" using HTTP GET method
      Then The status code of the response is 200
@@ -110,7 +110,7 @@ Feature: Unified mode configuration boot
   @skip-in-library-mode
   Scenario: Unified config with absolute profile path boots in server mode
     Given The service uses the lightspeed-stack-unified-absolute-profile.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I access endpoint "readiness" using HTTP GET method
      Then The status code of the response is 200

--- a/tests/e2e/features/unified-mode-legacy.feature
+++ b/tests/e2e/features/unified-mode-legacy.feature
@@ -28,7 +28,7 @@ Feature: Legacy two-file configuration during deprecation window
   @skip-in-library-mode
   Scenario: Legacy two-file configuration still boots and serves requests in server mode
     Given The service uses the lightspeed-stack.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I access endpoint "readiness" using HTTP GET method
      Then The status code of the response is 200

--- a/tests/e2e/features/unified-mode-migration.feature
+++ b/tests/e2e/features/unified-mode-migration.feature
@@ -23,7 +23,7 @@ Feature: Legacy to unified configuration migration
   # --- library mode (@skip-in-server-mode) ---
 
   @skip-in-server-mode
-  Scenario: Migrated unified configuration drives byte-identical Llama Stack behavior in library mode
+  Scenario: Migrated unified configuration drives byte-identical OGX behavior in library mode
     Given lightspeed-stack --migrate-config is run for the legacy migration fixture pair
       And The service uses the lightspeed-stack-unified-migrated.yaml configuration
       And The service is restarted
@@ -39,10 +39,10 @@ Feature: Legacy to unified configuration migration
   # --- server mode (@skip-in-library-mode) ---
 
   @skip-in-library-mode
-  Scenario: Migrated unified configuration drives byte-identical Llama Stack behavior in server mode
+  Scenario: Migrated unified configuration drives byte-identical OGX behavior in server mode
     Given lightspeed-stack --migrate-config is run for the legacy migration fixture pair
       And The service uses the lightspeed-stack-unified-migrated.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And Lightspeed Stack is restarted
      When I access endpoint "readiness" using HTTP GET method
      Then The status code of the response is 200

--- a/tests/e2e/features/unified-mode-synthesis.feature
+++ b/tests/e2e/features/unified-mode-synthesis.feature
@@ -54,6 +54,6 @@ Feature: Unified mode configuration synthesis
   @skip-in-library-mode
   Scenario: Synthesized run.yaml path is logged at startup in server mode
     Given The service uses the lightspeed-stack-unified-providers.yaml configuration
-      And Llama Stack is restarted
+      And OGX is restarted
       And Lightspeed Stack is restarted
      Then the lightspeed-stack container logs contain synthesized run.yaml

--- a/tests/e2e/features/unified-mode-validation.feature
+++ b/tests/e2e/features/unified-mode-validation.feature
@@ -13,7 +13,7 @@ Feature: Unified mode configuration validation
      Then the validation error contains --migrate-config
 
 
-  Scenario: llama_stack.config together with library_client_config_path fails at load
+  Scenario: ogx.config together with library_client_config_path fails at load
     Given The service uses the lightspeed-stack-invalid-config-and-legacy.yaml configuration
      When configuration validation is attempted for the active configuration
      Then the validation error contains --migrate-config

--- a/tests/e2e/utils/ogx_config_utils.py
+++ b/tests/e2e/utils/ogx_config_utils.py
@@ -9,24 +9,24 @@ from typing import Any, Optional
 import yaml
 
 from tests.e2e.utils.ogx_prow_utils import (
-    backup_llama_run_config_to_memory,
-    get_llama_run_config_content,
-    remove_llama_run_config_backup,
-    update_llama_run_configmap,
+    backup_ogx_run_config_to_memory,
+    get_ogx_run_config_content,
+    remove_ogx_run_config_backup,
+    update_ogx_run_configmap,
 )
 from tests.e2e.utils.utils import is_prow_environment
 
-_DEFAULT_LOCAL_LLAMA_CONFIG_PATH = "run.yaml"
-_DEFAULT_LOCAL_LLAMA_CONFIG_BACKUP_PATH = "run.yaml.proxy-backup"
-_llama_config_backup_key: dict[str, Optional[str]] = {"value": None}
+_DEFAULT_LOCAL_OGX_CONFIG_PATH = "run.yaml"
+_DEFAULT_LOCAL_OGX_CONFIG_BACKUP_PATH = "run.yaml.proxy-backup"
+_ogx_config_backup_key: dict[str, Optional[str]] = {"value": None}
 
 
-def clear_llama_config_backup() -> None:
+def clear_ogx_config_backup() -> None:
     """Drop in-memory run.yaml backup (e.g. at start of tls.feature)."""
-    _llama_config_backup_key["value"] = None
+    _ogx_config_backup_key["value"] = None
 
 
-def reset_llama_run_config_to_pipeline_default() -> None:
+def reset_ogx_run_config_to_pipeline_default() -> None:
     """Reset llama-stack-config run.yaml to Konflux/Prow pipeline seed (run-ci.yaml)."""
     if not is_prow_environment():
         return
@@ -35,49 +35,49 @@ def reset_llama_run_config_to_pipeline_default() -> None:
         print(f"WARN: pipeline run.yaml seed not found at {run_ci}", flush=True)
         return
     print(f"Resetting llama-stack-config from {run_ci.name}...", flush=True)
-    update_llama_run_configmap(str(run_ci))
+    update_ogx_run_configmap(str(run_ci))
 
 
-def _local_llama_config_path() -> str:
+def _local_ogx_config_path() -> str:
     """Return local run.yaml path for Docker/local e2e execution."""
-    return os.getenv("E2E_LLAMA_CONFIG_PATH", _DEFAULT_LOCAL_LLAMA_CONFIG_PATH)
+    return os.getenv("E2E_OGX_CONFIG_PATH", _DEFAULT_LOCAL_OGX_CONFIG_PATH)
 
 
-def _local_llama_config_backup_path() -> str:
+def _local_ogx_config_backup_path() -> str:
     """Return backup path used for local run.yaml mutations."""
     return os.getenv(
-        "E2E_LLAMA_CONFIG_BACKUP_PATH",
-        _DEFAULT_LOCAL_LLAMA_CONFIG_BACKUP_PATH,
+        "E2E_OGX_CONFIG_BACKUP_PATH",
+        _DEFAULT_LOCAL_OGX_CONFIG_BACKUP_PATH,
     )
 
 
 def backup_ogx_config() -> None:
     """Create a backup of the current OGX run config once per scenario."""
     if is_prow_environment():
-        if _llama_config_backup_key["value"] is None:
-            _llama_config_backup_key["value"] = backup_llama_run_config_to_memory()
+        if _ogx_config_backup_key["value"] is None:
+            _ogx_config_backup_key["value"] = backup_ogx_run_config_to_memory()
         return
 
-    backup_path = _local_llama_config_backup_path()
+    backup_path = _local_ogx_config_backup_path()
     if not os.path.exists(backup_path):
-        shutil.copy(_local_llama_config_path(), backup_path)
+        shutil.copy(_local_ogx_config_path(), backup_path)
 
 
-def load_llama_config() -> dict[str, Any]:
+def load_ogx_config() -> dict[str, Any]:
     """Load run.yaml configuration as a dictionary."""
     if is_prow_environment():
-        content = get_llama_run_config_content()
+        content = get_ogx_run_config_content()
         loaded = yaml.safe_load(content) or {}
         assert isinstance(loaded, dict), "Expected run.yaml to deserialize to a mapping"
         return loaded
 
-    with open(_local_llama_config_path(), encoding="utf-8") as file:
+    with open(_local_ogx_config_path(), encoding="utf-8") as file:
         loaded = yaml.safe_load(file) or {}
     assert isinstance(loaded, dict), "Expected run.yaml to deserialize to a mapping"
     return loaded
 
 
-def write_llama_config(config: dict[str, Any]) -> None:
+def write_ogx_config(config: dict[str, Any]) -> None:
     """Write run.yaml configuration in local or Prow environment."""
     if is_prow_environment():
         with tempfile.NamedTemporaryFile(
@@ -89,33 +89,33 @@ def write_llama_config(config: dict[str, Any]) -> None:
             yaml.dump(config, file, default_flow_style=False)
             temp_path = file.name
         try:
-            update_llama_run_configmap(temp_path)
+            update_ogx_run_configmap(temp_path)
         finally:
             if os.path.exists(temp_path):
                 os.remove(temp_path)
         return
 
-    with open(_local_llama_config_path(), "w", encoding="utf-8") as file:
+    with open(_local_ogx_config_path(), "w", encoding="utf-8") as file:
         yaml.dump(config, file, default_flow_style=False)
 
 
-def restore_llama_config_if_modified() -> bool:
+def restore_ogx_config_if_modified() -> bool:
     """Restore run config when a backup exists.
 
     Returns:
         True when a restore happened, otherwise False.
     """
     if is_prow_environment():
-        backup_key = _llama_config_backup_key["value"]
+        backup_key = _ogx_config_backup_key["value"]
         if backup_key is None:
             return False
-        update_llama_run_configmap(backup_key)
-        remove_llama_run_config_backup(backup_key)
-        _llama_config_backup_key["value"] = None
+        update_ogx_run_configmap(backup_key)
+        remove_ogx_run_config_backup(backup_key)
+        _ogx_config_backup_key["value"] = None
         return True
 
-    backup_path = _local_llama_config_backup_path()
+    backup_path = _local_ogx_config_backup_path()
     if not os.path.exists(backup_path):
         return False
-    shutil.move(backup_path, _local_llama_config_path())
+    shutil.move(backup_path, _local_ogx_config_path())
     return True

--- a/tests/e2e/utils/ogx_prow_utils.py
+++ b/tests/e2e/utils/ogx_prow_utils.py
@@ -7,35 +7,36 @@ from tests.e2e.utils.prow_utils import (
     update_config_configmap,
 )
 
-_LLAMA_CONFIGMAP_NAME = "llama-stack-config"
-_LLAMA_CONFIGMAP_KEY = "run.yaml"
+# OpenShift ConfigMap name (legacy K8s resource id in Prow manifests).
+_OGX_CONFIGMAP_NAME = "llama-stack-config"
+_OGX_CONFIGMAP_KEY = "run.yaml"
 
 
-def get_llama_run_config_content() -> str:
-    """Return llama-stack-config run.yaml content in Prow/OpenShift."""
+def get_ogx_run_config_content() -> str:
+    """Return OGX run.yaml ConfigMap content in Prow/OpenShift."""
     return get_configmap_content(
-        configmap_name=_LLAMA_CONFIGMAP_NAME,
-        configmap_key=_LLAMA_CONFIGMAP_KEY,
+        configmap_name=_OGX_CONFIGMAP_NAME,
+        configmap_key=_OGX_CONFIGMAP_KEY,
     )
 
 
-def backup_llama_run_config_to_memory() -> str:
-    """Backup llama-stack-config run.yaml into in-memory backup storage."""
+def backup_ogx_run_config_to_memory() -> str:
+    """Backup OGX run.yaml ConfigMap into in-memory backup storage."""
     return backup_configmap_to_memory(
-        configmap_name=_LLAMA_CONFIGMAP_NAME,
-        configmap_key=_LLAMA_CONFIGMAP_KEY,
+        configmap_name=_OGX_CONFIGMAP_NAME,
+        configmap_key=_OGX_CONFIGMAP_KEY,
     )
 
 
-def update_llama_run_configmap(source: str) -> None:
-    """Update or restore llama-stack-config run.yaml from file or backup key."""
+def update_ogx_run_configmap(source: str) -> None:
+    """Update or restore OGX run.yaml ConfigMap from file or backup key."""
     update_config_configmap(
         source,
-        configmap_name=_LLAMA_CONFIGMAP_NAME,
-        configmap_key=_LLAMA_CONFIGMAP_KEY,
+        configmap_name=_OGX_CONFIGMAP_NAME,
+        configmap_key=_OGX_CONFIGMAP_KEY,
     )
 
 
-def remove_llama_run_config_backup(backup_key: str) -> None:
-    """Remove a llama-stack-config run.yaml backup from in-memory storage."""
+def remove_ogx_run_config_backup(backup_key: str) -> None:
+    """Remove an OGX run.yaml ConfigMap backup from in-memory storage."""
     remove_configmap_backup(backup_key)

--- a/tests/e2e/utils/ogx_utils.py
+++ b/tests/e2e/utils/ogx_utils.py
@@ -5,7 +5,7 @@ instance during end-to-end tests: unregister/re-register shields (e.g. from the
 ``Given shields are disabled for this scenario`` step).
 
 Only applies when running OGX as a separate service (server mode).
-Requires E2E_LLAMA_STACK_URL or E2E_LLAMA_HOSTNAME and E2E_LLAMA_PORT.
+Requires E2E_OGX_STACK_URL or E2E_OGX_HOSTNAME and E2E_OGX_PORT.
 """
 
 import asyncio
@@ -22,16 +22,16 @@ from tests.e2e.utils.utils import is_prow_environment
 
 def _get_ogx_client() -> AsyncOgxClient:
     """Build an AsyncOgxClient from env (for e2e test use)."""
-    base_url = os.getenv("E2E_LLAMA_STACK_URL")
+    base_url = os.getenv("E2E_OGX_STACK_URL")
     if not base_url:
         if is_prow_environment():
-            host = os.getenv("E2E_LLAMA_HOSTNAME", "localhost")
+            host = os.getenv("E2E_OGX_HOSTNAME", "localhost")
         else:
             host = "localhost"
-        port = os.getenv("E2E_LLAMA_PORT", "8321")
+        port = os.getenv("E2E_OGX_PORT", "8321")
         base_url = f"http://{host}:{port}"
-    api_key = os.getenv("E2E_LLAMA_STACK_API_KEY", "xyzzy")
-    timeout = int(os.getenv("E2E_LLAMA_STACK_TIMEOUT", "60"))
+    api_key = os.getenv("E2E_OGX_STACK_API_KEY", "xyzzy")
+    timeout = int(os.getenv("E2E_OGX_STACK_TIMEOUT", "60"))
     return AsyncOgxClient(base_url=base_url, api_key=api_key, timeout=timeout)
 
 
@@ -106,10 +106,10 @@ def register_shield(
 ) -> None:
     """Re-register the shield via client.shields.register()."""
     if not provider_id:
-        provider_id = os.getenv("E2E_LLAMA_GUARD_PROVIDER_ID", "llama-guard")
+        provider_id = os.getenv("E2E_OGX_GUARD_PROVIDER_ID", "llama-guard")
     if not provider_shield_id:
         provider_shield_id = os.getenv(
-            "E2E_LLAMA_GUARD_PROVIDER_SHIELD_ID",
+            "E2E_OGX_GUARD_PROVIDER_SHIELD_ID",
             "openai/gpt-4o-mini",
         )
     asyncio.run(_register_shield_async(shield_id, provider_id, provider_shield_id))

--- a/tests/e2e/utils/prow_utils.py
+++ b/tests/e2e/utils/prow_utils.py
@@ -19,7 +19,8 @@ def get_namespace() -> str:
 # Mapping from container names (used in tests) to pod names (used in OpenShift)
 _POD_NAME_MAP = {
     "lightspeed-stack": "lightspeed-stack-service",
-    "llama-stack": "llama-stack-service",
+    "ogx": "llama-stack-service",
+    "llama-stack": "llama-stack-service",  # legacy alias
 }
 
 
@@ -86,14 +87,14 @@ def wait_for_pod_health(pod_name: str, max_attempts: int = 60) -> None:
         raise
 
 
-_LLAMA_RESTART_NAMES = frozenset({"llama-stack", "llama-stack-service"})
+_OGX_RESTART_NAMES = frozenset({"ogx", "llama-stack", "llama-stack-service"})
 _LIGHTSPEED_RESTART_NAMES = frozenset({"lightspeed-stack", "lightspeed-stack-service"})
 
 
 def restart_pod(container_name: str) -> None:
     """Restart OGX or Lightspeed pod in OpenShift/Prow (not Docker).
 
-    Maps ``container_name`` to the correct e2e-ops command: ``restart-llama-stack``
+    Maps ``container_name`` to the correct e2e-ops command: ``restart-ogx``
     vs ``restart-lightspeed``. Unknown names default to Lightspeed with a warning.
 
     For Lightspeed restarts, e2e-ops ensures OGX is running first. OGX pod logs
@@ -102,11 +103,11 @@ def restart_pod(container_name: str) -> None:
     CI failures with healthy pod logs are often **localhost port-forward** contention
     (pipeline forward vs hook restart), not application crashes—see e2e-ops.sh header.
     """
-    if container_name in _LLAMA_RESTART_NAMES:
-        op = "restart-llama-stack"
+    if container_name in _OGX_RESTART_NAMES:
+        op = "restart-ogx"
         # Subprocess cap must exceed e2e-ops internal waits (pod + in-pod health + port-forward).
         # Konflux TLS full recreate: ~6–12 min typical, 15+ min under load (user-reported 400s+).
-        if os.environ.get("E2E_COPY_MOCK_TLS_CERTS_TO_LLAMA") == "1":
+        if os.environ.get("E2E_COPY_MOCK_TLS_CERTS_TO_OGX") == "1":
             timeout = 1200
         elif os.environ.get("E2E_KONFLUX_E2E") == "1":
             timeout = 720
@@ -158,24 +159,24 @@ def restore_ogx_pod() -> None:
         timeout = 600
     else:
         timeout = 420
-    result = run_e2e_ops("restart-llama-stack", timeout=timeout)
+    result = run_e2e_ops("restart-ogx", timeout=timeout)
     print(result.stdout, end="")
     if result.returncode != 0:
         print(result.stderr, end="")
         raise subprocess.CalledProcessError(
-            result.returncode, "restart-llama-stack", result.stderr
+            result.returncode, "restart-ogx", result.stderr
         )
     print("✓ OGX pod restored successfully")
 
 
-def disrupt_llama_stack_pod() -> bool:
+def disrupt_ogx_pod() -> bool:
     """Disrupt OGX connection in Prow/OpenShift environment.
 
     Returns:
         True if the pod was running and has been disrupted, False otherwise.
     """
     try:
-        result = run_e2e_ops("disrupt-llama-stack", timeout=90)
+        result = run_e2e_ops("disrupt-ogx", timeout=90)
         print(result.stdout, end="")
 
         # Exit code 0 = disrupted (was running), exit code 2 = was not running

--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -268,7 +268,7 @@ def wait_for_ogx_ready(
     -------
         True if healthy; False if the wait soft-failed.
     """
-    return wait_for_container_health("llama-stack", max_attempts=max_attempts)
+    return wait_for_container_health("ogx", max_attempts=max_attempts)
 
 
 def validate_json_partially(actual: Any, expected: Any) -> None:
@@ -450,12 +450,12 @@ def restart_container(container_name: str) -> None:
     """
     if is_prow_environment():
         restart_pod(container_name)
-        if container_name == "llama-stack":
+        if container_name == "ogx":
             from tests.e2e.features.steps.health import (
-                reset_llama_stack_disrupt_once_tracking,
+                reset_ogx_disrupt_once_tracking,
             )
 
-            reset_llama_stack_disrupt_once_tracking()
+            reset_ogx_disrupt_once_tracking()
         return
 
     try:
@@ -476,16 +476,16 @@ def restart_container(container_name: str) -> None:
     # that restart the container don't time out.
     wait_for_container_health(container_name)
 
-    if container_name == "llama-stack":
+    if container_name == "ogx":
         from tests.e2e.features.steps.health import (
-            reset_llama_stack_disrupt_once_tracking,
+            reset_ogx_disrupt_once_tracking,
         )
 
-        reset_llama_stack_disrupt_once_tracking()
+        reset_ogx_disrupt_once_tracking()
 
 
 def restart_lightspeed_stack_service(
-    *, wait_http: bool = False, skip_llama_restore: bool = False
+    *, wait_http: bool = False, skip_ogx_restore: bool = False
 ) -> None:
     """Restart the lightspeed-stack container used by Behave steps.
 
@@ -497,22 +497,22 @@ def restart_lightspeed_stack_service(
         wait_http: When True, also call ``wait_for_lightspeed_stack_http_ready``
             after Docker health. Default False — generic ``The service is
             restarted`` relies on Docker health only; proxy/tls steps opt in.
-        skip_llama_restore: When True on Prow/Konflux, tell e2e-ops not to
+        skip_ogx_restore: When True on Prow/Konflux, tell e2e-ops not to
             bring llama back before recreating LCS (degraded-mode startup).
     """
-    previous = os.environ.get("E2E_SKIP_LLAMA_RESTORE_ON_LCS_RESTART")
-    if skip_llama_restore:
-        os.environ["E2E_SKIP_LLAMA_RESTORE_ON_LCS_RESTART"] = "1"
+    previous = os.environ.get("E2E_SKIP_OGX_RESTORE_ON_LCS_RESTART")
+    if skip_ogx_restore:
+        os.environ["E2E_SKIP_OGX_RESTORE_ON_LCS_RESTART"] = "1"
     try:
         restart_container("lightspeed-stack")
         if wait_http:
             wait_for_lightspeed_stack_http_ready()
     finally:
-        if skip_llama_restore:
+        if skip_ogx_restore:
             if previous is None:
-                os.environ.pop("E2E_SKIP_LLAMA_RESTORE_ON_LCS_RESTART", None)
+                os.environ.pop("E2E_SKIP_OGX_RESTORE_ON_LCS_RESTART", None)
             else:
-                os.environ["E2E_SKIP_LLAMA_RESTORE_ON_LCS_RESTART"] = previous
+                os.environ["E2E_SKIP_OGX_RESTORE_ON_LCS_RESTART"] = previous
 
 
 def wait_for_lightspeed_stack_http_ready(

--- a/tests/integration/test_configuration.py
+++ b/tests/integration/test_configuration.py
@@ -68,11 +68,11 @@ def test_loading_proper_configuration(configuration_filename: str) -> None:
     assert cors_config.allow_headers == ["foo_header", "bar_header", "baz_header"]
 
     # check 'ogx' section
-    ls_config = cfg.ogx_configuration
-    assert ls_config.use_as_library_client is False
-    assert str(ls_config.url) == "http://localhost:8321/"
-    assert ls_config.api_key is not None
-    assert ls_config.api_key.get_secret_value() == "xyzzy"
+    ogx_configuration = cfg.ogx_configuration
+    assert ogx_configuration.use_as_library_client is False
+    assert str(ogx_configuration.url) == "http://localhost:8321/"
+    assert ogx_configuration.api_key is not None
+    assert ogx_configuration.api_key.get_secret_value() == "xyzzy"
 
     # check 'user_data_collection' section
     udc_config = cfg.user_data_collection_configuration

--- a/tests/unit/models/config/test_ogx_configuration.py
+++ b/tests/unit/models/config/test_ogx_configuration.py
@@ -17,7 +17,7 @@ from models.config import (
 from utils.checks import InvalidConfigurationError
 
 # A complete, valid lightspeed-stack.yaml used as the base for root-model
-# (Configuration) validation tests; individual tests override its llama_stack
+# (Configuration) validation tests; individual tests override its ogx
 # and inference sections to exercise unified-vs-legacy mode detection.
 _BASE_CONFIG_PATH = "tests/configuration/lightspeed-stack.yaml"
 
@@ -28,68 +28,68 @@ def _base_config_dict() -> dict[str, Any]:
         return copy.deepcopy(yaml.safe_load(file))
 
 
-def test_llama_stack_configuration_constructor(subtests: SubTests) -> None:
+def test_ogx_cfg_constructor(subtests: SubTests) -> None:
     """
     Verify that the OgxConfiguration constructor accepts
     valid combinations of parameters and creates instances
     successfully.
     """
     with subtests.test(msg="Configuration for library mode"):
-        llama_stack_configuration = OgxConfiguration(
+        ogx_cfg = OgxConfiguration(
             use_as_library_client=True,
             library_client_config_path="tests/configuration/run.yaml",
             url=None,
             api_key=None,
             timeout=60,
         )
-        assert llama_stack_configuration is not None
-        assert llama_stack_configuration.allow_degraded_mode is False
-        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
-        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
+        assert ogx_cfg is not None
+        assert ogx_cfg.allow_degraded_mode is False
+        assert ogx_cfg.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert ogx_cfg.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Configuration for server mode"):
-        llama_stack_configuration = OgxConfiguration(
+        ogx_cfg = OgxConfiguration(
             use_as_library_client=False,
             url=AnyHttpUrl("http://localhost"),
             library_client_config_path=None,
             api_key=None,
             timeout=60,
         )
-        assert llama_stack_configuration is not None
-        assert llama_stack_configuration.allow_degraded_mode is False
-        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
-        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
+        assert ogx_cfg is not None
+        assert ogx_cfg.allow_degraded_mode is False
+        assert ogx_cfg.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert ogx_cfg.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Minimal configuration for server mode"):
-        llama_stack_configuration = OgxConfiguration(
+        ogx_cfg = OgxConfiguration(
             url="http://localhost"
         )  # pyright: ignore[reportCallIssue]
-        assert llama_stack_configuration is not None
-        assert llama_stack_configuration.allow_degraded_mode is False
-        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
-        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
+        assert ogx_cfg is not None
+        assert ogx_cfg.allow_degraded_mode is False
+        assert ogx_cfg.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert ogx_cfg.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Full configuration for server mode"):
-        llama_stack_configuration = OgxConfiguration(
+        ogx_cfg = OgxConfiguration(
             use_as_library_client=False, url="http://localhost", api_key="foo"
         )  # pyright: ignore[reportCallIssue]
-        assert llama_stack_configuration is not None
-        assert llama_stack_configuration.allow_degraded_mode is False
-        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
-        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
+        assert ogx_cfg is not None
+        assert ogx_cfg.allow_degraded_mode is False
+        assert ogx_cfg.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert ogx_cfg.retry_delay == constants.DEFAULT_RETRY_DELAY
 
     with subtests.test(msg="Degraded mode enabled"):
-        llama_stack_configuration = OgxConfiguration(
+        ogx_cfg = OgxConfiguration(
             url="http://localhost",
             allow_degraded_mode=True,
         )  # pyright: ignore[reportCallIssue]
-        assert llama_stack_configuration is not None
-        assert llama_stack_configuration.allow_degraded_mode is True
-        assert llama_stack_configuration.max_retries == constants.DEFAULT_MAX_RETRIES
-        assert llama_stack_configuration.retry_delay == constants.DEFAULT_RETRY_DELAY
+        assert ogx_cfg is not None
+        assert ogx_cfg.allow_degraded_mode is True
+        assert ogx_cfg.max_retries == constants.DEFAULT_MAX_RETRIES
+        assert ogx_cfg.retry_delay == constants.DEFAULT_RETRY_DELAY
 
 
-def test_llama_stack_configuration_no_run_yaml() -> None:
+def test_ogx_cfg_no_run_yaml() -> None:
     """
     Verify that constructing a OgxConfiguration with a
     non-existent or invalid library_client_config_path raises
@@ -105,7 +105,7 @@ def test_llama_stack_configuration_no_run_yaml() -> None:
         )  # pyright: ignore[reportCallIssue]
 
 
-def test_llama_stack_wrong_configuration_constructor_no_url() -> None:
+def test_ogx_wrong_configuration_constructor_no_url() -> None:
     """
     Verify that constructing a OgxConfiguration without
     specifying either a URL or enabling library client mode raises
@@ -118,7 +118,7 @@ def test_llama_stack_wrong_configuration_constructor_no_url() -> None:
         OgxConfiguration()  # pyright: ignore[reportCallIssue]
 
 
-def test_llama_stack_wrong_configuration_constructor_library_mode_off() -> None:
+def test_ogx_wrong_configuration_constructor_library_mode_off() -> None:
     """Test the OgxConfiguration constructor."""
     with pytest.raises(
         ValueError,
@@ -129,7 +129,7 @@ def test_llama_stack_wrong_configuration_constructor_library_mode_off() -> None:
         )  # pyright: ignore[reportCallIssue]
 
 
-def test_llama_stack_library_mode_without_source_is_allowed_on_nested_model() -> None:
+def test_ogx_library_mode_without_source_is_allowed_on_nested_model() -> None:
     """The nested model no longer requires a run source in library mode.
 
     A library-mode config may be driven by the root-level inference.providers,
@@ -146,7 +146,7 @@ def test_llama_stack_library_mode_without_source_is_allowed_on_nested_model() ->
     assert cfg.config is None
 
 
-def test_llama_stack_configuration_valid_http_url() -> None:
+def test_ogx_cfg_valid_http_url() -> None:
     """Test that valid HTTP URLs are accepted."""
     config = OgxConfiguration(
         url="http://localhost:8321"
@@ -155,55 +155,55 @@ def test_llama_stack_configuration_valid_http_url() -> None:
     assert str(config.url) == "http://localhost:8321/"
 
 
-def test_llama_stack_configuration_valid_https_url() -> None:
+def test_ogx_cfg_valid_https_url() -> None:
     """Test that valid HTTPS URLs are accepted."""
     config = OgxConfiguration(
-        url="https://llama-stack.example.com:8321"
+        url="https://ogx.example.com:8321"
     )  # pyright: ignore[reportCallIssue]
     assert config is not None
-    assert str(config.url) == "https://llama-stack.example.com:8321/"
+    assert str(config.url) == "https://ogx.example.com:8321/"
 
 
-def test_llama_stack_configuration_malformed_url_rejected() -> None:
+def test_ogx_cfg_malformed_url_rejected() -> None:
     """Test that malformed URLs are rejected with a ValidationError."""
     with pytest.raises(ValidationError, match="Input should be a valid URL"):
         OgxConfiguration(url="not-a-valid-url")  # pyright: ignore[reportCallIssue]
 
 
-def test_llama_stack_configuration_invalid_scheme_rejected() -> None:
+def test_ogx_cfg_invalid_scheme_rejected() -> None:
     """Test that URLs without http/https scheme are rejected."""
     with pytest.raises(ValidationError, match="URL scheme should be 'http' or 'https'"):
         OgxConfiguration(url="ftp://localhost:8321")  # pyright: ignore[reportCallIssue]
 
 
-def test_llama_stack_configuration_wrong_max_retries_count(subtests: SubTests) -> None:
+def test_ogx_cfg_wrong_max_retries_count(subtests: SubTests) -> None:
     """Test that malformed URLs are rejected with a ValidationError."""
     with subtests.test(msg="Configuration with zero max_retries count"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
             OgxConfiguration(
-                url="https://llama-stack.example.com:8321",
+                url="https://ogx.example.com:8321",
                 max_retries=0,
             )  # pyright: ignore[reportCallIssue]
     with subtests.test(msg="Configuration with negative max_retries count"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
             OgxConfiguration(
-                url="https://llama-stack.example.com:8321",
+                url="https://ogx.example.com:8321",
                 max_retries=-1,
             )  # pyright: ignore[reportCallIssue]
 
 
-def test_llama_stack_configuration_wrong_retry_delay_value(subtests: SubTests) -> None:
+def test_ogx_cfg_wrong_retry_delay_value(subtests: SubTests) -> None:
     """Test that malformed URLs are rejected with a ValidationError."""
     with subtests.test(msg="Configuration with zero retry_delay value"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
             OgxConfiguration(
-                url="https://llama-stack.example.com:8321",
+                url="https://ogx.example.com:8321",
                 retry_delay=0,
             )  # pyright: ignore[reportCallIssue]
     with subtests.test(msg="Configuration with negative retry_delay value"):
         with pytest.raises(ValidationError, match="Input should be greater than 0"):
             OgxConfiguration(
-                url="https://llama-stack.example.com:8321",
+                url="https://ogx.example.com:8321",
                 retry_delay=-1,
             )  # pyright: ignore[reportCallIssue]
 
@@ -214,7 +214,7 @@ def test_llama_stack_configuration_wrong_retry_delay_value(subtests: SubTests) -
 
 
 def test_library_mode_with_unified_config_no_path_is_valid() -> None:
-    """Library mode driven by llama_stack.config needs no library_client_config_path."""
+    """Library mode driven by ogx.config needs no library_client_config_path."""
     cfg = OgxConfiguration(
         use_as_library_client=True,
         config=UnifiedOgxConfig(),
@@ -236,7 +236,7 @@ def test_unified_config_accepts_byo_llm_baseline() -> None:
 
 
 def test_root_rejects_config_and_legacy_path_together() -> None:
-    """A llama_stack.config block and a legacy path in one file fail at load (R3)."""
+    """A ogx.config block and a legacy path in one file fail at load (R3)."""
     config_dict = _base_config_dict()
     config_dict["ogx"] = {
         "use_as_library_client": True,
@@ -327,7 +327,7 @@ def test_root_accepts_unified_library_config() -> None:
 def test_root_accepts_inference_providers_only_no_config_block() -> None:
     """Library mode driven by inference.providers alone is valid (UX: no config:{}).
 
-    The minimal unified library config needs no llama_stack.config block — a
+    The minimal unified library config needs no ogx.config block — a
     non-empty top-level inference.providers is a sufficient synthesis input.
     """
     config_dict = _base_config_dict()
@@ -492,7 +492,7 @@ def test_root_accepts_unified_marker_with_vector_store_providers_body() -> None:
 
 
 def test_root_accepts_unified_marker_with_config_block_body() -> None:
-    """'unified' agrees with a body whose only synthesis input is llama_stack.config."""
+    """'unified' agrees with a body whose only synthesis input is ogx.config."""
     config_dict = _clear_synthesis_inputs(_base_config_dict())
     config_dict["ogx"] = {
         "use_as_library_client": True,

--- a/tests/unit/telemetry/conftest.py
+++ b/tests/unit/telemetry/conftest.py
@@ -224,7 +224,7 @@ ALL_PII_VALUES = [
     PII_PROVIDER_API_KEY_ENV,
 ]
 
-SAMPLE_LLAMA_STACK_CONFIG: dict[str, Any] = {
+SAMPLE_OGX_CONFIG: dict[str, Any] = {
     "version": 2,
     "image_name": "starter",
     "container_image": None,
@@ -296,7 +296,7 @@ SAMPLE_LLAMA_STACK_CONFIG: dict[str, Any] = {
 }
 
 
-LLAMA_STACK_PII_VALUES = [
+OGX_PII_VALUES = [
     "sk-openai-secret-key",
     "/secret/path/kv_store.db",
     "/secret/path/sql_store.db",
@@ -794,7 +794,7 @@ def build_minimal_config() -> Configuration:
 
 @pytest.fixture(name="ogx_config_file")
 def ogx_config_file_fixture(tmp_path: Path) -> str:
-    """Write SAMPLE_LLAMA_STACK_CONFIG to a temp YAML file and return its path.
+    """Write SAMPLE_OGX_CONFIG to a temp YAML file and return its path.
 
     Parameters:
     ----------
@@ -805,5 +805,5 @@ def ogx_config_file_fixture(tmp_path: Path) -> str:
         str: Path to the temporary YAML file.
     """
     path = tmp_path / "ogx_config.yaml"
-    path.write_text(yaml.dump(SAMPLE_LLAMA_STACK_CONFIG))
+    path.write_text(yaml.dump(SAMPLE_OGX_CONFIG))
     return str(path)

--- a/tests/unit/telemetry/test_configuration_snapshot.py
+++ b/tests/unit/telemetry/test_configuration_snapshot.py
@@ -36,9 +36,9 @@ from telemetry.configuration_snapshot import (
 from tests.unit.telemetry.conftest import (
     ALL_PII_VALUES,
     BYOK_PORT,
-    LLAMA_STACK_PII_VALUES,
+    OGX_PII_VALUES,
     OKP_CHUNK_FILTER,
-    SAMPLE_LLAMA_STACK_CONFIG,
+    SAMPLE_OGX_CONFIG,
     build_fully_populated_config,
     build_minimal_config,
 )
@@ -383,20 +383,20 @@ class TestExtractStoreInfo:
 
     def test_inference_store(self) -> None:
         """Test inference store extraction."""
-        result = _extract_store_info(SAMPLE_LLAMA_STACK_CONFIG, "inference")
+        result = _extract_store_info(SAMPLE_OGX_CONFIG, "inference")
         assert result["type"] == "sql_sqlite"
         assert result["db_path"] == CONFIGURED
 
     def test_metadata_store_with_namespace(self) -> None:
         """Test metadata store extraction includes namespace."""
-        result = _extract_store_info(SAMPLE_LLAMA_STACK_CONFIG, "metadata")
+        result = _extract_store_info(SAMPLE_OGX_CONFIG, "metadata")
         assert result["type"] == "kv_sqlite"
         assert result["db_path"] == CONFIGURED
         assert result["namespace"] == "registry"
 
     def test_missing_store(self) -> None:
         """Test missing store returns not_configured."""
-        result = _extract_store_info(SAMPLE_LLAMA_STACK_CONFIG, "nonexistent")
+        result = _extract_store_info(SAMPLE_OGX_CONFIG, "nonexistent")
         assert result["type"] == NOT_CONFIGURED
         assert result["db_path"] == NOT_CONFIGURED
 
@@ -407,7 +407,7 @@ class TestExtractStoreInfo:
 
     def test_db_path_is_masked(self) -> None:
         """Test that db_path never leaks the actual path."""
-        result = _extract_store_info(SAMPLE_LLAMA_STACK_CONFIG, "inference")
+        result = _extract_store_info(SAMPLE_OGX_CONFIG, "inference")
         assert "/secret/path" not in str(result)
 
 
@@ -553,43 +553,43 @@ class TestBuildLightspeedStackSnapshot:
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["service"]["root_path"] == CONFIGURED
 
-    def test_llama_stack_timeout_passthrough(self) -> None:
-        """Test llama_stack timeout passes through."""
+    def test_ogx_timeout_passthrough(self) -> None:
+        """Test ogx timeout passes through."""
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["ogx"]["timeout"] == 180
 
-    def test_llama_stack_max_retries_passthrough(self) -> None:
-        """Test llama_stack max_retries passes through."""
+    def test_ogx_max_retries_passthrough(self) -> None:
+        """Test ogx max_retries passes through."""
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["ogx"]["max_retries"] == 5
 
-    def test_llama_stack_retry_delay_passthrough(self) -> None:
-        """Test llama_stack retry_delay passes through."""
+    def test_ogx_retry_delay_passthrough(self) -> None:
+        """Test ogx retry_delay passes through."""
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["ogx"]["retry_delay"] == 2
 
-    def test_llama_stack_allow_degraded_mode_passthrough(self) -> None:
-        """Test llama_stack allow_degraded_mode passes through."""
+    def test_ogx_allow_degraded_mode_passthrough(self) -> None:
+        """Test ogx allow_degraded_mode passes through."""
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["ogx"]["allow_degraded_mode"] is True
 
-    def test_llama_stack_config_baseline_passthrough(self) -> None:
-        """Test llama_stack config baseline passes through."""
+    def test_ogx_config_baseline_passthrough(self) -> None:
+        """Test ogx config baseline passes through."""
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["ogx"]["config"]["baseline"] == "default"
 
-    def test_llama_stack_config_profile_masked(self) -> None:
-        """Test llama_stack config profile is masked as sensitive."""
+    def test_ogx_config_profile_masked(self) -> None:
+        """Test ogx config profile is masked as sensitive."""
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["ogx"]["config"]["profile"] == CONFIGURED
 
-    def test_llama_stack_config_native_override_masked(self) -> None:
-        """Test llama_stack config native_override is masked as sensitive."""
+    def test_ogx_config_native_override_masked(self) -> None:
+        """Test ogx config native_override is masked as sensitive."""
         snapshot = build_lightspeed_stack_snapshot(build_fully_populated_config())
         assert snapshot["ogx"]["config"]["native_override"] == CONFIGURED
 
-    def test_llama_stack_config_none(self) -> None:
-        """Test llama_stack config fields when config is None."""
+    def test_ogx_config_none(self) -> None:
+        """Test ogx config fields when config is None."""
         snapshot = build_lightspeed_stack_snapshot(build_minimal_config())
         assert snapshot["ogx"]["config"]["baseline"] is None
         assert snapshot["ogx"]["config"]["profile"] == NOT_CONFIGURED
@@ -1158,7 +1158,7 @@ class TestBuildConfigurationSnapshot:
 
     @pytest.mark.asyncio
     async def test_combines_both_sources(self) -> None:
-        """Test that snapshot contains both lightspeed_stack and llama_stack."""
+        """Test that snapshot contains both lightspeed_stack and ogx."""
         result = await build_configuration_snapshot(build_minimal_config(), None)
         assert "lightspeed_stack" in result
         assert "ogx" in result
@@ -1197,10 +1197,10 @@ class TestPiiLeakPrevention:
     async def test_no_pii_in_ogx_snapshot(self, ogx_config_file: str) -> None:
         """Verify no PII leaks in OGX snapshot JSON."""
         json_str = json.dumps(await build_ogx_snapshot(ogx_config_file))
-        for pii_value in LLAMA_STACK_PII_VALUES:
+        for pii_value in OGX_PII_VALUES:
             assert (
                 pii_value not in json_str
-            ), f"PII leaked in llama-stack snapshot: '{pii_value}'"
+            ), f"PII leaked in OGX snapshot: '{pii_value}'"
 
     @pytest.mark.asyncio
     async def test_no_pii_in_combined_snapshot(self, ogx_config_file: str) -> None:
@@ -1209,7 +1209,7 @@ class TestPiiLeakPrevention:
             build_fully_populated_config(), ogx_config_file
         )
         json_str = json.dumps(snapshot)
-        for pii_value in ALL_PII_VALUES + LLAMA_STACK_PII_VALUES:
+        for pii_value in ALL_PII_VALUES + OGX_PII_VALUES:
             assert (
                 pii_value not in json_str
             ), f"PII leaked in combined snapshot: '{pii_value}'"

--- a/tests/unit/test_lightspeed_stack.py
+++ b/tests/unit/test_lightspeed_stack.py
@@ -168,7 +168,7 @@ def test_main_does_not_warn_in_unified_mode(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A unified-mode config (llama_stack.config) emits no deprecation WARN."""
+    """A unified-mode config (ogx.config) emits no deprecation WARN."""
     config_yaml = COMMON_CONFIG_SECTIONS + """
 ogx:
   use_as_library_client: true

--- a/tests/unit/test_ogx_configuration.py
+++ b/tests/unit/test_ogx_configuration.py
@@ -36,7 +36,7 @@ from ogx_configuration import (
 
 def test_enrich_azure_entra_id_inference_skips_when_not_configured() -> None:
     """Test enrich_azure_entra_id_inference does nothing without Entra ID config."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {
             "inference": [
                 {
@@ -47,15 +47,15 @@ def test_enrich_azure_entra_id_inference_skips_when_not_configured() -> None:
             ]
         }
     }
-    enrich_azure_entra_id_inference(ls_config, None)
-    assert ls_config["providers"]["inference"][0]["config"] == {
+    enrich_azure_entra_id_inference(ogx_config, None)
+    assert ogx_config["providers"]["inference"][0]["config"] == {
         "model_validation": True
     }
 
 
 def test_enrich_azure_entra_id_inference_sets_model_validation_false() -> None:
     """Test enrich_azure_entra_id_inference disables startup model validation."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {
             "inference": [
                 {
@@ -66,8 +66,8 @@ def test_enrich_azure_entra_id_inference_sets_model_validation_false() -> None:
             ]
         }
     }
-    enrich_azure_entra_id_inference(ls_config, {"tenant_id": "t"})
-    azure_config = ls_config["providers"]["inference"][0]["config"]
+    enrich_azure_entra_id_inference(ogx_config, {"tenant_id": "t"})
+    azure_config = ogx_config["providers"]["inference"][0]["config"]
     assert azure_config["model_validation"] is False
 
 
@@ -115,15 +115,15 @@ def test_generate_configuration_enriches_azure_entra_id(tmp_path: Path) -> None:
 
 def test_construct_vector_stores_section_empty() -> None:
     """Test with no BYOK RAG config."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag: list[dict[str, Any]] = []
-    output = construct_vector_stores_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ogx_config, byok_rag)
     assert len(output) == 0
 
 
 def test_construct_vector_stores_section_preserves_existing() -> None:
     """Test preserves existing vector_stores entries."""
-    ls_config = {
+    ogx_config = {
         "registered_resources": {
             "vector_stores": [
                 {"vector_store_id": "existing", "provider_id": "existing_provider"},
@@ -131,14 +131,14 @@ def test_construct_vector_stores_section_preserves_existing() -> None:
         }
     }
     byok_rag: list[dict[str, Any]] = []
-    output = construct_vector_stores_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["vector_store_id"] == "existing"
 
 
 def test_construct_vector_stores_section_adds_new() -> None:
     """Test adds new BYOK RAG entries."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "rag1",
@@ -147,7 +147,7 @@ def test_construct_vector_stores_section_adds_new() -> None:
             "embedding_dimension": 512,
         },
     ]
-    output = construct_vector_stores_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["vector_store_id"] == "store1"
     assert output[0]["provider_id"] == "byok_rag1"
@@ -157,17 +157,17 @@ def test_construct_vector_stores_section_adds_new() -> None:
 
 def test_construct_vector_stores_section_merge() -> None:
     """Test merges existing and new entries."""
-    ls_config = {
+    ogx_config = {
         "registered_resources": {"vector_stores": [{"vector_store_id": "existing"}]}
     }
     byok_rag = [{"rag_id": "rag1", "vector_db_id": "new_store"}]
-    output = construct_vector_stores_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ogx_config, byok_rag)
     assert len(output) == 2
 
 
 def test_construct_vector_stores_section_skips_duplicate_from_existing() -> None:
     """Test skips BYOK entry when vector_store_id already exists in config."""
-    ls_config = {
+    ogx_config = {
         "registered_resources": {
             "vector_stores": [
                 {"vector_store_id": "store1", "provider_id": "original_provider"},
@@ -182,7 +182,7 @@ def test_construct_vector_stores_section_skips_duplicate_from_existing() -> None
             "embedding_dimension": 512,
         },
     ]
-    output = construct_vector_stores_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["provider_id"] == "original_provider"
 
@@ -192,7 +192,7 @@ def test_construct_vector_stores_section_skips_duplicate_env_var(
 ) -> None:
     """Test skips BYOK entry when existing store uses an env var that resolves to the same ID."""
     monkeypatch.setenv("FAISS_VECTOR_STORE_ID", "vs_abc123")
-    ls_config = {
+    ogx_config = {
         "registered_resources": {
             "vector_stores": [
                 {
@@ -210,14 +210,14 @@ def test_construct_vector_stores_section_skips_duplicate_env_var(
             "embedding_dimension": 768,
         },
     ]
-    output = construct_vector_stores_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["provider_id"] == "faiss"
 
 
 def test_construct_vector_stores_section_skips_duplicate_within_byok() -> None:
     """Test skips duplicate vector_db_id entries within the BYOK RAG list."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "rag1",
@@ -232,7 +232,7 @@ def test_construct_vector_stores_section_skips_duplicate_within_byok() -> None:
             "embedding_dimension": 768,
         },
     ]
-    output = construct_vector_stores_section(ls_config, byok_rag)
+    output = construct_vector_stores_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["embedding_model"] == "sentence-transformers/byok_rag1_embedding"
 
@@ -244,24 +244,24 @@ def test_construct_vector_stores_section_skips_duplicate_within_byok() -> None:
 
 def test_construct_vector_io_providers_section_empty() -> None:
     """Test with no BYOK RAG config."""
-    ls_config: dict[str, Any] = {"providers": {}}
+    ogx_config: dict[str, Any] = {"providers": {}}
     byok_rag: list[dict[str, Any]] = []
-    output = construct_vector_io_providers_section(ls_config, byok_rag)
+    output = construct_vector_io_providers_section(ogx_config, byok_rag)
     assert len(output) == 0
 
 
 def test_construct_vector_io_providers_section_preserves_existing() -> None:
     """Test preserves existing vector_io entries."""
-    ls_config = {"providers": {"vector_io": [{"provider_id": "existing"}]}}
+    ogx_config = {"providers": {"vector_io": [{"provider_id": "existing"}]}}
     byok_rag: list[dict[str, Any]] = []
-    output = construct_vector_io_providers_section(ls_config, byok_rag)
+    output = construct_vector_io_providers_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["provider_id"] == "existing"
 
 
 def test_construct_vector_io_providers_section_adds_new() -> None:
     """Test adds new BYOK RAG entries using rag_id for provider naming."""
-    ls_config: dict[str, Any] = {"providers": {}}
+    ogx_config: dict[str, Any] = {"providers": {}}
     byok_rag = [
         {
             "rag_id": "rag1",
@@ -269,7 +269,7 @@ def test_construct_vector_io_providers_section_adds_new() -> None:
             "backend": "faiss",
         },
     ]
-    output = construct_vector_io_providers_section(ls_config, byok_rag)
+    output = construct_vector_io_providers_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["provider_id"] == "byok_rag1"
     assert output[0]["provider_type"] == "inline::faiss"
@@ -286,10 +286,10 @@ def test_construct_vector_io_providers_section_idempotent_reenrichment() -> None
             "backend": "faiss",
         },
     ]
-    ls_config: dict[str, Any] = {"providers": {}}
-    first = construct_vector_io_providers_section(ls_config, byok_rag)
-    ls_config["providers"] = {"vector_io": first}
-    second = construct_vector_io_providers_section(ls_config, byok_rag)
+    ogx_config: dict[str, Any] = {"providers": {}}
+    first = construct_vector_io_providers_section(ogx_config, byok_rag)
+    ogx_config["providers"] = {"vector_io": first}
+    second = construct_vector_io_providers_section(ogx_config, byok_rag)
     assert len(second) == 1
     assert second[0]["provider_id"] == "byok_rag1"
 
@@ -306,7 +306,7 @@ def test_construct_vector_io_providers_section_collapses_existing_duplicates() -
             }
         },
     }
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {"vector_io": [dup, dup, dup]},
     }
     byok_rag = [
@@ -316,14 +316,14 @@ def test_construct_vector_io_providers_section_collapses_existing_duplicates() -
             "backend": "faiss",
         },
     ]
-    output = construct_vector_io_providers_section(ls_config, byok_rag)
+    output = construct_vector_io_providers_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["provider_id"] == "byok_rag1"
 
 
 def test_construct_vector_io_providers_section_pgvector() -> None:
     """Test generates correct pgvector provider config."""
-    ls_config: dict[str, Any] = {"providers": {}}
+    ogx_config: dict[str, Any] = {"providers": {}}
     byok_rag = [
         {
             "rag_id": "pg1",
@@ -336,7 +336,7 @@ def test_construct_vector_io_providers_section_pgvector() -> None:
             "password": "${env.POSTGRES_PASSWORD}",
         },
     ]
-    output = construct_vector_io_providers_section(ls_config, byok_rag)
+    output = construct_vector_io_providers_section(ogx_config, byok_rag)
     assert len(output) == 1
     provider = output[0]
     assert provider["provider_id"] == "byok_pg1"
@@ -349,7 +349,7 @@ def test_construct_vector_io_providers_section_pgvector() -> None:
 
 def test_construct_vector_io_providers_section_mixed() -> None:
     """Test mixed faiss and pgvector entries generate correct configs."""
-    ls_config: dict[str, Any] = {"providers": {}}
+    ogx_config: dict[str, Any] = {"providers": {}}
     byok_rag = [
         {"rag_id": "f1", "vector_db_id": "vs_f", "backend": "faiss"},
         {
@@ -363,7 +363,7 @@ def test_construct_vector_io_providers_section_mixed() -> None:
             "password": "pass",
         },
     ]
-    output = construct_vector_io_providers_section(ls_config, byok_rag)
+    output = construct_vector_io_providers_section(ogx_config, byok_rag)
     assert len(output) == 2
     faiss_p = next(p for p in output if p["provider_id"] == "byok_f1")
     assert faiss_p["provider_type"] == "inline::faiss"
@@ -376,20 +376,20 @@ def test_construct_vector_io_providers_section_mixed() -> None:
 
 def test_construct_storage_backends_section_skips_pgvector() -> None:
     """Test pgvector entries are skipped (they use kv_default)."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [{"rag_id": "pg1", "vector_db_id": "vs_pg", "backend": "pgvector"}]
-    output = construct_storage_backends_section(ls_config, byok_rag)
+    output = construct_storage_backends_section(ogx_config, byok_rag)
     assert len(output) == 0
 
 
 def test_construct_storage_backends_section_mixed_faiss_pgvector() -> None:
     """Test only faiss entries get storage backends, pgvector is skipped."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {"rag_id": "f1", "vector_db_id": "vs_f", "db_path": "/tmp/f.db"},
         {"rag_id": "pg1", "vector_db_id": "vs_pg", "backend": "pgvector"},
     ]
-    output = construct_storage_backends_section(ls_config, byok_rag)
+    output = construct_storage_backends_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert "byok_f1_storage" in output
     assert "byok_pg1_storage" not in output
@@ -397,7 +397,7 @@ def test_construct_storage_backends_section_mixed_faiss_pgvector() -> None:
 
 def test_enrich_byok_rag_pgvector_end_to_end() -> None:
     """Test enrich_byok_rag with a pgvector store entry."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "pg1",
@@ -412,15 +412,16 @@ def test_enrich_byok_rag_pgvector_end_to_end() -> None:
             "password": "${env.POSTGRES_PASSWORD}",
         },
     ]
-    enrich_byok_rag(ls_config, byok_rag)
-    assert "byok_pg1_storage" not in ls_config.get("storage", {}).get("backends", {})
-    providers = ls_config["providers"]["vector_io"]
+    enrich_byok_rag(ogx_config, byok_rag)
+    assert "byok_pg1_storage" not in ogx_config.get("storage", {}).get("backends", {})
+    providers = ogx_config["providers"]["vector_io"]
     pg_p = next(p for p in providers if p["provider_id"] == "byok_pg1")
     assert pg_p["provider_type"] == "remote::pgvector"
     assert pg_p["config"]["persistence"]["backend"] == "kv_default"
     assert pg_p["config"]["host"] == "${env.POSTGRES_HOST}"
     store_ids = [
-        s["vector_store_id"] for s in ls_config["registered_resources"]["vector_stores"]
+        s["vector_store_id"]
+        for s in ogx_config["registered_resources"]["vector_stores"]
     ]
     assert "vs_pg" in store_ids
 
@@ -432,19 +433,19 @@ def test_enrich_byok_rag_skipped_still_dedupes_vector_io() -> None:
         "provider_type": "inline::faiss",
         "config": {"persistence": {"namespace": "vector_io::faiss", "backend": "b"}},
     }
-    ls_config: dict[str, Any] = {"providers": {"vector_io": [dup, dup, dup]}}
-    enrich_byok_rag(ls_config, [])
-    assert len(ls_config["providers"]["vector_io"]) == 1
+    ogx_config: dict[str, Any] = {"providers": {"vector_io": [dup, dup, dup]}}
+    enrich_byok_rag(ogx_config, [])
+    assert len(ogx_config["providers"]["vector_io"]) == 1
 
 
 def test_dedupe_providers_vector_io_in_place() -> None:
     """dedupe_providers_vector_io keeps one entry per provider_id."""
     a = {"provider_id": "p1", "provider_type": "inline::faiss", "config": {}}
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {"vector_io": [a, a, {"provider_id": "p2"}]}
     }
-    dedupe_providers_vector_io(ls_config)
-    ids = [p["provider_id"] for p in ls_config["providers"]["vector_io"]]
+    dedupe_providers_vector_io(ogx_config)
+    ids = [p["provider_id"] for p in ogx_config["providers"]["vector_io"]]
     assert ids == ["p1", "p2"]
 
 
@@ -455,15 +456,15 @@ def test_dedupe_providers_vector_io_in_place() -> None:
 
 def test_construct_storage_backends_section_empty() -> None:
     """Test with no BYOK RAG config."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag: list[dict[str, Any]] = []
-    output = construct_storage_backends_section(ls_config, byok_rag)
+    output = construct_storage_backends_section(ogx_config, byok_rag)
     assert len(output) == 0
 
 
 def test_construct_storage_backends_section_preserves_existing() -> None:
     """Test preserves existing backends."""
-    ls_config = {
+    ogx_config = {
         "storage": {
             "backends": {
                 "kv_default": {"type": "kv_sqlite", "db_path": "~/.llama/kv.db"}
@@ -471,14 +472,14 @@ def test_construct_storage_backends_section_preserves_existing() -> None:
         }
     }
     byok_rag: list[dict[str, Any]] = []
-    output = construct_storage_backends_section(ls_config, byok_rag)
+    output = construct_storage_backends_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert "kv_default" in output
 
 
 def test_construct_storage_backends_section_adds_new() -> None:
     """Test adds new BYOK RAG backend entries using rag_id for backend naming."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "rag1",
@@ -486,7 +487,7 @@ def test_construct_storage_backends_section_adds_new() -> None:
             "db_path": "/path/to/store1.db",
         },
     ]
-    output = construct_storage_backends_section(ls_config, byok_rag)
+    output = construct_storage_backends_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert "byok_rag1_storage" in output
     assert output["byok_rag1_storage"]["type"] == "kv_sqlite"
@@ -500,28 +501,28 @@ def test_construct_storage_backends_section_adds_new() -> None:
 
 def test_construct_models_section_empty() -> None:
     """Test with no BYOK RAG config."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag: list[dict[str, Any]] = []
-    output = construct_models_section(ls_config, byok_rag)
+    output = construct_models_section(ogx_config, byok_rag)
     assert len(output) == 0
 
 
 def test_construct_models_section_preserves_existing() -> None:
     """Test preserves existing models."""
-    ls_config = {
+    ogx_config = {
         "registered_resources": {
             "models": [{"model_id": "existing", "model_type": "llm"}]
         }
     }
     byok_rag: list[dict[str, Any]] = []
-    output = construct_models_section(ls_config, byok_rag)
+    output = construct_models_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["model_id"] == "existing"
 
 
 def test_construct_models_section_adds_embedding_model() -> None:
     """Test adds embedding model from BYOK RAG using rag_id for model naming."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "rag1",
@@ -530,7 +531,7 @@ def test_construct_models_section_adds_embedding_model() -> None:
             "embedding_dimension": 768,
         },
     ]
-    output = construct_models_section(ls_config, byok_rag)
+    output = construct_models_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["model_id"] == "byok_rag1_embedding"
     assert output[0]["model_type"] == "embedding"
@@ -541,7 +542,7 @@ def test_construct_models_section_adds_embedding_model() -> None:
 
 def test_construct_models_section_strips_prefix() -> None:
     """Test strips sentence-transformers/ prefix from embedding model."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "rag1",
@@ -550,14 +551,14 @@ def test_construct_models_section_strips_prefix() -> None:
             "embedding_dimension": 768,
         },
     ]
-    output = construct_models_section(ls_config, byok_rag)
+    output = construct_models_section(ogx_config, byok_rag)
     assert len(output) == 1
     assert output[0]["provider_model_id"] == "/usr/path/model"
 
 
 def test_byok_vector_store_uses_registered_embedding_id_not_load_path() -> None:
     """BYOK store lookup id matches registered model; path stays on provider_model_id."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "rhdh-docs",
@@ -566,8 +567,8 @@ def test_byok_vector_store_uses_registered_embedding_id_not_load_path() -> None:
             "embedding_dimension": 768,
         },
     ]
-    stores = construct_vector_stores_section(ls_config, byok_rag)
-    models = construct_models_section(ls_config, byok_rag)
+    stores = construct_vector_stores_section(ogx_config, byok_rag)
+    models = construct_models_section(ogx_config, byok_rag)
     assert stores[0]["embedding_model"] == (
         "sentence-transformers/byok_rhdh-docs_embedding"
     )
@@ -577,7 +578,7 @@ def test_byok_vector_store_uses_registered_embedding_id_not_load_path() -> None:
 
 def test_construct_models_section_registers_alias_per_rag_id_for_shared_path() -> None:
     """Two BYOK entries sharing a load path each get a byok_<rag_id>_embedding alias."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [
         {
             "rag_id": "docs-a",
@@ -592,8 +593,8 @@ def test_construct_models_section_registers_alias_per_rag_id_for_shared_path() -
             "embedding_dimension": 768,
         },
     ]
-    models = construct_models_section(ls_config, byok_rag)
-    stores = construct_vector_stores_section(ls_config, byok_rag)
+    models = construct_models_section(ogx_config, byok_rag)
+    stores = construct_vector_stores_section(ogx_config, byok_rag)
     assert {m["model_id"] for m in models} == {
         "byok_docs-a_embedding",
         "byok_docs-b_embedding",
@@ -609,42 +610,42 @@ def test_construct_models_section_registers_alias_per_rag_id_for_shared_path() -
 
 def test_construct_storage_backends_section_raises_on_missing_rag_id() -> None:
     """Test raises ValueError when rag_id is missing from a BYOK RAG entry."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [{"vector_db_id": "store1"}]
     with pytest.raises(ValueError, match="missing required 'rag_id'"):
-        construct_storage_backends_section(ls_config, byok_rag)
+        construct_storage_backends_section(ogx_config, byok_rag)
 
 
 def test_construct_vector_stores_section_raises_on_missing_rag_id() -> None:
     """Test raises ValueError when rag_id is missing from a BYOK RAG entry."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [{"vector_db_id": "store1"}]
     with pytest.raises(ValueError, match="missing required 'rag_id'"):
-        construct_vector_stores_section(ls_config, byok_rag)
+        construct_vector_stores_section(ogx_config, byok_rag)
 
 
 def test_construct_vector_stores_section_raises_on_missing_vector_db_id() -> None:
     """Test raises ValueError when vector_db_id is missing from a BYOK RAG entry."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [{"rag_id": "rag1"}]
     with pytest.raises(ValueError, match="missing required 'vector_db_id'"):
-        construct_vector_stores_section(ls_config, byok_rag)
+        construct_vector_stores_section(ogx_config, byok_rag)
 
 
 def test_construct_vector_io_section_raises_on_missing_rag_id() -> None:
     """Test raises ValueError when rag_id is missing from a BYOK RAG entry."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [{"vector_db_id": "store1"}]
     with pytest.raises(ValueError, match="missing required 'rag_id'"):
-        construct_vector_io_providers_section(ls_config, byok_rag)
+        construct_vector_io_providers_section(ogx_config, byok_rag)
 
 
 def test_construct_models_section_raises_on_missing_rag_id() -> None:
     """Test raises ValueError when rag_id is missing from a BYOK RAG entry."""
-    ls_config: dict[str, Any] = {}
+    ogx_config: dict[str, Any] = {}
     byok_rag = [{"vector_db_id": "store1", "embedding_model": "some-model"}]
     with pytest.raises(ValueError, match="missing required 'rag_id'"):
-        construct_models_section(ls_config, byok_rag)
+        construct_models_section(ogx_config, byok_rag)
 
 
 # =============================================================================
@@ -825,91 +826,94 @@ _OKP_RAG_CONFIG = {"inline": ["okp"]}
 
 def test_enrich_solr_skips_when_not_enabled() -> None:
     """Test enrich_solr does nothing when OKP is not in rag inline or tool lists."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, {"inline": [], "tool": []}, {})
-    assert not ls_config
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, {"inline": [], "tool": []}, {})
+    assert not ogx_config
 
 
 def test_enrich_solr_skips_when_empty_config() -> None:
     """Test enrich_solr does nothing with empty rag config."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, {}, {})
-    assert not ls_config
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, {}, {})
+    assert not ogx_config
 
 
 def test_enrich_solr_adds_vector_io_provider() -> None:
     """Test enrich_solr adds Solr provider to vector_io section."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
-    assert "providers" in ls_config
-    assert "vector_io" in ls_config["providers"]
-    provider_ids = [p["provider_id"] for p in ls_config["providers"]["vector_io"]]
+    assert "providers" in ogx_config
+    assert "vector_io" in ogx_config["providers"]
+    provider_ids = [p["provider_id"] for p in ogx_config["providers"]["vector_io"]]
     assert "okp_solr" in provider_ids
 
 
 def test_enrich_solr_adds_vector_store_registration() -> None:
     """Test enrich_solr registers the Solr vector store."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
-    assert "registered_resources" in ls_config
+    assert "registered_resources" in ogx_config
     store_ids = [
-        s["vector_store_id"] for s in ls_config["registered_resources"]["vector_stores"]
+        s["vector_store_id"]
+        for s in ogx_config["registered_resources"]["vector_stores"]
     ]
     assert "portal-rag" in store_ids
 
 
 def test_enrich_solr_adds_embedding_model() -> None:
     """Test enrich_solr registers the Solr embedding model."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
-    model_ids = [m["model_id"] for m in ls_config["registered_resources"]["models"]]
+    model_ids = [m["model_id"] for m in ogx_config["registered_resources"]["models"]]
     assert "sentence-transformers/solr_embedding" in model_ids
 
 
 def test_enrich_solr_skips_duplicate_provider() -> None:
     """Test enrich_solr does not add duplicate Solr provider."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {"vector_io": [{"provider_id": "okp_solr"}]}
     }
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
-    provider_ids = [p["provider_id"] for p in ls_config["providers"]["vector_io"]]
+    provider_ids = [p["provider_id"] for p in ogx_config["providers"]["vector_io"]]
     assert provider_ids.count("okp_solr") == 1
 
 
 def test_enrich_solr_skips_duplicate_vector_store() -> None:
     """Test enrich_solr does not add duplicate vector store registration."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "registered_resources": {"vector_stores": [{"vector_store_id": "portal-rag"}]}
     }
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
     store_ids = [
-        s["vector_store_id"] for s in ls_config["registered_resources"]["vector_stores"]
+        s["vector_store_id"]
+        for s in ogx_config["registered_resources"]["vector_stores"]
     ]
     assert store_ids.count("portal-rag") == 1
 
 
 def test_enrich_solr_preserves_existing_config() -> None:
     """Test enrich_solr preserves existing providers and resources."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {"vector_io": [{"provider_id": "existing_provider"}]},
         "registered_resources": {
             "vector_stores": [{"vector_store_id": "existing_store"}],
             "models": [{"model_id": "existing_model"}],
         },
     }
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
-    provider_ids = [p["provider_id"] for p in ls_config["providers"]["vector_io"]]
+    provider_ids = [p["provider_id"] for p in ogx_config["providers"]["vector_io"]]
     assert "existing_provider" in provider_ids
     assert "okp_solr" in provider_ids
 
     store_ids = [
-        s["vector_store_id"] for s in ls_config["registered_resources"]["vector_stores"]
+        s["vector_store_id"]
+        for s in ogx_config["registered_resources"]["vector_stores"]
     ]
     assert "existing_store" in store_ids
     assert "portal-rag" in store_ids
@@ -917,11 +921,13 @@ def test_enrich_solr_preserves_existing_config() -> None:
 
 def test_enrich_solr_default_chunk_filter_query() -> None:
     """Test enrich_solr uses the internal chunk filter when no user filter is set."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
     provider = next(
-        p for p in ls_config["providers"]["vector_io"] if p["provider_id"] == "okp_solr"
+        p
+        for p in ogx_config["providers"]["vector_io"]
+        if p["provider_id"] == "okp_solr"
     )
     assert (
         provider["config"]["chunk_window_config"]["chunk_filter_query"]
@@ -931,11 +937,13 @@ def test_enrich_solr_default_chunk_filter_query() -> None:
 
 def test_enrich_solr_user_chunk_filter_query_is_conjoined() -> None:
     """Test enrich_solr ANDs the user filter with the internal chunk filter."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"chunk_filter_query": "product:ansible"})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {"chunk_filter_query": "product:ansible"})
 
     provider = next(
-        p for p in ls_config["providers"]["vector_io"] if p["provider_id"] == "okp_solr"
+        p
+        for p in ogx_config["providers"]["vector_io"]
+        if p["provider_id"] == "okp_solr"
     )
     assert provider["config"]["chunk_window_config"]["chunk_filter_query"] == (
         "is_chunk:true AND product:ansible"
@@ -944,64 +952,64 @@ def test_enrich_solr_user_chunk_filter_query_is_conjoined() -> None:
 
 def test_enrich_solr_sets_default_search_mode_keyword() -> None:
     """Test enrich_solr propagates search_mode keyword to vector_stores config."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "keyword"})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {"search_mode": "keyword"})
 
     assert (
-        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        ogx_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
         == "keyword"
     )
 
 
 def test_enrich_solr_sets_default_search_mode_hybrid() -> None:
     """Test enrich_solr propagates search_mode hybrid to vector_stores config."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "hybrid"})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {"search_mode": "hybrid"})
 
     assert (
-        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        ogx_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
         == "hybrid"
     )
 
 
 def test_enrich_solr_maps_semantic_to_vector() -> None:
     """Test enrich_solr maps LCORE semantic to OGX vector search mode."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "semantic"})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {"search_mode": "semantic"})
 
     assert (
-        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        ogx_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
         == "vector"
     )
 
 
 def test_enrich_solr_maps_lexical_to_keyword() -> None:
     """Test enrich_solr maps LCORE lexical to OGX keyword via SOLR_SEARCH_MODE_MAP."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "lexical"})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {"search_mode": "lexical"})
 
     assert (
-        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        ogx_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
         == "keyword"
     )
 
 
 def test_enrich_solr_no_search_mode_skips_vector_stores() -> None:
     """Test enrich_solr does not set vector_stores when search_mode is absent."""
-    ls_config: dict[str, Any] = {}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {})
+    ogx_config: dict[str, Any] = {}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {})
 
-    assert "vector_stores" not in ls_config
+    assert "vector_stores" not in ogx_config
 
 
 def test_enrich_solr_preserves_existing_vector_stores() -> None:
     """Test enrich_solr preserves existing vector_stores config when adding search_mode."""
-    ls_config: dict[str, Any] = {"vector_stores": {"default_provider_id": "faiss"}}
-    enrich_solr(ls_config, _OKP_RAG_CONFIG, {"search_mode": "keyword"})
+    ogx_config: dict[str, Any] = {"vector_stores": {"default_provider_id": "faiss"}}
+    enrich_solr(ogx_config, _OKP_RAG_CONFIG, {"search_mode": "keyword"})
 
-    assert ls_config["vector_stores"]["default_provider_id"] == "faiss"
+    assert ogx_config["vector_stores"]["default_provider_id"] == "faiss"
     assert (
-        ls_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
+        ogx_config["vector_stores"]["chunk_retrieval_params"]["default_search_mode"]
         == "keyword"
     )
 
@@ -1013,7 +1021,7 @@ def test_enrich_solr_preserves_existing_vector_stores() -> None:
 
 def test_enrich_vector_store_faiss_appends() -> None:
     """Faiss provider appends vector_io, backend, and default_* settings."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {
             "vector_io": [
                 {
@@ -1038,7 +1046,7 @@ def test_enrich_vector_store_faiss_appends() -> None:
         },
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "notebooks",
             "providers": [
@@ -1052,26 +1060,26 @@ def test_enrich_vector_store_faiss_appends() -> None:
             ],
         },
     )
-    ids = {p["provider_id"] for p in ls_config["providers"]["vector_io"]}
+    ids = {p["provider_id"] for p in ogx_config["providers"]["vector_io"]}
     assert ids == {"faiss", "notebooks"}
     assert (
-        ls_config["storage"]["backends"]["vsprov_notebooks_storage"]["db_path"]
+        ogx_config["storage"]["backends"]["vsprov_notebooks_storage"]["db_path"]
         == "/var/lib/notebooks.db"
     )
-    assert ls_config["vector_stores"]["default_provider_id"] == "notebooks"
-    assert ls_config["vector_stores"]["default_embedding_model"]["model_id"] == (
+    assert ogx_config["vector_stores"]["default_provider_id"] == "notebooks"
+    assert ogx_config["vector_stores"]["default_embedding_model"]["model_id"] == (
         "vsprov_notebooks_embedding"
     )
     assert (
-        ls_config["vector_stores"]["annotation_prompt_params"]["enable_annotations"]
+        ogx_config["vector_stores"]["annotation_prompt_params"]["enable_annotations"]
         is False
     )
-    assert not ls_config["registered_resources"]["vector_stores"]
+    assert not ogx_config["registered_resources"]["vector_stores"]
 
 
 def test_enrich_vector_store_replaces_same_provider_id() -> None:
     """Same provider_id replaces the baseline entry and leaves orphan backends."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {
             "vector_io": [
                 {
@@ -1098,7 +1106,7 @@ def test_enrich_vector_store_replaces_same_provider_id() -> None:
         "vector_stores": {},
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "notebooks",
             "providers": [
@@ -1112,29 +1120,29 @@ def test_enrich_vector_store_replaces_same_provider_id() -> None:
             ],
         },
     )
-    providers = ls_config["providers"]["vector_io"]
+    providers = ogx_config["providers"]["vector_io"]
     assert len(providers) == 1
     assert providers[0]["provider_id"] == "notebooks"
     assert (
         providers[0]["config"]["persistence"]["backend"] == "vsprov_notebooks_storage"
     )
-    assert "kv_notebooks" in ls_config["storage"]["backends"]
+    assert "kv_notebooks" in ogx_config["storage"]["backends"]
     assert (
-        ls_config["storage"]["backends"]["vsprov_notebooks_storage"]["db_path"]
+        ogx_config["storage"]["backends"]["vsprov_notebooks_storage"]["db_path"]
         == "/new/notebooks.db"
     )
 
 
 def test_enrich_vector_store_pgvector_no_kv_backend() -> None:
     """Pgvector provider does not create a kv_sqlite storage backend."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
         "registered_resources": {},
         "vector_stores": {},
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "nb-pg",
             "providers": [
@@ -1154,7 +1162,7 @@ def test_enrich_vector_store_pgvector_no_kv_backend() -> None:
             ],
         },
     )
-    provider = ls_config["providers"]["vector_io"][0]
+    provider = ogx_config["providers"]["vector_io"][0]
     assert provider["provider_type"] == "remote::pgvector"
     assert provider["config"]["persistence"]["backend"] == "kv_default"
     assert provider["config"]["host"] == "${env.POSTGRES_HOST}"
@@ -1162,12 +1170,12 @@ def test_enrich_vector_store_pgvector_no_kv_backend() -> None:
     assert provider["config"]["db"] == "${env.POSTGRES_DATABASE}"
     assert provider["config"]["user"] == "${env.POSTGRES_USER}"
     assert provider["config"]["password"] == "${env.POSTGRES_PASSWORD}"
-    assert "vsprov_nb-pg_storage" not in ls_config["storage"]["backends"]
+    assert "vsprov_nb-pg_storage" not in ogx_config["storage"]["backends"]
 
 
 def test_enrich_vector_store_multiple_entries() -> None:
     """Multi-entry list: both providers, faiss-only backend, default_provider winner."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
         "registered_resources": {"models": [], "vector_stores": []},
@@ -1176,7 +1184,7 @@ def test_enrich_vector_store_multiple_entries() -> None:
         },
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "notebooks",
             "providers": [
@@ -1200,27 +1208,27 @@ def test_enrich_vector_store_multiple_entries() -> None:
             ],
         },
     )
-    ids = {p["provider_id"] for p in ls_config["providers"]["vector_io"]}
+    ids = {p["provider_id"] for p in ogx_config["providers"]["vector_io"]}
     assert ids == {"notebooks", "nb-pg"}
-    assert "vsprov_notebooks_storage" in ls_config["storage"]["backends"]
-    assert "vsprov_nb-pg_storage" not in ls_config["storage"]["backends"]
-    assert ls_config["vector_stores"]["default_provider_id"] == "notebooks"
-    assert ls_config["vector_stores"]["default_embedding_model"]["model_id"] == (
+    assert "vsprov_notebooks_storage" in ogx_config["storage"]["backends"]
+    assert "vsprov_nb-pg_storage" not in ogx_config["storage"]["backends"]
+    assert ogx_config["vector_stores"]["default_provider_id"] == "notebooks"
+    assert ogx_config["vector_stores"]["default_embedding_model"]["model_id"] == (
         "vsprov_notebooks_embedding"
     )
     assert (
-        ls_config["vector_stores"]["annotation_prompt_params"]["enable_annotations"]
+        ogx_config["vector_stores"]["annotation_prompt_params"]["enable_annotations"]
         is False
     )
     model_ids = {
-        m["provider_model_id"] for m in ls_config["registered_resources"]["models"]
+        m["provider_model_id"] for m in ogx_config["registered_resources"]["models"]
     }
     assert model_ids == {"/emb-faiss", "/emb-pg"}
 
 
 def test_enrich_vector_store_noop_without_entries() -> None:
     """Empty list leaves baseline vector_stores defaults unchanged."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {
             "vector_io": [
                 {"provider_id": "faiss", "provider_type": "inline::faiss", "config": {}}
@@ -1228,13 +1236,13 @@ def test_enrich_vector_store_noop_without_entries() -> None:
         },
         "vector_stores": {"default_provider_id": "faiss"},
     }
-    enrich_vector_store(ls_config, {"providers": []})
-    assert ls_config["vector_stores"]["default_provider_id"] == "faiss"
+    enrich_vector_store(ogx_config, {"providers": []})
+    assert ogx_config["vector_stores"]["default_provider_id"] == "faiss"
 
 
 def test_enrich_vector_store_registers_alias_when_load_path_shared_with_byok() -> None:
     """Shared provider_model_id with BYOK still registers vsprov_* for defaults."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
         "registered_resources": {
@@ -1252,7 +1260,7 @@ def test_enrich_vector_store_registers_alias_when_load_path_shared_with_byok() -
         "vector_stores": {},
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "notebooks",
             "providers": [
@@ -1266,19 +1274,19 @@ def test_enrich_vector_store_registers_alias_when_load_path_shared_with_byok() -
             ],
         },
     )
-    model_ids = {m["model_id"] for m in ls_config["registered_resources"]["models"]}
+    model_ids = {m["model_id"] for m in ogx_config["registered_resources"]["models"]}
     assert model_ids == {
         "byok_rhdh-docs_embedding",
         "vsprov_notebooks_embedding",
     }
-    assert ls_config["vector_stores"]["default_embedding_model"]["model_id"] == (
+    assert ogx_config["vector_stores"]["default_embedding_model"]["model_id"] == (
         "vsprov_notebooks_embedding"
     )
 
 
 def test_enrich_vector_store_dedupes_same_vsprov_model_id() -> None:
     """Re-enriching the same vector_store provider does not duplicate its model."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
         "registered_resources": {"models": [], "vector_stores": []},
@@ -1296,25 +1304,25 @@ def test_enrich_vector_store_dedupes_same_vsprov_model_id() -> None:
             }
         ],
     }
-    enrich_vector_store(ls_config, vector_store)
-    enrich_vector_store(ls_config, vector_store)
-    assert len(ls_config["registered_resources"]["models"]) == 1
+    enrich_vector_store(ogx_config, vector_store)
+    enrich_vector_store(ogx_config, vector_store)
+    assert len(ogx_config["registered_resources"]["models"]) == 1
     assert (
-        ls_config["registered_resources"]["models"][0]["model_id"]
+        ogx_config["registered_resources"]["models"][0]["model_id"]
         == "vsprov_notebooks_embedding"
     )
 
 
 def test_enrich_vector_store_updates_vsprov_alias_on_path_change() -> None:
     """Re-enrichment with a new embedding path refreshes the vsprov_* model row."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
         "registered_resources": {"models": [], "vector_stores": []},
         "vector_stores": {},
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "notebooks",
             "providers": [
@@ -1329,7 +1337,7 @@ def test_enrich_vector_store_updates_vsprov_alias_on_path_change() -> None:
         },
     )
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "notebooks",
             "providers": [
@@ -1343,7 +1351,7 @@ def test_enrich_vector_store_updates_vsprov_alias_on_path_change() -> None:
             ],
         },
     )
-    models = ls_config["registered_resources"]["models"]
+    models = ogx_config["registered_resources"]["models"]
     assert len(models) == 1
     assert models[0]["model_id"] == "vsprov_notebooks_embedding"
     assert models[0]["provider_model_id"] == "/new/embeddings_model"
@@ -1352,14 +1360,14 @@ def test_enrich_vector_store_updates_vsprov_alias_on_path_change() -> None:
 
 def test_enrich_vector_store_skips_embedding_without_dimension() -> None:
     """embedding_model without embedding_dimension does not register a model."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
         "registered_resources": {"models": []},
         "vector_stores": {"default_provider_id": "faiss"},
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "notebooks",
             "providers": [
@@ -1372,22 +1380,22 @@ def test_enrich_vector_store_skips_embedding_without_dimension() -> None:
             ],
         },
     )
-    assert ls_config["providers"]["vector_io"][0]["provider_id"] == "notebooks"
-    assert not ls_config["registered_resources"]["models"]
-    assert ls_config["vector_stores"]["default_provider_id"] == "notebooks"
-    assert "default_embedding_model" in ls_config["vector_stores"]
+    assert ogx_config["providers"]["vector_io"][0]["provider_id"] == "notebooks"
+    assert not ogx_config["registered_resources"]["models"]
+    assert ogx_config["vector_stores"]["default_provider_id"] == "notebooks"
+    assert "default_embedding_model" in ogx_config["vector_stores"]
 
 
 def test_enrich_vector_store_unmatched_default_provider_skips_defaults() -> None:
     """Unmatched default_provider still enriches providers but skips default_*."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {},
         "storage": {"backends": {}},
         "registered_resources": {"models": []},
         "vector_stores": {"default_provider_id": "faiss"},
     }
     enrich_vector_store(
-        ls_config,
+        ogx_config,
         {
             "default_provider": "missing",
             "providers": [
@@ -1401,10 +1409,10 @@ def test_enrich_vector_store_unmatched_default_provider_skips_defaults() -> None
             ],
         },
     )
-    assert ls_config["providers"]["vector_io"][0]["provider_id"] == "notebooks"
-    assert ls_config["vector_stores"]["default_provider_id"] == "faiss"
-    assert "default_embedding_model" not in ls_config["vector_stores"]
-    assert len(ls_config["registered_resources"]["models"]) == 1
+    assert ogx_config["providers"]["vector_io"][0]["provider_id"] == "notebooks"
+    assert ogx_config["vector_stores"]["default_provider_id"] == "faiss"
+    assert "default_embedding_model" not in ogx_config["vector_stores"]
+    assert len(ogx_config["registered_resources"]["models"]) == 1
 
 
 # =============================================================================

--- a/tests/unit/test_ogx_synthesize.py
+++ b/tests/unit/test_ogx_synthesize.py
@@ -42,9 +42,9 @@ OPENAI_CONDITIONAL_API_KEY = "${env.OPENAI_API_KEY:=}"
 # ---------------------------------------------------------------------------
 
 
-def _tool_runtime_ids(ls_config: dict[str, Any]) -> list[Optional[str]]:
+def _tool_runtime_ids(ogx_config: dict[str, Any]) -> list[Optional[str]]:
     """Return provider_id values from providers.tool_runtime."""
-    providers = ls_config.get("providers") or {}
+    providers = ogx_config.get("providers") or {}
     return [
         entry.get("provider_id")
         for entry in providers.get("tool_runtime") or []
@@ -52,19 +52,19 @@ def _tool_runtime_ids(ls_config: dict[str, Any]) -> list[Optional[str]]:
     ]
 
 
-def _inference_entries(ls_config: dict[str, Any]) -> list[dict[str, Any]]:
+def _inference_entries(ogx_config: dict[str, Any]) -> list[dict[str, Any]]:
     """Return inference provider dicts from a synthesized or baseline config."""
-    providers = ls_config.get("providers") or {}
+    providers = ogx_config.get("providers") or {}
     return [
         entry for entry in providers.get("inference") or [] if isinstance(entry, dict)
     ]
 
 
-def _openai_inference_entries(ls_config: dict[str, Any]) -> list[dict[str, Any]]:
+def _openai_inference_entries(ogx_config: dict[str, Any]) -> list[dict[str, Any]]:
     """Return remote::openai inference rows, including the conditional-id form."""
     return [
         entry
-        for entry in _inference_entries(ls_config)
+        for entry in _inference_entries(ogx_config)
         if entry.get("provider_type") == "remote::openai"
         or entry.get("provider_id") in ("openai", OPENAI_CONDITIONAL_PROVIDER_ID)
     ]
@@ -72,7 +72,7 @@ def _openai_inference_entries(ls_config: dict[str, Any]) -> list[dict[str, Any]]
 
 def test_ensure_mcp_tool_runtime_appends_and_preserves_rag() -> None:
     """MCP is appended; existing rag-runtime is untouched."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "apis": ["tool_runtime"],
         "providers": {
             "tool_runtime": [
@@ -84,15 +84,15 @@ def test_ensure_mcp_tool_runtime_appends_and_preserves_rag() -> None:
             ]
         },
     }
-    ensure_mcp_tool_runtime(ls_config)
-    assert _tool_runtime_ids(ls_config) == [
+    ensure_mcp_tool_runtime(ogx_config)
+    assert _tool_runtime_ids(ogx_config) == [
         "rag-runtime",
         "model-context-protocol",
     ]
 
     found = False
     found_entry = {}
-    for entry in ls_config["providers"]["tool_runtime"]:
+    for entry in ogx_config["providers"]["tool_runtime"]:
         if (
             isinstance(entry, dict)
             and entry.get("provider_id") == "model-context-protocol"
@@ -112,20 +112,20 @@ def test_ensure_mcp_tool_runtime_idempotent() -> None:
         "provider_type": "remote::model-context-protocol",
         "config": {"keep": True},
     }
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "apis": ["tool_runtime"],
         "providers": {"tool_runtime": [existing]},
     }
-    ensure_mcp_tool_runtime(ls_config)
-    assert ls_config["providers"]["tool_runtime"] == [existing]
+    ensure_mcp_tool_runtime(ogx_config)
+    assert ogx_config["providers"]["tool_runtime"] == [existing]
 
 
 def test_ensure_mcp_tool_runtime_adds_api_when_missing() -> None:
     """Thin baselines get tool_runtime in apis and the MCP provider."""
-    ls_config: dict[str, Any] = {}
-    ensure_mcp_tool_runtime(ls_config)
-    assert "tool_runtime" in ls_config["apis"]
-    assert _tool_runtime_ids(ls_config) == ["model-context-protocol"]
+    ogx_config: dict[str, Any] = {}
+    ensure_mcp_tool_runtime(ogx_config)
+    assert "tool_runtime" in ogx_config["apis"]
+    assert _tool_runtime_ids(ogx_config) == ["model-context-protocol"]
 
 
 # ---------------------------------------------------------------------------
@@ -267,7 +267,7 @@ def test_deep_merge_list_replace_does_not_mutate_inputs() -> None:
 
 def test_apply_high_level_inference_maps_type_and_emits_env_ref() -> None:
     """A remote provider maps to its provider_type with an ${env} api_key (R6)."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {
@@ -278,8 +278,8 @@ def test_apply_high_level_inference_maps_type_and_emits_env_ref() -> None:
             }
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    entry = ls_config["providers"]["inference"][0]
+    apply_high_level_inference(ogx_config, inference)
+    entry = ogx_config["providers"]["inference"][0]
     assert entry["provider_id"] == "openai"
     assert entry["provider_type"] == "remote::openai"
     assert entry["config"]["api_key"] == "${env.OPENAI_API_KEY}"
@@ -288,10 +288,10 @@ def test_apply_high_level_inference_maps_type_and_emits_env_ref() -> None:
 
 def test_apply_high_level_inference_hyphenates_provider_id() -> None:
     """sentence_transformers emits the hyphenated id the ecosystem expects."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {"providers": [{"type": "sentence_transformers"}]}
-    apply_high_level_inference(ls_config, inference)
-    entry = ls_config["providers"]["inference"][0]
+    apply_high_level_inference(ogx_config, inference)
+    entry = ogx_config["providers"]["inference"][0]
     assert entry["provider_id"] == "sentence-transformers"
     assert entry["provider_type"] == "inline::sentence-transformers"
     # no api_key / allowed_models -> no config block emitted
@@ -302,7 +302,7 @@ def test_apply_high_level_inference_replaces_existing_provider_id(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A high-level provider replaces a baseline entry with the same id."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {
             "inference": [
                 {
@@ -316,17 +316,17 @@ def test_apply_high_level_inference_replaces_existing_provider_id(
     }
     inference = {"providers": [{"type": "openai", "api_key_env": "NEW_KEY"}]}
     with caplog.at_level("INFO", logger="lightspeed_stack.ogx_configuration"):
-        apply_high_level_inference(ls_config, inference)
-    ids = [p["provider_id"] for p in ls_config["providers"]["inference"]]
+        apply_high_level_inference(ogx_config, inference)
+    ids = [p["provider_id"] for p in ogx_config["providers"]["inference"]]
     assert ids == ["openai", "other"]  # replaced in place, not duplicated
-    openai = ls_config["providers"]["inference"][0]
+    openai = ogx_config["providers"]["inference"][0]
     assert openai["config"]["api_key"] == "${env.NEW_KEY}"
     assert "provider_id='openai'" in caplog.text
 
 
 def test_apply_high_level_inference_replaces_conditional_provider_id() -> None:
     """The baseline ${env.OPENAI_API_KEY:+openai} row matches id openai."""
-    ls_config: dict[str, Any] = {
+    ogx_config: dict[str, Any] = {
         "providers": {
             "inference": [
                 {
@@ -342,18 +342,18 @@ def test_apply_high_level_inference_replaces_conditional_provider_id() -> None:
         }
     }
     inference = {"providers": [{"type": "openai", "api_key_env": "OPENAI_API_KEY"}]}
-    apply_high_level_inference(ls_config, inference)
-    openai_entries = _openai_inference_entries(ls_config)
+    apply_high_level_inference(ogx_config, inference)
+    openai_entries = _openai_inference_entries(ogx_config)
     assert len(openai_entries) == 1
     assert openai_entries[0]["provider_id"] == "openai"
     assert openai_entries[0]["config"]["api_key"] == "${env.OPENAI_API_KEY}"
-    ids = [entry["provider_id"] for entry in _inference_entries(ls_config)]
+    ids = [entry["provider_id"] for entry in _inference_entries(ogx_config)]
     assert ids == ["openai", "sentence-transformers"]
 
 
 def test_apply_high_level_inference_uses_explicit_id() -> None:
     """An explicit id is emitted as provider_id instead of the type-derived id."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {
@@ -363,15 +363,15 @@ def test_apply_high_level_inference_uses_explicit_id() -> None:
             }
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    entry = ls_config["providers"]["inference"][0]
+    apply_high_level_inference(ogx_config, inference)
+    entry = ogx_config["providers"]["inference"][0]
     assert entry["provider_id"] == "vllm-prod"
     assert entry["provider_type"] == "remote::vllm"
 
 
 def test_apply_high_level_inference_same_type_distinct_ids() -> None:
     """Two providers of the same type with distinct ids both appear."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {
@@ -388,8 +388,8 @@ def test_apply_high_level_inference_same_type_distinct_ids() -> None:
             },
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    by_id = {e["provider_id"]: e for e in ls_config["providers"]["inference"]}
+    apply_high_level_inference(ogx_config, inference)
+    by_id = {e["provider_id"]: e for e in ogx_config["providers"]["inference"]}
     assert set(by_id) == {"vllm-prod", "vllm-staging"}
     assert all(e["provider_type"] == "remote::vllm" for e in by_id.values())
     assert by_id["vllm-prod"]["config"]["url"] == "http://prod:8000"
@@ -400,7 +400,7 @@ def test_apply_high_level_inference_duplicate_id_last_wins(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Duplicate id keeps the last entry and logs an info message."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {
@@ -416,8 +416,8 @@ def test_apply_high_level_inference_duplicate_id_last_wins(
         ]
     }
     with caplog.at_level("INFO", logger="lightspeed_stack.ogx_configuration"):
-        apply_high_level_inference(ls_config, inference)
-    entries = ls_config["providers"]["inference"]
+        apply_high_level_inference(ogx_config, inference)
+    entries = ogx_config["providers"]["inference"]
     assert len(entries) == 1
     assert entries[0]["provider_id"] == "vllm-shared"
     assert entries[0]["config"]["api_token"] == "${env.SECOND_KEY}"
@@ -426,14 +426,14 @@ def test_apply_high_level_inference_duplicate_id_last_wins(
 
 def test_apply_high_level_inference_merges_extra() -> None:
     """The extra mapping is merged verbatim into the provider config block."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {"type": "vllm_rhaiis", "extra": {"url": "http://x", "tls_verify": False}}
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    entry = ls_config["providers"]["inference"][0]
+    apply_high_level_inference(ogx_config, inference)
+    entry = ogx_config["providers"]["inference"][0]
     assert entry["provider_id"] == "vllm-rhaiis"
     assert entry["provider_type"] == "remote::vllm"
     assert entry["config"] == {"url": "http://x", "tls_verify": False}
@@ -441,16 +441,16 @@ def test_apply_high_level_inference_merges_extra() -> None:
 
 def test_apply_high_level_inference_emits_api_token_for_vllm() -> None:
     """vLLM providers emit api_token from api_key_env, not api_key."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {"type": "vllm", "api_key_env": "VLLM_API_KEY"},
             {"type": "vllm_rhaiis", "api_key_env": "VLLM_API_KEY"},
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    vllm = ls_config["providers"]["inference"][0]
-    vllm_rhaiis = ls_config["providers"]["inference"][1]
+    apply_high_level_inference(ogx_config, inference)
+    vllm = ogx_config["providers"]["inference"][0]
+    vllm_rhaiis = ogx_config["providers"]["inference"][1]
     assert vllm["provider_id"] == "vllm"
     assert vllm["provider_type"] == "remote::vllm"
     assert vllm["config"]["api_token"] == "${env.VLLM_API_KEY}"
@@ -462,14 +462,14 @@ def test_apply_high_level_inference_emits_api_token_for_vllm() -> None:
 
 def test_apply_high_level_inference_maps_ollama() -> None:
     """ollama maps to remote::ollama with extra config merged."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {"type": "ollama", "extra": {"base_url": "http://localhost:11434"}}
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    entry = ls_config["providers"]["inference"][0]
+    apply_high_level_inference(ogx_config, inference)
+    entry = ogx_config["providers"]["inference"][0]
     assert entry["provider_id"] == "ollama"
     assert entry["provider_type"] == "remote::ollama"
     assert entry["config"]["base_url"] == "http://localhost:11434"
@@ -477,7 +477,7 @@ def test_apply_high_level_inference_maps_ollama() -> None:
 
 def test_apply_high_level_inference_maps_vllm() -> None:
     """vllm maps to remote::vllm with extra config merged."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {
@@ -487,8 +487,8 @@ def test_apply_high_level_inference_maps_vllm() -> None:
             }
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    entry = ls_config["providers"]["inference"][0]
+    apply_high_level_inference(ogx_config, inference)
+    entry = ogx_config["providers"]["inference"][0]
     assert entry["provider_id"] == "vllm"
     assert entry["provider_type"] == "remote::vllm"
     assert entry["config"]["api_token"] == "${env.VLLM_API_KEY}"
@@ -497,7 +497,7 @@ def test_apply_high_level_inference_maps_vllm() -> None:
 
 def test_apply_high_level_inference_extra_cannot_override_api_key_env() -> None:
     """api_key_env always wins over a conflicting key in extra."""
-    ls_config: dict[str, Any] = {"providers": {"inference": []}}
+    ogx_config: dict[str, Any] = {"providers": {"inference": []}}
     inference = {
         "providers": [
             {
@@ -507,8 +507,8 @@ def test_apply_high_level_inference_extra_cannot_override_api_key_env() -> None:
             }
         ]
     }
-    apply_high_level_inference(ls_config, inference)
-    entry = ls_config["providers"]["inference"][0]
+    apply_high_level_inference(ogx_config, inference)
+    entry = ogx_config["providers"]["inference"][0]
     assert entry["config"]["api_token"] == "${env.VLLM_API_KEY}"
 
 
@@ -522,9 +522,9 @@ def test_unified_inference_provider_accepts_ollama_and_vllm() -> None:
 
 def test_apply_high_level_inference_empty_is_noop() -> None:
     """No providers -> the inference list is left as-is."""
-    ls_config: dict[str, Any] = {"providers": {"inference": [{"provider_id": "x"}]}}
-    apply_high_level_inference(ls_config, {"providers": []})
-    assert ls_config["providers"]["inference"] == [{"provider_id": "x"}]
+    ogx_config: dict[str, Any] = {"providers": {"inference": [{"provider_id": "x"}]}}
+    apply_high_level_inference(ogx_config, {"providers": []})
+    assert ogx_config["providers"]["inference"] == [{"provider_id": "x"}]
 
 
 def test_provider_type_map_covers_every_literal_value() -> None:

--- a/tests/unit/utils/dumpers/test_models_dumper.py
+++ b/tests/unit/utils/dumpers/test_models_dumper.py
@@ -6756,7 +6756,7 @@ def test_dump_models(tmpdir: Path) -> None:
                             "type": "string"
                         },
                         "conversation": {
-                            "description": "The conversation ID in llama-stack format",
+                            "description": "The conversation ID in OGX format",
                             "title": "Conversation",
                             "type": "string"
                         },
@@ -9035,7 +9035,7 @@ def test_dump_models(tmpdir: Path) -> None:
                     "type": "object"
                 },
                 "TurnSummary": {
-                    "description": "Summary of a turn in llama stack.",
+                    "description": "Summary of a turn in OGX.",
                     "properties": {
                         "id": {
                             "default": "",

--- a/tests/unit/utils/test_compaction.py
+++ b/tests/unit/utils/test_compaction.py
@@ -74,11 +74,11 @@ def _make_history(num_pairs: int, words_per_message: int = 1) -> list[Any]:
 class TestIsMessageItem:
     """Tests for is_message_item."""
 
-    def test_llama_stack_message(self) -> None:
+    def test_ogx_message(self) -> None:
         """OGX message item is recognised."""
         assert is_message_item(_MessageItem("user", "hi")) is True
 
-    def test_llama_stack_tool_call(self) -> None:
+    def test_ogx_tool_call(self) -> None:
         """Tool-call item is not a message."""
         assert is_message_item(_ToolCallItem()) is False
 

--- a/tests/unit/utils/test_token_estimator.py
+++ b/tests/unit/utils/test_token_estimator.py
@@ -115,11 +115,11 @@ class TestEstimateTokens:
 class TestIsMessage:
     """Tests for the is_message_item duck-type check."""
 
-    def test_llama_stack_message_item(self) -> None:
+    def test_ogx_message_item(self) -> None:
         """An OGX-shaped object with type == 'message' is a message."""
         assert is_message_item(_MessageItem("user", "hi")) is True
 
-    def test_llama_stack_tool_call_item(self) -> None:
+    def test_ogx_tool_call_item(self) -> None:
         """A tool-call-shaped object is not a message."""
         assert is_message_item(_ToolCallItem()) is False
 
@@ -137,7 +137,7 @@ class TestIsMessage:
 class TestExtractMessageText:
     """Tests for the extract_message_text duck-type extractor."""
 
-    def test_llama_stack_string_content(self) -> None:
+    def test_ogx_string_content(self) -> None:
         """Plain string content is returned as-is."""
         assert extract_message_text(_MessageItem("user", "hello")) == "hello"
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

Identify any AI code assistants used in this PR (for transparency and review context)

- Assisted-by: Cursor

## Related Tickets & Documents

- Related Issue # https://redhat.atlassian.net/browse/LCORE-2547
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] PR has passed all pre-merge test jobs.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration, deployment, testing, and API documentation to consistently use OGX terminology.
  * Clarified current OGX configuration names while retaining legacy aliases where applicable.

* **Bug Fixes**
  * Updated service connections, environment variables, container references, and diagnostics to target the OGX service.
  * Updated end-to-end disruption, restart, readiness, proxy, and TLS flows for OGX deployments.

* **Tests**
  * Updated integration, unit, and end-to-end tests to use OGX naming and service endpoints while preserving existing coverage and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->