### PR TITLE
LCORE-3646: Class HealthStatus inherits from both str and enum

### DIFF
--- a/src/models/common/health.py
+++ b/src/models/common/health.py
@@ -1,12 +1,12 @@
 """Health-related shared models for readiness and diagnostics."""
 
-from enum import Enum
+from enum import StrEnum
 from typing import Optional
 
 from pydantic import BaseModel, Field
 
 
-class HealthStatus(str, Enum):
+class HealthStatus(StrEnum):
     """Health status enum for provider and service health checks.
 
     This enum serves two purposes:


### PR DESCRIPTION
## Description

LCORE-3646: Class `HealthStatus` inherits from both `str` and `enum`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal status representation was streamlined while preserving existing string-compatible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->