### PR TITLE
LCORE-3963: render the full ADF document in fetch-jira output, and fix its error handling

### DIFF
--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -147,9 +147,22 @@ def extract_text(node, depth=0):
                     text = f'**{text}**'
                 elif m.get('type') == 'code':
                     text = f'\`{text}\`'
+                elif m.get('type') == 'link':
+                    # Keep the target: a link whose text differs from its
+                    # href (ticket keys, "here", PR titles) is otherwise lost.
+                    href = m.get('attrs', {}).get('href', '')
+                    if href and href != text:
+                        text = text + ' <' + href + '>'
             return [text]
+        if ntype == 'inlineCard':
+            # Smart links (pasted Jira/GitHub URLs) carry the URL only here.
+            return ['<' + node.get('attrs', {}).get('url', '') + '>']
+        if ntype == 'mention':
+            return [node.get('attrs', {}).get('text', '@?')]
         if ntype == 'hardBreak':
             return ['\n']
+        if ntype == 'rule':
+            return ['---']
         if ntype == 'listItem':
             child_text = []
             for c in node.get('content', []):
@@ -170,6 +183,22 @@ def extract_text(node, depth=0):
             for c in node.get('content', []):
                 child_text.extend(extract_text(c, depth))
             return ['\`\`\`\n' + ''.join(child_text) + '\n\`\`\`']
+        if ntype == 'blockquote':
+            child_text = []
+            for c in node.get('content', []):
+                child_text.extend(extract_text(c, depth))
+            return ['> ' + l for l in ''.join(child_text).strip().split('\n')]
+        if ntype == 'table':
+            rows = []
+            for row in node.get('content', []):
+                cells = []
+                for cell in row.get('content', []):
+                    cell_text = []
+                    for c in cell.get('content', []):
+                        cell_text.extend(extract_text(c, depth))
+                    cells.append(''.join(cell_text).strip())
+                rows.append(' | '.join(cells))
+            return rows
         for c in node.get('content', []):
             lines.extend(extract_text(c, depth))
         if ntype == 'paragraph' and lines:

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -142,21 +142,30 @@ def extract_text(node, depth=0):
         if ntype == 'text':
             text = node.get('text', '')
             marks = node.get('marks', [])
+            href = ''
             for m in marks:
                 if m.get('type') == 'strong':
                     text = f'**{text}**'
                 elif m.get('type') == 'code':
                     text = f'\`{text}\`'
                 elif m.get('type') == 'link':
-                    # Keep the target: a link whose text differs from its
-                    # href (ticket keys, 'here', PR titles) is otherwise lost.
                     href = m.get('attrs', {}).get('href', '')
-                    if href and href != text:
-                        text = text + ' <' + href + '>'
+            # Keep the target: a link whose text differs from its href
+            # (ticket keys, 'here', PR titles) is otherwise lost. Appended
+            # after the other marks so the URL never lands inside a code
+            # span or bold run, whatever order the marks arrived in, and
+            # compared against the raw text so an autolinked bare URL that
+            # also carries a mark is still recognised as its own target.
+            if href and href != node.get('text', ''):
+                text = text + ' <' + href + '>'
             return [text]
         if ntype == 'inlineCard':
-            # Smart links (pasted Jira/GitHub URLs) carry the URL only here.
-            return ['<' + node.get('attrs', {}).get('url', '') + '>']
+            # Smart links (pasted Jira/GitHub URLs) carry the URL only here,
+            # either directly or inside the resolved JSON-LD 'data' blob.
+            attrs = node.get('attrs', {})
+            data = attrs.get('data')
+            url = attrs.get('url') or (data.get('url', '') if isinstance(data, dict) else '')
+            return ['<' + url + '>'] if url else []
         if ntype == 'mention':
             return [node.get('attrs', {}).get('text', '@?')]
         if ntype == 'hardBreak':
@@ -187,7 +196,12 @@ def extract_text(node, depth=0):
             child_text = []
             for c in node.get('content', []):
                 child_text.extend(extract_text(c, depth))
-            return ['> ' + l for l in ''.join(child_text).strip().split('\n')]
+            # Children already come back one line each; joining on '' would
+            # run every paragraph of the quote together into a single line.
+            quoted = '\n'.join(child_text).strip()
+            if not quoted:
+                return []
+            return ['> ' + ln if ln else '>' for ln in quoted.split('\n')]
         if ntype == 'table':
             rows = []
             for row in node.get('content', []):

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -86,37 +86,15 @@ fi
 # leading and trailing spaces so substring matching works cleanly).
 FETCHED_KEYS=" "
 
