### PR TITLE
LCORE-3647: Class JsonPathOperator inherits from both str and enum

### DIFF
--- a/src/models/config.py
+++ b/src/models/config.py
@@ -4,7 +4,7 @@
 
 import os
 import re
-from enum import Enum
+from enum import Enum, StrEnum
 from functools import cached_property
 from pathlib import Path
 from re import Pattern
@@ -1140,7 +1140,7 @@ class UserDataCollection(ConfigurationBase):
         return self
 
 
-class JsonPathOperator(str, Enum):
+class JsonPathOperator(StrEnum):
     """Supported operators for JSONPath evaluation.
 
     Note: this is not a real model, just an enumeration of all supported JSONPath operators.


### PR DESCRIPTION
## Description

LCORE-3647: Class JsonPathOperator inherits from both `str` and `enum`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3647
