### PR TITLE
LCORE-3649: Class AgentFinishReason inherits from both str and enum

### DIFF
--- a/src/utils/agents/query.py
+++ b/src/utils/agents/query.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import Optional
 
 from fastapi import HTTPException
@@ -60,7 +60,7 @@ logger = get_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
-class AgentFinishReason(str, Enum):
+class AgentFinishReason(StrEnum):
     """Finish reason for a completed agent model response."""
 
     CONTENT_FILTER = "content_filter"


### PR DESCRIPTION
## Description

LCORE-3649: Class `AgentFinishReason` inherits from both `str` and `enum`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3649