-fetch_ticket() {
-    local key="$1"
-    local indent="${2:-}"
-    local depth="${3:-0}"
+# The Python programs below are held in quoted heredocs rather than
+# passed inline to 'python3 -c'. An inline program sits inside a
+# double-quoted shell word, which makes every quote, dollar sign and
+# backtick in it shell syntax first and Python second. That is what broke
+# this file with an SC2140 warning, and it stays a hazard for anyone
+# editing the extractor. A <<'EOF' heredoc is passed through verbatim, so
+# the Python can be written exactly as Python.
 
-    # Cycle / dup protection
-    case "$FETCHED_KEYS" in
-        *" $key "*) return 0 ;;
-    esac
-    FETCHED_KEYS="$FETCHED_KEYS$key "
-
-    # The '|| data=' guard matters: under 'set -e' an unguarded assignment
-    # from a failing curl aborts the whole script, so a single unreachable
-    # ticket would kill a multi-ticket or recursive run instead of falling
-    # through to the 'Error fetching' branch below and carrying on.
-    local data
-    data=$(curl -sS --connect-timeout 10 --max-time 30 \
-        -u "$JIRA_EMAIL:$JIRA_TOKEN" \
-        "$JIRA_INSTANCE/rest/api/3/issue/$key?fields=summary,status,issuetype,description,issuelinks,subtasks,parent" 2>/dev/null) || data=''
-
-    # Optional: fetch comments (only if --comments was passed). Empty
-    # JSON object signals "no comments fetched" to the Python printer.
-    local comments_data='{}'
-    if [ "$FETCH_COMMENTS" -eq 1 ]; then
-        comments_data=$(curl -sS --connect-timeout 10 --max-time 30 \
-            -u "$JIRA_EMAIL:$JIRA_TOKEN" \
-            "$JIRA_INSTANCE/rest/api/3/issue/$key/comment" 2>/dev/null) || comments_data='{}'
-    fi
-
-    if echo "$data" | python3 -c "import sys,json; json.load(sys.stdin)['key']" >/dev/null 2>&1; then
-        python3 -c "
+PRINT_TICKET_PY=$(cat <<'PYEOF_PRINT_TICKET_PY'
 import json, sys, textwrap
 
 data = json.loads(sys.argv[1])
@@ -158,7 +136,7 @@ def extract_text(node, depth=0):
                 if m.get('type') == 'strong':
                     text = f'**{text}**'
                 elif m.get('type') == 'code':
-                    text = f'\`{text}\`'
+                    text = f'`{text}`'
                 elif m.get('type') == 'link':
                     href = m.get('attrs', {}).get('href', '')
             # Keep the target: a link whose text differs from its href
@@ -218,7 +196,7 @@ def extract_text(node, depth=0):
             child_text = []
             for c in node.get('content', []):
                 child_text.extend(extract_text(c, depth))
-            return ['\`\`\`\n' + ''.join(child_text) + '\n\`\`\`']
+            return ['```\n' + ''.join(child_text) + '\n```']
         if ntype == 'blockquote':
             child_text = []
             for c in node.get('content', []):
@@ -323,18 +301,10 @@ if comments:
         for line in text.split('\n'):
             print(f'{indent}    {line}')
         print()
-" "$data" "$indent" "$comments_data"
-    else
-        echo "${indent}Error fetching $key"
-        echo "$data" | head -3
-        return 1
-    fi
+PYEOF_PRINT_TICKET_PY
+)
 
