### PR TITLE
LCORE-4109: Use self as return type

### DIFF
--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,6 +1,6 @@
 """Configuration loader."""
 
-from typing import Any, Optional
+from typing import Any, Optional, Self
 
 import yaml
 
@@ -98,7 +98,7 @@ class AppConfig:  # pylint: disable=too-many-public-methods
 
     _instance = None
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> "AppConfig":
+    def __new__(cls, *args: Any, **kwargs: Any) -> Self:
         """Create a new instance of the class."""
         if not isinstance(cls._instance, cls):
             cls._instance = super().__new__(cls, *args, **kwargs)


### PR DESCRIPTION
## Description

LCORE-4109: Use `self` as return type

## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CVE fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Configuration Update
- [ ] Bump-up service version
- [ ] Bump-up dependent library [`pyproject.toml` + `uv.lock`]
- [ ] Bump-up dependent library [`requirements.*.txt` for Konflux]
- [ ] Bump-up library or tool used for development (does not change the final image)
- [ ] CI configuration change
- [ ] Konflux configuration change
- [ ] Unit tests improvement
- [ ] Integration tests improvement
- [ ] End to end tests improvement
- [ ] Benchmarks improvement


## Tools used to create PR

- Assisted-by: N/A
- Generated by: N/A

## Related Tickets & Documents

- Related Issue #LCORE-4109
