### PR TITLE
LCORE-3650: Class CancelStreamResult inherits from both and str and Enum

### DIFF
--- a/src/utils/stream_interrupts.py
+++ b/src/utils/stream_interrupts.py
@@ -4,7 +4,7 @@ import asyncio
 import datetime
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from threading import Lock
 from typing import Any, Optional, cast
 
@@ -53,7 +53,7 @@ class ActiveStream:
     conversation_id: Optional[str] = None
 
 
-class CancelStreamResult(str, Enum):
+class CancelStreamResult(StrEnum):
     """Outcomes when attempting to cancel a stream."""
 
     CANCELLED = "cancelled"


### PR DESCRIPTION
## Description

LCORE-3650: Class `CancelStreamResult` inherits from both and `str` and `Enum`

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-3650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the internal representation of stream cancellation results without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->