-    # Recurse into related tickets if depth > 0
-    if [ "$depth" -gt 0 ]; then
-        # Extract subtask + linked-issue keys from already-fetched data
-        local related_keys
-        related_keys=$(echo "$data" | python3 -c "
+RELATED_KEYS_PY=$(cat <<'PYEOF_RELATED_KEYS_PY'
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -350,14 +320,10 @@ try:
     print(' '.join(out))
 except Exception:
     pass
-" 2>/dev/null)
+PYEOF_RELATED_KEYS_PY
+)
 
-        # Also fetch JQL parent= children
-        local jql_kids
-        jql_kids=$(curl -sS --connect-timeout 10 --max-time 30 \
-            -u "$JIRA_EMAIL:$JIRA_TOKEN" \
-            "$JIRA_INSTANCE/rest/api/3/search/jql?jql=parent%3D${key}&fields=key&maxResults=20" 2>/dev/null | \
-            python3 -c "
+JQL_KIDS_PY=$(cat <<'PYEOF_JQL_KIDS_PY'
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -365,7 +331,73 @@ try:
         print(issue['key'])
 except Exception:
     pass
-" 2>/dev/null | tr '\n' ' ') || jql_kids=''
+PYEOF_JQL_KIDS_PY
+)
+
+CHILD_KEYS_PY=$(cat <<'PYEOF_CHILD_KEYS_PY'
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    for issue in data.get('issues', []):
+        key = issue['key']
+        summary = issue['fields']['summary']
+        status = issue['fields']['status']['name']
+        itype = issue['fields']['issuetype']['name']
+        print(f'{key} ({itype}) [{status}]: {summary}')
+except Exception:
+    pass
+PYEOF_CHILD_KEYS_PY
+)
+
+fetch_ticket() {
+    local key="$1"
+    local indent="${2:-}"
+    local depth="${3:-0}"
+
+    # Cycle / dup protection
+    case "$FETCHED_KEYS" in
+        *" $key "*) return 0 ;;
+    esac
+    FETCHED_KEYS="$FETCHED_KEYS$key "
+
+    # The '|| data=' guard matters: under 'set -e' an unguarded assignment
+    # from a failing curl aborts the whole script, so a single unreachable
+    # ticket would kill a multi-ticket or recursive run instead of falling
+    # through to the 'Error fetching' branch below and carrying on.
+    local data
+    data=$(curl -sS --connect-timeout 10 --max-time 30 \
+        -u "$JIRA_EMAIL:$JIRA_TOKEN" \
+        "$JIRA_INSTANCE/rest/api/3/issue/$key?fields=summary,status,issuetype,description,issuelinks,subtasks,parent" 2>/dev/null) || data=''
+
+    # Optional: fetch comments (only if --comments was passed). Empty
+    # JSON object signals "no comments fetched" to the Python printer.
+    local comments_data='{}'
+    if [ "$FETCH_COMMENTS" -eq 1 ]; then
+        comments_data=$(curl -sS --connect-timeout 10 --max-time 30 \
+            -u "$JIRA_EMAIL:$JIRA_TOKEN" \
+            "$JIRA_INSTANCE/rest/api/3/issue/$key/comment" 2>/dev/null) || comments_data='{}'
+    fi
+
+    if echo "$data" | python3 -c "import sys,json; json.load(sys.stdin)['key']" >/dev/null 2>&1; then
+        python3 -c "$PRINT_TICKET_PY" "$data" "$indent" "$comments_data"
+    else
+        echo "${indent}Error fetching $key"
+        echo "$data" | head -3
+        return 1
+    fi
+
+    # Recurse into related tickets if depth > 0
+    if [ "$depth" -gt 0 ]; then
+        # Extract subtask + linked-issue keys from already-fetched data
+        local related_keys
+        related_keys=$(echo "$data" | python3 -c "$RELATED_KEYS_PY" 2>/dev/null)
+
+        # Also fetch JQL parent= children
+        local jql_kids
+        jql_kids=$(curl -sS --connect-timeout 10 --max-time 30 \
+            -u "$JIRA_EMAIL:$JIRA_TOKEN" \
+            "$JIRA_INSTANCE/rest/api/3/search/jql?jql=parent%3D${key}&fields=key&maxResults=20" 2>/dev/null | \
+            python3 -c "$JQL_KIDS_PY" 2>/dev/null | tr '\n' ' ') || jql_kids=''
 
         local rk
         for rk in $related_keys $jql_kids; do
@@ -394,19 +426,7 @@ if [ "$LINKED_DEPTH" -eq 0 ]; then
     CHILD_KEYS=$(curl -sS --connect-timeout 10 --max-time 30 \
         -u "$JIRA_EMAIL:$JIRA_TOKEN" \
         "$JIRA_INSTANCE/rest/api/3/search/jql?jql=parent%3D${TICKET}&fields=key,summary,status,issuetype&maxResults=20" 2>/dev/null | \
-        python3 -c "
-import json, sys
-try:
-    data = json.load(sys.stdin)
-    for issue in data.get('issues', []):
-        key = issue['key']
-        summary = issue['fields']['summary']
-        status = issue['fields']['status']['name']
-        itype = issue['fields']['issuetype']['name']
-        print(f'{key} ({itype}) [{status}]: {summary}')
-except Exception:
-    pass
-" 2>/dev/null) || CHILD_KEYS=''
+        python3 -c "$CHILD_KEYS_PY" 2>/dev/null) || CHILD_KEYS=''
 
     if [ -n "$CHILD_KEYS" ]; then
         echo "Child issues:"

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -149,7 +149,7 @@ def extract_text(node, depth=0):
                     text = f'\`{text}\`'
                 elif m.get('type') == 'link':
                     # Keep the target: a link whose text differs from its
-                    # href (ticket keys, "here", PR titles) is otherwise lost.
+                    # href (ticket keys, 'here', PR titles) is otherwise lost.
                     href = m.get('attrs', {}).get('href', '')
                     if href and href != text:
                         text = text + ' <' + href + '>'

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -97,10 +97,14 @@ fetch_ticket() {
     esac
     FETCHED_KEYS="$FETCHED_KEYS$key "
 
+    # The '|| data=' guard matters: under 'set -e' an unguarded assignment
+    # from a failing curl aborts the whole script, so a single unreachable
+    # ticket would kill a multi-ticket or recursive run instead of falling
+    # through to the 'Error fetching' branch below and carrying on.
     local data
     data=$(curl -sS --connect-timeout 10 --max-time 30 \
         -u "$JIRA_EMAIL:$JIRA_TOKEN" \
-        "$JIRA_INSTANCE/rest/api/3/issue/$key?fields=summary,status,issuetype,description,issuelinks,subtasks,parent" 2>/dev/null)
+        "$JIRA_INSTANCE/rest/api/3/issue/$key?fields=summary,status,issuetype,description,issuelinks,subtasks,parent" 2>/dev/null) || data=''
 
     # Optional: fetch comments (only if --comments was passed). Empty
     # JSON object signals "no comments fetched" to the Python printer.
@@ -361,19 +365,26 @@ try:
         print(issue['key'])
 except Exception:
     pass
-" 2>/dev/null | tr '\n' ' ')
+" 2>/dev/null | tr '\n' ' ') || jql_kids=''
 
         local rk
         for rk in $related_keys $jql_kids; do
             [ -z "$rk" ] && continue
             echo
-            fetch_ticket "$rk" "${indent}  " $((depth - 1))
+            # A relation we cannot fetch is reported by fetch_ticket and
+            # then tolerated: it must not abandon the rest of the recursion.
+            fetch_ticket "$rk" "${indent}  " $((depth - 1)) || true
         done
     fi
 }
 
+# Every requested ticket is attempted even when an earlier one fails, so
+# one unreachable key does not hide the rest of the output; the script
+# still exits non-zero if any of them failed.
+EXIT_STATUS=0
+
 # Fetch main ticket (with depth recursion if requested)
-fetch_ticket "$TICKET" "" "$LINKED_DEPTH"
+fetch_ticket "$TICKET" "" "$LINKED_DEPTH" || EXIT_STATUS=1
 
 # At depth 0, also list JQL parent= children as a flat summary (legacy
 # behavior — useful as a quick "what's underneath" overview without
@@ -395,7 +406,7 @@ try:
         print(f'{key} ({itype}) [{status}]: {summary}')
 except Exception:
     pass
-" 2>/dev/null)
+" 2>/dev/null) || CHILD_KEYS=''
 
     if [ -n "$CHILD_KEYS" ]; then
         echo "Child issues:"
@@ -414,5 +425,7 @@ for extra in "$@"; do
     fi
     echo "────────────────────────────────────────────────────────"
     echo ""
-    fetch_ticket "$extra" "" "$LINKED_DEPTH"
+    fetch_ticket "$extra" "" "$LINKED_DEPTH" || EXIT_STATUS=1
 done
+
+exit "$EXIT_STATUS"

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -122,6 +122,10 @@ def clean_url(url):
     return url.split('#icft=')[0] if '#icft=' in url else url
 
 
+# List kinds that may appear nested inside a listItem.
+NESTED_LIST_TYPES = ('bulletList', 'orderedList', 'taskList')
+
+
 # ADF (Atlassian Document Format) → markdown-ish text extractor.
 # Hoisted to top-level so both description and comments can use it.
 def extract_text(node, depth=0):
@@ -136,7 +140,18 @@ def extract_text(node, depth=0):
                 if m.get('type') == 'strong':
                     text = f'**{text}**'
                 elif m.get('type') == 'code':
-                    text = f'`{text}`'
+                    # A code run may itself contain backticks, which would
+                    # end the span early. Fence it with one more backtick
+                    # than its longest internal run, padding when the text
+                    # starts or ends with one.
+                    longest = 0
+                    run = 0
+                    for char in text:
+                        run = run + 1 if char == '`' else 0
+                        longest = max(longest, run)
+                    fence = '`' * (longest + 1)
+                    pad = ' ' if text.startswith('`') or text.endswith('`') else ''
+                    text = fence + pad + text + pad + fence
                 elif m.get('type') == 'em':
                     text = f'_{text}_'
                 elif m.get('type') == 'strike':
@@ -215,15 +230,22 @@ def extract_text(node, depth=0):
                 return []
             return joined.split('\n') + ['']
         if ntype == 'listItem':
-            child_text = []
+            own_text = []
+            nested = []
             for c in node.get('content', []):
-                child_text.extend(extract_text(c, depth))
+                if isinstance(c, dict) and c.get('type') in NESTED_LIST_TYPES:
+                    # A nested list has already indented its own lines; folding
+                    # it into the parent's text would flatten the whole tree
+                    # onto one line.
+                    nested.extend(extract_text(c, depth))
+                else:
+                    own_text.extend(extract_text(c, depth))
             # Join on a newline before collapsing so an item holding two
             # paragraphs keeps a space between them instead of running the
             # last word of one into the first word of the next. The marker
             # is added by the enclosing list, which is the only place that
             # knows whether the item needs a bullet or a number.
-            return [' '.join('\n'.join(child_text).split())]
+            return [' '.join('\n'.join(own_text).split())] + nested
         if ntype in ('bulletList', 'orderedList'):
             ordered = ntype == 'orderedList'
             first = node.get('attrs', {}).get('order', 1) if ordered else 1
@@ -232,11 +254,14 @@ def extract_text(node, depth=0):
             except (ValueError, TypeError):
                 first = 1
             for number, c in enumerate(node.get('content', []), start=first):
-                for item in extract_text(c, depth + 1):
-                    if not item:
-                        continue
-                    marker = f'{number}. ' if ordered else '- '
-                    lines.append('  ' * (depth + 1) + marker + item)
+                item_lines = [item for item in extract_text(c, depth + 1) if item]
+                if not item_lines:
+                    continue
+                marker = f'{number}. ' if ordered else '- '
+                lines.append('  ' * (depth + 1) + marker + item_lines[0])
+                # Anything after the first line is a nested list that brought
+                # its own marker and indentation.
+                lines.extend(item_lines[1:])
             return lines
         if ntype == 'taskList':
             for c in node.get('content', []):
@@ -323,7 +348,11 @@ def extract_text(node, depth=0):
                     # middle of the row and break the whole table. Join on a
                     # newline first so the paragraph boundary survives as the
                     # space that separates them.
-                    cells.append(' '.join('\n'.join(cell_text).split()))
+                    cell = ' '.join('\n'.join(cell_text).split())
+                    # An unescaped pipe in the text would open a new column
+                    # and shift every cell after it.
+                    cell = cell.replace('\\', '\\\\').replace('|', '\\|')
+                    cells.append(cell)
                 if not cells:
                     continue
                 rows.append(' | '.join(cells))
@@ -413,6 +442,65 @@ if comments:
 PYEOF_PRINT_TICKET_PY
 )
 
