### PR TITLE
LCORE-4069: compare JSON-in-string assertions by content, not by key order

### DIFF
--- a/tests/e2e/utils/utils.py
+++ b/tests/e2e/utils/utils.py
@@ -271,10 +271,72 @@ def wait_for_ogx_ready(
     return wait_for_container_health("llama-stack", max_attempts=max_attempts)
 
 
+def _parsed_json_container(value: Any) -> Optional[Any]:
+    """Return ``value`` parsed as a JSON object or array, or None.
+
+    Only objects and arrays qualify. A bare string such as ``"1e3"`` is plain
+    text here, not a document whose formatting may be normalised.
+
+    Parameters:
+    ----------
+        value: Candidate value, only strings are considered.
+
+    Returns:
+    -------
+        The parsed ``dict`` or ``list``, or None when ``value`` is not a string
+        holding a JSON object or array.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except ValueError:
+        return None
+    return parsed if isinstance(parsed, (dict, list)) else None
+
+
+def _json_values_equal(left: Any, right: Any) -> bool:
+    """Return True when two parsed JSON values are equal, including their types.
+
+    Plain ``==`` is not enough: Python treats ``True == 1``, ``False == 0``
+    and ``1 == 1.0`` as equal, so ``{"enabled": true}`` would match
+    ``{"enabled": 1}``. Object key order is ignored; array order is not.
+
+    Parameters:
+    ----------
+        left: First parsed JSON value.
+        right: Second parsed JSON value.
+
+    Returns:
+    -------
+        True when both values have the same JSON types and contents.
+    """
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _json_values_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _json_values_equal(item_left, item_right)
+            for item_left, item_right in zip(left, right)
+        )
+    return left == right
+
+
 def validate_json_partially(actual: Any, expected: Any) -> None:
     """Recursively validate that `actual` JSON contains all keys and values specified in `expected`.
 
     Extra elements/keys are ignored. Raises AssertionError if validation fails.
+
+    Values that are strings holding a serialized JSON object or array are
+    compared by parsed content rather than byte for byte, so a producer that
+    emits its keys in a different order still matches. The comparison stays
+    exact — same keys, same values, same JSON types, and array element order
+    still significant — because relaxing it to the partial semantics used
+    elsewhere would silently weaken every existing assertion over an embedded
+    JSON document.
 
     Returns:
         None
@@ -303,6 +365,16 @@ def validate_json_partially(actual: Any, expected: Any) -> None:
             ), f"No matching element found in list for schema item {schema_item}, got {actual}"
 
     else:
+        if actual != expected:
+            parsed_actual = _parsed_json_container(actual)
+            parsed_expected = _parsed_json_container(expected)
+            if parsed_actual is not None and parsed_expected is not None:
+                assert _json_values_equal(parsed_actual, parsed_expected), (
+                    f"JSON-in-string mismatch: expected {parsed_expected}, "
+                    f"got {parsed_actual}"
+                )
+                return
+
         assert actual == expected, f"Value mismatch: expected {expected}, got {actual}"
 
 


### PR DESCRIPTION
## Description

`main` has failed the E2E Tests workflow on every merge since 2026-09-03 (first red run: the merge of #2601). Both `library / ci / skills` and `server / ci / skills` fail on the same two scenarios:

```
tests/e2e/features/skills.feature:694  Skills directory path discovers all skills in subdirectories via query endpoint
tests/e2e/features/skills.feature:724  ... via streaming_query endpoint
```

The assertion:

```
expected content: {"echo":"Echo back …","summarize":"Summarize text …"}
actual   content: {"summarize":"Summarize text …","echo":"Echo back …"}
```

Same two pairs. Only the key order differs.

### Root cause

`list_skills` returns a mapping whose key order is the filesystem scan order:

- `pydantic_ai_skills/directory.py` finds skills with `root_dir.glob('**/SKILL.md')`, which is not sorted.
- `pydantic_ai_skills/toolset.py` builds the tool result from that dict, so the JSON key order follows the scan.
- `validate_json_partially()` compared the two serialized objects as raw strings, byte for byte.

So the assertion has always depended on filesystem order. That also explains why only one shard failed on 2026-09-03 and both fail now: different runners, different directory layouts.

### The fix

When both sides are strings holding a JSON object or array, `validate_json_partially()` now compares the parsed values instead of the raw text.

The comparison stays exact: same keys, same values, same JSON types (`true` never matches `1`, `1` never matches `1.0`), and array order still matters. Only object key order is ignored.

Reordering the expected string in the feature file would not fix this. It would only move the flake to the next filesystem layout.

### Not in scope

The unsorted order also changes the model's prompt prefix between deployments, which works against prompt caching. That order comes from `pydantic_ai_skills`, not from LCS.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [x] E2E tests improvement
- [ ] Other (please describe):

## Tools used to create PR

- Assisted-by: Claude Opus 4.8
- Generated by: Claude Opus 4.8

## Related Tickets & Documents

- Related Issue # LCORE-4069
- Closes # LCORE-4069

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
- [ ] PR has passed all pre-merge test jobs.

## Testing

1. Check the failure on `main`: the `skills` shards of any recent merge run fail on `skills.feature:694` and `:724` with the key-order mismatch above.

2. Check the `skills` shards on this PR. Expected: both green. On the first push of this PR, `server / ci / skills` reported 9 scenarios passed, 0 failed, including both scenarios above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partial JSON validation by comparing serialized objects and arrays based on their parsed content rather than formatting or key order.
  * Preserved strict type matching and array element ordering during comparisons.

* **Documentation**
  * Updated validation guidance to describe the enhanced JSON comparison behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->