### PR TITLE
LCORE-4018: Redundant open mode arguments are unnecessary and should be removed to avoid confusion

### DIFF
--- a/src/client/ogx.py
+++ b/src/client/ogx.py
@@ -132,7 +132,7 @@ class AsyncOgxClientHolder(metaclass=Singleton):
                 "is not set"
             )
 
-        with open(config_file, "r", encoding="utf-8") as f:
+        with open(config_file, encoding="utf-8") as f:
             lcs_config = yaml.safe_load(f)
 
         output_path = os.environ.get(
@@ -158,7 +158,7 @@ class AsyncOgxClientHolder(metaclass=Singleton):
     def _enrich_library_config(self, input_config_path: str) -> str:
         """Enrich OGX config with BYOK RAG and OKP Solr settings."""
         try:
-            with open(input_config_path, "r", encoding="utf-8") as f:
+            with open(input_config_path, encoding="utf-8") as f:
                 ls_config = yaml.safe_load(f)
         except (OSError, yaml.YAMLError) as e:
             logger.warning("Failed to read OGX config: %s", e)

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -1742,7 +1742,7 @@ class Customization(ConfigurationBase):
             checks.file_check(self.agent_card_path, "agent card")
 
             try:
-                with open(self.agent_card_path, "r", encoding="utf-8") as f:
+                with open(self.agent_card_path, encoding="utf-8") as f:
                     self.agent_card_config = yaml.safe_load(f)
             except yaml.YAMLError as e:
                 raise ValueError(

--- a/src/ogx_configuration.py
+++ b/src/ogx_configuration.py
@@ -1010,7 +1010,7 @@ def load_default_baseline() -> dict[str, Any]:
         OSError: If the shipped baseline file cannot be read.
         yaml.YAMLError: If the baseline file is not valid YAML.
     """
-    with open(DEFAULT_BASELINE_RESOURCE, "r", encoding="utf-8") as file:
+    with open(DEFAULT_BASELINE_RESOURCE, encoding="utf-8") as file:
         return yaml.safe_load(file)
 
 
@@ -1257,7 +1257,7 @@ def synthesize_configuration(  # pylint: disable=too-many-locals
     if unified and unified.get("profile"):
         profile_path = _resolve_profile_path(unified["profile"], config_file_dir)
         logger.info("Loading synthesis baseline from profile %s", profile_path)
-        with open(profile_path, "r", encoding="utf-8") as file:
+        with open(profile_path, encoding="utf-8") as file:
             baseline = yaml.safe_load(file) or {}
     elif unified and unified.get("baseline") == "empty":
         logger.info("Synthesizing from an empty baseline")
@@ -1421,9 +1421,9 @@ def migrate_config_dumb(
         ValueError: If either input file does not parse to a mapping (e.g. an
             empty or comment-only file).
     """
-    with open(run_yaml_path, "r", encoding="utf-8") as file:
+    with open(run_yaml_path, encoding="utf-8") as file:
         run_yaml = yaml.safe_load(file)
-    with open(lightspeed_yaml_path, "r", encoding="utf-8") as file:
+    with open(lightspeed_yaml_path, encoding="utf-8") as file:
         lcs_config = yaml.safe_load(file)
 
     # An empty or comment-only YAML file parses to None; fail with a clear
@@ -1479,7 +1479,7 @@ def generate_configuration(
     """
     logger.info("Reading OGX configuration from file %s", input_file)
 
-    with open(input_file, "r", encoding="utf-8") as file:
+    with open(input_file, encoding="utf-8") as file:
         ls_config = yaml.safe_load(file)
 
     dedupe_providers_vector_io(ls_config)
@@ -1575,7 +1575,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    with open(args.config, "r", encoding="utf-8") as f:
+    with open(args.config, encoding="utf-8") as f:
         config = yaml.safe_load(f)
 
     if has_synthesis_input(config):

--- a/src/telemetry/configuration_snapshot.py
+++ b/src/telemetry/configuration_snapshot.py
@@ -721,7 +721,7 @@ def _read_yaml_file(config_path: str) -> Any:
         The parsed YAML content, or None on failure.
     """
     try:
-        with open(config_path, "r", encoding="utf-8") as f:
+        with open(config_path, encoding="utf-8") as f:
             return yaml.safe_load(f)
     except (OSError, yaml.YAMLError) as e:
         logger.warning("Failed to read OGX config for snapshot: %s", e)

--- a/tests/e2e/gen_scenario_list.py
+++ b/tests/e2e/gen_scenario_list.py
@@ -52,9 +52,7 @@ for filename in files:
     if filename.endswith(".feature"):
         # feature file header
         print(f"## [`{filename}`]({FEATURES_URL_PREFIX}/{filename})\n")
-        with open(
-            os.path.join(FEATURE_DIRECTORY, filename), "r", encoding="utf-8"
-        ) as fin:
+        with open(os.path.join(FEATURE_DIRECTORY, filename), encoding="utf-8") as fin:
             for line in fin:
                 line = line.strip()
                 # process all scenarios and scenario outlines

--- a/tests/integration/test_unified_synthesis.py
+++ b/tests/integration/test_unified_synthesis.py
@@ -168,7 +168,7 @@ def _legacy_enriched(tmp_path: Path, enrichment: dict[str, Any]) -> dict[str, An
 
 def _base_config_dict() -> dict[str, Any]:
     """Load the base lightspeed-stack.yaml fixture as a fresh dict."""
-    with open(_BASE_CONFIG_PATH, "r", encoding="utf-8") as file:
+    with open(_BASE_CONFIG_PATH, encoding="utf-8") as file:
         return copy.deepcopy(yaml.safe_load(file))
 
 

--- a/tests/unit/models/config/test_dump_configuration.py
+++ b/tests/unit/models/config/test_dump_configuration.py
@@ -110,7 +110,7 @@ def test_dump_configuration_minimal_cfg(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -336,7 +336,7 @@ def test_dump_configuration_valid_values(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -552,7 +552,7 @@ def test_dump_configuration_with_one_mcp_server(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         assert content is not None
         assert "mcp_servers" in content
@@ -604,7 +604,7 @@ def test_dump_configuration_with_more_mcp_servers(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         assert content is not None
         assert "mcp_servers" in content
@@ -715,7 +715,7 @@ def test_dump_configuration_with_quota_limiters(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -995,7 +995,7 @@ def test_dump_configuration_with_quota_limiters_different_values(
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -1230,7 +1230,7 @@ def test_dump_configuration_with_vector_store(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
 
     assert content["vector_store"] == {
@@ -1310,7 +1310,7 @@ def test_dump_configuration_byok(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -1566,7 +1566,7 @@ def test_dump_configuration_pg_namespace(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -1807,7 +1807,7 @@ def test_dump_configuration_with_one_skill(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -1884,7 +1884,7 @@ def test_dump_configuration_with_skills(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -1962,7 +1962,7 @@ def test_dump_configuration_allow_degraded_mode(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -2206,7 +2206,7 @@ def test_dump_configuration_max_retries_settings(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -2450,7 +2450,7 @@ def test_dump_configuration_retry_count_settings(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None
@@ -2700,7 +2700,7 @@ def test_dump_configuration_specific_compaction_values(tmp_path: Path) -> None:
     dump_file = tmp_path / "test.json"
     cfg.dump(dump_file)
 
-    with open(dump_file, "r", encoding="utf-8") as fin:
+    with open(dump_file, encoding="utf-8") as fin:
         content = json.load(fin)
         # content should be loaded
         assert content is not None

--- a/tests/unit/models/config/test_ogx_configuration.py
+++ b/tests/unit/models/config/test_ogx_configuration.py
@@ -24,7 +24,7 @@ _BASE_CONFIG_PATH = "tests/configuration/lightspeed-stack.yaml"
 
 def _base_config_dict() -> dict[str, Any]:
     """Load the base lightspeed-stack.yaml fixture as a fresh dict."""
-    with open(_BASE_CONFIG_PATH, "r", encoding="utf-8") as file:
+    with open(_BASE_CONFIG_PATH, encoding="utf-8") as file:
         return copy.deepcopy(yaml.safe_load(file))
 
 

--- a/tests/unit/models/config/test_vector_store.py
+++ b/tests/unit/models/config/test_vector_store.py
@@ -17,7 +17,7 @@ _BASE_CONFIG_PATH = "tests/configuration/lightspeed-stack.yaml"
 
 def _base_config_dict() -> dict[str, Any]:
     """Load the base lightspeed-stack.yaml fixture as a fresh dict."""
-    with open(_BASE_CONFIG_PATH, "r", encoding="utf-8") as file:
+    with open(_BASE_CONFIG_PATH, encoding="utf-8") as file:
         return copy.deepcopy(yaml.safe_load(file))
 
 

--- a/tests/unit/utils/dumpers/test_config_dumper.py
+++ b/tests/unit/utils/dumpers/test_config_dumper.py
@@ -47,7 +47,7 @@ def test_dump_schema(tmpdir: Path) -> None:
     filename = tmpdir / "foo.json"
     dump_schema(str(filename))
 
-    with open(filename, "r", encoding="utf-8") as fin:
+    with open(filename, encoding="utf-8") as fin:
         # schema should be stored in JSON format
         content = load(fin)
         assert content is not None

--- a/tests/unit/utils/dumpers/test_models_dumper.py
+++ b/tests/unit/utils/dumpers/test_models_dumper.py
@@ -10030,7 +10030,7 @@ def test_dump_models(tmpdir: Path) -> None:
     filename = tmpdir / "foo.json"
     dump_models(str(filename))
 
-    with open(filename, "r", encoding="utf-8") as fin:
+    with open(filename, encoding="utf-8") as fin:
         # schema should be stored in JSON format
         content = load(fin)
         assert content is not None
@@ -10279,7 +10279,7 @@ def test_dump_models(tmpdir: Path) -> None:
 
 def check_json_file_content(filename: Path, expected_schemas: list[str]) -> None:
     """Check the content of provided JSON file with OpenAPI-compatible schema."""
-    with open(filename, "r", encoding="utf-8") as fin:
+    with open(filename, encoding="utf-8") as fin:
         # schema should be stored in JSON format
         content = load(fin)
         assert content is not None

--- a/tests/unit/utils/test_checks.py
+++ b/tests/unit/utils/test_checks.py
@@ -15,7 +15,7 @@ from utils import checks
 def input_file_fixture(tmp_path: Path) -> str:
     """Create file manually using the tmp_path fixture."""
     filename = os.path.join(tmp_path, "mydoc.csv")
-    with open(filename, "wt", encoding="utf-8") as fout:
+    with open(filename, "w", encoding="utf-8") as fout:
         fout.write("some content!")
     return filename
 

--- a/tests/unit/utils/test_endpoints.py
+++ b/tests/unit/utils/test_endpoints.py
@@ -23,7 +23,7 @@ from utils import endpoints
 def input_file_fixture(tmp_path: Path) -> str:
     """Create file manually using the tmp_path fixture."""
     filename = os.path.join(tmp_path, "prompt.txt")
-    with open(filename, "wt", encoding="utf-8") as fout:
+    with open(filename, "w", encoding="utf-8") as fout:
         fout.write("this is prompt!")
     return filename
 


### PR DESCRIPTION
## Description

LCORE-4018: Redundant open mode arguments are unnecessary and should be removed to avoid confusion

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-4018