+# Prints the next startAt offset for a comment page, or nothing when the
+# thread is exhausted.
+COMMENT_NEXT_PY=$(cat <<'PYEOF_COMMENT_NEXT_PY'
+import json, sys
+try:
+    page = json.load(open(sys.argv[1]))
+    start = int(page.get('startAt', 0))
+    got = len(page.get('comments', []))
+    total = int(page.get('total', 0))
+    if got and start + got < total:
+        print(start + got)
+except Exception:
+    pass
+PYEOF_COMMENT_NEXT_PY
+)
+
+# Merges numbered comment pages back into one response-shaped document.
+MERGE_COMMENTS_PY=$(cat <<'PYEOF_MERGE_COMMENTS_PY'
+import json, os, sys
+directory = sys.argv[1]
+names = sorted(os.listdir(directory), key=lambda f: int(f.split('.')[0]))
+comments = []
+total = 0
+for name in names:
+    page = json.load(open(os.path.join(directory, name)))
+    comments.extend(page.get('comments', []))
+    total = max(total, int(page.get('total', 0)))
+print(json.dumps({'comments': comments, 'total': max(total, len(comments))}))
+PYEOF_MERGE_COMMENTS_PY
+)
+
+# Prints the search cursor for the next page, or nothing when it is the last.
+SEARCH_NEXT_PY=$(cat <<'PYEOF_SEARCH_NEXT_PY'
+import json, sys
+try:
+    page = json.load(open(sys.argv[1]))
+    token = page.get('nextPageToken')
+    if token and page.get('isLast') is not True:
+        print(token)
+except Exception:
+    pass
+PYEOF_SEARCH_NEXT_PY
+)
+
+# Merges numbered search pages into one issues list.
+MERGE_ISSUES_PY=$(cat <<'PYEOF_MERGE_ISSUES_PY'
+import json, os, sys
+directory = sys.argv[1]
+names = sorted(os.listdir(directory), key=lambda f: int(f.split('.')[0]))
+issues = []
+last = True
+for name in names:
+    page = json.load(open(os.path.join(directory, name)))
+    issues.extend(page.get('issues', []))
+    last = page.get('isLast') is not False and not page.get('nextPageToken')
+print(json.dumps({'issues': issues, 'isLast': last}))
+PYEOF_MERGE_ISSUES_PY
+)
+
 RELATED_KEYS_PY=$(cat <<'PYEOF_RELATED_KEYS_PY'
 import json, sys
 try:
@@ -462,6 +550,65 @@ except Exception:
 PYEOF_CHILD_KEYS_PY
 )
 
