### PR TITLE
LCORE-3395: point lint-openapi at docs/devel_doc/openapi.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,9 +339,9 @@ docstyle:	## Check the docstring style using Docstyle checker
 ruff:	## Check source code using Ruff linter
 	uv run ruff check src tests --per-file-ignores=tests/*:S101 --per-file-ignores=scripts/*:S101
 
-lint-openapi: ## Lint docs/openapi.json (Spectral OAS ruleset; fail on error)
+lint-openapi: ## Lint docs/devel_doc/openapi.json (Spectral OAS ruleset; fail on error)
 	@if command -v npx >/dev/null 2>&1; then \
-		npx --yes @stoplight/spectral-cli@6 lint docs/openapi.json --fail-severity error --display-only-failures; \
+		npx --yes @stoplight/spectral-cli@6 lint docs/devel_doc/openapi.json --fail-severity error --display-only-failures; \
 	else \
 		echo "lint-openapi: skipping Spectral (npx not found). Install Node.js for OpenAPI lint locally; CI still runs it."; \
 	fi


### PR DESCRIPTION
## Description

`docs/openapi.json` moved to `docs/devel_doc/openapi.json`; the `generate-schema` target and the `openapi_spectral` workflow already use the new path, but `make lint-openapi` (and so `make verify`) still linted the old one, which no longer exists. Point the target at the current file. Closes LCORE-3395.

## Type of change

- [x] Other (please describe): developer tooling (Makefile)

## Tools used to create PR

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-3395
- Closes # LCORE-3395

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] PR has passed all pre-merge test jobs.

## Testing

Run `make lint-openapi` from the repo root with Node available: Spectral now lints `docs/devel_doc/openapi.json` and exits 0 (previously: file not found).