+# Jira serves list endpoints one page at a time. Pages are collected as files
+# under a scratch directory and merged, so a long comment thread or a parent
+# with many children is returned whole rather than silently cut off at the
+# first page. PAGE_LIMIT is a stop so a malformed cursor cannot spin forever.
+PAGE_LIMIT=50
+PAGE_DIR=$(mktemp -d)
+trap 'rm -rf "$PAGE_DIR"' EXIT
+
+fetch_all_comments() {
+    local key="$1"
+    local dir="$PAGE_DIR/comments"
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    local start=0
+    local page_no=0
+    while [ "$page_no" -lt "$PAGE_LIMIT" ]; do
+        curl -sS --connect-timeout 10 --max-time 30 \
+            -u "$JIRA_EMAIL:$JIRA_TOKEN" \
+            "$JIRA_INSTANCE/rest/api/3/issue/$key/comment?startAt=$start&maxResults=100" \
+            -o "$dir/$page_no.json" 2>/dev/null || return 1
+        start=$(python3 -c "$COMMENT_NEXT_PY" "$dir/$page_no.json" 2>/dev/null) || return 1
+        page_no=$((page_no + 1))
+        if [ -z "$start" ]; then
+            break
+        fi
+    done
+    python3 -c "$MERGE_COMMENTS_PY" "$dir" 2>/dev/null || return 1
+}
+
+fetch_all_children() {
+    local parent="$1"
+    local fields="$2"
+    local dir="$PAGE_DIR/children"
+    rm -rf "$dir"
+    mkdir -p "$dir"
+    local token=''
+    local page_no=0
+    local url
+    while [ "$page_no" -lt "$PAGE_LIMIT" ]; do
+        url="$JIRA_INSTANCE/rest/api/3/search/jql?jql=parent%3D${parent}&fields=${fields}&maxResults=100"
+        if [ -n "$token" ]; then
+            url="$url&nextPageToken=$token"
+        fi
+        curl -sS --connect-timeout 10 --max-time 30 \
+            -u "$JIRA_EMAIL:$JIRA_TOKEN" "$url" -o "$dir/$page_no.json" 2>/dev/null || return 1
+        token=$(python3 -c "$SEARCH_NEXT_PY" "$dir/$page_no.json" 2>/dev/null) || return 1
+        page_no=$((page_no + 1))
+        if [ -z "$token" ]; then
+            break
+        fi
+    done
+    python3 -c "$MERGE_ISSUES_PY" "$dir" 2>/dev/null || return 1
+}
+
+# Every requested ticket is attempted even when an earlier one fails, so one
+# unreachable key does not hide the rest of the output; the script still exits
+# non-zero if any of them failed, including a failure deep in the recursion.
+EXIT_STATUS=0
+
 fetch_ticket() {
     local key="$1"
     local indent="${2:-}"
@@ -486,9 +633,7 @@ fetch_ticket() {
     # JSON object signals "no comments fetched" to the Python printer.
     local comments_data='{}'
     if [ "$FETCH_COMMENTS" -eq 1 ]; then
-        comments_data=$(curl -sS --connect-timeout 10 --max-time 30 \
-            -u "$JIRA_EMAIL:$JIRA_TOKEN" \
-            "$JIRA_INSTANCE/rest/api/3/issue/$key/comment" 2>/dev/null) || comments_data='{}'
+        comments_data=$(fetch_all_comments "$key") || comments_data='{}'
     fi
 
     if echo "$data" | python3 -c "import sys,json; json.load(sys.stdin)['key']" >/dev/null 2>&1; then
@@ -507,26 +652,21 @@ fetch_ticket() {
 
         # Also fetch JQL parent= children
         local jql_kids
-        jql_kids=$(curl -sS --connect-timeout 10 --max-time 30 \
-            -u "$JIRA_EMAIL:$JIRA_TOKEN" \
-            "$JIRA_INSTANCE/rest/api/3/search/jql?jql=parent%3D${key}&fields=key&maxResults=20" 2>/dev/null | \
+        jql_kids=$(fetch_all_children "$key" "key" 2>/dev/null | \
             python3 -c "$JQL_KIDS_PY" 2>/dev/null | tr '\n' ' ') || jql_kids=''
 
         local rk
         for rk in $related_keys $jql_kids; do
             [ -z "$rk" ] && continue
             echo
-            # A relation we cannot fetch is reported by fetch_ticket and
-            # then tolerated: it must not abandon the rest of the recursion.
-            fetch_ticket "$rk" "${indent}  " $((depth - 1)) || true
+            # A relation we cannot fetch must not abandon the rest of the
+            # recursion, but it is still a failure: record it rather than
+            # swallowing it, or the run reports success having printed an
+            # error.
+            fetch_ticket "$rk" "${indent}  " $((depth - 1)) || EXIT_STATUS=1
         done
     fi
 }
-
-# Every requested ticket is attempted even when an earlier one fails, so
-# one unreachable key does not hide the rest of the output; the script
-# still exits non-zero if any of them failed.
-EXIT_STATUS=0
 
 # Fetch main ticket (with depth recursion if requested)
 fetch_ticket "$TICKET" "" "$LINKED_DEPTH" || EXIT_STATUS=1
@@ -536,9 +676,7 @@ fetch_ticket "$TICKET" "" "$LINKED_DEPTH" || EXIT_STATUS=1
 # fetching each one). At depth > 0, the recursive fetch_ticket already
 # pulled them in, so skip this listing to avoid duplication.
 if [ "$LINKED_DEPTH" -eq 0 ]; then
-    CHILD_KEYS=$(curl -sS --connect-timeout 10 --max-time 30 \
-        -u "$JIRA_EMAIL:$JIRA_TOKEN" \
-        "$JIRA_INSTANCE/rest/api/3/search/jql?jql=parent%3D${TICKET}&fields=key,summary,status,issuetype&maxResults=20" 2>/dev/null | \
+    CHILD_KEYS=$(fetch_all_children "$TICKET" "key,summary,status,issuetype" 2>/dev/null | \
         python3 -c "$CHILD_KEYS_PY" 2>/dev/null) || CHILD_KEYS=''
 
     if [ -n "$CHILD_KEYS" ]; then

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -153,9 +153,12 @@ def extract_text(node, depth=0):
             if href and href != node.get('text', ''):
                 text = text + ' <' + href + '>'
             return [text]
-        if ntype == 'inlineCard':
+        if ntype in ('inlineCard', 'blockCard', 'embedCard'):
             # Smart links (pasted Jira/GitHub URLs) carry the URL only here,
             # either directly or inside the resolved JSON-LD 'data' blob.
+            # blockCard and embedCard are the block forms Jira produces when
+            # a URL is pasted on a line of its own, which is how most
+            # tickets reference a PR or another ticket.
             attrs = node.get('attrs', {})
             data = attrs.get('data')
             url = attrs.get('url') or (data.get('url', '') if isinstance(data, dict) else '')
@@ -255,10 +258,32 @@ def extract_text(node, depth=0):
                 child_text.extend(extract_text(c, depth))
             return ['#' * level + ' ' + ''.join(child_text).strip()]
         if ntype == 'codeBlock':
+            language = node.get('attrs', {}).get('language', '') or ''
             child_text = []
             for c in node.get('content', []):
                 child_text.extend(extract_text(c, depth))
-            return ['```\n' + ''.join(child_text) + '\n```']
+            return ['```' + language + '\n' + ''.join(child_text) + '\n```']
+        if ntype in ('expand', 'nestedExpand'):
+            # The title is usually the only summary of what the collapsed
+            # block holds, and collapsing is exactly what an author does
+            # with long logs and stack traces.
+            title = node.get('attrs', {}).get('title', '')
+            child_text = []
+            for c in node.get('content', []):
+                child_text.extend(extract_text(c, depth))
+            body = '\n'.join(child_text).strip('\n')
+            head = ['**' + title + '**'] if title else []
+            return head + (body.split('\n') if body else []) + ['']
+        if ntype == 'decisionList':
+            for c in node.get('content', []):
+                lines.extend(extract_text(c, depth + 1))
+            return lines
+        if ntype == 'decisionItem':
+            child_text = []
+            for c in node.get('content', []):
+                child_text.extend(extract_text(c, depth))
+            body = ' '.join('\n'.join(child_text).split())
+            return ['  ' * depth + '- [decision] ' + body] if body else []
         if ntype == 'panel':
             # Jira panels carry their severity in the attrs, not the text,
             # so an info note and a warning read the same without this.
@@ -360,7 +385,13 @@ if subtasks:
 # comments_data is the empty {} sentinel.)
 comments = comments_data.get('comments', []) if isinstance(comments_data, dict) else []
 if comments:
-    print(f'{indent}Comments ({len(comments)}):')
+    # The endpoint caps a page at 100 comments. Saying so beats letting a
+    # reader believe a truncated thread is the whole discussion.
+    total = comments_data.get('total', len(comments))
+    if isinstance(total, int) and total > len(comments):
+        print(f'{indent}Comments ({len(comments)} of {total}; rest not fetched):')
+    else:
+        print(f'{indent}Comments ({len(comments)}):')
     for c in comments:
         author = c.get('author', {}).get('displayName') or c.get('author', {}).get('emailAddress') or 'unknown'
         created = c.get('created', '')[:10]  # YYYY-MM-DD
@@ -422,6 +453,10 @@ try:
         status = issue['fields']['status']['name']
         itype = issue['fields']['issuetype']['name']
         print(f'{key} ({itype}) [{status}]: {summary}')
+    # maxResults caps this request; a parent with more children would
+    # otherwise show a short list indistinguishable from a complete one.
+    if data.get('isLast') is False or data.get('nextPageToken'):
+        print('(more children exist than were fetched)')
 except Exception:
     pass
 PYEOF_CHILD_KEYS_PY

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -95,7 +95,7 @@ FETCHED_KEYS=" "
 # the Python can be written exactly as Python.
 
 PRINT_TICKET_PY=$(cat <<'PYEOF_PRINT_TICKET_PY'
-import json, sys, textwrap
+import datetime, json, sys, textwrap
 
 data = json.loads(sys.argv[1])
 indent = sys.argv[2]
@@ -137,6 +137,10 @@ def extract_text(node, depth=0):
                     text = f'**{text}**'
                 elif m.get('type') == 'code':
                     text = f'`{text}`'
+                elif m.get('type') == 'em':
+                    text = f'_{text}_'
+                elif m.get('type') == 'strike':
+                    text = f'~~{text}~~'
                 elif m.get('type') == 'link':
                     href = m.get('attrs', {}).get('href', '')
             # Keep the target: a link whose text differs from its href
@@ -159,6 +163,36 @@ def extract_text(node, depth=0):
             return ['<' + url + '>'] if url else []
         if ntype == 'mention':
             return [node.get('attrs', {}).get('text', '@?')]
+        if ntype == 'emoji':
+            attrs = node.get('attrs', {})
+            return [attrs.get('text') or attrs.get('shortName') or '']
+        if ntype == 'status':
+            # A status lozenge carries meaning no other node repeats, so a
+            # ticket saying a step is DONE reads as empty without this.
+            label = node.get('attrs', {}).get('text', '')
+            return ['[' + label + ']'] if label else []
+        if ntype == 'date':
+            timestamp = node.get('attrs', {}).get('timestamp', '')
+            if not timestamp:
+                return []
+            try:
+                moment = datetime.datetime.fromtimestamp(
+                    int(timestamp) / 1000, datetime.timezone.utc
+                )
+                return [moment.strftime('%Y-%m-%d')]
+            except (ValueError, TypeError, OverflowError, OSError):
+                return [str(timestamp)]
+        if ntype in ('media', 'mediaInline'):
+            # Attachments have no text of their own; name them so a ticket
+            # that argues from a screenshot does not read as if it argued
+            # from nothing.
+            attrs = node.get('attrs', {})
+            name = attrs.get('alt') or attrs.get('id') or ''
+            return ['[attachment: ' + name + ']'] if name else ['[attachment]']
+        if ntype in ('mediaSingle', 'mediaGroup'):
+            for c in node.get('content', []):
+                lines.extend(extract_text(c, depth))
+            return lines
         if ntype == 'hardBreak':
             return ['\n']
         if ntype == 'rule':
@@ -181,11 +215,39 @@ def extract_text(node, depth=0):
             child_text = []
             for c in node.get('content', []):
                 child_text.extend(extract_text(c, depth))
-            return ['  ' * depth + '- ' + ''.join(child_text).strip()]
+            # Join on a newline before collapsing so an item holding two
+            # paragraphs keeps a space between them instead of running the
+            # last word of one into the first word of the next. The marker
+            # is added by the enclosing list, which is the only place that
+            # knows whether the item needs a bullet or a number.
+            return [' '.join('\n'.join(child_text).split())]
         if ntype in ('bulletList', 'orderedList'):
+            ordered = ntype == 'orderedList'
+            first = node.get('attrs', {}).get('order', 1) if ordered else 1
+            try:
+                first = int(first)
+            except (ValueError, TypeError):
+                first = 1
+            for number, c in enumerate(node.get('content', []), start=first):
+                for item in extract_text(c, depth + 1):
+                    if not item:
+                        continue
+                    marker = f'{number}. ' if ordered else '- '
+                    lines.append('  ' * (depth + 1) + marker + item)
+            return lines
+        if ntype == 'taskList':
             for c in node.get('content', []):
                 lines.extend(extract_text(c, depth + 1))
             return lines
+        if ntype == 'taskItem':
+            # Without the box a done item and an open one render identically.
+            child_text = []
+            for c in node.get('content', []):
+                child_text.extend(extract_text(c, depth))
+            body = ' '.join('\n'.join(child_text).split())
+            state = node.get('attrs', {}).get('state', 'TODO')
+            box = '[x]' if state == 'DONE' else '[ ]'
+            return ['  ' * depth + '- ' + box + ' ' + body] if body else []
         if ntype == 'heading':
             level = node.get('attrs', {}).get('level', 1)
             child_text = []
@@ -197,6 +259,19 @@ def extract_text(node, depth=0):
             for c in node.get('content', []):
                 child_text.extend(extract_text(c, depth))
             return ['```\n' + ''.join(child_text) + '\n```']
+        if ntype == 'panel':
+            # Jira panels carry their severity in the attrs, not the text,
+            # so an info note and a warning read the same without this.
+            panel_type = node.get('attrs', {}).get('panelType', 'info')
+            child_text = []
+            for c in node.get('content', []):
+                child_text.extend(extract_text(c, depth))
+            body = '\n'.join(child_text).strip()
+            if not body:
+                return []
+            body_lines = body.split('\n')
+            head = '**[' + panel_type.upper() + ']** ' + body_lines[0]
+            return [head] + body_lines[1:] + ['']
         if ntype == 'blockquote':
             child_text = []
             for c in node.get('content', []):
@@ -241,7 +316,10 @@ def extract_text(node, depth=0):
 desc = fields.get('description')
 if desc and isinstance(desc, dict):
     text_lines = extract_text(desc)
-    desc_text = '\n'.join(text_lines).strip()
+    # Strip newlines only: a plain strip() would also eat the indent of the
+    # first line, so a description opening with a list lost its leading
+    # bullet indent while every later item kept it.
+    desc_text = '\n'.join(text_lines).strip('\n')
     if desc_text:
         for line in desc_text.split('\n'):
             print(f'{indent}{line}')
@@ -291,7 +369,7 @@ if comments:
         if isinstance(body, dict):
             # Reuse the same ADF extractor used for descriptions.
             text_lines = extract_text(body)
-            text = '\n'.join(text_lines).strip()
+            text = '\n'.join(text_lines).strip('\n')
             if not text:
                 text = '(comment body in ADF format; no text extracted)'
         elif isinstance(body, str):

--- a/dev-tools/fetch-jira.sh
+++ b/dev-tools/fetch-jira.sh
@@ -133,6 +133,13 @@ if parent_key:
 print()
 
 
+# Jira appends its own '#icft=KEY' tracking fragment to internal smart
+# links and issue mentions. It is never part of the target and only adds
+# noise to the rendered line, so drop it from every URL we print.
+def clean_url(url):
+    return url.split('#icft=')[0] if '#icft=' in url else url
+
+
 # ADF (Atlassian Document Format) → markdown-ish text extractor.
 # Hoisted to top-level so both description and comments can use it.
 def extract_text(node, depth=0):
@@ -156,6 +163,7 @@ def extract_text(node, depth=0):
             # span or bold run, whatever order the marks arrived in, and
             # compared against the raw text so an autolinked bare URL that
             # also carries a mark is still recognised as its own target.
+            href = clean_url(href)
             if href and href != node.get('text', ''):
                 text = text + ' <' + href + '>'
             return [text]
@@ -165,6 +173,7 @@ def extract_text(node, depth=0):
             attrs = node.get('attrs', {})
             data = attrs.get('data')
             url = attrs.get('url') or (data.get('url', '') if isinstance(data, dict) else '')
+            url = clean_url(url)
             return ['<' + url + '>'] if url else []
         if ntype == 'mention':
             return [node.get('attrs', {}).get('text', '@?')]
@@ -172,6 +181,20 @@ def extract_text(node, depth=0):
             return ['\n']
         if ntype == 'rule':
             return ['---']
+        if ntype == 'paragraph':
+            # A paragraph's children are inline runs — text, smart links,
+            # mentions. The generic block walk below puts every child on its
+            # own line, which chops any sentence containing a link into
+            # fragments, so join them into one flowing line instead and let
+            # an explicit hardBreak be the only thing that splits it.
+            joined = ''.join(
+                piece
+                for c in node.get('content', [])
+                for piece in extract_text(c, depth)
+            )
+            if not joined.strip():
+                return []
+            return joined.split('\n') + ['']
         if ntype == 'listItem':
             child_text = []
             for c in node.get('content', []):
@@ -206,17 +229,29 @@ def extract_text(node, depth=0):
             rows = []
             for row in node.get('content', []):
                 cells = []
+                header = False
                 for cell in row.get('content', []):
+                    if cell.get('type') == 'tableHeader':
+                        header = True
                     cell_text = []
                     for c in cell.get('content', []):
                         cell_text.extend(extract_text(c, depth))
-                    cells.append(''.join(cell_text).strip())
+                    # Collapse to a single line: a cell holding two
+                    # paragraphs would otherwise inject a newline into the
+                    # middle of the row and break the whole table. Join on a
+                    # newline first so the paragraph boundary survives as the
+                    # space that separates them.
+                    cells.append(' '.join('\n'.join(cell_text).split()))
+                if not cells:
+                    continue
                 rows.append(' | '.join(cells))
-            return rows
+                # Emit the markdown rule under a header row so the result is
+                # a real table rather than pipe-separated lines.
+                if header and len(rows) == 1:
+                    rows.append(' | '.join(['---'] * len(cells)))
+            return rows + [''] if rows else []
         for c in node.get('content', []):
             lines.extend(extract_text(c, depth))
-        if ntype == 'paragraph' and lines:
-            lines.append('')
     return lines
 
 


### PR DESCRIPTION
## Description

`dev-tools/fetch-jira.sh` renders a Jira ticket's ADF description and comments to text. Its extractor handled only strong/code marks, lists, headings and code blocks, so most of what a ticket actually contains was dropped or flattened. Link targets vanished, leaving bare text like "PR #2451" with nothing to follow. Smart links produced nothing at all, even though the URL is their entire content. Mentions, tables, attachments, status lozenges, dates, task checkboxes, panel types and ordered-list numbering all disappeared or lost their meaning. Since most bug reports reference other tickets and PRs by smart link, the tool was hiding exactly the references a reader needs.

This PR renders all of it, and fixes several problems found while doing so.

**ADF coverage.** Link marks render as `text <href>`, with Jira's `#icft=` click-tracking fragment stripped. `inlineCard`, `blockCard` and `embedCard` all resolve their URL, from either `attrs.url` or the resolved `attrs.data.url`. Tables become markdown with a rule under header rows. Also handled: mentions, `rule`, blockquotes, panels (keeping their type), `expand`/`nestedExpand` (keeping the title that says what is collapsed), task items (keeping the checkbox), decisions, attachments, emoji, dates, status lozenges, the `em` and `strike` marks, the `codeBlock` language, and ordered-list numbering.

**Paragraph rendering.** The extractor returns one entry per line and the block walk extended that list for every child, so a paragraph of inline nodes came out one node per line — a sentence containing a link was chopped into fragments. Paragraphs now join their inline children into one line, with `hardBreak` the only thing that splits them.

**Error handling.** The script runs under `set -euo pipefail`, which defeated its own error handling. The main issue fetch assigned from an unguarded `curl`, so a connection failure aborted before the `Error fetching` branch below it could run; that branch was dead for anything but an HTTP error with a JSON body. The two JQL lookups piped `curl` into `python3`, where `pipefail` turned a curl failure into a failed assignment. `fetch_ticket` then returns 1 after reporting a failure and every call site was unguarded, so the first unreachable ticket ended the whole run. Every requested ticket is now attempted and reported, and the script still exits non-zero if any failed.

**Silent truncation.** The comment endpoint pages at 100 and the child search asks for 20, and a partial result was presented exactly like a complete one. Neither is worth paginating here, but both responses say when they are partial, so that is now reported.

**Quoting.** All four embedded Python programs were passed inline to `python3 -c`, which puts them inside a double-quoted shell word — every quote, dollar sign and backtick in ~200 lines of Python was shell syntax first and Python second. That is not hypothetical: a comment containing the word `"here"` in double quotes closed the shell string and reopened it, which shellcheck reported as SC2140 and CI failed on. Each program moves into a quoted heredoc, so the Python is written as Python. This commit is a pure move, verified by diffing the output of four invocations before and after.

Closes LCORE-3963.

## Type of change

- [x] Other (please describe): developer tooling (dev-tools)

## Tools used to create PR

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-3963
- Closes # LCORE-3963

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] PR has passed all pre-merge test jobs.

## Testing

Requires `~/.config/jira/credentials.json`. No unit tests: this is a standalone dev script with no test harness in the repo.

1. Check the linter CI job passes locally, since an earlier revision of this branch failed it:

   ```
   shellcheck -- */*.sh && bash -n dev-tools/fetch-jira.sh
   ```

   Both are clean. `make shellcheck` runs the same command in CI.

2. Fetch a ticket whose description is link-heavy and confirm the targets appear:

   ```
   dev-tools/fetch-jira.sh 3788
   ```

   LCORE-3788's five smart links now render as `<https://redhat.atlassian.net/browse/LCORE-1572>` and similar; before this branch, `grep -c '<https' ` on that output returned 0. The tracking fragment (`#icft=LCORE-1572`) is stripped. Its two `orderedList` nodes now number `1.`–`2.` and `1.`–`4.` where they previously rendered as bullets; its two `bulletList` nodes are unchanged. Prose that was previously one fragment per line now reads as sentences.

3. Confirm comments and recursion still render:

   ```
   dev-tools/fetch-jira.sh --comments 3883
   dev-tools/fetch-jira.sh --linked-depth 1 3788
   ```

   Code blocks and lists in the comment thread are byte-identical to the output before this branch.

4. Confirm a failure no longer ends the run. Point `instance` in the credentials file at a closed port, then:

   ```
   dev-tools/fetch-jira.sh 3963 3883
   ```

   Both tickets are reported and the exit status is 1:

   ```
   Error fetching LCORE-3963

   ────────────────────────────────────────────────────────

   Error fetching LCORE-3883
   ```

   Before this branch the same command printed nothing and exited 7, because `set -e` killed the script inside the command substitution.

5. The extractor was also driven directly against a synthetic ADF document covering every node type and mark handled here, including cases the live tickets do not contain: multi-paragraph blockquotes and table cells, an `inlineCard` carrying `attrs.data.url` instead of `attrs.url`, a link mark combined with a `code` mark in both orders, an autolinked bare URL, and both truncation notices in the firing and non-firing directions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Jira descriptions and comments now support richer formatting, including links, mentions, lists, tables, code blocks, panels, attachments, and other structured content.
  * Jira links are cleaned to remove tracking fragments.
  * Extracted content better preserves indentation and formatting.
  * Comment output indicates when results were truncated after 100 comments.
  * Multi-ticket and recursive fetches continue processing when individual requests fail, while clearly reporting an overall failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->